### PR TITLE
feat(server): Go signaling server skeleton

### DIFF
--- a/apps/server/.golangci.yml
+++ b/apps/server/.golangci.yml
@@ -1,0 +1,19 @@
+version: '2'
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - revive
+    - bodyclose
+
+run:
+  timeout: 3m
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/apps/server/cmd/agyd/main.go
+++ b/apps/server/cmd/agyd/main.go
@@ -1,0 +1,57 @@
+// Command agyd is the agy signaling + relay server. In M0 it serves the web bundle
+// over TLS (or reverse-proxies the Vite dev server) and exposes /healthz. Signaling
+// and relay are added in M1/M5.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/agy/server/internal/httpserver"
+)
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	cfg := httpserver.ConfigFromEnv()
+	srv, err := httpserver.New(cfg, logger)
+	if err != nil {
+		logger.Error("failed to build server", "err", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Info("agyd listening",
+			"addr", cfg.Addr,
+			"tls", cfg.TLSCert != "",
+			"mode", cfg.Mode(),
+		)
+		errCh <- srv.ListenAndServe()
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("server exited", "err", err)
+			os.Exit(1)
+		}
+	case <-ctx.Done():
+		logger.Info("shutting down")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			logger.Error("graceful shutdown failed", "err", err)
+			os.Exit(1)
+		}
+	}
+}

--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -1,0 +1,5 @@
+module github.com/agy/server
+
+go 1.26.5
+
+require github.com/go-chi/chi/v5 v5.3.1

--- a/apps/server/go.sum
+++ b/apps/server/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
+github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=

--- a/apps/server/internal/httpserver/headers.go
+++ b/apps/server/internal/httpserver/headers.go
@@ -1,0 +1,26 @@
+package httpserver
+
+import "net/http"
+
+// securityHeaders applies the baseline hardening from plan.md §14. The CSP is
+// deliberately strict; connect-src stays 'self' because signaling runs same-origin
+// (wss to the same host). Referrer-Policy is an extra guard so the URL fragment
+// secret can never leak via Referer. Tightened further for release in M7.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Content-Security-Policy",
+			"default-src 'self'; "+
+				"connect-src 'self' wss: https:; "+
+				"img-src 'self' data:; "+
+				"style-src 'self' 'unsafe-inline'; "+
+				"script-src 'self'; "+
+				"object-src 'none'; "+
+				"base-uri 'none'; "+
+				"frame-ancestors 'none'")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/apps/server/internal/httpserver/server.go
+++ b/apps/server/internal/httpserver/server.go
@@ -1,0 +1,154 @@
+// Package httpserver wires the HTTP surface for agyd: health, security headers, and
+// serving the web app — either from a built directory (prod) or by proxying the Vite
+// dev server (dev). Signaling/relay handlers mount onto this router in later milestones.
+package httpserver
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// Config controls how agyd serves the web app and terminates TLS.
+type Config struct {
+	Addr     string // listen address, e.g. ":8443"
+	TLSCert  string // path to TLS cert (PEM); empty => plain HTTP (dev/testing only)
+	TLSKey   string // path to TLS key (PEM)
+	WebDir   string // directory of the built web bundle to serve (prod)
+	DevProxy string // URL of the Vite dev server to proxy to (dev); overrides WebDir
+}
+
+// ConfigFromEnv reads configuration from AGY_* environment variables with defaults.
+func ConfigFromEnv() Config {
+	return Config{
+		Addr:     env("AGY_ADDR", ":8443"),
+		TLSCert:  os.Getenv("AGY_TLS_CERT"),
+		TLSKey:   os.Getenv("AGY_TLS_KEY"),
+		WebDir:   os.Getenv("AGY_WEB_DIR"),
+		DevProxy: os.Getenv("AGY_WEB_DEV_PROXY"),
+	}
+}
+
+// Mode reports how the web app is being served, for logging.
+func (c Config) Mode() string {
+	switch {
+	case c.DevProxy != "":
+		return "dev-proxy"
+	case c.WebDir != "":
+		return "static"
+	default:
+		return "api-only"
+	}
+}
+
+// Server wraps *http.Server with agy's config so it can choose TLS vs plain HTTP.
+type Server struct {
+	http *http.Server
+	cfg  Config
+}
+
+// New builds a Server with the agy router and sensible timeouts.
+func New(cfg Config, logger *slog.Logger) (*Server, error) {
+	handler, err := router(cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+	return &Server{
+		cfg: cfg,
+		http: &http.Server{
+			Addr:              cfg.Addr,
+			Handler:           handler,
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       120 * time.Second,
+			TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12},
+			// No WriteTimeout: signaling/relay use long-lived streaming connections.
+		},
+	}, nil
+}
+
+// ListenAndServe serves over TLS when a cert/key are configured, else plain HTTP.
+func (s *Server) ListenAndServe() error {
+	if s.cfg.TLSCert != "" && s.cfg.TLSKey != "" {
+		return s.http.ListenAndServeTLS(s.cfg.TLSCert, s.cfg.TLSKey)
+	}
+	return s.http.ListenAndServe()
+}
+
+// Shutdown gracefully stops the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.http.Shutdown(ctx)
+}
+
+func router(cfg Config, logger *slog.Logger) (http.Handler, error) {
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RealIP)
+	r.Use(middleware.Recoverer)
+	r.Use(securityHeaders)
+
+	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	// Web app: dev proxy takes precedence, then a static build dir.
+	switch {
+	case cfg.DevProxy != "":
+		proxy, err := devProxy(cfg.DevProxy)
+		if err != nil {
+			return nil, err
+		}
+		r.Handle("/*", proxy)
+	case cfg.WebDir != "":
+		r.Handle("/*", spaFileServer(cfg.WebDir))
+	default:
+		logger.Warn("no web source configured; serving /healthz only")
+	}
+
+	return r, nil
+}
+
+// devProxy reverse-proxies everything (including Vite HMR websockets) to the dev server.
+func devProxy(target string) (http.Handler, error) {
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, fmt.Errorf("invalid AGY_WEB_DEV_PROXY %q: %w", target, err)
+	}
+	return httputil.NewSingleHostReverseProxy(u), nil
+}
+
+// spaFileServer serves static files and falls back to index.html for client routes.
+func spaFileServer(dir string) http.Handler {
+	fs := http.FileServer(http.Dir(dir))
+	index := strings.TrimRight(dir, "/") + "/index.html"
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		path := strings.TrimPrefix(req.URL.Path, "/")
+		if path == "" {
+			http.ServeFile(w, req, index)
+			return
+		}
+		if _, err := os.Stat(dir + "/" + path); os.IsNotExist(err) {
+			http.ServeFile(w, req, index) // SPA deep-link fallback
+			return
+		}
+		fs.ServeHTTP(w, req)
+	})
+}
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/apps/server/internal/httpserver/server_test.go
+++ b/apps/server/internal/httpserver/server_test.go
@@ -1,0 +1,86 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func testRouter(t *testing.T, cfg Config) http.Handler {
+	t.Helper()
+	h, err := router(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+	return h
+}
+
+func TestHealthz(t *testing.T) {
+	h := testRouter(t, Config{})
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("status field = %q, want ok", body["status"])
+	}
+}
+
+func TestSecurityHeaders(t *testing.T) {
+	h := testRouter(t, Config{})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if got := rec.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Errorf("Referrer-Policy = %q, want no-referrer", got)
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got == "" {
+		t.Error("missing Content-Security-Policy")
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+}
+
+func TestSPAFallback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<!doctype html>hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := testRouter(t, Config{WebDir: dir})
+
+	// A client-side route with no matching file falls back to index.html.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/send/abc", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if body := rec.Body.String(); body != "<!doctype html>hi" {
+		t.Fatalf("body = %q, want index.html contents", body)
+	}
+}
+
+func TestModeReporting(t *testing.T) {
+	cases := map[string]Config{
+		"dev-proxy": {DevProxy: "http://localhost:5173"},
+		"static":    {WebDir: "/tmp/x"},
+		"api-only":  {},
+	}
+	for want, cfg := range cases {
+		if got := cfg.Mode(); got != want {
+			t.Errorf("Mode() = %q, want %q", got, want)
+		}
+	}
+}

--- a/go.work
+++ b/go.work
@@ -1,0 +1,3 @@
+go 1.26.5
+
+use ./apps/server


### PR DESCRIPTION
chi router with /healthz, TLS serving, and graceful shutdown. Serves the
built SPA with index.html fallback and reverse-proxies to Vite in dev.
Security headers (CSP, Referrer-Policy: no-referrer, nosniff, DENY) are
applied to every response. Config is via AGY_* environment variables.