### PR TITLE
ci: harden web install and align Go lint toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Check formatting
         run: pnpm run format:check
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.24'
           cache-dependency-path: apps/server/go.sum
 
       - name: Vet
@@ -70,7 +70,7 @@ jobs:
         run: go build ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
           working-directory: apps/server


### PR DESCRIPTION
The web install now runs with --ignore-scripts: pnpm 11 treats blocked
dependency build scripts as a fatal error under CI, and blocking them
also keeps arbitrary postinstall code out of the build.

Pin the server job to Go 1.24 and upgrade golangci-lint-action to v7 so
the linter matches the module's Go directive and the v2 config format.