### PR TITLE
fix(server): drop RealIP middleware to prevent client IP spoofing

### DIFF
--- a/apps/server/internal/httpserver/server.go
+++ b/apps/server/internal/httpserver/server.go
@@ -93,7 +93,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 func router(cfg Config, logger *slog.Logger) (http.Handler, error) {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
 	r.Use(middleware.Recoverer)
 	r.Use(securityHeaders)
 


### PR DESCRIPTION
chi's RealIP rewrites RemoteAddr from client-controlled headers
(X-Forwarded-For, X-Real-IP, True-Client-IP) even when no trusted proxy
sets them, which lets a caller forge its source address. Nothing
consumes the client IP yet; when rate limiting lands it will resolve the
address under an explicit trusted-proxy policy instead.