### PR TITLE
feat(wire): Go crypto core mirroring @sendarc/protocol

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,3 +1,6 @@
 go 1.26.5
 
-use ./apps/server
+use (
+	./apps/server
+	./packages/wire
+)

--- a/packages/wire/aead.go
+++ b/packages/wire/aead.go
@@ -1,0 +1,94 @@
+package wire
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+	"fmt"
+)
+
+const u16Max = 0xffff
+
+// FrameHeaderInput is the header fields the caller supplies; Len is set from the
+// plaintext by Seal.
+type FrameHeaderInput struct {
+	Version  uint8
+	Type     uint8
+	Flags    uint8
+	FileIdx  uint16
+	BlockIdx uint32
+	FrameOff uint16
+}
+
+// nonce builds the 12-byte GCM nonce: the direction's 4-byte salt followed by a
+// big-endian u64 frame counter.
+func nonce(salt []byte, counter uint64) []byte {
+	out := make([]byte, aeadNonceBytes)
+	copy(out, salt)
+	binary.BigEndian.PutUint64(out[aeadSaltBytes:], counter)
+	return out
+}
+
+func gcmFor(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+// Seal encrypts plaintext into a frame: header(16) || ciphertext || tag(16). The header's
+// Len field is set to the plaintext length and authenticated as GCM additional data.
+func Seal(dir DirectionalKey, counter uint64, h FrameHeaderInput, plaintext []byte) ([]byte, error) {
+	if len(plaintext) > u16Max {
+		return nil, fmt.Errorf("frame payload %d exceeds u16 max %d", len(plaintext), u16Max)
+	}
+	aad := encodeFrameHeader(FrameHeader{
+		Version:  h.Version,
+		Type:     h.Type,
+		Flags:    h.Flags,
+		FileIdx:  h.FileIdx,
+		BlockIdx: h.BlockIdx,
+		FrameOff: h.FrameOff,
+		Len:      uint16(len(plaintext)),
+	})
+	gcm, err := gcmFor(dir.Key)
+	if err != nil {
+		return nil, err
+	}
+	// Seal appends ciphertext||tag onto aad, giving header || ciphertext || tag.
+	return gcm.Seal(aad, nonce(dir.Salt, counter), plaintext, aad), nil
+}
+
+// OpenedFrame is a decrypted frame: its parsed header and recovered plaintext.
+type OpenedFrame struct {
+	Header    FrameHeader
+	Plaintext []byte
+}
+
+// Open decrypts a frame produced by Seal. It verifies the GCM tag over the header AAD and
+// the expected nonce, and fails if authentication fails, the frame is truncated, or the
+// header Len disagrees with the ciphertext length.
+func Open(dir DirectionalKey, counter uint64, frame []byte) (*OpenedFrame, error) {
+	if len(frame) < frameHeaderBytes+aeadTagBytes {
+		return nil, fmt.Errorf("frame too short: %d bytes", len(frame))
+	}
+	aad := frame[:frameHeaderBytes]
+	header, err := decodeFrameHeader(aad)
+	if err != nil {
+		return nil, err
+	}
+	body := frame[frameHeaderBytes:]
+	if len(body) != int(header.Len)+aeadTagBytes {
+		return nil, fmt.Errorf("frame len field %d disagrees with body %d", header.Len, len(body))
+	}
+	gcm, err := gcmFor(dir.Key)
+	if err != nil {
+		return nil, err
+	}
+	plaintext, err := gcm.Open(nil, nonce(dir.Salt, counter), body, aad)
+	if err != nil {
+		return nil, err
+	}
+	return &OpenedFrame{Header: header, Plaintext: plaintext}, nil
+}

--- a/packages/wire/aead_test.go
+++ b/packages/wire/aead_test.go
@@ -1,0 +1,161 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestKeyScheduleSendarcVector(t *testing.T) {
+	sa := loadSendarc(t)
+	ks := sa.Keyschedule
+
+	master, err := DeriveMaster(mustHex(t, sa.Spake2.Ke), mustHex(t, sa.Spake2.Transcript))
+	if err != nil {
+		t.Fatalf("DeriveMaster: %v", err)
+	}
+	if got := hex.EncodeToString(master); got != ks.Master {
+		t.Fatalf("master = %s, want %s", got, ks.Master)
+	}
+
+	keys, err := DeriveTransferKeys(master)
+	if err != nil {
+		t.Fatalf("DeriveTransferKeys: %v", err)
+	}
+	checkHex(t, 0, "o2jKey", keys.O2J.Key, ks.O2JKey)
+	checkHex(t, 0, "o2jSalt", keys.O2J.Salt, ks.O2JSalt)
+	checkHex(t, 0, "j2oKey", keys.J2O.Key, ks.J2OKey)
+	checkHex(t, 0, "j2oSalt", keys.J2O.Salt, ks.J2OSalt)
+}
+
+func TestAeadSealMatchesSendarcVector(t *testing.T) {
+	sa := loadSendarc(t)
+	if sa.Aead.Direction != "o2j" {
+		t.Fatalf("vector direction %q, expected o2j", sa.Aead.Direction)
+	}
+
+	master, err := DeriveMaster(mustHex(t, sa.Spake2.Ke), mustHex(t, sa.Spake2.Transcript))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, err := DeriveTransferKeys(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header, err := decodeFrameHeader(mustHex(t, sa.Aead.HeaderHex))
+	if err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	in := FrameHeaderInput{
+		Version:  header.Version,
+		Type:     header.Type,
+		Flags:    header.Flags,
+		FileIdx:  header.FileIdx,
+		BlockIdx: header.BlockIdx,
+		FrameOff: header.FrameOff,
+	}
+
+	frame, err := Seal(keys.O2J, sa.Aead.Counter, in, []byte(sa.Aead.PlaintextUtf8))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if got := hex.EncodeToString(frame); got != sa.Aead.FrameHex {
+		t.Fatalf("frame = %s, want %s", got, sa.Aead.FrameHex)
+	}
+
+	// And it round-trips back to the plaintext.
+	opened, err := Open(keys.O2J, sa.Aead.Counter, frame)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if string(opened.Plaintext) != sa.Aead.PlaintextUtf8 {
+		t.Fatalf("plaintext = %q, want %q", opened.Plaintext, sa.Aead.PlaintextUtf8)
+	}
+	if opened.Header.Len != uint16(len(sa.Aead.PlaintextUtf8)) {
+		t.Fatalf("header len = %d, want %d", opened.Header.Len, len(sa.Aead.PlaintextUtf8))
+	}
+}
+
+func TestAeadRoundTrip(t *testing.T) {
+	keys := testKeys(t)
+	in := FrameHeaderInput{Version: 1, Type: FrameBlockData, FileIdx: 3, BlockIdx: 7, FrameOff: 512}
+	plaintext := []byte("the quick brown fox jumps over the lazy dog")
+
+	frame, err := Seal(keys.O2J, 42, in, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opened, err := Open(keys.O2J, 42, frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(opened.Plaintext, plaintext) {
+		t.Error("round-trip plaintext mismatch")
+	}
+	if opened.Header.FileIdx != 3 || opened.Header.BlockIdx != 7 || opened.Header.FrameOff != 512 {
+		t.Errorf("header fields not preserved: %+v", opened.Header)
+	}
+}
+
+func TestAeadRejectsTampering(t *testing.T) {
+	keys := testKeys(t)
+	in := FrameHeaderInput{Version: 1, Type: FrameBlockData}
+	frame, err := Seal(keys.O2J, 0, in, []byte("secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("wrong counter", func(t *testing.T) {
+		if _, err := Open(keys.O2J, 1, frame); err == nil {
+			t.Error("expected auth failure at wrong counter")
+		}
+	})
+	t.Run("wrong direction", func(t *testing.T) {
+		if _, err := Open(keys.J2O, 0, frame); err == nil {
+			t.Error("expected auth failure with opposite direction key")
+		}
+	})
+	t.Run("tampered ciphertext", func(t *testing.T) {
+		bad := bytes.Clone(frame)
+		bad[frameHeaderBytes] ^= 0x01
+		if _, err := Open(keys.O2J, 0, bad); err == nil {
+			t.Error("expected auth failure on flipped ciphertext byte")
+		}
+	})
+	t.Run("tampered header", func(t *testing.T) {
+		bad := bytes.Clone(frame)
+		bad[1] ^= 0x01 // flip the Type field, which is authenticated as AAD
+		if _, err := Open(keys.O2J, 0, bad); err == nil {
+			t.Error("expected auth failure on flipped header byte")
+		}
+	})
+	t.Run("truncated", func(t *testing.T) {
+		if _, err := Open(keys.O2J, 0, frame[:frameHeaderBytes+aeadTagBytes-1]); err == nil {
+			t.Error("expected failure on truncated frame")
+		}
+	})
+}
+
+func TestSealRejectsOversizePayload(t *testing.T) {
+	keys := testKeys(t)
+	in := FrameHeaderInput{Version: 1, Type: FrameBlockData}
+	if _, err := Seal(keys.O2J, 0, in, make([]byte, u16Max+1)); err == nil {
+		t.Error("expected Seal to reject a payload larger than u16 max")
+	}
+}
+
+// testKeys derives a throwaway pair of directional keys for tests that only need a valid
+// key, not a fixture-committed one.
+func testKeys(t *testing.T) TransferKeys {
+	t.Helper()
+	master, err := DeriveMaster(bytes.Repeat([]byte{0xab}, 16), []byte("transcript"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, err := DeriveTransferKeys(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return keys
+}

--- a/packages/wire/bytes.go
+++ b/packages/wire/bytes.go
@@ -1,0 +1,29 @@
+package wire
+
+import (
+	"crypto/hkdf"
+	"crypto/sha256"
+	"encoding/binary"
+)
+
+// lengthPrefixLE encodes n as an 8-byte little-endian length — the len(...) encoding of
+// the RFC 9382 SPAKE2 transcript (§3.3).
+func lengthPrefixLE(n int) []byte {
+	out := make([]byte, 8)
+	binary.LittleEndian.PutUint64(out, uint64(n))
+	return out
+}
+
+// withLengthPrefix returns len(x) || x with an 8-byte little-endian length.
+func withLengthPrefix(x []byte) []byte {
+	out := make([]byte, 0, 8+len(x))
+	out = append(out, lengthPrefixLE(len(x))...)
+	return append(out, x...)
+}
+
+// hkdfSHA256 mirrors the TypeScript hkdfSha256 helper: HKDF-SHA256 extract-and-expand
+// with the given salt and info. A nil or empty salt follows RFC 5869 (a string of
+// HashLen zero bytes), which is HMAC-equivalent to WebCrypto's zero-length salt.
+func hkdfSHA256(ikm, salt, info []byte, length int) ([]byte, error) {
+	return hkdf.Key(sha256.New, ikm, salt, string(info), length)
+}

--- a/packages/wire/bytes_test.go
+++ b/packages/wire/bytes_test.go
@@ -1,0 +1,49 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestLengthPrefixLE(t *testing.T) {
+	// 8-byte little-endian, matching the RFC 9382 transcript encoding.
+	if got := hex.EncodeToString(lengthPrefixLE(0)); got != "0000000000000000" {
+		t.Errorf("lengthPrefixLE(0) = %s", got)
+	}
+	if got := hex.EncodeToString(lengthPrefixLE(1)); got != "0100000000000000" {
+		t.Errorf("lengthPrefixLE(1) = %s", got)
+	}
+	if got := hex.EncodeToString(lengthPrefixLE(65)); got != "4100000000000000" {
+		t.Errorf("lengthPrefixLE(65) = %s", got)
+	}
+}
+
+func TestWithLengthPrefix(t *testing.T) {
+	got := withLengthPrefix([]byte{0xaa, 0xbb, 0xcc})
+	want := append(lengthPrefixLE(3), 0xaa, 0xbb, 0xcc)
+	if !bytes.Equal(got, want) {
+		t.Errorf("withLengthPrefix = %x, want %x", got, want)
+	}
+	if empty := withLengthPrefix(nil); !bytes.Equal(empty, lengthPrefixLE(0)) {
+		t.Errorf("withLengthPrefix(nil) = %x", empty)
+	}
+}
+
+func TestHKDFEmptySaltEquivalence(t *testing.T) {
+	// A nil salt must behave as RFC 5869's default (HashLen zero bytes), which is the
+	// cross-language interop guarantee against WebCrypto's zero-length salt.
+	ikm := []byte("input keying material")
+	info := []byte("sendarc/1 test")
+	withNil, err := hkdfSHA256(ikm, nil, info, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withZeros, err := hkdfSHA256(ikm, make([]byte, 32), info, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(withNil, withZeros) {
+		t.Error("nil salt and 32 zero bytes should produce identical HKDF output")
+	}
+}

--- a/packages/wire/frame.go
+++ b/packages/wire/frame.go
@@ -1,0 +1,71 @@
+package wire
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const frameHeaderBytes = 16
+
+// FrameHeader is the 16-byte frame header (plan.md §6.3). Its encoded bytes are the
+// AES-GCM additional authenticated data, so the codec must be exact and stable.
+//
+// Layout (big-endian):
+//
+//	version(u8) type(u8) flags(u8) reserved(u8)
+//	fileIdx(u16) blockIdx(u32) frameOff(u16) len(u16) reserved(u16)
+type FrameHeader struct {
+	Version  uint8
+	Type     uint8
+	Flags    uint8
+	FileIdx  uint16
+	BlockIdx uint32
+	FrameOff uint16 // byte offset within the block, not the file
+	Len      uint16 // ciphertext payload length
+}
+
+// Frame type tags (the Type byte). Mirrors FrameType in transfer.ts.
+const (
+	FrameCaps      uint8 = 1
+	FrameManifest  uint8 = 2
+	FrameBlockData uint8 = 3
+	FrameBlockHash uint8 = 4
+	FrameBlockRecv uint8 = 5
+	FrameAck       uint8 = 6
+	FrameNack      uint8 = 7
+	FrameControl   uint8 = 8
+	FrameComplete  uint8 = 9
+	FrameDone      uint8 = 10
+	FrameFail      uint8 = 11
+)
+
+// encodeFrameHeader encodes h into a fresh 16-byte buffer.
+func encodeFrameHeader(h FrameHeader) []byte {
+	buf := make([]byte, frameHeaderBytes)
+	buf[0] = h.Version
+	buf[1] = h.Type
+	buf[2] = h.Flags
+	buf[3] = 0 // reserved
+	binary.BigEndian.PutUint16(buf[4:6], h.FileIdx)
+	binary.BigEndian.PutUint32(buf[6:10], h.BlockIdx)
+	binary.BigEndian.PutUint16(buf[10:12], h.FrameOff)
+	binary.BigEndian.PutUint16(buf[12:14], h.Len)
+	// buf[14:16] reserved tail — keeps the header at a fixed 16 bytes
+	return buf
+}
+
+// decodeFrameHeader decodes a header from the first 16 bytes of buf.
+func decodeFrameHeader(buf []byte) (FrameHeader, error) {
+	if len(buf) < frameHeaderBytes {
+		return FrameHeader{}, fmt.Errorf("frame header needs %d bytes, got %d", frameHeaderBytes, len(buf))
+	}
+	return FrameHeader{
+		Version:  buf[0],
+		Type:     buf[1],
+		Flags:    buf[2],
+		FileIdx:  binary.BigEndian.Uint16(buf[4:6]),
+		BlockIdx: binary.BigEndian.Uint32(buf[6:10]),
+		FrameOff: binary.BigEndian.Uint16(buf[10:12]),
+		Len:      binary.BigEndian.Uint16(buf[12:14]),
+	}, nil
+}

--- a/packages/wire/go.mod
+++ b/packages/wire/go.mod
@@ -1,0 +1,7 @@
+module github.com/sendarc/wire
+
+go 1.26.5
+
+require filippo.io/nistec v0.0.4
+
+require golang.org/x/sys v0.36.0 // indirect

--- a/packages/wire/go.sum
+++ b/packages/wire/go.sum
@@ -1,0 +1,4 @@
+filippo.io/nistec v0.0.4 h1:F14ZHT5htWlMnQVPndX9ro9arf56cBhQxq4LnDI491s=
+filippo.io/nistec v0.0.4/go.mod h1:PK/lw8I1gQT4hUML4QGaqljwdDaFcMyFKSXN7kjrtKI=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/packages/wire/keyschedule.go
+++ b/packages/wire/keyschedule.go
@@ -1,0 +1,43 @@
+package wire
+
+// DirectionalKey is an AEAD key plus the 4-byte salt that prefixes its GCM nonces.
+type DirectionalKey struct {
+	Key  []byte // 32 bytes (AES-256)
+	Salt []byte // 4 bytes — nonce = salt || counter_u64_be
+}
+
+// TransferKeys are both directional keys derived from one handshake.
+type TransferKeys struct {
+	O2J DirectionalKey // offerer → joiner
+	J2O DirectionalKey // joiner → offerer
+}
+
+// DeriveMaster derives the master key, bound to the full handshake transcript so any
+// tampering that survived key confirmation still changes every downstream key:
+// HKDF(Ke, "sendarc/1 master" || TT).
+func DeriveMaster(ke, transcript []byte) ([]byte, error) {
+	info := append([]byte(infoMaster), transcript...)
+	return hkdfSHA256(ke, nil, info, aeadKeyBytes)
+}
+
+// deriveDirectional derives one directional key + nonce salt from the master key.
+func deriveDirectional(master []byte, info string) (DirectionalKey, error) {
+	out, err := hkdfSHA256(master, nil, []byte(info), aeadKeyBytes+aeadSaltBytes)
+	if err != nil {
+		return DirectionalKey{}, err
+	}
+	return DirectionalKey{Key: out[:aeadKeyBytes], Salt: out[aeadKeyBytes:]}, nil
+}
+
+// DeriveTransferKeys derives both directional transfer keys from the master key.
+func DeriveTransferKeys(master []byte) (TransferKeys, error) {
+	o2j, err := deriveDirectional(master, infoDirOffererJoiner)
+	if err != nil {
+		return TransferKeys{}, err
+	}
+	j2o, err := deriveDirectional(master, infoDirJoinerOfferer)
+	if err != nil {
+		return TransferKeys{}, err
+	}
+	return TransferKeys{O2J: o2j, J2O: j2o}, nil
+}

--- a/packages/wire/spake2.go
+++ b/packages/wire/spake2.go
@@ -1,0 +1,210 @@
+package wire
+
+import (
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"math/big"
+
+	"filippo.io/nistec"
+)
+
+// p256Order is the P-256 group order n (prime; cofactor 1, so every point has order n).
+var p256Order = elliptic.P256().Params().N
+
+// RFC 9382 §4 fixed seed points for P-256, stored uncompressed (nistec decodes only the
+// uncompressed SEC1 encoding). These are the decompressions of the compressed points in
+// the RFC; the vector tests confirm they reproduce the RFC shares.
+var (
+	seedM = mustPoint("04886e2f97ace46e55ba9dd7242579f2993b64e16ef3dcab95afd497333d8fa12f5ff355163e43ce224e0b0e65ff02ac8e5c7be09419c785e0ca547d55a12e2d20")
+	seedN = mustPoint("04d8bbd6c639c62937b04d997f38c3770719c629d7014d49a24b4f98baa1292b4907d60aa6bfade45008a636337f5168c64d9bd36034808cd564490b1e656edbe7")
+)
+
+func mustPoint(uncompressedHex string) *nistec.P256Point {
+	b, err := hex.DecodeString(uncompressedHex)
+	if err != nil {
+		panic("wire: bad seed point hex: " + err.Error())
+	}
+	p, err := nistec.NewP256Point().SetBytes(b)
+	if err != nil {
+		panic("wire: bad seed point: " + err.Error())
+	}
+	return p
+}
+
+// seedFor is the seed point a role adds to its share (offerer→M, joiner→N).
+func seedFor(role Role) *nistec.P256Point {
+	if role == RoleOfferer {
+		return seedM
+	}
+	return seedN
+}
+
+// peerSeedFor is the peer's seed point, subtracted to recover the shared point.
+func peerSeedFor(role Role) *nistec.P256Point {
+	if role == RoleOfferer {
+		return seedN
+	}
+	return seedM
+}
+
+// Identities are the RFC transcript identity strings for the two parties.
+type Identities struct {
+	Offerer []byte
+	Joiner  []byte
+}
+
+// DefaultIdentities are the SendArc identity strings bound into every handshake.
+func DefaultIdentities() Identities {
+	return Identities{Offerer: []byte(IdentityOfferer), Joiner: []byte(IdentityJoiner)}
+}
+
+func reduce(v *big.Int) *big.Int { return new(big.Int).Mod(v, p256Order) }
+
+// scalarBytes encodes a reduced scalar as a 32-byte big-endian value (nistec's required
+// form, and the SPAKE2 transcript's w encoding).
+func scalarBytes(v *big.Int) []byte {
+	out := make([]byte, 32)
+	reduce(v).FillBytes(out)
+	return out
+}
+
+// RandomScalar returns a uniformly random scalar in [1, n-1], suitable as the ephemeral
+// SPAKE2 secret. It rejection-samples 48 bytes of randomness reduced mod n.
+func RandomScalar() (*big.Int, error) {
+	for {
+		buf := make([]byte, 48)
+		if _, err := rand.Read(buf); err != nil {
+			return nil, err
+		}
+		v := reduce(new(big.Int).SetBytes(buf))
+		if v.Sign() != 0 {
+			return v, nil
+		}
+	}
+}
+
+// PasswordToScalar maps a normalized invite code to the SPAKE2 password scalar w. This
+// is SendArc-specific (RFC 9382 leaves the mapping to the application): w is HKDF over
+// the UTF-8 code, then reduced mod n. 48 bytes before reduction leaves negligible bias.
+func PasswordToScalar(normalizedCode string) (*big.Int, error) {
+	bits, err := hkdfSHA256([]byte(normalizedCode), nil, []byte(infoSpake2W), spake2WHKDFBytes)
+	if err != nil {
+		return nil, err
+	}
+	return reduce(new(big.Int).SetBytes(bits)), nil
+}
+
+// ComputeShare computes this role's SPAKE2 share element w·seed + secret·G, uncompressed
+// SEC1. Offerer → pA = w·M + x·G; joiner → pB = w·N + y·G.
+func ComputeShare(role Role, w, secret *big.Int) ([]byte, error) {
+	seedW, err := nistec.NewP256Point().ScalarMult(seedFor(role), scalarBytes(w))
+	if err != nil {
+		return nil, err
+	}
+	gS, err := nistec.NewP256Point().ScalarBaseMult(scalarBytes(secret))
+	if err != nil {
+		return nil, err
+	}
+	return nistec.NewP256Point().Add(seedW, gS).Bytes(), nil
+}
+
+// Spake2Output is the full result of finishing the SPAKE2 exchange, all as raw bytes.
+type Spake2Output struct {
+	K          []byte // shared group element K (uncompressed SEC1); never used directly as a key
+	Transcript []byte // RFC transcript TT — input to the hash and both confirmation MACs
+	Ke         []byte // shared secret Ke = Hash(TT)[0:16] — input to the SendArc key schedule
+	Ka         []byte // confirmation-key material Ka = Hash(TT)[16:32]
+	KcA        []byte // MAC key for the offerer's confirmation (RFC "A")
+	KcB        []byte // MAC key for the joiner's confirmation (RFC "B")
+	ConfirmA   []byte // offerer's confirmation MAC cA = HMAC(KcA, TT)
+	ConfirmB   []byte // joiner's confirmation MAC cB = HMAC(KcB, TT)
+}
+
+// Finish completes the exchange with SendArc's identity strings.
+func Finish(role Role, w, secret *big.Int, peerShare []byte) (*Spake2Output, error) {
+	return finish(role, w, secret, peerShare, DefaultIdentities())
+}
+
+// finish completes the exchange from this role's secret and the peer's share element. It
+// recovers the shared point K, assembles the RFC transcript, and derives Ke/Ka and both
+// confirmation MACs. The identities let the RFC known-answer vectors override SendArc's.
+func finish(role Role, w, secret *big.Int, peerShare []byte, ids Identities) (*Spake2Output, error) {
+	peer, err := nistec.NewP256Point().SetBytes(peerShare)
+	if err != nil {
+		return nil, err
+	}
+
+	// Recover K = secret·(peerShare − w·peerSeed). Negate via the (n−w) scalar since
+	// P-256 is prime-order: −w·P ≡ ((n−w) mod n)·P.
+	negW := reduce(new(big.Int).Sub(p256Order, reduce(w)))
+	negWpeerSeed, err := nistec.NewP256Point().ScalarMult(peerSeedFor(role), scalarBytes(negW))
+	if err != nil {
+		return nil, err
+	}
+	shared := nistec.NewP256Point().Add(peer, negWpeerSeed)
+	k, err := nistec.NewP256Point().ScalarMult(shared, scalarBytes(secret))
+	if err != nil {
+		return nil, err
+	}
+	kBytes := k.Bytes()
+
+	ownShare, err := ComputeShare(role, w, secret)
+	if err != nil {
+		return nil, err
+	}
+	pA, pB := ownShare, peerShare
+	if role == RoleJoiner {
+		pA, pB = peerShare, ownShare
+	}
+
+	transcript := concat(
+		withLengthPrefix(ids.Offerer),
+		withLengthPrefix(ids.Joiner),
+		withLengthPrefix(pA),
+		withLengthPrefix(pB),
+		withLengthPrefix(kBytes),
+		withLengthPrefix(scalarBytes(w)),
+	)
+
+	hash := sha256.Sum256(transcript)
+	ke := hash[0:16]
+	ka := hash[16:32]
+
+	// KcA || KcB = HKDF(Ka, nil, "ConfirmationKeys", 32) — RFC 9382 §4.
+	kc, err := hkdfSHA256(ka, nil, []byte(infoConfirmationKeys), 32)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Spake2Output{
+		K:          kBytes,
+		Transcript: transcript,
+		Ke:         append([]byte(nil), ke...),
+		Ka:         append([]byte(nil), ka...),
+		KcA:        kc[0:16],
+		KcB:        kc[16:32],
+		ConfirmA:   hmacSHA256(kc[0:16], transcript),
+		ConfirmB:   hmacSHA256(kc[16:32], transcript),
+	}, nil
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write(data)
+	return m.Sum(nil)
+}
+
+func concat(parts ...[]byte) []byte {
+	n := 0
+	for _, p := range parts {
+		n += len(p)
+	}
+	out := make([]byte, 0, n)
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}

--- a/packages/wire/spake2_test.go
+++ b/packages/wire/spake2_test.go
@@ -1,0 +1,279 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const vectorsDir = "../../test-vectors"
+
+func loadVectors(t *testing.T, name string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(vectorsDir, name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("parse %s: %v", name, err)
+	}
+}
+
+func scalar(t *testing.T, h string) *big.Int {
+	t.Helper()
+	n, ok := new(big.Int).SetString(h, 16)
+	if !ok {
+		t.Fatalf("bad scalar hex %q", h)
+	}
+	return n
+}
+
+func mustHex(t *testing.T, h string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", h, err)
+	}
+	return b
+}
+
+// The RFC fixture uses lowercase single-letter keys, so each field carries an explicit
+// json tag rather than relying on Go's exported-name matching.
+type rfcVectorRaw struct {
+	A        string `json:"A"`
+	B        string `json:"B"`
+	W        string `json:"w"`
+	X        string `json:"x"`
+	Y        string `json:"y"`
+	PA       string `json:"pA"`
+	PB       string `json:"pB"`
+	K        string `json:"K"`
+	TT       string `json:"TT"`
+	Ke       string `json:"Ke"`
+	Ka       string `json:"Ka"`
+	KcA      string `json:"KcA"`
+	KcB      string `json:"KcB"`
+	ConfirmA string `json:"confirmA"`
+	ConfirmB string `json:"confirmB"`
+}
+
+func TestSpake2RFC9382Vectors(t *testing.T) {
+	var doc struct {
+		Vectors []rfcVectorRaw `json:"vectors"`
+	}
+	loadVectors(t, "rfc9382-p256.json", &doc)
+	if len(doc.Vectors) == 0 {
+		t.Fatal("no RFC vectors loaded")
+	}
+
+	for i, v := range doc.Vectors {
+		ids := Identities{Offerer: []byte(v.A), Joiner: []byte(v.B)}
+		w := scalar(t, v.W)
+
+		// Both shares reproduce.
+		pA, err := ComputeShare(RoleOfferer, w, scalar(t, v.X))
+		if err != nil {
+			t.Fatalf("vector %d offerer share: %v", i, err)
+		}
+		if got := hex.EncodeToString(pA); got != v.PA {
+			t.Errorf("vector %d pA = %s, want %s", i, got, v.PA)
+		}
+		pB, err := ComputeShare(RoleJoiner, w, scalar(t, v.Y))
+		if err != nil {
+			t.Fatalf("vector %d joiner share: %v", i, err)
+		}
+		if got := hex.EncodeToString(pB); got != v.PB {
+			t.Errorf("vector %d pB = %s, want %s", i, got, v.PB)
+		}
+
+		// Offerer derives the full transcript, K, and MACs.
+		out, err := finish(RoleOfferer, w, scalar(t, v.X), mustHex(t, v.PB), ids)
+		if err != nil {
+			t.Fatalf("vector %d offerer finish: %v", i, err)
+		}
+		checkHex(t, i, "K", out.K, v.K)
+		checkHex(t, i, "TT", out.Transcript, v.TT)
+		checkHex(t, i, "Ke", out.Ke, v.Ke)
+		checkHex(t, i, "Ka", out.Ka, v.Ka)
+		checkHex(t, i, "KcA", out.KcA, v.KcA)
+		checkHex(t, i, "KcB", out.KcB, v.KcB)
+		checkHex(t, i, "confirmA", out.ConfirmA, v.ConfirmA)
+		checkHex(t, i, "confirmB", out.ConfirmB, v.ConfirmB)
+
+		// Joiner derives the identical transcript and K.
+		outB, err := finish(RoleJoiner, w, scalar(t, v.Y), mustHex(t, v.PA), ids)
+		if err != nil {
+			t.Fatalf("vector %d joiner finish: %v", i, err)
+		}
+		checkHex(t, i, "joiner K", outB.K, v.K)
+		checkHex(t, i, "joiner TT", outB.Transcript, v.TT)
+		if !bytes.Equal(out.Ke, outB.Ke) {
+			t.Errorf("vector %d: offerer and joiner disagree on Ke", i)
+		}
+	}
+}
+
+func checkHex(t *testing.T, i int, field string, got []byte, want string) {
+	t.Helper()
+	if g := hex.EncodeToString(got); g != want {
+		t.Errorf("vector %d %s = %s, want %s", i, field, g, want)
+	}
+}
+
+type sendarcVectors struct {
+	Code   string `json:"code"`
+	Spake2 struct {
+		W          string `json:"w"`
+		X          string `json:"x"`
+		Y          string `json:"y"`
+		PA         string `json:"pA"`
+		PB         string `json:"pB"`
+		K          string `json:"K"`
+		Transcript string `json:"transcript"`
+		Ke         string `json:"Ke"`
+		Ka         string `json:"Ka"`
+		ConfirmA   string `json:"confirmA"`
+		ConfirmB   string `json:"confirmB"`
+	} `json:"spake2"`
+	Keyschedule struct {
+		Master  string `json:"master"`
+		O2JKey  string `json:"o2jKey"`
+		O2JSalt string `json:"o2jSalt"`
+		J2OKey  string `json:"j2oKey"`
+		J2OSalt string `json:"j2oSalt"`
+	} `json:"keyschedule"`
+	Aead struct {
+		Direction     string `json:"direction"`
+		Counter       uint64 `json:"counter"`
+		HeaderHex     string `json:"headerHex"`
+		PlaintextUtf8 string `json:"plaintextUtf8"`
+		FrameHex      string `json:"frameHex"`
+	} `json:"aead"`
+}
+
+func loadSendarc(t *testing.T) sendarcVectors {
+	t.Helper()
+	var sa sendarcVectors
+	loadVectors(t, "sendarc-crypto.json", &sa)
+	return sa
+}
+
+func TestSpake2SendarcVector(t *testing.T) {
+	sa := loadSendarc(t)
+
+	// w is derived from the invite code via the SendArc mapping.
+	w, err := PasswordToScalar(sa.Code)
+	if err != nil {
+		t.Fatalf("PasswordToScalar: %v", err)
+	}
+	if got := hex.EncodeToString(scalarBytes(w)); got != sa.Spake2.W {
+		t.Fatalf("w = %s, want %s", got, sa.Spake2.W)
+	}
+
+	pA, err := ComputeShare(RoleOfferer, w, scalar(t, sa.Spake2.X))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(pA); got != sa.Spake2.PA {
+		t.Errorf("pA = %s, want %s", got, sa.Spake2.PA)
+	}
+	pB, err := ComputeShare(RoleJoiner, w, scalar(t, sa.Spake2.Y))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(pB); got != sa.Spake2.PB {
+		t.Errorf("pB = %s, want %s", got, sa.Spake2.PB)
+	}
+
+	out, err := Finish(RoleOfferer, w, scalar(t, sa.Spake2.X), mustHex(t, sa.Spake2.PB))
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkHex(t, 0, "K", out.K, sa.Spake2.K)
+	checkHex(t, 0, "transcript", out.Transcript, sa.Spake2.Transcript)
+	checkHex(t, 0, "Ke", out.Ke, sa.Spake2.Ke)
+	checkHex(t, 0, "confirmA", out.ConfirmA, sa.Spake2.ConfirmA)
+	checkHex(t, 0, "confirmB", out.ConfirmB, sa.Spake2.ConfirmB)
+}
+
+func TestSpake2HandshakeAgrees(t *testing.T) {
+	w, err := PasswordToScalar("4-brave-otter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, _ := RandomScalar()
+	y, _ := RandomScalar()
+	pA, _ := ComputeShare(RoleOfferer, w, x)
+	pB, _ := ComputeShare(RoleJoiner, w, y)
+	a, err := Finish(RoleOfferer, w, x, pB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Finish(RoleJoiner, w, y, pA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a.Ke, b.Ke) {
+		t.Error("peers disagree on Ke")
+	}
+	if !bytes.Equal(a.Transcript, b.Transcript) {
+		t.Error("peers disagree on transcript")
+	}
+	if !bytes.Equal(a.ConfirmB, b.ConfirmB) || !bytes.Equal(a.ConfirmA, b.ConfirmA) {
+		t.Error("peers disagree on confirmations")
+	}
+}
+
+func TestSpake2WrongCodeFailsClosed(t *testing.T) {
+	wRight, _ := PasswordToScalar("4-brave-otter")
+	wWrong, _ := PasswordToScalar("4-brave-otten")
+	x, _ := RandomScalar()
+	y, _ := RandomScalar()
+	pA, _ := ComputeShare(RoleOfferer, wRight, x)
+	pBWrong, _ := ComputeShare(RoleJoiner, wWrong, y)
+	a, err := Finish(RoleOfferer, wRight, x, pBWrong)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Finish(RoleJoiner, wWrong, y, pA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(a.Ke, b.Ke) {
+		t.Error("wrong code still agreed on Ke")
+	}
+	if bytes.Equal(a.ConfirmB, b.ConfirmB) {
+		t.Error("wrong code still produced matching confirmation")
+	}
+}
+
+func TestSpake2FreshRandomness(t *testing.T) {
+	w, _ := PasswordToScalar("4-brave-otter")
+	derive := func() []byte {
+		x, _ := RandomScalar()
+		y, _ := RandomScalar()
+		pB, _ := ComputeShare(RoleJoiner, w, y)
+		a, err := Finish(RoleOfferer, w, x, pB)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return a.Ke
+	}
+	if bytes.Equal(derive(), derive()) {
+		t.Error("two sessions with the same code produced identical Ke")
+	}
+}
+
+func TestSpake2RejectsOffCurveShare(t *testing.T) {
+	w, _ := PasswordToScalar("4-brave-otter")
+	x, _ := RandomScalar()
+	garbage := make([]byte, 65)
+	garbage[0] = 0x04 // claims uncompressed but coordinates are all zero → not on curve
+	if _, err := Finish(RoleOfferer, w, x, garbage); err == nil {
+		t.Error("expected off-curve peer share to be rejected")
+	}
+}

--- a/packages/wire/wire.go
+++ b/packages/wire/wire.go
@@ -1,0 +1,50 @@
+// Package wire is the Go mirror of the @sendarc/protocol crypto core: the SPAKE2
+// handshake, the key schedule, and the AES-256-GCM frame codec that secure a SendArc
+// transfer. The web client runs the TypeScript implementation; the server and CLI run
+// this one. The two are kept byte-identical — only the elliptic-curve point arithmetic
+// uses a third-party library (filippo.io/nistec here, @noble/curves in TS); the hash,
+// HKDF, and MAC use each language's standard library. Both are verified against the
+// RFC 9382 Appendix B vectors and a shared set of deterministic SendArc vectors under
+// test-vectors/.
+package wire
+
+// Role identifies the two ends of a transfer. The offerer sends the invite and plays
+// RFC 9382 party "A"; the joiner accepts it and plays party "B".
+type Role string
+
+const (
+	RoleOfferer Role = "offerer"
+	RoleJoiner  Role = "joiner"
+)
+
+// ProtocolVersion is embedded in the handshake transcript and the caps message. It must
+// match PROTOCOL_VERSION in packages/protocol/src/constants.ts.
+const ProtocolVersion = "sendarc/1"
+
+// The RFC transcript identity strings SendArc binds into every handshake.
+const (
+	IdentityOfferer = ProtocolVersion + " offerer"
+	IdentityJoiner  = ProtocolVersion + " joiner"
+)
+
+// AES-256-GCM parameters for the frame AEAD (see aead.go).
+const (
+	aeadKeyBytes   = 32
+	aeadNonceBytes = 12
+	aeadTagBytes   = 16
+	aeadSaltBytes  = 4
+)
+
+// HKDF info strings. confirmationKeys is fixed by RFC 9382 §4 and must not change; the
+// rest are SendArc's own key schedule layered on the RFC output.
+const (
+	infoSpake2W          = ProtocolVersion + " spake2 w"
+	infoConfirmationKeys = "ConfirmationKeys"
+	infoMaster           = ProtocolVersion + " master"
+	infoDirOffererJoiner = ProtocolVersion + " o2j"
+	infoDirJoinerOfferer = ProtocolVersion + " j2o"
+)
+
+// spake2WHKDFBytes is the HKDF output length reduced mod n to form the scalar w. 48 bytes
+// (384 bits) reduced into the 256-bit scalar field leaves negligible modular bias.
+const spake2WHKDFBytes = 48

--- a/packages/wire/words.go
+++ b/packages/wire/words.go
@@ -1,0 +1,142 @@
+package wire
+
+import (
+	"crypto/rand"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Invite-code words. The sender generates a short word code (e.g. "brave-otter") from
+// this 256-word list — one byte of entropy per word — which the server never sees. The
+// full normalized string "<room>-<words>" is the SPAKE2 password. This list and the
+// normalization rules are the wire contract; they must match packages/protocol/src/
+// words.ts byte-for-byte or the handshake fails closed.
+
+const (
+	defaultWordCount = 2
+	wordlistSize     = 256
+	codeSeparator    = "-"
+)
+
+// wordlist matches WORDLIST in packages/protocol/src/words.ts byte-for-byte. Order is
+// significant — the index is the byte value.
+var wordlist = [wordlistSize]string{
+	"ant", "ape", "bat", "bear", "bee", "bird", "bison", "boar",
+	"bug", "calf", "camel", "carp", "cat", "chick", "clam", "cobra",
+	"colt", "coral", "cow", "crab", "crane", "crow", "cub", "deer",
+	"dingo", "dodo", "dog", "dove", "duck", "eagle", "eel", "elk",
+	"emu", "ewe", "falcon", "fawn", "ferret", "finch", "fish", "flea",
+	"fly", "foal", "fox", "frog", "gecko", "goat", "goose", "gull",
+	"hare", "hawk", "hen", "heron", "hog", "horse", "hound", "ibex",
+	"jay", "koala", "lamb", "lark", "lion", "lizard", "llama", "lynx",
+	"mole", "moose", "moth", "mouse", "mule", "newt", "otter", "owl",
+	"ox", "panda", "pig", "pika", "pony", "pug", "puma", "quail",
+	"rabbit", "ram", "rat", "raven", "ray", "robin", "seal", "shark",
+	"sheep", "shrew", "shrimp", "skunk", "sloth", "slug", "snail", "snake",
+	"sole", "sparrow", "spider", "squid", "stag", "stork", "swan", "tapir",
+	"teal", "tiger", "toad", "trout", "tuna", "turkey", "viper", "vole",
+	"walrus", "wasp", "weasel", "whale", "wolf", "wombat", "worm", "wren",
+	"yak", "zebra", "beetle", "bream", "cod", "dolphin", "gnu", "hyena",
+	"acorn", "amber", "ash", "aspen", "bark", "bay", "beach", "birch",
+	"bloom", "branch", "breeze", "brook", "bush", "cave", "cedar", "cliff",
+	"cloud", "clover", "coast", "comet", "cove", "creek", "dawn", "delta",
+	"dew", "dune", "dusk", "earth", "ember", "fern", "field", "fjord",
+	"flame", "fog", "forest", "frost", "glade", "glen", "grove", "gust",
+	"hail", "hill", "ice", "island", "ivy", "lake", "leaf", "lily",
+	"maple", "marsh", "meadow", "mist", "moon", "moss", "mount", "oak",
+	"ocean", "palm", "peak", "pebble", "pine", "plain", "pond", "rain",
+	"reef", "ridge", "river", "rock", "root", "rose", "sand", "sea",
+	"seed", "shade", "shell", "shore", "sky", "sleet", "snow", "spring",
+	"star", "stone", "storm", "stream", "summit", "sun", "surf", "swamp",
+	"thaw", "tide", "trail", "tree", "tulip", "valley", "vine", "wave",
+	"well", "wind", "wood", "anchor", "arrow", "badge", "beacon", "bell",
+	"boat", "bolt", "book", "boot", "bottle", "bowl", "brick", "bridge",
+	"broom", "brush", "bucket", "candle", "cape", "cart", "chain", "chair",
+	"clock", "coal", "coin", "comb", "cord", "crown", "cup", "dial",
+}
+
+// NormalizeCode canonicalizes a raw code into the exact string used as the SPAKE2
+// password. It lowercases ASCII letters, treats every run of other characters as one
+// separator, and trims separators from the ends. It is mirrored in TypeScript — the two
+// must agree byte-for-byte or the handshake fails closed.
+func NormalizeCode(raw string) string {
+	var b strings.Builder
+	pendingSep := false
+	for _, ch := range raw {
+		var mapped rune
+		switch {
+		case ch >= 'A' && ch <= 'Z':
+			mapped = ch + ('a' - 'A')
+		case (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9'):
+			mapped = ch
+		default:
+			pendingSep = b.Len() > 0
+			continue
+		}
+		if pendingSep {
+			b.WriteString(codeSeparator)
+			pendingSep = false
+		}
+		b.WriteRune(mapped)
+	}
+	return b.String()
+}
+
+// FormatCode formats an invite code from a room number and its word part.
+func FormatCode(room int, words string) string {
+	return strconv.Itoa(room) + codeSeparator + words
+}
+
+// ParsedCode is the room number and word part parsed from a code.
+type ParsedCode struct {
+	Room  int
+	Words string
+}
+
+// ParseCode parses a raw code into its room number and word part. The first segment must
+// be the digits of the room; the remainder is the (already normalized) word part.
+func ParseCode(raw string) (ParsedCode, error) {
+	normalized := NormalizeCode(raw)
+	sep := strings.Index(normalized, codeSeparator)
+	if sep <= 0 {
+		return ParsedCode{}, fmt.Errorf(`code must be "<room>-<words>"`)
+	}
+	roomPart := normalized[:sep]
+	words := normalized[sep+1:]
+	room, err := strconv.Atoi(roomPart)
+	if err != nil {
+		return ParsedCode{}, fmt.Errorf("room must be a number")
+	}
+	if words == "" {
+		return ParsedCode{}, fmt.Errorf("code is missing its words")
+	}
+	return ParsedCode{Room: room, Words: words}, nil
+}
+
+// GenerateWords generates a random word part with count words. Each word is chosen by one
+// uniformly random byte — the list is exactly 256 entries, so the mapping is unbiased.
+func GenerateWords(count int) (string, error) {
+	if count < 1 {
+		return "", fmt.Errorf("word count must be >= 1")
+	}
+	buf := make([]byte, count)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	picked := make([]string, count)
+	for i, b := range buf {
+		picked[i] = wordlist[int(b)%wordlistSize]
+	}
+	return strings.Join(picked, codeSeparator), nil
+}
+
+// GenerateCode generates a full invite code for a server-allocated room, using the
+// default word count.
+func GenerateCode(room int) (string, error) {
+	words, err := GenerateWords(defaultWordCount)
+	if err != nil {
+		return "", err
+	}
+	return FormatCode(room, words), nil
+}

--- a/packages/wire/words_test.go
+++ b/packages/wire/words_test.go
@@ -1,0 +1,118 @@
+package wire
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestWordlistShape(t *testing.T) {
+	if len(wordlist) != wordlistSize {
+		t.Fatalf("wordlist has %d entries, want %d", len(wordlist), wordlistSize)
+	}
+	valid := regexp.MustCompile(`^[a-z]{2,8}$`)
+	seen := make(map[string]bool, wordlistSize)
+	for i, w := range wordlist {
+		if !valid.MatchString(w) {
+			t.Errorf("word %d %q is not 2-8 lowercase letters", i, w)
+		}
+		if seen[w] {
+			t.Errorf("duplicate word %q at index %d", w, i)
+		}
+		seen[w] = true
+	}
+}
+
+func TestNormalizeCode(t *testing.T) {
+	cases := map[string]string{
+		"4-Brave-Otter":     "4-brave-otter",
+		"  4  brave otter ": "4-brave-otter",
+		"4_BRAVE__OTTER":    "4-brave-otter",
+		"4-brave-otter":     "4-brave-otter",
+		"7-Ant-Ape":         "7-ant-ape",
+		"":                  "",
+		"---":               "",
+	}
+	for in, want := range cases {
+		if got := NormalizeCode(in); got != want {
+			t.Errorf("NormalizeCode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseCodeRoundTrip(t *testing.T) {
+	code := FormatCode(4, "brave-otter")
+	if code != "4-brave-otter" {
+		t.Fatalf("FormatCode = %q", code)
+	}
+	parsed, err := ParseCode(code)
+	if err != nil {
+		t.Fatalf("ParseCode: %v", err)
+	}
+	if parsed.Room != 4 || parsed.Words != "brave-otter" {
+		t.Errorf("parsed = %+v", parsed)
+	}
+}
+
+func TestParseCodeNormalizesFirst(t *testing.T) {
+	parsed, err := ParseCode("  4 · Brave · Otter ")
+	if err != nil {
+		t.Fatalf("ParseCode: %v", err)
+	}
+	if parsed.Room != 4 || parsed.Words != "brave-otter" {
+		t.Errorf("parsed = %+v", parsed)
+	}
+}
+
+func TestParseCodeRejects(t *testing.T) {
+	for _, raw := range []string{"", "brave-otter", "4", "4-", "-brave"} {
+		if _, err := ParseCode(raw); err == nil {
+			t.Errorf("ParseCode(%q) should have failed", raw)
+		}
+	}
+}
+
+func TestGenerateWords(t *testing.T) {
+	words, err := GenerateWords(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(words, codeSeparator)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 words, got %d (%q)", len(parts), words)
+	}
+	for _, p := range parts {
+		if !inWordlist(p) {
+			t.Errorf("generated word %q is not in the wordlist", p)
+		}
+	}
+	if _, err := GenerateWords(0); err == nil {
+		t.Error("GenerateWords(0) should fail")
+	}
+}
+
+func TestGenerateCode(t *testing.T) {
+	code, err := GenerateCode(12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseCode(code)
+	if err != nil {
+		t.Fatalf("generated code %q does not parse: %v", code, err)
+	}
+	if parsed.Room != 12 {
+		t.Errorf("room = %d, want 12", parsed.Room)
+	}
+	if len(strings.Split(parsed.Words, codeSeparator)) != defaultWordCount {
+		t.Errorf("expected %d words in %q", defaultWordCount, parsed.Words)
+	}
+}
+
+func inWordlist(w string) bool {
+	for _, x := range wordlist {
+		if x == w {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Add packages/wire, the Go half of the SendArc crypto core that the
server and CLI link against while the browser runs the TypeScript
package. The two implementations are kept byte-identical: only the
elliptic-curve point arithmetic uses a third-party library
(filippo.io/nistec here, @noble/curves in TS); SHA-256, HKDF, HMAC,
and AES-GCM come from each language's standard library.

Contents:

  - SPAKE2 over P-256 per RFC 9382 (SPAKE2-P256-SHA256-HKDF-HMAC),
    with the SendArc role mapping (offerer = party A, joiner = B) and
    the invite code -> scalar w derivation.
  - The key schedule layered on the RFC output: transcript-bound
    master key and the two directional AEAD keys.
  - The AES-256-GCM frame codec with the 16-byte header as additional
    authenticated data.
  - The 256-word invite list and code normalization, mirrored from
    packages/protocol/src/words.ts.

Interop is enforced by test: both this package and the vitest suite
load the shared fixtures in docs/test-vectors/ and assert identical
output. Coverage includes the RFC 9382 Appendix B known-answer
vectors for both roles, the deterministic SendArc vector reproduced
end to end (w, shares, transcript, K, key schedule, sealed frame),
and the fail-closed cases: wrong code, off-curve share, tampered
frame, fresh randomness per session.

nistec decodes only uncompressed points and takes 32-byte big-endian
scalars, so the RFC seed points M and N are stored uncompressed and
scalars are reduced mod n before use. HKDF with a nil salt matches
WebCrypto's zero-length salt (both resolve to RFC 5869's HashLen zero
bytes), which is what keeps the derived keys identical across the two
languages.

Register the module in go.work alongside apps/server.