### PR TITLE
feat(server): blind WebSocket signaling for peer rendezvous

### DIFF
--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -3,3 +3,5 @@ module github.com/sendarc/server
 go 1.24
 
 require github.com/go-chi/chi/v5 v5.3.1
+
+require github.com/coder/websocket v1.8.15

--- a/apps/server/go.sum
+++ b/apps/server/go.sum
@@ -1,2 +1,4 @@
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=

--- a/apps/server/internal/httpserver/server.go
+++ b/apps/server/internal/httpserver/server.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/sendarc/server/internal/signal"
 )
 
 // Config controls how sendarcd serves the web app and terminates TLS.
@@ -27,6 +29,8 @@ type Config struct {
 	TLSKey   string // path to TLS key (PEM)
 	WebDir   string // directory of the built web bundle to serve (prod)
 	DevProxy string // URL of the Vite dev server to proxy to (dev); overrides WebDir
+
+	Signal signal.Config // signaling limits + WSS origin allowlist
 }
 
 // ConfigFromEnv reads configuration from SENDARC_* environment variables with defaults.
@@ -37,6 +41,7 @@ func ConfigFromEnv() Config {
 		TLSKey:   os.Getenv("SENDARC_TLS_KEY"),
 		WebDir:   os.Getenv("SENDARC_WEB_DIR"),
 		DevProxy: os.Getenv("SENDARC_WEB_DEV_PROXY"),
+		Signal:   signal.ConfigFromEnv(),
 	}
 }
 
@@ -54,18 +59,22 @@ func (c Config) Mode() string {
 
 // Server wraps *http.Server with SendArc's config so it can choose TLS vs plain HTTP.
 type Server struct {
-	http *http.Server
-	cfg  Config
+	http   *http.Server
+	cfg    Config
+	cancel context.CancelFunc
 }
 
 // New builds a Server with the SendArc router and sensible timeouts.
 func New(cfg Config, logger *slog.Logger) (*Server, error) {
-	handler, err := router(cfg, logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	handler, err := router(ctx, cfg, logger)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	return &Server{
-		cfg: cfg,
+		cfg:    cfg,
+		cancel: cancel,
 		http: &http.Server{
 			Addr:              cfg.Addr,
 			Handler:           handler,
@@ -85,12 +94,13 @@ func (s *Server) ListenAndServe() error {
 	return s.http.ListenAndServe()
 }
 
-// Shutdown gracefully stops the server.
+// Shutdown gracefully stops the server and its background workers.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.cancel()
 	return s.http.Shutdown(ctx)
 }
 
-func router(cfg Config, logger *slog.Logger) (http.Handler, error) {
+func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler, error) {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Recoverer)
@@ -101,6 +111,10 @@ func router(cfg Config, logger *slog.Logger) (http.Handler, error) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
+
+	// Signaling endpoint: origin-checked WebSocket rendezvous (plan.md §6.1).
+	hub := signal.NewHub(ctx, cfg.Signal, logger)
+	r.Handle("/ws", hub.Handler(ctx))
 
 	// Web app: dev proxy takes precedence, then a static build dir.
 	switch {

--- a/apps/server/internal/httpserver/server_test.go
+++ b/apps/server/internal/httpserver/server_test.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -13,7 +14,7 @@ import (
 
 func testRouter(t *testing.T, cfg Config) http.Handler {
 	t.Helper()
-	h, err := router(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h, err := router(context.Background(), cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatalf("router: %v", err)
 	}

--- a/apps/server/internal/signal/handler.go
+++ b/apps/server/internal/signal/handler.go
@@ -1,0 +1,78 @@
+package signal
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// Handler returns the HTTP handler for the signaling endpoint (mounted at /ws). It
+// enforces the origin allowlist and per-IP connection rate limit before upgrading,
+// then hands the socket to the hub. baseCtx bounds the lifetime of every accepted
+// connection.
+func (h *Hub) Handler(baseCtx context.Context) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !h.originAllowed(r) {
+			http.Error(w, "origin not allowed", http.StatusForbidden)
+			h.logger.Warn("signal: rejected origin", "origin", r.Header.Get("Origin"))
+			return
+		}
+		if !h.allowConnection(clientIP(r)) {
+			http.Error(w, "too many connections", http.StatusTooManyRequests)
+			return
+		}
+
+		// originAllowed above is our origin policy, so we disable the library's own
+		// origin check to keep that policy in one place (and to admit native clients
+		// that send no Origin header). Note: despite its name, this option governs
+		// only the WebSocket Origin-header check — it has nothing to do with TLS,
+		// which is terminated by http.Server before the request reaches here.
+		ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			return // Accept has already written the failure
+		}
+
+		p := newPeer(ws, h)
+		p.serve(baseCtx)
+	})
+}
+
+// originAllowed applies the WSS origin policy. Native clients (no Origin header) are
+// always allowed. Browser clients must match the configured allowlist, or — when the
+// allowlist is empty — be same-origin with the request host.
+func (h *Hub) originAllowed(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true // non-browser client (CLI); browsers always set Origin
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	if len(h.cfg.AllowedOrigins) == 0 {
+		return strings.EqualFold(u.Host, r.Host)
+	}
+	for _, allowed := range h.cfg.AllowedOrigins {
+		if strings.EqualFold(origin, allowed) || strings.EqualFold(u.Host, allowed) {
+			return true
+		}
+	}
+	return false
+}
+
+// clientIP extracts the remote IP for per-IP rate limiting. It trusts only the direct
+// socket peer — the server sits behind no header-setting proxy in its threat model,
+// so forwarded-for headers are deliberately ignored (they are client-controlled).
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/apps/server/internal/signal/hub.go
+++ b/apps/server/internal/signal/hub.go
@@ -1,0 +1,185 @@
+package signal
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Hub owns every room and the goroutine that reaps idle ones. A room holds at most
+// two peers — the offerer that created it and the joiner that paired in.
+type Hub struct {
+	cfg    Config
+	logger *slog.Logger
+
+	mu    sync.Mutex
+	rooms map[int]*room
+
+	// connLimiters is the per-IP connection-rate limiter, checked at upgrade time.
+	connMu       sync.Mutex
+	connLimiters map[string]*tokenBucket
+}
+
+type room struct {
+	number   int
+	offerer  *peer
+	joiner   *peer
+	lastSeen time.Time
+}
+
+// NewHub builds a Hub and starts its reaper. The reaper stops when ctx is canceled.
+func NewHub(ctx context.Context, cfg Config, logger *slog.Logger) *Hub {
+	h := &Hub{
+		cfg:          cfg,
+		logger:       orDiscard(logger),
+		rooms:        make(map[int]*room),
+		connLimiters: make(map[string]*tokenBucket),
+	}
+	go h.reap(ctx)
+	return h
+}
+
+// allowConnection reports whether a new connection from ip is within the per-IP
+// connection-rate limit.
+func (h *Hub) allowConnection(ip string) bool {
+	h.connMu.Lock()
+	defer h.connMu.Unlock()
+	b, ok := h.connLimiters[ip]
+	if !ok {
+		b = newTokenBucket(h.cfg.ConnBurst, h.cfg.ConnPerSec)
+		h.connLimiters[ip] = b
+	}
+	return b.allow()
+}
+
+// createRoom allocates the smallest free room number, seats p as its offerer, and
+// returns the room number.
+func (h *Hub) createRoom(p *peer) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	n := 0
+	for {
+		if _, taken := h.rooms[n]; !taken {
+			break
+		}
+		n++
+	}
+	h.rooms[n] = &room{number: n, offerer: p, lastSeen: time.Now()}
+	p.room = n
+	p.role = roleOfferer
+	return n
+}
+
+// join seats p as the joiner of an existing room and returns the offerer it paired
+// with. It enforces strict 1:1 pairing: an unknown or already-full room is refused.
+func (h *Hub) join(p *peer, number int) (*peer, string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[number]
+	if !ok {
+		return nil, errUnknownRoom
+	}
+	if r.joiner != nil || r.offerer == nil {
+		return nil, errRoomFull
+	}
+	r.joiner = p
+	r.lastSeen = time.Now()
+	p.room = number
+	p.role = roleJoiner
+	return r.offerer, ""
+}
+
+// partner returns the other peer in p's room, or nil if the room is gone or p is not
+// yet paired. It also refreshes the room's activity timestamp.
+func (h *Hub) partner(p *peer) *peer {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[p.room]
+	if !ok {
+		return nil
+	}
+	r.lastSeen = time.Now()
+	switch p {
+	case r.offerer:
+		return r.joiner
+	case r.joiner:
+		return r.offerer
+	default:
+		return nil
+	}
+}
+
+// remove drops p from its room. If a partner remains it is returned so the caller can
+// notify it; the room is then deleted (M1 tears down on either peer leaving).
+func (h *Hub) remove(p *peer) *peer {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[p.room]
+	if !ok {
+		return nil
+	}
+	var other *peer
+	switch p {
+	case r.offerer:
+		other = r.joiner
+	case r.joiner:
+		other = r.offerer
+	default:
+		return nil
+	}
+	delete(h.rooms, r.number)
+	return other
+}
+
+// reap periodically frees rooms whose last activity is older than the idle timeout,
+// closing any sockets still attached. It runs until ctx is canceled.
+func (h *Hub) reap(ctx context.Context) {
+	interval := h.cfg.IdleTimeout / 2
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			h.reapOnce(now)
+		}
+	}
+}
+
+func (h *Hub) reapOnce(now time.Time) {
+	h.mu.Lock()
+	var stale []*room
+	for n, r := range h.rooms {
+		if now.Sub(r.lastSeen) > h.cfg.IdleTimeout {
+			stale = append(stale, r)
+			delete(h.rooms, n)
+		}
+	}
+	h.mu.Unlock()
+
+	for _, r := range stale {
+		h.logger.Info("signal: reaping idle room", "room", r.number)
+		for _, p := range []*peer{r.offerer, r.joiner} {
+			if p != nil {
+				p.close(byeFrame("idle timeout"))
+			}
+		}
+	}
+}
+
+// roomCount reports the number of live rooms (used by tests).
+func (h *Hub) roomCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.rooms)
+}

--- a/apps/server/internal/signal/hub_test.go
+++ b/apps/server/internal/signal/hub_test.go
@@ -1,0 +1,147 @@
+package signal
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// newTestPeer builds a peer without a socket, for hub-logic tests that never write.
+func newTestPeer() *peer {
+	return &peer{
+		room:   -1,
+		send:   make(chan []byte, sendBuffer),
+		done:   make(chan struct{}),
+		closed: make(chan struct{}),
+	}
+}
+
+func testHub(t *testing.T) *Hub {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return NewHub(ctx, DefaultConfig(), nil)
+}
+
+func TestCreateRoomAllocatesSmallestFree(t *testing.T) {
+	h := testHub(t)
+
+	a, b, c := newTestPeer(), newTestPeer(), newTestPeer()
+	if n := h.createRoom(a); n != 0 {
+		t.Fatalf("first room = %d, want 0", n)
+	}
+	if n := h.createRoom(b); n != 1 {
+		t.Fatalf("second room = %d, want 1", n)
+	}
+	if n := h.createRoom(c); n != 2 {
+		t.Fatalf("third room = %d, want 2", n)
+	}
+
+	// Freeing room 1 makes it the smallest free slot again.
+	h.remove(b)
+	d := newTestPeer()
+	if n := h.createRoom(d); n != 1 {
+		t.Fatalf("reused room = %d, want 1", n)
+	}
+}
+
+func TestJoinPairsAndIsOneToOne(t *testing.T) {
+	h := testHub(t)
+	off := newTestPeer()
+	room := h.createRoom(off)
+
+	join := newTestPeer()
+	other, code := h.join(join, room)
+	if code != "" {
+		t.Fatalf("join failed: %s", code)
+	}
+	if other != off {
+		t.Fatal("join did not return the offerer")
+	}
+	if off.role != roleOfferer || join.role != roleJoiner {
+		t.Fatalf("roles = %q/%q", off.role, join.role)
+	}
+
+	// A second join for the same room is refused: strict 1:1.
+	third := newTestPeer()
+	if _, code := h.join(third, room); code != errRoomFull {
+		t.Fatalf("third join code = %q, want %q", code, errRoomFull)
+	}
+}
+
+func TestJoinUnknownRoom(t *testing.T) {
+	h := testHub(t)
+	if _, code := h.join(newTestPeer(), 999); code != errUnknownRoom {
+		t.Fatalf("code = %q, want %q", code, errUnknownRoom)
+	}
+}
+
+func TestPartnerAndRemove(t *testing.T) {
+	h := testHub(t)
+	off := newTestPeer()
+	room := h.createRoom(off)
+	join := newTestPeer()
+	if _, code := h.join(join, room); code != "" {
+		t.Fatalf("join: %s", code)
+	}
+
+	if h.partner(off) != join || h.partner(join) != off {
+		t.Fatal("partner lookup wrong")
+	}
+
+	// Removing one peer returns the other and deletes the room.
+	if other := h.remove(off); other != join {
+		t.Fatal("remove did not surface the partner")
+	}
+	if h.roomCount() != 0 {
+		t.Fatalf("room count = %d, want 0", h.roomCount())
+	}
+	if h.partner(join) != nil {
+		t.Fatal("partner of a removed room should be nil")
+	}
+}
+
+func TestReapClosesIdleRooms(t *testing.T) {
+	h := testHub(t)
+	off := newTestPeer()
+	h.createRoom(off)
+
+	// Backdate the room past the idle timeout, then reap.
+	h.mu.Lock()
+	for _, r := range h.rooms {
+		r.lastSeen = time.Now().Add(-2 * h.cfg.IdleTimeout)
+	}
+	h.mu.Unlock()
+
+	h.reapOnce(time.Now())
+	if h.roomCount() != 0 {
+		t.Fatalf("room count after reap = %d, want 0", h.roomCount())
+	}
+	select {
+	case <-off.done:
+		// closed as expected
+	default:
+		t.Fatal("reaped peer was not closed")
+	}
+}
+
+func TestTokenBucket(t *testing.T) {
+	b := newTokenBucket(2, 1) // burst 2, 1 token/sec
+	t0 := time.Now()
+
+	if !b.allowAt(t0) {
+		t.Fatal("first call should be allowed by burst")
+	}
+	if !b.allowAt(t0) {
+		t.Fatal("second call should be allowed by burst")
+	}
+	if b.allowAt(t0) {
+		t.Fatal("third call in the same instant should be denied")
+	}
+	if !b.allowAt(t0.Add(time.Second)) {
+		t.Fatal("one token should have refilled after a second")
+	}
+	if b.allowAt(t0.Add(time.Second)) {
+		t.Fatal("only one token should refill per second")
+	}
+}

--- a/apps/server/internal/signal/message.go
+++ b/apps/server/internal/signal/message.go
@@ -1,0 +1,212 @@
+// Package signal implements the SendArc rendezvous server: a blind WebSocket
+// forwarder and pairer. It allocates room numbers, links exactly two sockets per
+// room, and relays the peers' SPAKE2 handshake and encrypted capability frames
+// without inspecting them. It never sees the word code, any key, or any plaintext —
+// only room numbers and connection metadata (plan.md §5.5, §6.1).
+package signal
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Wire message types (plan.md §6.1). Control types are handled by the server; the
+// forwardable types are relayed peer-to-peer as opaque bytes.
+const (
+	typeCreate     = "create"
+	typeCreated    = "created"
+	typeJoin       = "join"
+	typePeerJoined = "peer-joined"
+	typePake       = "pake"
+	typeConfirm    = "confirm"
+	typeCaps       = "caps"
+	typeSDP        = "sdp"
+	typeICE        = "ice"
+	typeBye        = "bye"
+	typeError      = "error"
+)
+
+// Role labels echoed to peers on pairing. These are routing labels only; their
+// cryptographic meaning lives in packages/wire (wire.Role) and must stay in sync
+// with it — the offerer created the room, the joiner joined it.
+const (
+	roleOfferer = "offerer"
+	roleJoiner  = "joiner"
+)
+
+// forwardable is the set of peer→peer types the server relays without inspection.
+// sdp and ice are unused until M2 but are relayed now so the handshake path is
+// complete; their bodies are never parsed.
+var forwardable = map[string]bool{
+	typePake:    true,
+	typeConfirm: true,
+	typeCaps:    true,
+	typeSDP:     true,
+	typeICE:     true,
+}
+
+// Error codes carried in an error message's "code" field.
+const (
+	errBadMessage  = "bad_message"
+	errUnknownRoom = "unknown_room"
+	errRoomFull    = "room_full"
+	errNotPaired   = "not_paired"
+	errRateLimited = "rate_limited"
+	errProtocol    = "protocol"
+)
+
+// clientMsg is the envelope the server parses from a client. Only type and room are
+// read; the payloads of forwardable messages are relayed as raw bytes and never
+// decoded here, which is what keeps the server blind to handshake contents.
+type clientMsg struct {
+	Type string `json:"type"`
+	Room *int   `json:"room,omitempty"`
+}
+
+// createdMsg tells the offerer which room number the server allocated.
+type createdMsg struct {
+	Type string `json:"type"`
+	Room int    `json:"room"`
+}
+
+// peerJoinedMsg notifies a socket that its room is now paired, with its own role.
+type peerJoinedMsg struct {
+	Type string `json:"type"`
+	Role string `json:"role"`
+}
+
+// byeMsg tears a session down.
+type byeMsg struct {
+	Type   string `json:"type"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// errorMsg reports a protocol or limit error to a single socket.
+type errorMsg struct {
+	Type string `json:"type"`
+	Code string `json:"code"`
+	Msg  string `json:"msg,omitempty"`
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		// The server-built messages above are all trivially marshalable; a failure
+		// here is a programming error, not a runtime condition.
+		panic("signal: marshal server message: " + err.Error())
+	}
+	return b
+}
+
+func createdFrame(room int) []byte {
+	return mustJSON(createdMsg{Type: typeCreated, Room: room})
+}
+
+func peerJoinedFrame(role string) []byte {
+	return mustJSON(peerJoinedMsg{Type: typePeerJoined, Role: role})
+}
+
+func byeFrame(reason string) []byte {
+	return mustJSON(byeMsg{Type: typeBye, Reason: reason})
+}
+
+func errorFrame(code, msg string) []byte {
+	return mustJSON(errorMsg{Type: typeError, Code: code, Msg: msg})
+}
+
+// Config controls the signaling server's limits and origin policy.
+type Config struct {
+	// AllowedOrigins is the WSS origin allowlist for browser clients. An empty list
+	// permits only same-origin browser connections. Native clients (CLI) send no
+	// Origin header and are always allowed.
+	AllowedOrigins []string
+
+	// IdleTimeout closes a socket that sends nothing for this long, and bounds how
+	// long an unpaired room lingers before the reaper frees it.
+	IdleTimeout time.Duration
+
+	// MaxMessageBytes caps a single inbound WebSocket message; larger frames close
+	// the connection. Handshake and caps frames are small, so this stays modest.
+	MaxMessageBytes int64
+
+	// MsgBurst / MsgPerSec are the per-connection message-rate token bucket.
+	MsgBurst  int
+	MsgPerSec float64
+
+	// ConnBurst / ConnPerSec are the per-IP connection-rate token bucket applied at
+	// upgrade time.
+	ConnBurst  int
+	ConnPerSec float64
+}
+
+// DefaultConfig returns limits sized for the rendezvous workload: a handful of tiny
+// JSON control messages per session, not a data path.
+func DefaultConfig() Config {
+	return Config{
+		IdleTimeout:     2 * time.Minute,
+		MaxMessageBytes: 64 * 1024,
+		MsgBurst:        32,
+		MsgPerSec:       16,
+		ConnBurst:       16,
+		ConnPerSec:      8,
+	}
+}
+
+// ConfigFromEnv layers SENDARC_* overrides onto DefaultConfig.
+func ConfigFromEnv() Config {
+	cfg := DefaultConfig()
+	if v := os.Getenv("SENDARC_ALLOWED_ORIGINS"); v != "" {
+		for _, o := range strings.Split(v, ",") {
+			if o = strings.TrimSpace(o); o != "" {
+				cfg.AllowedOrigins = append(cfg.AllowedOrigins, o)
+			}
+		}
+	}
+	if d, ok := envDuration("SENDARC_SIGNAL_IDLE_TIMEOUT"); ok {
+		cfg.IdleTimeout = d
+	}
+	if n, ok := envInt("SENDARC_SIGNAL_MAX_MESSAGE_BYTES"); ok {
+		cfg.MaxMessageBytes = int64(n)
+	}
+	return cfg
+}
+
+func envDuration(key string) (time.Duration, bool) {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0, false
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return 0, false
+	}
+	return d, true
+}
+
+func envInt(key string) (int, bool) {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// slog helper so callers can pass a nil logger.
+func orDiscard(l *slog.Logger) *slog.Logger {
+	if l != nil {
+		return l
+	}
+	return slog.New(slog.NewTextHandler(discard{}, nil))
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/apps/server/internal/signal/peer.go
+++ b/apps/server/internal/signal/peer.go
@@ -1,0 +1,203 @@
+package signal
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+const (
+	// writeTimeout bounds a single socket write; a peer that can't accept a frame in
+	// this window is treated as dead. It also bounds how long forwarding to a stuck
+	// peer can stall the sender's read loop.
+	writeTimeout = 10 * time.Second
+	// sendBuffer is the per-peer outbound queue depth. Rendezvous traffic is a few
+	// tiny control frames, so a shallow buffer is plenty; a full buffer means the
+	// socket is wedged.
+	sendBuffer = 16
+)
+
+// peer is one WebSocket connection and its place in a room. A single writer goroutine
+// owns every write to ws; all other goroutines hand it frames through send. done is
+// closed exactly once to unwind both the reader and the writer.
+type peer struct {
+	ws     *websocket.Conn
+	hub    *Hub
+	logger *slog.Logger
+
+	room int    // -1 until the peer creates or joins a room
+	role string // set on create/join
+
+	send      chan []byte
+	closeOnce sync.Once
+	done      chan struct{}
+	farewell  []byte // final frame to flush before closing; set under closeOnce
+	closed    chan struct{}
+}
+
+func newPeer(ws *websocket.Conn, h *Hub) *peer {
+	return &peer{
+		ws:     ws,
+		hub:    h,
+		logger: h.logger,
+		room:   -1,
+		send:   make(chan []byte, sendBuffer),
+		done:   make(chan struct{}),
+		closed: make(chan struct{}),
+	}
+}
+
+// serve runs the connection: it starts the writer, reads and dispatches frames until
+// the socket closes or a protocol error ends it, then tears the room down.
+func (p *peer) serve(ctx context.Context) {
+	p.ws.SetReadLimit(p.hub.cfg.MaxMessageBytes)
+	msgLimiter := newTokenBucket(p.hub.cfg.MsgBurst, p.hub.cfg.MsgPerSec)
+
+	go p.writeLoop(ctx)
+	defer p.teardown()
+
+	for {
+		readCtx, cancel := context.WithTimeout(ctx, p.hub.cfg.IdleTimeout)
+		typ, data, err := p.ws.Read(readCtx)
+		cancel()
+		if err != nil {
+			return
+		}
+		if typ != websocket.MessageText {
+			p.close(errorFrame(errBadMessage, "expected a text frame"))
+			return
+		}
+		if !msgLimiter.allow() {
+			p.close(errorFrame(errRateLimited, "too many messages"))
+			return
+		}
+		if !p.dispatch(data) {
+			return
+		}
+	}
+}
+
+// dispatch handles one inbound frame. It returns false when the connection should
+// end. Only type (and room, for join) is ever parsed; forwardable payloads are
+// relayed as the exact bytes received so the server stays blind to their contents.
+func (p *peer) dispatch(data []byte) bool {
+	var m clientMsg
+	if err := json.Unmarshal(data, &m); err != nil || m.Type == "" {
+		p.close(errorFrame(errBadMessage, "invalid message"))
+		return false
+	}
+
+	switch m.Type {
+	case typeCreate:
+		if p.room >= 0 {
+			p.close(errorFrame(errProtocol, "already in a room"))
+			return false
+		}
+		room := p.hub.createRoom(p)
+		p.logger.Info("signal: room created", "room", room)
+		p.enqueue(createdFrame(room))
+		return true
+
+	case typeJoin:
+		if p.room >= 0 {
+			p.close(errorFrame(errProtocol, "already in a room"))
+			return false
+		}
+		if m.Room == nil {
+			p.close(errorFrame(errBadMessage, "join requires a room"))
+			return false
+		}
+		other, code := p.hub.join(p, *m.Room)
+		if code != "" {
+			p.close(errorFrame(code, ""))
+			return false
+		}
+		p.logger.Info("signal: room paired", "room", p.room)
+		p.enqueue(peerJoinedFrame(p.role))
+		other.enqueue(peerJoinedFrame(other.role))
+		return true
+
+	case typeBye:
+		if other := p.hub.partner(p); other != nil {
+			other.enqueue(data)
+		}
+		p.close(nil)
+		return false
+
+	default:
+		if !forwardable[m.Type] {
+			p.close(errorFrame(errBadMessage, "unknown message type"))
+			return false
+		}
+		other := p.hub.partner(p)
+		if other == nil {
+			p.close(errorFrame(errNotPaired, "not paired yet"))
+			return false
+		}
+		other.enqueue(data)
+		return true
+	}
+}
+
+// writeLoop is the sole writer of ws. It flushes queued frames until done is closed,
+// then writes any farewell frame and closes the socket.
+func (p *peer) writeLoop(ctx context.Context) {
+	for {
+		select {
+		case data := <-p.send:
+			if !p.rawWrite(ctx, data) {
+				p.close(nil)
+				return
+			}
+		case <-p.done:
+			if p.farewell != nil {
+				p.rawWrite(ctx, p.farewell)
+			}
+			_ = p.ws.Close(websocket.StatusNormalClosure, "")
+			close(p.closed)
+			return
+		}
+	}
+}
+
+func (p *peer) rawWrite(ctx context.Context, data []byte) bool {
+	writeCtx, cancel := context.WithTimeout(ctx, writeTimeout)
+	defer cancel()
+	return p.ws.Write(writeCtx, websocket.MessageText, data) == nil
+}
+
+// enqueue hands a frame to this peer's writer. It blocks only until the buffer has
+// room or the peer is closing, so a stalled partner cannot wedge the caller for
+// longer than that partner's own write timeout.
+func (p *peer) enqueue(data []byte) {
+	select {
+	case p.send <- data:
+	case <-p.done:
+	}
+}
+
+// close signals teardown, optionally flushing one final frame first. It is safe to
+// call from any goroutine and any number of times; only the first call takes effect,
+// so the farewell of the first caller wins.
+func (p *peer) close(farewell []byte) {
+	p.closeOnce.Do(func() {
+		p.farewell = farewell
+		close(p.done)
+	})
+}
+
+// teardown removes the peer from its room and notifies any remaining partner, then
+// ensures this peer's socket is closed.
+func (p *peer) teardown() {
+	if other := p.hub.remove(p); other != nil {
+		other.close(byeFrame("peer left"))
+	}
+	p.close(nil)
+	// Wait for the writer to finish closing the socket so the goroutine cannot
+	// outlive the connection.
+	<-p.closed
+}

--- a/apps/server/internal/signal/ratelimit.go
+++ b/apps/server/internal/signal/ratelimit.go
@@ -1,0 +1,47 @@
+package signal
+
+import (
+	"sync"
+	"time"
+)
+
+// tokenBucket is a minimal token-bucket rate limiter. It refills continuously at a
+// fixed rate up to a burst capacity; allow reports whether one token is available
+// and, if so, spends it. It is safe for concurrent use.
+type tokenBucket struct {
+	mu     sync.Mutex
+	tokens float64
+	burst  float64
+	rate   float64 // tokens per second
+	last   time.Time
+}
+
+func newTokenBucket(burst int, perSec float64) *tokenBucket {
+	return &tokenBucket{
+		tokens: float64(burst),
+		burst:  float64(burst),
+		rate:   perSec,
+		last:   time.Now(),
+	}
+}
+
+func (b *tokenBucket) allow() bool {
+	return b.allowAt(time.Now())
+}
+
+// allowAt is the time-injectable core, kept separate so tests can drive it
+// deterministically.
+func (b *tokenBucket) allowAt(now time.Time) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if elapsed := now.Sub(b.last).Seconds(); elapsed > 0 {
+		b.tokens = min(b.burst, b.tokens+elapsed*b.rate)
+		b.last = now
+	}
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -1,0 +1,272 @@
+package signal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// testServer starts an httptest server running the signaling handler with cfg and
+// returns its ws:// base URL.
+func testServer(t *testing.T, cfg Config) string {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	hub := NewHub(ctx, cfg, nil)
+	srv := httptest.NewServer(hub.Handler(ctx))
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+}
+
+type client struct {
+	t    *testing.T
+	conn *websocket.Conn
+}
+
+func dial(t *testing.T, url, origin string) (*client, error) {
+	t.Helper()
+	opts := &websocket.DialOptions{}
+	if origin != "" {
+		opts.HTTPHeader = http.Header{"Origin": {origin}}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	// coder/websocket's Dial documents that the handshake response body never needs
+	// to be closed by the caller, so bodyclose's warning does not apply here.
+	conn, _, err := websocket.Dial(ctx, url, opts) //nolint:bodyclose // see comment
+	if err != nil {
+		return nil, err
+	}
+	c := &client{t: t, conn: conn}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+	return c, nil
+}
+
+func mustDial(t *testing.T, url string) *client {
+	t.Helper()
+	c, err := dial(t, url, "")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	return c
+}
+
+func (c *client) send(v any) {
+	c.t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		c.t.Fatalf("marshal: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := c.conn.Write(ctx, websocket.MessageText, data); err != nil {
+		c.t.Fatalf("write: %v", err)
+	}
+}
+
+// sendRaw writes exact bytes, for asserting verbatim forwarding.
+func (c *client) sendRaw(data []byte) {
+	c.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := c.conn.Write(ctx, websocket.MessageText, data); err != nil {
+		c.t.Fatalf("write raw: %v", err)
+	}
+}
+
+func (c *client) recv() map[string]any {
+	c.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	typ, data, err := c.conn.Read(ctx)
+	if err != nil {
+		c.t.Fatalf("read: %v", err)
+	}
+	if typ != websocket.MessageText {
+		c.t.Fatalf("frame type = %v, want text", typ)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		c.t.Fatalf("unmarshal %q: %v", data, err)
+	}
+	return m
+}
+
+func (c *client) recvRaw() []byte {
+	c.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, data, err := c.conn.Read(ctx)
+	if err != nil {
+		c.t.Fatalf("read raw: %v", err)
+	}
+	return data
+}
+
+// pair runs create/join and returns the offerer and joiner clients, both having
+// consumed their peer-joined frames.
+func pair(t *testing.T, url string) (offerer, joiner *client, room int) {
+	t.Helper()
+	offerer = mustDial(t, url)
+	offerer.send(map[string]any{"type": typeCreate})
+
+	created := offerer.recv()
+	if created["type"] != typeCreated {
+		t.Fatalf("expected created, got %v", created)
+	}
+	room = int(created["room"].(float64))
+
+	joiner = mustDial(t, url)
+	joiner.send(map[string]any{"type": typeJoin, "room": room})
+
+	oj := offerer.recv()
+	jj := joiner.recv()
+	if oj["type"] != typePeerJoined || oj["role"] != roleOfferer {
+		t.Fatalf("offerer peer-joined wrong: %v", oj)
+	}
+	if jj["type"] != typePeerJoined || jj["role"] != roleJoiner {
+		t.Fatalf("joiner peer-joined wrong: %v", jj)
+	}
+	return offerer, joiner, room
+}
+
+func TestCreateJoinPeerJoined(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	_, _, room := pair(t, url)
+	if room != 0 {
+		t.Fatalf("first room = %d, want 0", room)
+	}
+}
+
+func TestBlindForwardVerbatim(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	offerer, joiner, _ := pair(t, url)
+
+	// A pake frame the server must relay byte-for-byte without inspecting it.
+	frame := []byte(`{"type":"pake","msg":"AAECAwQF-_base64url"}`)
+	offerer.sendRaw(frame)
+	if got := joiner.recvRaw(); string(got) != string(frame) {
+		t.Fatalf("forwarded frame = %s, want %s", got, frame)
+	}
+
+	// And the reverse direction.
+	conf := []byte(`{"type":"confirm","mac":"deadbeef"}`)
+	joiner.sendRaw(conf)
+	if got := offerer.recvRaw(); string(got) != string(conf) {
+		t.Fatalf("forwarded confirm = %s, want %s", got, conf)
+	}
+}
+
+func TestJoinUnknownRoomOverWire(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	c := mustDial(t, url)
+	c.send(map[string]any{"type": typeJoin, "room": 4242})
+	m := c.recv()
+	if m["type"] != typeError || m["code"] != errUnknownRoom {
+		t.Fatalf("expected unknown_room error, got %v", m)
+	}
+}
+
+func TestSecondJoinRejected(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	_, _, room := pair(t, url)
+
+	third := mustDial(t, url)
+	third.send(map[string]any{"type": typeJoin, "room": room})
+	m := third.recv()
+	if m["type"] != typeError || m["code"] != errRoomFull {
+		t.Fatalf("expected room_full error, got %v", m)
+	}
+}
+
+func TestForwardBeforePairRejected(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	offerer := mustDial(t, url)
+	offerer.send(map[string]any{"type": typeCreate})
+	if m := offerer.recv(); m["type"] != typeCreated {
+		t.Fatalf("expected created, got %v", m)
+	}
+	// No joiner yet, so a forwardable message has nowhere to go.
+	offerer.send(map[string]any{"type": typePake, "msg": "x"})
+	if m := offerer.recv(); m["type"] != typeError || m["code"] != errNotPaired {
+		t.Fatalf("expected not_paired error, got %v", m)
+	}
+}
+
+func TestByeNotifiesPartner(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	offerer, joiner, _ := pair(t, url)
+
+	offerer.send(map[string]any{"type": typeBye, "reason": "done"})
+	m := joiner.recv()
+	if m["type"] != typeBye {
+		t.Fatalf("partner should receive bye, got %v", m)
+	}
+}
+
+func TestDisconnectNotifiesPartner(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	offerer, joiner, _ := pair(t, url)
+
+	// Offerer drops abruptly; the joiner should be told the peer left.
+	_ = offerer.conn.Close(websocket.StatusNormalClosure, "")
+	m := joiner.recv()
+	if m["type"] != typeBye {
+		t.Fatalf("expected bye on partner disconnect, got %v", m)
+	}
+}
+
+func TestUnknownTypeRejected(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	c := mustDial(t, url)
+	c.send(map[string]any{"type": "definitely-not-a-real-type"})
+	m := c.recv()
+	if m["type"] != typeError || m["code"] != errBadMessage {
+		t.Fatalf("expected bad_message error, got %v", m)
+	}
+}
+
+func TestOriginAllowlist(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AllowedOrigins = []string{"https://sendarc.example"}
+	url := testServer(t, cfg)
+
+	// An allowed browser origin connects.
+	if _, err := dial(t, url, "https://sendarc.example"); err != nil {
+		t.Fatalf("allowed origin was rejected: %v", err)
+	}
+	// A disallowed origin is refused at the upgrade.
+	if _, err := dial(t, url, "https://evil.example"); err == nil {
+		t.Fatal("disallowed origin should have been rejected")
+	}
+	// A native client (no Origin header) is always allowed.
+	if _, err := dial(t, url, ""); err != nil {
+		t.Fatalf("native client (no origin) was rejected: %v", err)
+	}
+}
+
+func TestMessageSizeCap(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxMessageBytes = 256
+	url := testServer(t, cfg)
+
+	c := mustDial(t, url)
+	big := make([]byte, cfg.MaxMessageBytes+1)
+	for i := range big {
+		big[i] = 'a'
+	}
+	// Writing may succeed locally; the server closes the socket for exceeding the
+	// read limit, so a subsequent read fails.
+	c.sendRaw(big)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, _, err := c.conn.Read(ctx); err == nil {
+		t.Fatal("expected the socket to close after an oversize message")
+	}
+}


### PR DESCRIPTION
Add the signaling transport that lets two peers find each other and
exchange handshake material without the server learning anything about
the session it brokers.

- Rooms are allocated by smallest free number and paired strictly 1:1;
  a room is torn down as soon as either peer leaves, and its partner is
  notified.
- pake, confirm, caps, sdp, and ice frames are forwarded verbatim
  between the two peers. The server parses only the routing envelope
  (type and room), never the bodies, so it cannot see the word code,
  SDP, or any ciphertext it relays.
- Connections are guarded by an origin allowlist (native clients with no
  Origin are admitted), a per-IP connection rate limit, a per-connection
  message rate limit, a message-size cap, and an idle-room reaper.

Mount the hub at /ws and give the HTTP server a cancelable context so
the reaper stops on shutdown.