### PR TITLE
feat(protocol): rendezvous handshake state machine and browser transport

### DIFF
--- a/apps/web/src/lib/session/rendezvous.ts
+++ b/apps/web/src/lib/session/rendezvous.ts
@@ -1,0 +1,145 @@
+/**
+ * Browser rendezvous orchestrator — the seam between the transport and the pure handshake
+ * state machine. It owns a {@link SignalingClient} and a {@link RendezvousSession}, wiring
+ * the socket's inbound frames into `session.handle` and the session's outbound sink into
+ * `client.send`, then drives the lifecycle: connect (with backoff) → `start` → resolve with
+ * the session keys, or fail closed.
+ *
+ * The two layers below it stay ignorant of each other — the state machine never touches a
+ * `WebSocket`, and the client never parses a handshake. This module is the only place that
+ * knows both, which keeps each unit-testable and gives the Svelte UI a single object to
+ * bind against: a live `phase`, the invite `code` once allocated, and a `done` promise.
+ *
+ * A socket drop after opening is mapped to a session `abort`, so the UI observes exactly
+ * one terminal outcome (`done` rejects) whether the failure came from the peer, the crypto,
+ * or the wire.
+ */
+
+import {
+  RendezvousSession,
+  type CapsPayload,
+  type RendezvousPhase,
+  type RendezvousResult,
+  type SignalMsg,
+} from '@sendarc/protocol';
+
+import { SignalingClient, type BackoffOptions } from '../signaling/client.js';
+
+export interface RendezvousControllerOptions {
+  /** Signaling endpoint. Defaults to `/ws` on the current origin (ws/wss to match the page). */
+  url?: string;
+  /** Overrides for this peer's announced capabilities. */
+  localCaps?: Partial<CapsPayload>;
+  onPhase?: (phase: RendezvousPhase) => void;
+  /** Fires once the full invite code is known (after `created` for an offerer, immediately for a joiner). */
+  onCode?: (code: string) => void;
+  backoff?: Partial<BackoffOptions>;
+}
+
+/** A rendezvous in progress. `done` settles once, mirroring the session's outcome. */
+export interface RendezvousController {
+  /** The full invite code, once allocated/known. */
+  readonly code: string | undefined;
+  readonly phase: RendezvousPhase;
+  /** Resolves with the session keys on success; rejects with a `RendezvousError` otherwise. */
+  readonly done: Promise<RendezvousResult>;
+  /** Abort locally: notify the peer with `bye` and tear down the socket. Idempotent. */
+  cancel(reason?: string): void;
+}
+
+/** Start as the offerer: allocate a room and display the generated invite code. */
+export function offer(
+  opts: RendezvousControllerOptions & { words?: string; wordCount?: number } = {},
+): RendezvousController {
+  return run((sink) => {
+    const session = new RendezvousSession({
+      role: 'offerer',
+      transport: sink,
+      ...pick(opts),
+      ...(opts.words !== undefined ? { words: opts.words } : {}),
+      ...(opts.wordCount !== undefined ? { wordCount: opts.wordCount } : {}),
+    });
+    return session;
+  }, opts);
+}
+
+/** Start as the joiner: pair into the room named by an invite code typed or opened from a link. */
+export function join(opts: RendezvousControllerOptions & { code: string }): RendezvousController {
+  return run(
+    (sink) =>
+      new RendezvousSession({
+        role: 'joiner',
+        code: opts.code,
+        transport: sink,
+        ...pick(opts),
+      }),
+    opts,
+  );
+}
+
+/** Common wiring for both roles: connect, bind the socket to the session, own the teardown. */
+function run(
+  make: (sink: { send(msg: SignalMsg): void }) => RendezvousSession,
+  opts: RendezvousControllerOptions,
+): RendezvousController {
+  const url = opts.url ?? defaultSignalingUrl();
+
+  // The two layers reference each other, so one closure must name the other before it is
+  // constructed: the session's sink calls `client.send`, but nothing sends until the socket
+  // has opened (connect → start), by which point `client` below is initialized.
+  const session = make({ send: (msg) => client.send(msg) });
+
+  const client = new SignalingClient({
+    url,
+    onMessage: (msg) => session.handle(msg),
+    onClose: (clean, code, reason) => {
+      // A post-open drop is terminal; translate it into a session failure. If the session
+      // already settled (the normal close we trigger on `done`), abort is a no-op.
+      session.abort(clean ? `signaling closed (${code})` : `signaling lost (${code} ${reason})`);
+    },
+    onError: (err) => session.abort(err.message),
+    ...(opts.backoff !== undefined ? { backoff: opts.backoff } : {}),
+  });
+
+  // Tear the socket down once the handshake settles either way — success frees the room on
+  // the server, failure stops a doomed retry loop.
+  void session.done.then(
+    () => client.close(),
+    () => client.close(),
+  );
+
+  client.connect().then(
+    () => session.start(),
+    (err: unknown) => session.abort(err instanceof Error ? err.message : String(err)),
+  );
+
+  return {
+    get code() {
+      return session.code;
+    },
+    get phase() {
+      return session.phase;
+    },
+    done: session.done,
+    cancel: (reason = 'cancelled') => {
+      session.abort(reason);
+      client.close();
+    },
+  };
+}
+
+/** Pull the options shared by both roles into the shape the session constructor expects. */
+function pick(opts: RendezvousControllerOptions) {
+  return {
+    ...(opts.localCaps !== undefined ? { localCaps: opts.localCaps } : {}),
+    ...(opts.onPhase !== undefined ? { onPhase: opts.onPhase } : {}),
+    ...(opts.onCode !== undefined ? { onCode: opts.onCode } : {}),
+  };
+}
+
+/** `/ws` on the current origin, with the scheme upgraded to match http→ws / https→wss. */
+function defaultSignalingUrl(): string {
+  const { protocol, host } = window.location;
+  const scheme = protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${scheme}//${host}/ws`;
+}

--- a/apps/web/src/lib/signaling/client.ts
+++ b/apps/web/src/lib/signaling/client.ts
@@ -1,0 +1,166 @@
+/**
+ * Browser signaling transport — a thin, typed wrapper over the native `WebSocket` that
+ * speaks the SendArc signaling messages (`@sendarc/protocol`). It JSON-encodes outbound
+ * frames, parses inbound ones back into {@link SignalMsg}, and retries the *initial*
+ * connection with exponential backoff so a briefly-unreachable server (cold start, a
+ * flaky network) does not fail the session before it begins.
+ *
+ * Reconnection is deliberately limited to that first connect. Once the socket has opened,
+ * the server holds this session's room and pairing on *this* connection; a drop tears the
+ * room down and notifies the peer with `bye`, so a fresh socket cannot resume it — it
+ * would only allocate a new, unrelated room. Recovering a dropped session by
+ * re-handshaking under the same code is a later milestone (plan.md §M6); here a
+ * post-open close is surfaced as a terminal event for the caller to handle.
+ */
+
+import type { SignalMsg } from '@sendarc/protocol';
+
+/** Backoff schedule for the initial connect. Delays are `base * factor^n`, capped at `maxMs`. */
+export interface BackoffOptions {
+  /** Number of retries after the first attempt before giving up. */
+  retries: number;
+  baseMs: number;
+  maxMs: number;
+  factor: number;
+  /** Random 0..jitter fraction added to each delay to avoid thundering herds. */
+  jitter: number;
+}
+
+export const DEFAULT_BACKOFF: BackoffOptions = {
+  retries: 5,
+  baseMs: 250,
+  maxMs: 4000,
+  factor: 2,
+  jitter: 0.25,
+};
+
+export interface SignalingClientOptions {
+  url: string;
+  /** A parsed inbound signaling message. */
+  onMessage: (msg: SignalMsg) => void;
+  /** The socket closed after having opened. `clean` is the WebSocket close cleanliness. */
+  onClose?: (clean: boolean, code: number, reason: string) => void;
+  /** A transport-level problem (connect exhausted, malformed inbound frame). */
+  onError?: (err: Error) => void;
+  backoff?: Partial<BackoffOptions>;
+}
+
+export class SignalingClient {
+  private readonly opts: SignalingClientOptions;
+  private readonly backoff: BackoffOptions;
+  private ws?: WebSocket;
+  private opened = false;
+  private closedByUser = false;
+  private retryTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(opts: SignalingClientOptions) {
+    this.opts = opts;
+    this.backoff = { ...DEFAULT_BACKOFF, ...opts.backoff };
+  }
+
+  /** True once the underlying socket is open and accepting sends. */
+  get isOpen(): boolean {
+    return this.opened && this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  /**
+   * Open the socket, retrying with backoff until the first successful open. Resolves when
+   * open; rejects if every attempt fails or {@link close} is called first.
+   */
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => this.attempt(0, resolve, reject));
+  }
+
+  private attempt(n: number, resolve: () => void, reject: (e: Error) => void): void {
+    if (this.closedByUser) {
+      reject(new Error('signaling: closed before connect'));
+      return;
+    }
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(this.opts.url);
+    } catch (err) {
+      this.retryOrFail(n, resolve, reject, toError(err));
+      return;
+    }
+    this.ws = ws;
+
+    ws.onopen = () => {
+      this.opened = true;
+      resolve();
+    };
+    ws.onmessage = (ev: MessageEvent) => this.dispatch(ev);
+    ws.onerror = () => {
+      // The error event carries no detail; the following close event has the code.
+      if (!this.opened) return; // handled by onclose → retry
+    };
+    ws.onclose = (ev: CloseEvent) => {
+      if (this.opened) {
+        // A drop after opening is terminal for this session (see the file header).
+        this.opts.onClose?.(ev.wasClean, ev.code, ev.reason);
+        return;
+      }
+      this.retryOrFail(
+        n,
+        resolve,
+        reject,
+        new Error(`signaling: connect failed (code ${ev.code})`),
+      );
+    };
+  }
+
+  private retryOrFail(
+    n: number,
+    resolve: () => void,
+    reject: (e: Error) => void,
+    err: Error,
+  ): void {
+    if (this.closedByUser || n >= this.backoff.retries) {
+      reject(err);
+      return;
+    }
+    const raw = Math.min(this.backoff.maxMs, this.backoff.baseMs * this.backoff.factor ** n);
+    const delay = raw * (1 + Math.random() * this.backoff.jitter);
+    this.retryTimer = setTimeout(() => this.attempt(n + 1, resolve, reject), delay);
+  }
+
+  private dispatch(ev: MessageEvent): void {
+    if (typeof ev.data !== 'string') {
+      this.opts.onError?.(new Error('signaling: non-text frame'));
+      return;
+    }
+    let msg: SignalMsg;
+    try {
+      const parsed: unknown = JSON.parse(ev.data);
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        typeof (parsed as { type?: unknown }).type !== 'string'
+      ) {
+        throw new Error('missing type');
+      }
+      msg = parsed as SignalMsg;
+    } catch (err) {
+      this.opts.onError?.(new Error(`signaling: malformed frame: ${toError(err).message}`));
+      return;
+    }
+    this.opts.onMessage(msg);
+  }
+
+  /** JSON-encode and send a signaling message. Throws if the socket is not open. */
+  send(msg: SignalMsg): void {
+    if (!this.isOpen) throw new Error('signaling: socket not open');
+    this.ws!.send(JSON.stringify(msg));
+  }
+
+  /** Close the socket and cancel any pending reconnect. Idempotent. */
+  close(code = 1000, reason = ''): void {
+    this.closedByUser = true;
+    if (this.retryTimer) clearTimeout(this.retryTimer);
+    this.ws?.close(code, reason);
+  }
+}
+
+function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -20,6 +20,9 @@ export const CODE_SEPARATOR = '-';
 /** Framing (see plan.md §6.3). Header is fixed-size and used as AES-GCM AAD. */
 export const FRAME_HEADER_BYTES = 16;
 
+/** Frame-header format version (the header's first byte). Bumped only if the header layout changes. */
+export const FRAME_VERSION = 1;
+
 /** Default DataChannel/relay payload size; negotiable up to MAX_FRAME_BYTES via caps. */
 export const DEFAULT_FRAME_BYTES = 16 * 1024;
 export const MAX_FRAME_BYTES = 64 * 1024;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -14,3 +14,4 @@ export * from './spake2.js';
 export * from './keyschedule.js';
 export * from './aead.js';
 export * from './words.js';
+export * from './rendezvous.js';

--- a/packages/protocol/src/rendezvous.test.ts
+++ b/packages/protocol/src/rendezvous.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import { RendezvousSession, type RendezvousPhase } from './rendezvous.js';
+import type { Role, SignalMsg } from './signaling.js';
+import { base64urlToBytes, bytesToBase64url, bytesToHex } from './bytes.js';
+
+/**
+ * A stand-in for the blind signaling server: it allocates a room, pairs the two peers,
+ * and forwards `pake`/`confirm`/`caps` verbatim — exactly the envelope the real server
+ * sees. Everything it is handed is recorded in {@link seen} so a test can assert the
+ * word code never crosses it. A per-instance hook can tamper with forwarded frames.
+ */
+class MockHub {
+  offerer?: RendezvousSession;
+  joiner?: RendezvousSession;
+  readonly seen: SignalMsg[] = [];
+
+  constructor(
+    private readonly room = 0,
+    private readonly onForward: (msg: SignalMsg) => SignalMsg = (m) => m,
+  ) {}
+
+  sinkFor(role: Role): { send(msg: SignalMsg): void } {
+    return { send: (msg) => this.route(role, msg) };
+  }
+
+  private route(from: Role, msg: SignalMsg): void {
+    this.seen.push(msg);
+    if (msg.type === 'create') {
+      this.offerer!.handle({ type: 'created', room: this.room });
+      return;
+    }
+    if (msg.type === 'join') {
+      this.offerer!.handle({ type: 'peer-joined', role: 'offerer' });
+      this.joiner!.handle({ type: 'peer-joined', role: 'joiner' });
+      return;
+    }
+    const other = from === 'offerer' ? this.joiner! : this.offerer!;
+    other.handle(this.onForward(msg));
+  }
+}
+
+/** Wire an offerer/joiner pair to a hub; the joiner is given `code` out-of-band. */
+function makePair(hub: MockHub, code: string, words = 'brave-otter') {
+  const phases: RendezvousPhase[] = [];
+  const offerer = new RendezvousSession({
+    role: 'offerer',
+    words,
+    transport: hub.sinkFor('offerer'),
+    onPhase: (p) => phases.push(p),
+  });
+  const joiner = new RendezvousSession({ role: 'joiner', code, transport: hub.sinkFor('joiner') });
+  hub.offerer = offerer;
+  hub.joiner = joiner;
+  return { offerer, joiner, phases };
+}
+
+describe('RendezvousSession', () => {
+  it('drives both peers to the same key and round-trips caps', async () => {
+    const hub = new MockHub(0);
+    const { offerer, joiner, phases } = makePair(hub, '0-brave-otter');
+    offerer.start();
+    joiner.start();
+
+    const [ro, rj] = await Promise.all([offerer.done, joiner.done]);
+
+    // Same handshake, same master key and directional keys on both ends.
+    expect(bytesToHex(ro.master)).toBe(bytesToHex(rj.master));
+    expect(bytesToHex(ro.keys.o2j.key)).toBe(bytesToHex(rj.keys.o2j.key));
+    expect(bytesToHex(ro.keys.j2o.key)).toBe(bytesToHex(rj.keys.j2o.key));
+
+    expect(ro.role).toBe('offerer');
+    expect(rj.role).toBe('joiner');
+    expect(ro.code).toBe('0-brave-otter');
+    expect(rj.code).toBe('0-brave-otter');
+
+    // Each side received the other's caps.
+    expect(ro.remoteCaps).toEqual(rj.localCaps);
+    expect(rj.remoteCaps).toEqual(ro.localCaps);
+
+    // The caps exchange consumed counter 0 in each direction; the transfer continues at 1.
+    expect(ro.sendCounter).toBe(1);
+    expect(ro.recvCounter).toBe(1);
+
+    expect(offerer.phase).toBe('established');
+    expect(phases).toEqual([
+      'allocating',
+      'waiting',
+      'handshaking',
+      'confirming',
+      'exchanging-caps',
+      'established',
+    ]);
+  });
+
+  it('fails closed when the codes disagree', async () => {
+    const hub = new MockHub(0);
+    // Offerer's words are brave-otter; the joiner types a wrong last word.
+    const { offerer, joiner } = makePair(hub, '0-brave-tiger');
+    offerer.start();
+    joiner.start();
+
+    await expect(offerer.done).rejects.toMatchObject({ code: 'confirmation_failed' });
+    await expect(joiner.done).rejects.toMatchObject({ code: 'confirmation_failed' });
+    expect(offerer.phase).toBe('failed');
+  });
+
+  it('rejects a tampered caps frame at the GCM check', async () => {
+    // Corrupt every forwarded caps frame so both peers' opens fail.
+    const hub = new MockHub(0, (msg) => {
+      if (msg.type !== 'caps') return msg;
+      const bytes = base64urlToBytes(msg.frame);
+      bytes[bytes.length - 1] ^= 0xff; // flip a tag byte
+      return { ...msg, frame: bytesToBase64url(bytes) };
+    });
+    const { offerer, joiner } = makePair(hub, '0-brave-otter');
+    offerer.start();
+    joiner.start();
+
+    await expect(offerer.done).rejects.toMatchObject({ code: 'bad_peer_message' });
+    await expect(joiner.done).rejects.toMatchObject({ code: 'bad_peer_message' });
+  });
+
+  it('never lets the word code reach the server', async () => {
+    const hub = new MockHub(0);
+    const { offerer, joiner } = makePair(hub, '0-brave-otter');
+    offerer.start();
+    joiner.start();
+    await Promise.all([offerer.done, joiner.done]);
+
+    const allowed = new Set(['create', 'join', 'pake', 'confirm', 'caps', 'bye']);
+    for (const msg of hub.seen) {
+      expect(allowed.has(msg.type)).toBe(true);
+      const json = JSON.stringify(msg);
+      expect(json).not.toContain('brave');
+      expect(json).not.toContain('otter');
+      expect(json).not.toContain('words');
+      expect(json).not.toContain('code');
+    }
+  });
+});

--- a/packages/protocol/src/rendezvous.ts
+++ b/packages/protocol/src/rendezvous.ts
@@ -1,0 +1,423 @@
+/**
+ * Rendezvous state machine — drives one peer through the M1 handshake over the blind
+ * signaling channel (plan.md §5.2): `create`/`join` → `peer-joined` → `pake` → `confirm`
+ * → an encrypted `caps` round-trip, ending with a shared master key and both directional
+ * transfer keys.
+ *
+ * The machine is transport-agnostic: it is handed a `send` sink for outbound signaling
+ * messages and fed inbound ones via {@link RendezvousSession.handle}. That keeps it pure
+ * and unit-testable (two sessions can be wired mouth-to-ear with no socket) and lets the
+ * browser and any other TS host supply their own transport. The Go CLI mirrors this flow
+ * against `packages/wire`.
+ *
+ * It carries no invite words onto the wire: only the SPAKE2 share, the confirmation MAC,
+ * and the AEAD-sealed caps ever leave, so the server it talks through learns only the
+ * room number it already allocated. A wrong or edited code fails closed at key
+ * confirmation (RFC 9382 §4), never producing a session.
+ */
+
+import {
+  DEFAULT_BLOCK_BYTES,
+  DEFAULT_FRAME_BYTES,
+  DEFAULT_WORD_COUNT,
+  FRAME_VERSION,
+  PROTOCOL_VERSION,
+} from './constants.js';
+import type { Role, SignalErrorCode, SignalMsg } from './signaling.js';
+import { FrameType, type Feature, type SinkHint } from './transfer.js';
+import {
+  computeShare,
+  finish,
+  passwordToScalar,
+  randomScalar,
+  type Spake2Output,
+} from './spake2.js';
+import {
+  deriveMaster,
+  deriveTransferKeys,
+  type DirectionalKey,
+  type TransferKeys,
+} from './keyschedule.js';
+import { open, seal } from './aead.js';
+import { formatCode, generateWords, normalizeCode, parseCode } from './words.js';
+import { base64urlToBytes, bytesToBase64url, constantTimeEqual, utf8 } from './bytes.js';
+
+/** Where a session is in the handshake. Advances monotonically until `established` or `failed`. */
+export type RendezvousPhase =
+  | 'idle' // not started
+  | 'allocating' // offerer: sent `create`, awaiting the room number
+  | 'waiting' // awaiting the other peer to join
+  | 'handshaking' // paired; SPAKE2 share sent, awaiting the peer's
+  | 'confirming' // shared point derived; confirmation MAC sent, awaiting the peer's
+  | 'exchanging-caps' // key confirmed; encrypted caps sent, awaiting the peer's
+  | 'established' // both caps exchanged; keys ready
+  | 'failed'; // aborted or rejected
+
+/** The capability announcement each peer seals as its first frame under the session key. */
+export interface CapsPayload {
+  version: string;
+  maxFrame: number;
+  blockSize: number;
+  features: Feature[];
+  sinkHints: SinkHint[];
+}
+
+/** Everything a completed handshake yields — enough to run the M2 transfer under the same key. */
+export interface RendezvousResult {
+  readonly role: Role;
+  readonly room: number;
+  /** The full normalized invite code (`<room>-<words>`); the SPAKE2 password. */
+  readonly code: string;
+  /** SendArc master key, bound to the handshake transcript. */
+  readonly master: Uint8Array;
+  /** Both directional AEAD keys + nonce salts. */
+  readonly keys: TransferKeys;
+  /** Raw SPAKE2 output, retained for the M2 SDP/ICE MAC keys (KcA/KcB). */
+  readonly spake2: Spake2Output;
+  readonly localCaps: CapsPayload;
+  readonly remoteCaps: CapsPayload;
+  /**
+   * Next per-direction frame counters. The caps exchange consumed counter 0 in each
+   * direction, so both are 1: the transfer must continue from here without resetting,
+   * or it would reuse an AES-GCM nonce (plan.md §5.3 counter-continuity invariant).
+   */
+  readonly sendCounter: number;
+  readonly recvCounter: number;
+}
+
+/** Reasons a rendezvous can fail: a server `error` code, or a client-side handshake failure. */
+export type RendezvousErrorCode =
+  | SignalErrorCode
+  | 'confirmation_failed'
+  | 'bad_peer_message'
+  | 'peer_left'
+  | 'aborted'
+  | 'protocol';
+
+export class RendezvousError extends Error {
+  constructor(
+    readonly code: RendezvousErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RendezvousError';
+  }
+}
+
+/** The outbound half of the signaling channel the session drives. */
+export interface SignalingSink {
+  send(msg: SignalMsg): void;
+}
+
+interface CommonOptions {
+  transport: SignalingSink;
+  /** Overrides for this peer's announced capabilities. */
+  localCaps?: Partial<CapsPayload>;
+  onPhase?: (phase: RendezvousPhase) => void;
+  /** Fires once the full invite code is known (immediately for a joiner; after `created` for an offerer). */
+  onCode?: (code: string) => void;
+}
+
+/** Construct an offerer (allocates a room) or a joiner (pairs into an existing one). */
+export type RendezvousOptions =
+  | (CommonOptions & { role: 'offerer'; words?: string; wordCount?: number })
+  | (CommonOptions & { role: 'joiner'; code: string });
+
+function defaultCaps(): CapsPayload {
+  return {
+    version: PROTOCOL_VERSION,
+    maxFrame: DEFAULT_FRAME_BYTES,
+    blockSize: DEFAULT_BLOCK_BYTES,
+    features: [],
+    sinkHints: [],
+  };
+}
+
+const CAPS_HEADER = {
+  version: FRAME_VERSION,
+  type: FrameType.Caps,
+  flags: 0,
+  fileIdx: 0,
+  blockIdx: 0,
+  frameOff: 0,
+} as const;
+
+export class RendezvousSession {
+  readonly role: Role;
+  /** Resolves with the session keys on success, rejects with a {@link RendezvousError}. */
+  readonly done: Promise<RendezvousResult>;
+
+  private readonly opts: RendezvousOptions;
+  private readonly localCaps: CapsPayload;
+  private resolve!: (r: RendezvousResult) => void;
+  private reject!: (e: RendezvousError) => void;
+
+  private _phase: RendezvousPhase = 'idle';
+  private _code?: string;
+  private settled = false;
+
+  // Handshake state, filled in as the exchange proceeds.
+  private room = -1;
+  private words = '';
+  private w?: bigint; // SPAKE2 password scalar
+  private secret?: bigint; // ephemeral secret (x for offerer, y for joiner)
+  private shareSent = false;
+  private spake2?: Spake2Output;
+  private keys?: TransferKeys;
+  private master?: Uint8Array;
+  private sendCounter = 0;
+  private recvCounter = 0;
+
+  /** Serializes all async work so messages are processed strictly in arrival order. */
+  private chain: Promise<void> = Promise.resolve();
+
+  constructor(opts: RendezvousOptions) {
+    this.opts = opts;
+    this.role = opts.role;
+    this.localCaps = { ...defaultCaps(), ...opts.localCaps };
+    this.done = new Promise<RendezvousResult>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+    // Surface unhandled rejections only through `done`; callers that ignore it still run.
+    this.done.catch(() => {});
+  }
+
+  get phase(): RendezvousPhase {
+    return this._phase;
+  }
+
+  /** The invite code, once known. Undefined for an offerer until the room is allocated. */
+  get code(): string | undefined {
+    return this._code;
+  }
+
+  /** Begin the handshake: an offerer sends `create`, a joiner sends `join`. */
+  start(): void {
+    this.enqueue(() => this.runStart());
+  }
+
+  /** Feed one inbound signaling message. Safe to call before {@link start} resolves it in order. */
+  handle(msg: SignalMsg): void {
+    this.enqueue(() => this.process(msg));
+  }
+
+  /** Abort locally: notify the peer with `bye` and reject `done`. Idempotent. */
+  abort(reason = 'aborted'): void {
+    if (this.settled) return;
+    try {
+      this.opts.transport.send({ type: 'bye', reason });
+    } catch {
+      // best-effort; the transport may already be gone
+    }
+    this.fail(new RendezvousError('aborted', reason));
+  }
+
+  // --- internal ---------------------------------------------------------------
+
+  private enqueue(fn: () => Promise<void>): void {
+    this.chain = this.chain.then(fn).catch((err: unknown) => this.fail(toError(err)));
+  }
+
+  private setPhase(phase: RendezvousPhase): void {
+    this._phase = phase;
+    this.opts.onPhase?.(phase);
+  }
+
+  private fail(err: RendezvousError): void {
+    if (this.settled) return;
+    this.settled = true;
+    this.setPhase('failed');
+    this.reject(err);
+  }
+
+  private async runStart(): Promise<void> {
+    if (this.settled || this._phase !== 'idle') return;
+    this.secret = randomScalar();
+    if (this.opts.role === 'joiner') {
+      const parsed = parseCode(this.opts.code);
+      this.room = parsed.room;
+      this.words = parsed.words;
+      this._code = formatCode(parsed.room, parsed.words);
+      this.w = await passwordToScalar(this._code);
+      this.opts.onCode?.(this._code);
+      this.opts.transport.send({ type: 'join', room: this.room });
+      this.setPhase('waiting');
+    } else {
+      this.words = this.opts.words ?? generateWords(this.opts.wordCount ?? DEFAULT_WORD_COUNT);
+      this.opts.transport.send({ type: 'create' });
+      this.setPhase('allocating');
+    }
+  }
+
+  private async process(msg: SignalMsg): Promise<void> {
+    if (this.settled) return;
+    switch (msg.type) {
+      case 'created':
+        return this.onCreated(msg.room);
+      case 'peer-joined':
+        return this.onPeerJoined(msg.role);
+      case 'pake':
+        return this.onPake(msg.msg);
+      case 'confirm':
+        return this.onConfirm(msg.mac);
+      case 'caps':
+        return this.onCaps(msg.frame);
+      case 'bye':
+        return this.fail(new RendezvousError('peer_left', msg.reason || 'peer left'));
+      case 'error':
+        return this.fail(new RendezvousError(msg.code, msg.msg || msg.code));
+      default:
+        // `create`/`join`/`sdp`/`ice` are not inbound to a client at this stage.
+        return this.fail(
+          new RendezvousError('protocol', `unexpected ${msg.type} in ${this._phase}`),
+        );
+    }
+  }
+
+  private async onCreated(room: number): Promise<void> {
+    if (this.role !== 'offerer' || this._phase !== 'allocating') {
+      return this.fail(new RendezvousError('protocol', 'unexpected created'));
+    }
+    this.room = room;
+    this._code = formatCode(room, this.words);
+    this.w = await passwordToScalar(normalizeCode(this._code));
+    this.opts.onCode?.(this._code);
+    this.setPhase('waiting');
+  }
+
+  private async onPeerJoined(role: Role): Promise<void> {
+    if (this._phase !== 'waiting' || role !== this.role) {
+      return this.fail(new RendezvousError('protocol', 'unexpected peer-joined'));
+    }
+    // Paired. Send our SPAKE2 share; the peer sends theirs independently (one round trip).
+    const share = computeShare(this.role, this.w!, this.secret!);
+    this.shareSent = true;
+    this.opts.transport.send({ type: 'pake', msg: bytesToBase64url(share) });
+    this.setPhase('handshaking');
+  }
+
+  private async onPake(shareB64: string): Promise<void> {
+    if (!this.shareSent) {
+      return this.fail(new RendezvousError('protocol', 'pake before pairing'));
+    }
+    let peerShare: Uint8Array;
+    try {
+      peerShare = base64urlToBytes(shareB64);
+    } catch {
+      return this.fail(new RendezvousError('bad_peer_message', 'malformed pake'));
+    }
+    // finish decodes and validates the peer's point; an off-curve share throws here.
+    try {
+      this.spake2 = await finish(this.role, this.w!, this.secret!, peerShare);
+    } catch {
+      return this.fail(new RendezvousError('bad_peer_message', 'invalid pake share'));
+    }
+    const ownConfirm = this.role === 'offerer' ? this.spake2.confirmA : this.spake2.confirmB;
+    this.opts.transport.send({ type: 'confirm', mac: bytesToBase64url(ownConfirm) });
+    this.setPhase('confirming');
+  }
+
+  private async onConfirm(macB64: string): Promise<void> {
+    if (!this.spake2) {
+      return this.fail(new RendezvousError('protocol', 'confirm before pake'));
+    }
+    let got: Uint8Array;
+    try {
+      got = base64urlToBytes(macB64);
+    } catch {
+      return this.fail(new RendezvousError('bad_peer_message', 'malformed confirm'));
+    }
+    const expected = this.role === 'offerer' ? this.spake2.confirmB : this.spake2.confirmA;
+    if (!constantTimeEqual(got, expected)) {
+      // Wrong code or a MITM: fail closed (RFC 9382 §4). This is the core M1 guarantee.
+      return this.fail(new RendezvousError('confirmation_failed', 'key confirmation failed'));
+    }
+    // Confirmed. Derive the transfer keys and send our encrypted caps.
+    this.master = await deriveMaster(this.spake2.Ke, this.spake2.transcript);
+    this.keys = await deriveTransferKeys(this.master);
+    const frame = await seal(
+      this.sendDir(),
+      this.sendCounter++,
+      CAPS_HEADER,
+      utf8(JSON.stringify(this.localCaps)),
+    );
+    this.opts.transport.send({ type: 'caps', frame: bytesToBase64url(frame) });
+    this.setPhase('exchanging-caps');
+    // The peer's caps may already be queued; it is processed next, keys now in hand.
+  }
+
+  private async onCaps(frameB64: string): Promise<void> {
+    if (!this.keys) {
+      return this.fail(new RendezvousError('protocol', 'caps before key confirmation'));
+    }
+    let opened;
+    try {
+      const frame = base64urlToBytes(frameB64);
+      opened = await open(this.recvDir(), this.recvCounter++, frame);
+    } catch {
+      return this.fail(new RendezvousError('bad_peer_message', 'caps failed to decrypt'));
+    }
+    if (opened.header.type !== FrameType.Caps) {
+      return this.fail(new RendezvousError('bad_peer_message', 'first frame is not caps'));
+    }
+    const remoteCaps = parseCaps(opened.plaintext);
+    if (!remoteCaps) {
+      return this.fail(new RendezvousError('bad_peer_message', 'malformed caps payload'));
+    }
+    this.settled = true;
+    this.setPhase('established');
+    this.resolve({
+      role: this.role,
+      room: this.room,
+      code: this._code!,
+      master: this.master!,
+      keys: this.keys,
+      spake2: this.spake2!,
+      localCaps: this.localCaps,
+      remoteCaps,
+      sendCounter: this.sendCounter,
+      recvCounter: this.recvCounter,
+    });
+  }
+
+  private sendDir(): DirectionalKey {
+    return this.role === 'offerer' ? this.keys!.o2j : this.keys!.j2o;
+  }
+
+  private recvDir(): DirectionalKey {
+    return this.role === 'offerer' ? this.keys!.j2o : this.keys!.o2j;
+  }
+}
+
+function parseCaps(plaintext: Uint8Array): CapsPayload | undefined {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(new TextDecoder().decode(plaintext));
+  } catch {
+    return undefined;
+  }
+  if (typeof obj !== 'object' || obj === null) return undefined;
+  const c = obj as Record<string, unknown>;
+  if (
+    typeof c.version !== 'string' ||
+    typeof c.maxFrame !== 'number' ||
+    typeof c.blockSize !== 'number' ||
+    !Array.isArray(c.features) ||
+    !Array.isArray(c.sinkHints)
+  ) {
+    return undefined;
+  }
+  return {
+    version: c.version,
+    maxFrame: c.maxFrame,
+    blockSize: c.blockSize,
+    features: c.features as Feature[],
+    sinkHints: c.sinkHints as SinkHint[],
+  };
+}
+
+function toError(err: unknown): RendezvousError {
+  if (err instanceof RendezvousError) return err;
+  return new RendezvousError('protocol', err instanceof Error ? err.message : String(err));
+}


### PR DESCRIPTION
Add the transport-agnostic RendezvousSession that drives one peer through
the M1 handshake over the blind signaling channel: create/join, SPAKE2
share exchange, RFC 9382 key confirmation (fail-closed on mismatch), and
an AEAD-sealed caps round-trip yielding the master key and both
directional transfer keys. The machine is fed inbound messages via
handle() and writes through an injected sink, so two sessions can be
wired mouth-to-ear without a socket.

On the browser side, SignalingClient wraps the native WebSocket with
typed JSON framing and backoff on the initial connect, and the session
orchestrator binds it to a RendezvousSession, exposing phase, code, and
a done promise for the UI. A post-open drop is mapped to a single
terminal abort; resuming a dropped session is deferred to M6.

Tests cover the happy path (shared keys, caps round-trip, counter
continuity), fail-closed on divergent codes, tampered-caps rejection at
the GCM check, and that the word code never crosses the wire.