### PR TITLE
feat(cli): Go rendezvous state machine mirroring the browser peer

### DIFF
--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -1,0 +1,14 @@
+module github.com/sendarc/cli
+
+go 1.24.0
+
+require github.com/sendarc/wire v0.0.0
+
+require (
+	filippo.io/nistec v0.0.4 // indirect
+	golang.org/x/sys v0.36.0 // indirect
+)
+
+// The wire crypto core is a sibling module in this repo. A local replace keeps it resolvable
+// both under the go.work workspace and in standalone module builds (as CI runs each module).
+replace github.com/sendarc/wire => ../../packages/wire

--- a/apps/cli/go.sum
+++ b/apps/cli/go.sum
@@ -1,0 +1,4 @@
+filippo.io/nistec v0.0.4 h1:F14ZHT5htWlMnQVPndX9ro9arf56cBhQxq4LnDI491s=
+filippo.io/nistec v0.0.4/go.mod h1:PK/lw8I1gQT4hUML4QGaqljwdDaFcMyFKSXN7kjrtKI=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/apps/cli/internal/rendezvous/caps.go
+++ b/apps/cli/internal/rendezvous/caps.go
@@ -1,0 +1,45 @@
+package rendezvous
+
+import "github.com/sendarc/wire"
+
+// Default caps values. These mirror the protocol constants in
+// packages/protocol/src/constants.ts (DEFAULT_FRAME_BYTES, DEFAULT_BLOCK_BYTES); they are
+// announced in caps and negotiable, so they are defaults rather than hard limits.
+const (
+	defaultFrameBytes = 16 * 1024
+	defaultBlockBytes = 1024 * 1024
+	// capsFrameVersion is the frame-header version byte (FRAME_VERSION in constants.ts).
+	capsFrameVersion = 1
+)
+
+// Caps is the capability announcement each peer seals as its first frame under the session
+// key. Its JSON shape matches CapsPayload in rendezvous.ts, so a browser peer can decode a
+// CLI peer's caps and vice versa. Features and SinkHints are always non-nil so they
+// serialize as [] (an array), which the TypeScript parser requires.
+type Caps struct {
+	Version   string   `json:"version"`
+	MaxFrame  int      `json:"maxFrame"`
+	BlockSize int      `json:"blockSize"`
+	Features  []string `json:"features"`
+	SinkHints []string `json:"sinkHints"`
+}
+
+// DefaultCaps returns the capabilities a CLI peer announces by default.
+func DefaultCaps() Caps {
+	return Caps{
+		Version:   wire.ProtocolVersion,
+		MaxFrame:  defaultFrameBytes,
+		BlockSize: defaultBlockBytes,
+		Features:  []string{},
+		SinkHints: []string{},
+	}
+}
+
+// capsHeader is the fixed frame header for the caps frame: version, Caps type, all
+// indices zero. Seal fills in the length.
+func capsHeader() wire.FrameHeaderInput {
+	return wire.FrameHeaderInput{
+		Version: capsFrameVersion,
+		Type:    wire.FrameCaps,
+	}
+}

--- a/apps/cli/internal/rendezvous/message.go
+++ b/apps/cli/internal/rendezvous/message.go
@@ -1,0 +1,74 @@
+// Package rendezvous drives one CLI peer through the SendArc M1 handshake over the blind
+// signaling channel (plan.md §5.2): create/join → peer-joined → pake → confirm → an
+// AEAD-sealed caps round-trip, ending with a shared master key and both directional
+// transfer keys.
+//
+// It is the Go mirror of packages/protocol/src/rendezvous.ts and speaks the identical
+// signaling envelope, so a CLI peer and a browser peer interoperate through the same
+// server. The state machine is transport-agnostic: it writes outbound messages to an
+// injected Sink and is fed inbound ones via [Session.Handle], which keeps it unit-testable
+// (two sessions can be wired mouth-to-ear with no socket) and independent of the WebSocket
+// client in internal/wsclient.
+package rendezvous
+
+import "encoding/json"
+
+// Signaling message type tags (plan.md §6.1). These match the string tags in
+// packages/protocol/src/signaling.ts exactly; the server forwards the peer→peer bodies
+// verbatim, so a mismatch here would break interop with a browser peer.
+const (
+	typeCreate     = "create"
+	typeCreated    = "created"
+	typeJoin       = "join"
+	typePeerJoined = "peer-joined"
+	typePake       = "pake"
+	typeConfirm    = "confirm"
+	typeCaps       = "caps"
+	typeBye        = "bye"
+	typeError      = "error"
+)
+
+// Message is the SendArc signaling envelope. One flat struct covers every message type;
+// the fields used depend on Type, and omitempty keeps each serialized frame minimal and
+// byte-compatible with the TypeScript union in signaling.ts. The word code is never a
+// field here — only the SPAKE2 share, the confirmation MAC, and the sealed caps travel.
+type Message struct {
+	Type string `json:"type"`
+	// Room is set on join (client→server) and created (server→client).
+	Room *int `json:"room,omitempty"`
+	// Role is the peer's routing role, echoed by the server on peer-joined.
+	Role string `json:"role,omitempty"`
+	// Msg carries the base64url SPAKE2 share on pake, and the human text on error.
+	Msg string `json:"msg,omitempty"`
+	// Mac is the base64url RFC 9382 key-confirmation MAC on confirm.
+	Mac string `json:"mac,omitempty"`
+	// Frame is the base64url AEAD-sealed frame on caps.
+	Frame string `json:"frame,omitempty"`
+	// Reason is the optional detail on bye.
+	Reason string `json:"reason,omitempty"`
+	// Code is the machine-readable error code on error.
+	Code string `json:"code,omitempty"`
+}
+
+// Sink is the outbound half of the signaling channel the session drives.
+type Sink interface {
+	Send(Message) error
+}
+
+// SinkFunc adapts a plain function to a Sink.
+type SinkFunc func(Message) error
+
+func (f SinkFunc) Send(m Message) error { return f(m) }
+
+// MarshalMessage encodes a signaling message to its JSON wire form.
+func MarshalMessage(m Message) ([]byte, error) { return json.Marshal(m) }
+
+// UnmarshalMessage decodes a JSON signaling frame. A frame missing a type is rejected so
+// the session can fail cleanly rather than act on an empty tag.
+func UnmarshalMessage(data []byte) (Message, error) {
+	var m Message
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Message{}, err
+	}
+	return m, nil
+}

--- a/apps/cli/internal/rendezvous/session.go
+++ b/apps/cli/internal/rendezvous/session.go
@@ -1,0 +1,497 @@
+package rendezvous
+
+import (
+	"crypto/hmac"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/sendarc/wire"
+)
+
+// Phase is where a session is in the handshake. It advances monotonically until
+// PhaseEstablished or PhaseFailed. The values mirror RendezvousPhase in rendezvous.ts.
+type Phase string
+
+const (
+	PhaseIdle           Phase = "idle"
+	PhaseAllocating     Phase = "allocating"      // offerer: sent create, awaiting the room number
+	PhaseWaiting        Phase = "waiting"         // awaiting the other peer to join
+	PhaseHandshaking    Phase = "handshaking"     // paired; SPAKE2 share sent, awaiting the peer's
+	PhaseConfirming     Phase = "confirming"      // shared point derived; MAC sent, awaiting the peer's
+	PhaseExchangingCaps Phase = "exchanging-caps" // key confirmed; caps sent, awaiting the peer's
+	PhaseEstablished    Phase = "established"     // both caps exchanged; keys ready
+	PhaseFailed         Phase = "failed"
+)
+
+// Error codes for a failed rendezvous: the client-side handshake failures plus any server
+// error code relayed on an error message.
+const (
+	CodeConfirmationFailed = "confirmation_failed"
+	CodeBadPeerMessage     = "bad_peer_message"
+	CodePeerLeft           = "peer_left"
+	CodeAborted            = "aborted"
+	CodeProtocol           = "protocol"
+)
+
+// Error is a typed rendezvous failure carrying a stable Code.
+type Error struct {
+	Code string
+	Msg  string
+}
+
+func (e *Error) Error() string { return fmt.Sprintf("rendezvous: %s: %s", e.Code, e.Msg) }
+
+// Role identifies which end of the handshake this peer plays.
+type Role = wire.Role
+
+const (
+	RoleOfferer = wire.RoleOfferer
+	RoleJoiner  = wire.RoleJoiner
+)
+
+// Result is everything a completed handshake yields — enough to run the M2 transfer under
+// the same key. The caps exchange consumed frame counter 0 in each direction, so both
+// counters are 1: the transfer must continue from here without resetting, or it would
+// reuse an AES-GCM nonce.
+type Result struct {
+	Role        Role
+	Room        int
+	Code        string // the full normalized invite code (<room>-<words>); the SPAKE2 password
+	Master      []byte
+	Keys        wire.TransferKeys
+	Spake2      *wire.Spake2Output // retained for the M2 SDP/ICE MAC keys (KcA/KcB)
+	LocalCaps   Caps
+	RemoteCaps  Caps
+	SendCounter uint64
+	RecvCounter uint64
+}
+
+// Options configures a session. Exactly one role is built per session; Code is required for
+// a joiner, Words/WordCount apply only to an offerer.
+type Options struct {
+	Role      Role
+	Transport Sink
+	// Joiner only: the invite code to pair into.
+	Code string
+	// Offerer only: fixed words (mainly for tests) and/or a word count. Empty Words means
+	// generate WordCount words; zero WordCount means the protocol default.
+	Words     string
+	WordCount int
+	// LocalCaps overrides the announced capabilities. Nil uses DefaultCaps.
+	LocalCaps *Caps
+	// OnPhase and OnCode are optional progress callbacks, invoked while a state transition
+	// holds the session lock — they must not call back into the session.
+	OnPhase func(Phase)
+	OnCode  func(string)
+}
+
+// Session is a transport-agnostic rendezvous state machine. Start it once, feed inbound
+// messages with Handle, and Wait for the result. All state transitions are serialized by a
+// mutex, so Handle may be called from the socket read loop while Wait blocks elsewhere.
+type Session struct {
+	role      Role
+	sink      Sink
+	localCaps Caps
+	onPhase   func(Phase)
+	onCode    func(string)
+
+	// joiner input / offerer generation
+	joinCode string
+	words    string
+
+	mu      sync.Mutex
+	phase   Phase
+	code    string
+	room    int
+	w       *big.Int // SPAKE2 password scalar
+	secret  *big.Int // ephemeral secret (x for offerer, y for joiner)
+	shared  bool     // our SPAKE2 share has been sent
+	spake2  *wire.Spake2Output
+	keys    wire.TransferKeys
+	master  []byte
+	sendCtr uint64
+	recvCtr uint64
+
+	settled bool
+	result  *Result
+	err     error
+	done    chan struct{}
+}
+
+// New builds a session for the configured role. It does not touch the network until Start.
+func New(opts Options) *Session {
+	caps := DefaultCaps()
+	if opts.LocalCaps != nil {
+		caps = *opts.LocalCaps
+	}
+	return &Session{
+		role:      opts.Role,
+		sink:      opts.Transport,
+		localCaps: caps,
+		onPhase:   opts.OnPhase,
+		onCode:    opts.OnCode,
+		joinCode:  opts.Code,
+		words:     opts.Words,
+		phase:     PhaseIdle,
+		room:      -1,
+		done:      make(chan struct{}),
+	}
+}
+
+// Phase returns the current handshake phase.
+func (s *Session) Phase() Phase {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.phase
+}
+
+// Code returns the invite code once known (empty for an offerer until the room is allocated).
+func (s *Session) Code() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.code
+}
+
+// Done is closed when the session settles, successfully or not.
+func (s *Session) Done() <-chan struct{} { return s.done }
+
+// Result blocks until the session settles, then returns the keys or the failure.
+func (s *Session) Result() (*Result, error) {
+	<-s.done
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.result, s.err
+}
+
+// Start begins the handshake: an offerer sends create, a joiner sends join.
+func (s *Session) Start() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.settled || s.phase != PhaseIdle {
+		return
+	}
+	secret, err := wire.RandomScalar()
+	if err != nil {
+		s.fail(&Error{CodeProtocol, "generate secret: " + err.Error()})
+		return
+	}
+	s.secret = secret
+
+	if s.role == RoleJoiner {
+		parsed, err := wire.ParseCode(s.joinCode)
+		if err != nil {
+			s.fail(&Error{CodeProtocol, "invalid code: " + err.Error()})
+			return
+		}
+		s.room = parsed.Room
+		s.words = parsed.Words
+		s.code = wire.FormatCode(parsed.Room, parsed.Words)
+		if s.w, err = wire.PasswordToScalar(wire.NormalizeCode(s.code)); err != nil {
+			s.fail(&Error{CodeProtocol, "derive w: " + err.Error()})
+			return
+		}
+		if s.onCode != nil {
+			s.onCode(s.code)
+		}
+		if !s.emit(Message{Type: typeJoin, Room: &s.room}) {
+			return
+		}
+		s.setPhase(PhaseWaiting)
+		return
+	}
+
+	// Offerer: generate the words now; the room number arrives in created.
+	if s.words == "" {
+		w, err := wire.GenerateWords(wordCountOrDefault(0))
+		if err != nil {
+			s.fail(&Error{CodeProtocol, "generate words: " + err.Error()})
+			return
+		}
+		s.words = w
+	}
+	if !s.emit(Message{Type: typeCreate}) {
+		return
+	}
+	s.setPhase(PhaseAllocating)
+}
+
+// Handle feeds one inbound signaling message.
+func (s *Session) Handle(msg Message) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.settled {
+		return
+	}
+	switch msg.Type {
+	case typeCreated:
+		s.onCreated(msg)
+	case typePeerJoined:
+		s.onPeerJoined(msg)
+	case typePake:
+		s.onPake(msg)
+	case typeConfirm:
+		s.onConfirm(msg)
+	case typeCaps:
+		s.onCaps(msg)
+	case typeBye:
+		s.fail(&Error{CodePeerLeft, orDefault(msg.Reason, "peer left")})
+	case typeError:
+		s.fail(&Error{orDefault(msg.Code, CodeProtocol), orDefault(msg.Msg, msg.Code)})
+	default:
+		s.fail(&Error{CodeProtocol, "unexpected " + msg.Type + " in " + string(s.phase)})
+	}
+}
+
+// Abort notifies the peer with bye and fails the session. Safe to call concurrently and
+// more than once.
+func (s *Session) Abort(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.settled {
+		return
+	}
+	_ = s.sink.Send(Message{Type: typeBye, Reason: reason}) // best-effort
+	s.fail(&Error{CodeAborted, orDefault(reason, "aborted")})
+}
+
+// Fail settles the session with a transport-level error (e.g. the socket dropped). It does
+// not send bye, since the transport is already gone.
+func (s *Session) Fail(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if re, ok := err.(*Error); ok {
+		s.fail(re)
+		return
+	}
+	s.fail(&Error{CodePeerLeft, err.Error()})
+}
+
+// --- handlers (all run under s.mu) ------------------------------------------
+
+func (s *Session) onCreated(msg Message) {
+	if s.role != RoleOfferer || s.phase != PhaseAllocating || msg.Room == nil {
+		s.fail(&Error{CodeProtocol, "unexpected created"})
+		return
+	}
+	s.room = *msg.Room
+	s.code = wire.FormatCode(s.room, s.words)
+	w, err := wire.PasswordToScalar(wire.NormalizeCode(s.code))
+	if err != nil {
+		s.fail(&Error{CodeProtocol, "derive w: " + err.Error()})
+		return
+	}
+	s.w = w
+	if s.onCode != nil {
+		s.onCode(s.code)
+	}
+	s.setPhase(PhaseWaiting)
+}
+
+func (s *Session) onPeerJoined(msg Message) {
+	if s.phase != PhaseWaiting || Role(msg.Role) != s.role {
+		s.fail(&Error{CodeProtocol, "unexpected peer-joined"})
+		return
+	}
+	// Paired. Send our SPAKE2 share; the peer sends theirs independently (one round trip).
+	share, err := wire.ComputeShare(s.role, s.w, s.secret)
+	if err != nil {
+		s.fail(&Error{CodeProtocol, "compute share: " + err.Error()})
+		return
+	}
+	s.shared = true
+	if !s.emit(Message{Type: typePake, Msg: b64encode(share)}) {
+		return
+	}
+	s.setPhase(PhaseHandshaking)
+}
+
+func (s *Session) onPake(msg Message) {
+	if !s.shared {
+		s.fail(&Error{CodeProtocol, "pake before pairing"})
+		return
+	}
+	peerShare, err := b64decode(msg.Msg)
+	if err != nil {
+		s.fail(&Error{CodeBadPeerMessage, "malformed pake"})
+		return
+	}
+	// Finish decodes and validates the peer's point; an off-curve share errors here.
+	out, err := wire.Finish(s.role, s.w, s.secret, peerShare)
+	if err != nil {
+		s.fail(&Error{CodeBadPeerMessage, "invalid pake share"})
+		return
+	}
+	s.spake2 = out
+	ownConfirm := out.ConfirmA
+	if s.role == RoleJoiner {
+		ownConfirm = out.ConfirmB
+	}
+	if !s.emit(Message{Type: typeConfirm, Mac: b64encode(ownConfirm)}) {
+		return
+	}
+	s.setPhase(PhaseConfirming)
+}
+
+func (s *Session) onConfirm(msg Message) {
+	if s.spake2 == nil {
+		s.fail(&Error{CodeProtocol, "confirm before pake"})
+		return
+	}
+	got, err := b64decode(msg.Mac)
+	if err != nil {
+		s.fail(&Error{CodeBadPeerMessage, "malformed confirm"})
+		return
+	}
+	expected := s.spake2.ConfirmB
+	if s.role == RoleJoiner {
+		expected = s.spake2.ConfirmA
+	}
+	if !hmac.Equal(got, expected) {
+		// Wrong code or a MITM: fail closed (RFC 9382 §4). This is the core M1 guarantee.
+		s.fail(&Error{CodeConfirmationFailed, "key confirmation failed"})
+		return
+	}
+	// Confirmed. Derive the transfer keys and send our encrypted caps.
+	master, err := wire.DeriveMaster(s.spake2.Ke, s.spake2.Transcript)
+	if err != nil {
+		s.fail(&Error{CodeProtocol, "derive master: " + err.Error()})
+		return
+	}
+	s.master = master
+	keys, err := wire.DeriveTransferKeys(master)
+	if err != nil {
+		s.fail(&Error{CodeProtocol, "derive transfer keys: " + err.Error()})
+		return
+	}
+	s.keys = keys
+
+	payload, err := json.Marshal(s.localCaps)
+	if err != nil {
+		s.fail(&Error{CodeProtocol, "marshal caps: " + err.Error()})
+		return
+	}
+	frame, err := wire.Seal(s.sendDir(), s.sendCtr, capsHeader(), payload)
+	if err != nil {
+		s.fail(&Error{CodeProtocol, "seal caps: " + err.Error()})
+		return
+	}
+	s.sendCtr++
+	if !s.emit(Message{Type: typeCaps, Frame: b64encode(frame)}) {
+		return
+	}
+	s.setPhase(PhaseExchangingCaps)
+}
+
+func (s *Session) onCaps(msg Message) {
+	if s.keys.O2J.Key == nil {
+		s.fail(&Error{CodeProtocol, "caps before key confirmation"})
+		return
+	}
+	frame, err := b64decode(msg.Frame)
+	if err != nil {
+		s.fail(&Error{CodeBadPeerMessage, "malformed caps"})
+		return
+	}
+	opened, err := wire.Open(s.recvDir(), s.recvCtr, frame)
+	if err != nil {
+		s.fail(&Error{CodeBadPeerMessage, "caps failed to decrypt"})
+		return
+	}
+	s.recvCtr++
+	if opened.Header.Type != wire.FrameCaps {
+		s.fail(&Error{CodeBadPeerMessage, "first frame is not caps"})
+		return
+	}
+	var remote Caps
+	if err := json.Unmarshal(opened.Plaintext, &remote); err != nil {
+		s.fail(&Error{CodeBadPeerMessage, "malformed caps payload"})
+		return
+	}
+	s.succeed(&Result{
+		Role:        s.role,
+		Room:        s.room,
+		Code:        s.code,
+		Master:      s.master,
+		Keys:        s.keys,
+		Spake2:      s.spake2,
+		LocalCaps:   s.localCaps,
+		RemoteCaps:  remote,
+		SendCounter: s.sendCtr,
+		RecvCounter: s.recvCtr,
+	})
+}
+
+// --- helpers (all run under s.mu) -------------------------------------------
+
+func (s *Session) sendDir() wire.DirectionalKey {
+	if s.role == RoleOfferer {
+		return s.keys.O2J
+	}
+	return s.keys.J2O
+}
+
+func (s *Session) recvDir() wire.DirectionalKey {
+	if s.role == RoleOfferer {
+		return s.keys.J2O
+	}
+	return s.keys.O2J
+}
+
+// emit sends an outbound message, failing the session if the transport rejects it. It
+// returns false if the session failed, so callers stop advancing.
+func (s *Session) emit(msg Message) bool {
+	if err := s.sink.Send(msg); err != nil {
+		s.fail(&Error{CodePeerLeft, "send " + msg.Type + ": " + err.Error()})
+		return false
+	}
+	return true
+}
+
+func (s *Session) setPhase(p Phase) {
+	s.phase = p
+	if s.onPhase != nil {
+		s.onPhase(p)
+	}
+}
+
+func (s *Session) fail(err *Error) {
+	if s.settled {
+		return
+	}
+	s.settled = true
+	s.err = err
+	s.setPhase(PhaseFailed)
+	close(s.done)
+}
+
+func (s *Session) succeed(r *Result) {
+	if s.settled {
+		return
+	}
+	s.settled = true
+	s.result = r
+	s.setPhase(PhaseEstablished)
+	close(s.done)
+}
+
+func wordCountOrDefault(n int) int {
+	if n > 0 {
+		return n
+	}
+	return 2 // DEFAULT_WORD_COUNT (constants.ts)
+}
+
+func orDefault(v, fallback string) string {
+	if v != "" {
+		return v
+	}
+	return fallback
+}
+
+// base64url without padding (RFC 4648 §5), matching bytesToBase64url in the TS core.
+func b64encode(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+func b64decode(s string) ([]byte, error) { return base64.RawURLEncoding.DecodeString(s) }

--- a/apps/cli/internal/rendezvous/session_test.go
+++ b/apps/cli/internal/rendezvous/session_test.go
@@ -1,0 +1,277 @@
+package rendezvous
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/sendarc/wire"
+)
+
+// mockHub stands in for the blind signaling server: it allocates a room, pairs the two
+// peers, and forwards pake/confirm/caps verbatim — exactly the envelope the real server
+// sees. Every message handed to it is recorded in seen so a test can assert the word code
+// never crosses it; onForward can tamper with a forwarded frame.
+//
+// Unlike the TypeScript MockHub, delivery is queued rather than synchronous. A Session
+// serializes its transitions under a mutex, so routing a message straight back into a peer
+// that is still inside a handler (e.g. the sealed caps returning to an offerer mid-onConfirm)
+// would deadlock. Instead sinkFor only enqueues; run drains the queue, so every Handle runs
+// outside any session's lock — deterministic and single-goroutine.
+type mockHub struct {
+	offerer   *Session
+	joiner    *Session
+	room      int
+	onForward func(Message) Message
+
+	seen  []Message
+	queue []routed
+}
+
+type routed struct {
+	from Role
+	msg  Message
+}
+
+func newHub(room int) *mockHub {
+	return &mockHub{room: room, onForward: func(m Message) Message { return m }}
+}
+
+func (h *mockHub) sinkFor(role Role) Sink {
+	return SinkFunc(func(m Message) error {
+		h.seen = append(h.seen, m)
+		h.queue = append(h.queue, routed{from: role, msg: m})
+		return nil
+	})
+}
+
+// run drains the queue until both peers are quiet, dispatching each outbound message to its
+// destination the way the server would.
+func (h *mockHub) run() {
+	for len(h.queue) > 0 {
+		r := h.queue[0]
+		h.queue = h.queue[1:]
+		h.dispatch(r.from, r.msg)
+	}
+}
+
+func (h *mockHub) dispatch(from Role, msg Message) {
+	switch msg.Type {
+	case typeCreate:
+		room := h.room
+		h.offerer.Handle(Message{Type: typeCreated, Room: &room})
+	case typeJoin:
+		h.offerer.Handle(Message{Type: typePeerJoined, Role: string(RoleOfferer)})
+		h.joiner.Handle(Message{Type: typePeerJoined, Role: string(RoleJoiner)})
+	default:
+		other := h.joiner
+		if from == RoleJoiner {
+			other = h.offerer
+		}
+		other.Handle(h.onForward(msg))
+	}
+}
+
+// makePair wires an offerer/joiner pair to a hub; the joiner is given code out-of-band.
+func makePair(h *mockHub, code, words string) (offerer, joiner *Session, phases *[]Phase) {
+	seq := &[]Phase{}
+	offerer = New(Options{
+		Role:      RoleOfferer,
+		Transport: h.sinkFor(RoleOfferer),
+		Words:     words,
+		OnPhase:   func(p Phase) { *seq = append(*seq, p) },
+	})
+	joiner = New(Options{
+		Role:      RoleJoiner,
+		Transport: h.sinkFor(RoleJoiner),
+		Code:      code,
+	})
+	h.offerer = offerer
+	h.joiner = joiner
+	return offerer, joiner, seq
+}
+
+func TestSessionReachesSharedKeyAndRoundTripsCaps(t *testing.T) {
+	hub := newHub(0)
+	offerer, joiner, phases := makePair(hub, "0-brave-otter", "brave-otter")
+	offerer.Start()
+	joiner.Start()
+	hub.run()
+
+	ro, err := offerer.Result()
+	if err != nil {
+		t.Fatalf("offerer: %v", err)
+	}
+	rj, err := joiner.Result()
+	if err != nil {
+		t.Fatalf("joiner: %v", err)
+	}
+
+	// Same handshake, same master key and directional keys on both ends.
+	if !bytes.Equal(ro.Master, rj.Master) {
+		t.Error("master keys differ")
+	}
+	if !bytes.Equal(ro.Keys.O2J.Key, rj.Keys.O2J.Key) {
+		t.Error("o2j keys differ")
+	}
+	if !bytes.Equal(ro.Keys.J2O.Key, rj.Keys.J2O.Key) {
+		t.Error("j2o keys differ")
+	}
+
+	if ro.Role != RoleOfferer || rj.Role != RoleJoiner {
+		t.Errorf("roles: offerer=%q joiner=%q", ro.Role, rj.Role)
+	}
+	if ro.Code != "0-brave-otter" || rj.Code != "0-brave-otter" {
+		t.Errorf("codes: offerer=%q joiner=%q", ro.Code, rj.Code)
+	}
+
+	// Each side received the other's caps.
+	if !reflect.DeepEqual(ro.RemoteCaps, rj.LocalCaps) {
+		t.Errorf("offerer remote caps %+v != joiner local caps %+v", ro.RemoteCaps, rj.LocalCaps)
+	}
+	if !reflect.DeepEqual(rj.RemoteCaps, ro.LocalCaps) {
+		t.Errorf("joiner remote caps %+v != offerer local caps %+v", rj.RemoteCaps, ro.LocalCaps)
+	}
+
+	// The caps exchange consumed counter 0 in each direction; the transfer continues at 1.
+	if ro.SendCounter != 1 || ro.RecvCounter != 1 {
+		t.Errorf("offerer counters: send=%d recv=%d, want 1/1", ro.SendCounter, ro.RecvCounter)
+	}
+
+	if got := offerer.Phase(); got != PhaseEstablished {
+		t.Errorf("offerer phase = %q, want established", got)
+	}
+	want := []Phase{
+		PhaseAllocating,
+		PhaseWaiting,
+		PhaseHandshaking,
+		PhaseConfirming,
+		PhaseExchangingCaps,
+		PhaseEstablished,
+	}
+	if !reflect.DeepEqual(*phases, want) {
+		t.Errorf("offerer phases = %v, want %v", *phases, want)
+	}
+}
+
+func TestSessionFailsClosedWhenCodesDisagree(t *testing.T) {
+	hub := newHub(0)
+	// Offerer's words are brave-otter; the joiner types a wrong last word.
+	offerer, joiner, _ := makePair(hub, "0-brave-tiger", "brave-otter")
+	offerer.Start()
+	joiner.Start()
+	hub.run()
+
+	assertFailsWith(t, "offerer", offerer, CodeConfirmationFailed)
+	assertFailsWith(t, "joiner", joiner, CodeConfirmationFailed)
+	if got := offerer.Phase(); got != PhaseFailed {
+		t.Errorf("offerer phase = %q, want failed", got)
+	}
+}
+
+func TestSessionRejectsTamperedCapsFrame(t *testing.T) {
+	// Corrupt every forwarded caps frame so both peers' opens fail.
+	hub := newHub(0)
+	hub.onForward = func(m Message) Message {
+		if m.Type != typeCaps {
+			return m
+		}
+		raw, err := b64decode(m.Frame)
+		if err != nil {
+			t.Fatalf("decode caps frame: %v", err)
+		}
+		raw[len(raw)-1] ^= 0xff // flip a tag byte
+		m.Frame = b64encode(raw)
+		return m
+	}
+	offerer, joiner, _ := makePair(hub, "0-brave-otter", "brave-otter")
+	offerer.Start()
+	joiner.Start()
+	hub.run()
+
+	assertFailsWith(t, "offerer", offerer, CodeBadPeerMessage)
+	assertFailsWith(t, "joiner", joiner, CodeBadPeerMessage)
+}
+
+func TestSessionNeverLeaksWordCode(t *testing.T) {
+	hub := newHub(0)
+	offerer, joiner, _ := makePair(hub, "0-brave-otter", "brave-otter")
+	offerer.Start()
+	joiner.Start()
+	hub.run()
+
+	if _, err := offerer.Result(); err != nil {
+		t.Fatalf("offerer: %v", err)
+	}
+	if _, err := joiner.Result(); err != nil {
+		t.Fatalf("joiner: %v", err)
+	}
+
+	allowed := map[string]bool{
+		typeCreate: true, typeJoin: true, typePake: true,
+		typeConfirm: true, typeCaps: true, typeBye: true,
+	}
+	for _, m := range hub.seen {
+		if !allowed[m.Type] {
+			t.Errorf("server saw disallowed message type %q", m.Type)
+		}
+		enc, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal seen message: %v", err)
+		}
+		for _, leak := range []string{"brave", "otter", "words", "code"} {
+			if strings.Contains(string(enc), leak) {
+				t.Errorf("message %q leaked %q: %s", m.Type, leak, enc)
+			}
+		}
+	}
+}
+
+func assertFailsWith(t *testing.T, who string, s *Session, code string) {
+	t.Helper()
+	_, err := s.Result()
+	if err == nil {
+		t.Fatalf("%s: expected failure %q, got success", who, code)
+	}
+	var re *Error
+	if !errorsAs(err, &re) {
+		t.Fatalf("%s: error %v is not a *rendezvous.Error", who, err)
+	}
+	if re.Code != code {
+		t.Errorf("%s: code = %q, want %q", who, re.Code, code)
+	}
+}
+
+// errorsAs is a tiny local errors.As so the test needs no extra import beyond the ones it
+// already uses; the session only ever settles with a *Error.
+func errorsAs(err error, target **Error) bool {
+	re, ok := err.(*Error)
+	if ok {
+		*target = re
+	}
+	return ok
+}
+
+// Guard: the caps payload the session seals must be valid JSON for wire.FrameCaps, so a
+// browser peer can parse it. This mirrors DefaultCaps round-tripping through encoding/json.
+func TestDefaultCapsJSONShape(t *testing.T) {
+	enc, err := json.Marshal(DefaultCaps())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(enc, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["version"] != wire.ProtocolVersion {
+		t.Errorf("version = %v, want %q", got["version"], wire.ProtocolVersion)
+	}
+	// features/sinkHints must serialize as arrays, never null.
+	for _, k := range []string{"features", "sinkHints"} {
+		if _, ok := got[k].([]any); !ok {
+			t.Errorf("%s = %v (%T), want a JSON array", k, got[k], got[k])
+		}
+	}
+}

--- a/go.work
+++ b/go.work
@@ -1,6 +1,7 @@
-go 1.26.5
+go 1.24.0
 
 use (
+	./apps/cli
 	./apps/server
 	./packages/wire
 )

--- a/packages/wire/go.mod
+++ b/packages/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/sendarc/wire
 
-go 1.26.5
+go 1.24.0
 
 require filippo.io/nistec v0.0.4
 


### PR DESCRIPTION
Add the terminal client's half of the M1 handshake: a transport-agnostic
rendezvous Session that a CLI peer drives over the same blind signaling
channel a browser peer uses. It speaks the identical envelope
(create/join, pake, confirm, AEAD-sealed caps) and derives the same
master key and directional transfer keys, so a CLI and a browser can pair
through one server.

The machine is a synchronous, mutex-serialized mirror of
RendezvousSession in @sendarc/protocol: outbound messages go to an
injected Sink, inbound ones arrive via Handle, and Result blocks until
the handshake settles. Because transitions hold a lock, the test hub
forwards through a FIFO queue drained outside every session, so delivery
never re-enters a peer mid-handler.

Tests wire two sessions mouth-to-ear and cover the happy path (shared
keys, caps round-trip, counter continuity), fail-closed key confirmation
on a wrong code, tampered-caps rejection at the GCM check, and that the
word code never reaches the server.

The module joins the workspace with a local replace on the wire core so
it also builds standalone, the way CI runs each module. Pin wire and the
CLI to go 1.24 to match the server module and the CI toolchain.