### PR TITLE
feat(cli): sendarc send/receive over the signaling WebSocket

### DIFF
--- a/apps/cli/cmd/sendarc/main.go
+++ b/apps/cli/cmd/sendarc/main.go
@@ -1,0 +1,243 @@
+// Command sendarc is the terminal client for a SendArc transfer. It drives one M1
+// rendezvous over the blind signaling server:
+//
+//	sendarc send            # allocate a room, print the invite code + link, wait
+//	sendarc receive <code>  # join with a code (or a pasted invite link)
+//
+// Both ends run SPAKE2 over the invite code, confirm the key (failing closed on a
+// mismatch), and exchange sealed capabilities — the point where the M2 encrypted file
+// transfer will begin. The word half of the code never reaches the server.
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/sendarc/cli/internal/rendezvous"
+	"github.com/sendarc/cli/internal/wsclient"
+)
+
+const defaultServer = "wss://localhost:8443/ws"
+
+func main() {
+	if len(os.Args) < 2 {
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "send":
+		os.Exit(runSend(os.Args[2:]))
+	case "receive", "recv":
+		os.Exit(runReceive(os.Args[2:]))
+	case "-h", "--help", "help":
+		usage(os.Stdout)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "sendarc: unknown command %q\n\n", os.Args[1])
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func usage(w *os.File) {
+	fmt.Fprint(w, `sendarc — secure peer-to-peer file transfer
+
+Usage:
+  sendarc send [flags]
+  sendarc receive <code|link> [flags]
+
+Flags:
+  --server URL             signaling server (default `+defaultServer+`)
+  --insecure-skip-verify   skip TLS verification; self-signed dev certs only
+  --words N                number of words in the invite code (send only; 0 = default)
+`)
+}
+
+func runSend(args []string) int {
+	fs := flag.NewFlagSet("send", flag.ExitOnError)
+	server := fs.String("server", defaultServer, "signaling server URL")
+	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
+	words := fs.Int("words", 0, "number of words in the invite code (0 = default)")
+	parseArgs(fs, args)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Fprintf(os.Stderr, "Connecting to %s …\n", *server)
+	res, err := wsclient.Rendezvous(ctx, *server, wsclient.DialOptions{InsecureSkipVerify: *insecure},
+		rendezvous.Options{
+			Role:      rendezvous.RoleOfferer,
+			WordCount: *words,
+			OnCode: func(code string) {
+				fmt.Println()
+				fmt.Printf("  Invite code:  %s\n", code)
+				if link := inviteLink(*server, code); link != "" {
+					fmt.Printf("  Invite link:  %s\n", link)
+				}
+				fmt.Println()
+			},
+			OnPhase: phasePrinter(rendezvous.RoleOfferer),
+		})
+	return report("receiver", res, err)
+}
+
+func runReceive(args []string) int {
+	fs := flag.NewFlagSet("receive", flag.ExitOnError)
+	server := fs.String("server", defaultServer, "signaling server URL")
+	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
+	positionals := parseArgs(fs, args)
+
+	code := ""
+	if len(positionals) > 0 {
+		code = normalizeCodeArg(positionals[0])
+	}
+	if code == "" {
+		fmt.Fprintln(os.Stderr, "sendarc receive: an invite code (or link) is required")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Fprintf(os.Stderr, "Connecting to %s …\n", *server)
+	fmt.Fprintf(os.Stderr, "Joining %s …\n", code)
+	res, err := wsclient.Rendezvous(ctx, *server, wsclient.DialOptions{InsecureSkipVerify: *insecure},
+		rendezvous.Options{
+			Role:    rendezvous.RoleJoiner,
+			Code:    code,
+			OnPhase: phasePrinter(rendezvous.RoleJoiner),
+		})
+	return report("sender", res, err)
+}
+
+// parseArgs parses flags that may appear before or after positional arguments. Go's flag
+// package stops at the first non-flag token, so `receive <code> --server X` would otherwise
+// silently ignore --server; this re-parses past each positional and returns the collected
+// positionals in order.
+func parseArgs(fs *flag.FlagSet, args []string) []string {
+	var positionals []string
+	for {
+		_ = fs.Parse(args)
+		if fs.NArg() == 0 {
+			break
+		}
+		positionals = append(positionals, fs.Arg(0))
+		args = fs.Args()[1:]
+	}
+	return positionals
+}
+
+// phasePrinter surfaces the two transitions worth a human's attention — waiting for the
+// peer (offerer only) and the start of the key handshake — and stays quiet for the rest so
+// the output reads as progress, not a state-machine trace.
+func phasePrinter(role rendezvous.Role) func(rendezvous.Phase) {
+	return func(p rendezvous.Phase) {
+		switch p {
+		case rendezvous.PhaseWaiting:
+			if role == rendezvous.RoleOfferer {
+				fmt.Fprintln(os.Stderr, "Waiting for the receiver to join …")
+			}
+		case rendezvous.PhaseHandshaking:
+			fmt.Fprintln(os.Stderr, "Establishing a secure channel …")
+		}
+	}
+}
+
+// report prints the outcome and returns the process exit code. peer names the other side
+// for the success line ("receiver" for a sender, "sender" for a receiver).
+func report(peer string, res *rendezvous.Result, err error) int {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nFailed: %s\n", handshakeError(err))
+		return 1
+	}
+	fmt.Printf("\n✓ Secure channel established with the %s.\n", peer)
+	fmt.Printf("  Fingerprint:  %s\n", fingerprint(res.Master))
+	fmt.Printf("  Peer:         %s\n", describeCaps(res.RemoteCaps))
+	fmt.Fprintln(os.Stderr, "\nBoth sides should see the same fingerprint. File transfer arrives in the next milestone.")
+	return 0
+}
+
+// handshakeError renders a rendezvous failure as a human-readable line, translating the
+// stable codes into plain guidance where it helps.
+func handshakeError(err error) string {
+	var re *rendezvous.Error
+	if errorsAs(err, &re) {
+		switch re.Code {
+		case rendezvous.CodeConfirmationFailed:
+			return "the invite codes did not match — double-check the code and try again"
+		case rendezvous.CodePeerLeft:
+			return "the other side disconnected"
+		case rendezvous.CodeAborted:
+			return "cancelled"
+		}
+		return re.Msg
+	}
+	return err.Error()
+}
+
+func errorsAs(err error, target **rendezvous.Error) bool {
+	re, ok := err.(*rendezvous.Error)
+	if ok {
+		*target = re
+	}
+	return ok
+}
+
+// fingerprint is a short authentication string derived from the master key: a hash (so no
+// raw key bytes are exposed) truncated to 32 bits and shown as two hex groups. Both peers
+// derive the same value, giving the humans an out-of-band check on top of SPAKE2.
+func fingerprint(master []byte) string {
+	sum := sha256.Sum256(append([]byte("sendarc/sas\x00"), master...))
+	return fmt.Sprintf("%02x%02x %02x%02x", sum[0], sum[1], sum[2], sum[3])
+}
+
+func describeCaps(c rendezvous.Caps) string {
+	return fmt.Sprintf("%s (frame %s, block %s)", c.Version, humanBytes(c.MaxFrame), humanBytes(c.BlockSize))
+}
+
+func humanBytes(n int) string {
+	switch {
+	case n >= 1<<20 && n%(1<<20) == 0:
+		return fmt.Sprintf("%d MiB", n>>20)
+	case n >= 1<<10 && n%(1<<10) == 0:
+		return fmt.Sprintf("%d KiB", n>>10)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+// inviteLink turns the signaling URL into the web app's join link for the same deployment:
+// wss/ws → https/http, drop the /ws path, and carry the code in the fragment so it never
+// hits the server. Returns "" if the server URL cannot be parsed.
+func inviteLink(serverURL, code string) string {
+	u, err := url.Parse(serverURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	switch u.Scheme {
+	case "wss":
+		u.Scheme = "https"
+	case "ws":
+		u.Scheme = "http"
+	}
+	u.Path = "/"
+	u.RawQuery = ""
+	u.Fragment = code
+	return u.String()
+}
+
+// normalizeCodeArg accepts either a bare code or a full invite link and returns the code.
+func normalizeCodeArg(arg string) string {
+	arg = strings.TrimSpace(arg)
+	if i := strings.LastIndex(arg, "#"); i >= 0 {
+		return arg[i+1:]
+	}
+	return arg
+}

--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -2,7 +2,10 @@ module github.com/sendarc/cli
 
 go 1.24.0
 
-require github.com/sendarc/wire v0.0.0
+require (
+	github.com/coder/websocket v1.8.15
+	github.com/sendarc/wire v0.0.0
+)
 
 require (
 	filippo.io/nistec v0.0.4 // indirect

--- a/apps/cli/go.sum
+++ b/apps/cli/go.sum
@@ -1,4 +1,6 @@
 filippo.io/nistec v0.0.4 h1:F14ZHT5htWlMnQVPndX9ro9arf56cBhQxq4LnDI491s=
 filippo.io/nistec v0.0.4/go.mod h1:PK/lw8I1gQT4hUML4QGaqljwdDaFcMyFKSXN7kjrtKI=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/apps/cli/internal/wsclient/client.go
+++ b/apps/cli/internal/wsclient/client.go
@@ -1,0 +1,195 @@
+// Package wsclient binds a rendezvous.Session to the SendArc signaling server over a
+// WebSocket. It is the CLI's counterpart to the browser's SignalingClient +
+// rendezvous orchestrator (apps/web/src/lib/signaling, .../session): it dials the
+// server, JSON-encodes the session's outbound messages as text frames, decodes inbound
+// frames back into rendezvous.Message, and drives one handshake to completion.
+//
+// As in the browser, reconnection is limited to the initial connect. Once the socket is
+// open the server holds this session's room on this connection; a drop tears the room
+// down and notifies the peer with bye, so a fresh socket cannot resume it (recovery under
+// the same code is deferred to M6). A post-open drop is surfaced as a terminal failure.
+package wsclient
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sendarc/cli/internal/rendezvous"
+)
+
+const (
+	// writeTimeout bounds a single frame write. Rendezvous frames are tiny, so a write
+	// that cannot complete in this window means the socket is wedged.
+	writeTimeout = 10 * time.Second
+	// readLimit caps a single inbound frame. Server control frames and relayed caps are
+	// small; this guards against a rogue server streaming unbounded data at the client.
+	readLimit = 1 << 20
+)
+
+// BackoffOptions is the schedule for retrying the initial connect. Delays are
+// base * factor^n, capped at max, with up to jitter extra to avoid synchronized retries.
+type BackoffOptions struct {
+	Retries int
+	Base    time.Duration
+	Max     time.Duration
+	Factor  float64
+	Jitter  float64
+}
+
+// DefaultBackoff mirrors the browser client's schedule (client.ts DEFAULT_BACKOFF).
+var DefaultBackoff = BackoffOptions{
+	Retries: 5,
+	Base:    250 * time.Millisecond,
+	Max:     4 * time.Second,
+	Factor:  2,
+	Jitter:  0.25,
+}
+
+// DialOptions configures how the client connects.
+type DialOptions struct {
+	// InsecureSkipVerify disables TLS certificate verification. It is meant for a
+	// self-signed development certificate (e.g. mkcert) and must not be used otherwise.
+	InsecureSkipVerify bool
+	// Backoff overrides the initial-connect retry schedule. The zero value uses
+	// DefaultBackoff.
+	Backoff BackoffOptions
+}
+
+// Client is a live signaling connection. It implements rendezvous.Sink, writing each
+// message as a WebSocket text frame. All writes happen on the goroutine that drives the
+// session (Start plus the Run read loop), so there is never more than one concurrent
+// writer; Close is the only method safe to call from another goroutine.
+type Client struct {
+	ws        *websocket.Conn
+	closeOnce sync.Once
+}
+
+// Dial connects to the signaling endpoint at url, retrying the initial connect with
+// backoff so a briefly-unreachable server (cold start, flaky network) does not fail the
+// session before it begins.
+func Dial(ctx context.Context, url string, opts DialOptions) (*Client, error) {
+	b := opts.Backoff
+	if b == (BackoffOptions{}) {
+		b = DefaultBackoff
+	}
+
+	dialOpts := &websocket.DialOptions{}
+	if opts.InsecureSkipVerify {
+		dialOpts.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // opt-in dev flag
+			},
+		}
+	}
+
+	var lastErr error
+	for n := 0; ; n++ {
+		ws, _, err := websocket.Dial(ctx, url, dialOpts)
+		if err == nil {
+			ws.SetReadLimit(readLimit)
+			return &Client{ws: ws}, nil
+		}
+		lastErr = err
+		if n >= b.Retries || ctx.Err() != nil {
+			return nil, fmt.Errorf("wsclient: connect to %s failed after %d attempt(s): %w", url, n+1, lastErr)
+		}
+		select {
+		case <-time.After(backoffDelay(b, n)):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func backoffDelay(b BackoffOptions, n int) time.Duration {
+	d := float64(b.Base)
+	for i := 0; i < n; i++ {
+		d *= b.Factor
+	}
+	if d > float64(b.Max) {
+		d = float64(b.Max)
+	}
+	return time.Duration(d * (1 + rand.Float64()*b.Jitter))
+}
+
+// Send writes one signaling message as a text frame, satisfying rendezvous.Sink.
+func (c *Client) Send(m rendezvous.Message) error {
+	data, err := rendezvous.MarshalMessage(m)
+	if err != nil {
+		return err
+	}
+	// A dedicated timeout context (not the session's) so a farewell bye written during
+	// cancellation still gets a chance to flush.
+	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
+	defer cancel()
+	return c.ws.Write(ctx, websocket.MessageText, data)
+}
+
+// Run reads inbound frames and dispatches each to onMessage until the socket closes or
+// ctx is cancelled, then returns the terminating error. Closing the socket (Close) is the
+// clean way to stop it.
+func (c *Client) Run(ctx context.Context, onMessage func(rendezvous.Message)) error {
+	for {
+		typ, data, err := c.ws.Read(ctx)
+		if err != nil {
+			return err
+		}
+		if typ != websocket.MessageText {
+			return errors.New("wsclient: expected a text frame")
+		}
+		msg, err := rendezvous.UnmarshalMessage(data)
+		if err != nil {
+			return fmt.Errorf("wsclient: malformed frame: %w", err)
+		}
+		onMessage(msg)
+	}
+}
+
+// Close closes the socket. It is idempotent and safe to call from any goroutine, so it can
+// unblock Run from a watcher when the session settles.
+func (c *Client) Close() {
+	c.closeOnce.Do(func() {
+		_ = c.ws.Close(websocket.StatusNormalClosure, "")
+	})
+}
+
+// Rendezvous dials the server and drives one handshake to completion: it wires the session
+// to the socket, starts it, pumps inbound frames, and returns the session result. sopts
+// carries the role and its inputs; its Transport is set here and any provided value is
+// ignored.
+func Rendezvous(ctx context.Context, url string, dopts DialOptions, sopts rendezvous.Options) (*rendezvous.Result, error) {
+	client, err := Dial(ctx, url, dopts)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	sopts.Transport = client
+	sess := rendezvous.New(sopts)
+
+	// Close the socket once the handshake settles, so the read loop below unblocks.
+	go func() {
+		<-sess.Done()
+		client.Close()
+	}()
+
+	sess.Start()
+	if err := client.Run(ctx, sess.Handle); err != nil {
+		// The read loop ended. If we were cancelled (Ctrl-C), abort with a best-effort
+		// bye; otherwise the socket dropped mid-handshake — fail closed. Either is a
+		// no-op if the session already settled (the normal close from the watcher).
+		if ctx.Err() != nil {
+			sess.Abort("cancelled")
+		} else {
+			sess.Fail(err)
+		}
+	}
+	return sess.Result()
+}

--- a/apps/cli/internal/wsclient/client_test.go
+++ b/apps/cli/internal/wsclient/client_test.go
@@ -1,0 +1,218 @@
+package wsclient_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sendarc/cli/internal/rendezvous"
+	"github.com/sendarc/cli/internal/wsclient"
+)
+
+// blindHub is a minimal stand-in for the SendArc signaling server, enough to drive one
+// two-peer handshake over a real WebSocket. It allocates a room on create, pairs the peers
+// on join, and forwards every subsequent frame to the other peer verbatim — it never parses
+// pake/confirm/caps, mirroring the real server's blindness. It exists so this package can be
+// tested against a live socket without importing the server module.
+type blindHub struct {
+	mu    sync.Mutex
+	rooms map[int]*hubRoom
+	next  int
+}
+
+type hubRoom struct {
+	offerer, joiner *hubPeer
+}
+
+// hubPeer serializes writes to one connection, since both the peer's own read loop (control
+// replies) and the other peer's read loop (forwarded frames) may target it.
+type hubPeer struct {
+	conn *websocket.Conn
+	wmu  sync.Mutex
+}
+
+func (p *hubPeer) send(ctx context.Context, m rendezvous.Message) {
+	data, err := rendezvous.MarshalMessage(m)
+	if err != nil {
+		return
+	}
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	_ = p.conn.Write(ctx, websocket.MessageText, data)
+}
+
+func (p *hubPeer) forward(ctx context.Context, data []byte) {
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	_ = p.conn.Write(ctx, websocket.MessageText, data)
+}
+
+func newBlindHub() *blindHub { return &blindHub{rooms: map[int]*hubRoom{}} }
+
+func (h *blindHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.CloseNow()
+	ctx := r.Context()
+	self := &hubPeer{conn: conn}
+
+	var room *hubRoom
+	var role rendezvous.Role
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		if typ != websocket.MessageText {
+			return
+		}
+		msg, err := rendezvous.UnmarshalMessage(data)
+		if err != nil {
+			return
+		}
+
+		switch msg.Type {
+		case "create":
+			h.mu.Lock()
+			id := h.next
+			h.next++
+			room = &hubRoom{offerer: self}
+			h.rooms[id] = room
+			h.mu.Unlock()
+			role = rendezvous.RoleOfferer
+			self.send(ctx, rendezvous.Message{Type: "created", Room: &id})
+
+		case "join":
+			if msg.Room == nil {
+				return
+			}
+			h.mu.Lock()
+			room = h.rooms[*msg.Room]
+			h.mu.Unlock()
+			if room == nil {
+				return
+			}
+			room.joiner = self
+			role = rendezvous.RoleJoiner
+			self.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(rendezvous.RoleJoiner)})
+			room.offerer.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(rendezvous.RoleOfferer)})
+
+		default:
+			// Blind forward to the other end of the room.
+			other := room.joiner
+			if role == rendezvous.RoleJoiner {
+				other = room.offerer
+			}
+			if other != nil {
+				other.forward(ctx, data)
+			}
+		}
+	}
+}
+
+// wsURL rewrites an httptest TLS server URL (https://…) to its wss:// equivalent.
+func wsURL(httpsURL string) string {
+	return "wss" + strings.TrimPrefix(httpsURL, "https")
+}
+
+func TestRendezvousOverWebSocket(t *testing.T) {
+	srv := httptest.NewTLSServer(newBlindHub())
+	defer srv.Close()
+	url := wsURL(srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// The offerer generates the code; the joiner can only start once it is known — exactly
+	// the human hand-off (read the code off one screen, type it into the other).
+	codeCh := make(chan string, 1)
+	dopts := wsclient.DialOptions{InsecureSkipVerify: true}
+
+	var (
+		offRes, joinRes *rendezvous.Result
+		offErr, joinErr error
+		wg              sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		offRes, offErr = wsclient.Rendezvous(ctx, url, dopts, rendezvous.Options{
+			Role:   rendezvous.RoleOfferer,
+			Words:  "brave-otter",
+			OnCode: func(c string) { codeCh <- c },
+		})
+	}()
+
+	select {
+	case code := <-codeCh:
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			joinRes, joinErr = wsclient.Rendezvous(ctx, url, dopts, rendezvous.Options{
+				Role: rendezvous.RoleJoiner,
+				Code: code,
+			})
+		}()
+	case <-ctx.Done():
+		t.Fatal("offerer never produced a code")
+	}
+
+	wg.Wait()
+
+	if offErr != nil {
+		t.Fatalf("offerer: %v", offErr)
+	}
+	if joinErr != nil {
+		t.Fatalf("joiner: %v", joinErr)
+	}
+
+	if !bytes.Equal(offRes.Master, joinRes.Master) {
+		t.Error("master keys differ across the socket")
+	}
+	if !bytes.Equal(offRes.Keys.O2J.Key, joinRes.Keys.O2J.Key) ||
+		!bytes.Equal(offRes.Keys.J2O.Key, joinRes.Keys.J2O.Key) {
+		t.Error("directional transfer keys differ across the socket")
+	}
+	if offRes.Code != "0-brave-otter" || joinRes.Code != "0-brave-otter" {
+		t.Errorf("codes: offerer=%q joiner=%q, want 0-brave-otter", offRes.Code, joinRes.Code)
+	}
+	if !reflect.DeepEqual(offRes.RemoteCaps, joinRes.LocalCaps) ||
+		!reflect.DeepEqual(joinRes.RemoteCaps, offRes.LocalCaps) {
+		t.Error("caps did not round-trip across the socket")
+	}
+}
+
+// A connect against a dead address must exhaust the (shortened) backoff and return an error
+// rather than blocking forever.
+func TestDialFailsAfterBackoff(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := wsclient.Dial(ctx, "ws://127.0.0.1:1", wsclient.DialOptions{
+		Backoff: wsclient.BackoffOptions{Retries: 1, Base: time.Millisecond, Max: time.Millisecond, Factor: 2},
+	})
+	if err == nil {
+		t.Fatal("expected a dial error against a closed port")
+	}
+}
+
+// The invite code exchanged out-of-band must be parseable back into its parts, so a joiner
+// started from a copied code targets the same room. (Sanity check on the code the hub sees.)
+func TestJoinerCodeIsWellFormed(t *testing.T) {
+	var m rendezvous.Message
+	if err := json.Unmarshal([]byte(`{"type":"join","room":7}`), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.Type != "join" || m.Room == nil || *m.Room != 7 {
+		t.Errorf("join envelope = %+v", m)
+	}
+}


### PR DESCRIPTION
Add the transport and command layer that turns the rendezvous state
machine into a working terminal client, completing the M1 CLI path.

internal/wsclient binds a Session to a coder/websocket connection: it
dials with initial-connect backoff (mirroring the browser client),
encodes outbound messages as text frames, decodes inbound ones back
into the signaling envelope, and drives one handshake to completion.
Writes stay on the single goroutine that runs the session; a watcher
closes the socket once the handshake settles so the read loop unwinds.
Reconnection is limited to the initial connect, matching the server's
one-room-per-connection model.

cmd/sendarc exposes `send` and `receive <code|link>`: the sender prints
the invite code and the equivalent web link (code carried in the URL
fragment, never sent to the server) and waits; the receiver joins by
code or pasted link. Both report a short master-key fingerprint so the
two humans can compare out of band, and a code mismatch fails closed
with a plain-language message. Flags are accepted on either side of the
positional argument.

Tested end to end against the real server over a plain ws:// port: both
peers derive the same fingerprint and exchange caps, the server log
shows only room numbers, and a wrong word fails closed on both ends.