### PR TITLE
feat(web): send/receive screens over the rendezvous handshake

### DIFF
--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -1,24 +1,188 @@
 <script lang="ts">
-  import { PROTOCOL_VERSION } from '@sendarc/protocol';
+  import type { CapsPayload, RendezvousPhase } from '@sendarc/protocol';
+  import { RendezvousError } from '@sendarc/protocol';
 
-  // M0 hello route: proves the toolchain, the workspace import of @sendarc/protocol,
-  // and secure-context APIs are wired. Real send/receive screens arrive in M1.
-  const secureContext = typeof window !== 'undefined' && window.isSecureContext;
-  const hasWebCrypto = typeof crypto !== 'undefined' && 'subtle' in crypto;
+  import { offer, join, type RendezvousController } from './lib/session/rendezvous.js';
+  import {
+    codeFromHash,
+    describeCaps,
+    describeError,
+    inviteLinkFor,
+    phaseLabel,
+    sasFingerprint,
+    type ErrorLike,
+  } from './lib/session/present.js';
+
+  type Screen = 'home' | 'sending' | 'receiving' | 'done' | 'failed';
+
+  let screen = $state<Screen>('home');
+  let phase = $state<RendezvousPhase>('idle');
+  let code = $state('');
+  let link = $state('');
+  let codeInput = $state(readHashCode());
+  let copied = $state(false);
+  let fingerprint = $state('');
+  let peerCaps = $state<CapsPayload | undefined>(undefined);
+  let errorText = $state('');
+
+  let controller: RendezvousController | undefined;
+  let copyTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function readHashCode(): string {
+    return typeof window === 'undefined' ? '' : codeFromHash(window.location.hash);
+  }
+
+  function startSend() {
+    reset();
+    screen = 'sending';
+    track(
+      offer({
+        onPhase: (p) => (phase = p),
+        onCode: (c) => {
+          code = c;
+          link = typeof window === 'undefined' ? '' : inviteLinkFor(window.location.href, c);
+        },
+      }),
+    );
+  }
+
+  function startReceive() {
+    const trimmed = codeInput.trim();
+    if (trimmed === '') return;
+    reset();
+    screen = 'receiving';
+    track(
+      join({
+        code: trimmed,
+        onPhase: (p) => (phase = p),
+      }),
+    );
+  }
+
+  // Bind a controller's terminal outcome to the success/failure screens. The `done` promise
+  // settles exactly once — either the peers confirmed the same key (show the fingerprint) or
+  // the handshake failed closed (show why).
+  function track(ctrl: RendezvousController) {
+    controller = ctrl;
+    ctrl.done.then(
+      async (res) => {
+        if (controller !== ctrl) return; // superseded by a restart
+        fingerprint = await sasFingerprint(res.master);
+        peerCaps = res.remoteCaps;
+        screen = 'done';
+      },
+      (err: unknown) => {
+        if (controller !== ctrl) return;
+        errorText = describeError(asErrorLike(err));
+        screen = 'failed';
+      },
+    );
+  }
+
+  function asErrorLike(err: unknown): ErrorLike {
+    if (err instanceof RendezvousError) return { code: err.code, message: err.message };
+    return { code: 'unknown', message: err instanceof Error ? err.message : String(err) };
+  }
+
+  async function copy(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+      clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => (copied = false), 1500);
+    } catch {
+      // Clipboard blocked (permission/insecure context): the code stays on screen to copy by hand.
+    }
+  }
+
+  /** Tear down any in-flight rendezvous and clear the transient handshake state. */
+  function reset() {
+    controller?.cancel();
+    controller = undefined;
+    phase = 'idle';
+    code = '';
+    link = '';
+    copied = false;
+    fingerprint = '';
+    peerCaps = undefined;
+    errorText = '';
+  }
+
+  function backHome() {
+    reset();
+    screen = 'home';
+  }
 </script>
 
 <main>
-  <h1>SendArc</h1>
-  <p>Secure, end-to-end-encrypted, peer-to-peer file transfer.</p>
-  <dl>
-    <dt>Protocol</dt>
-    <dd>{PROTOCOL_VERSION}</dd>
-    <dt>Secure context</dt>
-    <dd>{secureContext ? 'yes' : 'no'}</dd>
-    <dt>WebCrypto</dt>
-    <dd>{hasWebCrypto ? 'available' : 'missing'}</dd>
-  </dl>
-  <p class="hint">M0 foundation — the transfer UI lands in M1.</p>
+  <header>
+    <h1>SendArc</h1>
+    <p class="tagline">Secure, end-to-end-encrypted, peer-to-peer file transfer.</p>
+  </header>
+
+  {#if screen === 'home'}
+    <section class="choices">
+      <button class="primary" onclick={startSend}>Send a file</button>
+
+      <form
+        class="receive"
+        onsubmit={(e) => {
+          e.preventDefault();
+          startReceive();
+        }}
+      >
+        <label for="code">Have an invite code?</label>
+        <div class="row">
+          <input
+            id="code"
+            type="text"
+            placeholder="e.g. 4-brave-otter"
+            autocomplete="off"
+            spellcheck="false"
+            bind:value={codeInput}
+          />
+          <button type="submit" disabled={codeInput.trim() === ''}>Receive</button>
+        </div>
+      </form>
+    </section>
+  {:else if screen === 'sending'}
+    <section class="progress">
+      {#if code}
+        <p class="lead">Share this code with the person receiving the file:</p>
+        <div class="code-card">
+          <span class="code">{code}</span>
+          <button class="copy" onclick={() => copy(code)}>{copied ? 'Copied' : 'Copy'}</button>
+        </div>
+        {#if link}
+          <button class="link" onclick={() => copy(link)} title="Copy invite link">{link}</button>
+        {/if}
+      {/if}
+      <p class="status" aria-live="polite">{phaseLabel(phase)}</p>
+      <button class="ghost" onclick={backHome}>Cancel</button>
+    </section>
+  {:else if screen === 'receiving'}
+    <section class="progress">
+      <p class="status" aria-live="polite">{phaseLabel(phase)}</p>
+      <button class="ghost" onclick={backHome}>Cancel</button>
+    </section>
+  {:else if screen === 'done'}
+    <section class="result ok">
+      <h2>✓ Secure channel established</h2>
+      <p>Compare this fingerprint with the other side — it must match on both screens.</p>
+      <p class="fingerprint">{fingerprint}</p>
+      {#if peerCaps}
+        <p class="caps">Peer: {describeCaps(peerCaps)}</p>
+      {/if}
+      <p class="hint">File transfer arrives in the next milestone.</p>
+      <button class="primary" onclick={backHome}>Start over</button>
+    </section>
+  {:else if screen === 'failed'}
+    <section class="result bad">
+      <h2>Connection failed</h2>
+      <p>{errorText}</p>
+      <button class="primary" onclick={backHome}>Try again</button>
+    </section>
+  {/if}
 </main>
 
 <style>
@@ -31,21 +195,148 @@
       -apple-system,
       sans-serif;
     line-height: 1.5;
+    color: #1a1a1a;
+  }
+  header {
+    margin-bottom: 2rem;
   }
   h1 {
-    margin-bottom: 0.25rem;
+    margin: 0 0 0.25rem;
   }
-  dl {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 0.25rem 1rem;
-    margin: 1.5rem 0;
+  .tagline {
+    margin: 0;
+    color: #666;
   }
-  dt {
+
+  .choices {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+  .receive {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .receive label {
     font-weight: 600;
   }
-  .hint {
-    color: #666;
+  .row {
+    display: flex;
+    gap: 0.5rem;
+  }
+  input {
+    flex: 1;
+    padding: 0.6rem 0.75rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 0.5rem;
+  }
+  input:focus {
+    outline: 2px solid #3b5bdb;
+    outline-offset: 1px;
+    border-color: transparent;
+  }
+
+  button {
+    font: inherit;
+    cursor: pointer;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    padding: 0.6rem 1rem;
+  }
+  button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .primary {
+    background: #3b5bdb;
+    color: #fff;
+    font-weight: 600;
+  }
+  .primary:hover:not(:disabled) {
+    background: #364fc7;
+  }
+  .ghost {
+    background: none;
+    border-color: #ccc;
+    color: #555;
+  }
+  .ghost:hover {
+    background: #f1f3f5;
+  }
+
+  .progress,
+  .result {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+  .lead {
+    margin: 0;
+  }
+  .code-card {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+  }
+  .code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 1.4rem;
+    letter-spacing: 0.02em;
+  }
+  .copy {
+    background: #e7eaf6;
+    color: #3b5bdb;
+    font-weight: 600;
+  }
+  .link {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #3b5bdb;
+    font-size: 0.85rem;
+    text-align: left;
+    word-break: break-all;
+    text-decoration: underline;
+  }
+  .status {
+    color: #555;
+    margin: 0;
+  }
+
+  .result h2 {
+    margin: 0;
+  }
+  .fingerprint {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 1.6rem;
+    letter-spacing: 0.08em;
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem;
+    margin: 0;
+  }
+  .ok h2 {
+    color: #2b8a3e;
+  }
+  .bad h2 {
+    color: #c92a2a;
+  }
+  .caps {
+    color: #555;
     font-size: 0.9rem;
+    margin: 0;
+  }
+  .hint {
+    color: #868e96;
+    font-size: 0.85rem;
+    margin: 0;
   }
 </style>

--- a/apps/web/src/lib/session/present.test.ts
+++ b/apps/web/src/lib/session/present.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  codeFromHash,
+  describeCaps,
+  describeError,
+  humanBytes,
+  inviteLinkFor,
+  phaseLabel,
+  sasFingerprint,
+} from './present.js';
+
+describe('sasFingerprint', () => {
+  it('matches the canonical cross-implementation vector', async () => {
+    // master = 0,1,…,31. The Go CLI and a Python reference both derive "7948 2d83"; the
+    // browser must agree, since the two humans read this value to each other out of band.
+    const master = Uint8Array.from({ length: 32 }, (_, i) => i);
+    expect(await sasFingerprint(master)).toBe('7948 2d83');
+  });
+
+  it('formats as two space-separated 16-bit hex groups', async () => {
+    const fp = await sasFingerprint(new Uint8Array(32));
+    expect(fp).toMatch(/^[0-9a-f]{4} [0-9a-f]{4}$/);
+  });
+});
+
+describe('inviteLinkFor', () => {
+  it('carries the code in the fragment', () => {
+    expect(inviteLinkFor('https://send.example/', '3-brave-otter')).toBe(
+      'https://send.example/#3-brave-otter',
+    );
+  });
+
+  it('replaces an existing fragment and keeps the path', () => {
+    expect(inviteLinkFor('https://send.example/app#stale', '5-lively-quail')).toBe(
+      'https://send.example/app#5-lively-quail',
+    );
+  });
+});
+
+describe('codeFromHash', () => {
+  it('strips the leading hash and trims', () => {
+    expect(codeFromHash('#3-brave-otter')).toBe('3-brave-otter');
+    expect(codeFromHash('  #7-lively-quail  ')).toBe('7-lively-quail');
+  });
+
+  it('returns empty for no fragment', () => {
+    expect(codeFromHash('')).toBe('');
+    expect(codeFromHash('#')).toBe('');
+  });
+});
+
+describe('humanBytes', () => {
+  it('uses IEC units on exact multiples and bytes otherwise', () => {
+    expect(humanBytes(1 << 20)).toBe('1 MiB');
+    expect(humanBytes(16 * 1024)).toBe('16 KiB');
+    expect(humanBytes(1500)).toBe('1500 B');
+    expect(humanBytes(0)).toBe('0 B');
+  });
+});
+
+describe('describeCaps', () => {
+  it('reads version, frame, and block sizes', () => {
+    expect(
+      describeCaps({
+        version: '1',
+        maxFrame: 16384,
+        blockSize: 1 << 20,
+        features: [],
+        sinkHints: [],
+      }),
+    ).toBe('1 · 16 KiB frames · 1 MiB blocks');
+  });
+});
+
+describe('describeError', () => {
+  it('translates a confirmation failure into code-mismatch guidance', () => {
+    expect(describeError({ code: 'confirmation_failed', message: 'x' })).toMatch(/did not match/i);
+  });
+
+  it('falls back to the message for unknown codes', () => {
+    expect(describeError({ code: 'weird', message: 'something specific' })).toBe(
+      'something specific',
+    );
+  });
+});
+
+describe('phaseLabel', () => {
+  it('labels every known phase', () => {
+    expect(phaseLabel('waiting')).toMatch(/waiting/i);
+    expect(phaseLabel('established')).toBe('Connected');
+  });
+});

--- a/apps/web/src/lib/session/present.ts
+++ b/apps/web/src/lib/session/present.ts
@@ -1,0 +1,100 @@
+/**
+ * Presentation helpers for the rendezvous UI — the pure, DOM-free functions the Svelte
+ * component leans on. Keeping them here (rather than inline in App.svelte) makes the
+ * fingerprint, link, and formatting logic unit-testable without a browser harness, and lets
+ * the fingerprint stay provably identical to the Go CLI's short authentication string.
+ */
+
+import {
+  bytesToHex,
+  concatBytes,
+  sha256,
+  utf8,
+  type CapsPayload,
+  type RendezvousPhase,
+} from '@sendarc/protocol';
+
+/** The minimal shape describeError reads — satisfied by a RendezvousError instance. */
+export interface ErrorLike {
+  readonly code: string;
+  readonly message: string;
+}
+
+/** Human labels for each handshake phase, shown live as the connection progresses. */
+const PHASE_LABEL: Record<RendezvousPhase, string> = {
+  idle: 'Starting…',
+  allocating: 'Reserving a room…',
+  waiting: 'Waiting for the other side…',
+  handshaking: 'Establishing a secure channel…',
+  confirming: 'Confirming the code…',
+  'exchanging-caps': 'Exchanging capabilities…',
+  established: 'Connected',
+  failed: 'Failed',
+};
+
+export function phaseLabel(p: RendezvousPhase): string {
+  return PHASE_LABEL[p] ?? p;
+}
+
+/**
+ * Short authentication string derived from the master key: a domain-separated hash (so no
+ * raw key bytes are exposed) truncated to 32 bits and shown as two hex groups. It is byte
+ * -for-byte identical to the Go CLI's fingerprint, so a browser peer and a terminal peer
+ * can read the same value to each other as an out-of-band check on top of SPAKE2.
+ */
+export async function sasFingerprint(master: Uint8Array): Promise<string> {
+  const digest = await sha256(concatBytes(utf8('sendarc/sas\0'), master));
+  const hex = bytesToHex(digest.subarray(0, 4));
+  return `${hex.slice(0, 4)} ${hex.slice(4, 8)}`;
+}
+
+/** The current page URL with the invite code carried in the fragment (never sent to a server). */
+export function inviteLinkFor(href: string, code: string): string {
+  const u = new URL(href);
+  u.hash = code;
+  return u.toString();
+}
+
+/** The invite code embedded in a URL fragment, or '' if there is none. */
+export function codeFromHash(hash: string): string {
+  return hash.trim().replace(/^#/, '').trim();
+}
+
+/** Byte counts as IEC units on exact multiples, matching the CLI's humanBytes. */
+export function humanBytes(n: number): string {
+  if (n >= 1 << 20 && n % (1 << 20) === 0) return `${n >> 20} MiB`;
+  if (n >= 1 << 10 && n % (1 << 10) === 0) return `${n >> 10} KiB`;
+  return `${n} B`;
+}
+
+export function describeCaps(c: CapsPayload): string {
+  return `${c.version} · ${humanBytes(c.maxFrame)} frames · ${humanBytes(c.blockSize)} blocks`;
+}
+
+/** Turn a rendezvous failure into a plain-language line, translating the stable codes. */
+export function describeError(e: ErrorLike): string {
+  switch (e.code) {
+    case 'confirmation_failed':
+      return 'The codes did not match. Double-check the invite code and try again.';
+    case 'bad_peer_message':
+    case 'bad_message':
+    case 'too_large':
+      return 'The connection was corrupted. Please start over.';
+    case 'peer_left':
+    case 'peer_gone':
+      return 'The other side disconnected.';
+    case 'unknown_room':
+      return 'That invite link is unknown — it may have expired or been mistyped.';
+    case 'already_paired':
+    case 'room_taken':
+      return 'That room is already in use — ask the sender for a fresh code.';
+    case 'expired':
+      return 'This invite has expired. Ask the sender for a new one.';
+    case 'rate_limited':
+      return 'Too many attempts. Wait a moment and try again.';
+    case 'aborted':
+      return 'Cancelled.';
+    default:
+      return e.message || 'The connection failed.';
+  }
+}


### PR DESCRIPTION
Replace the M0 placeholder with the two-role UI that binds to the
offer()/join() orchestrator. The sender allocates a room, shows the
copyable invite code and a fragment-only link; the receiver either
types a code or auto-fills it from location.hash. Both surface the live
handshake phase and settle on a success screen with the short
authentication string, or a plain-language failure when confirmation
fails closed.

The presentation helpers (phase labels, SAS fingerprint, invite link,
byte formatting, error text) live in a DOM-free module so they unit-test
in node. The fingerprint is pinned to the cross-implementation vector
the Go CLI also produces, so a browser and a terminal peer read the same
value to each other.