### PR TITLE
feat(protocol): verify-before-write receiver with whole-file digest check

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -20,3 +20,4 @@ export * from './transfer-ports.js';
 export * from './transfer-chunker.js';
 export * from './transfer-messages.js';
 export * from './transfer-sender.js';
+export * from './transfer-receiver.js';

--- a/packages/protocol/src/transfer-ports.ts
+++ b/packages/protocol/src/transfer-ports.ts
@@ -37,13 +37,17 @@ export interface Digest {
   hexDigest(): string | Promise<string>;
 }
 
-/** A transfer failure carrying one of the protocol's `fail` reasons. */
+/**
+ * A transfer failure carrying one of the protocol's `fail` reasons. The `reason` is the
+ * machine-readable tag sent on the wire; it is always prefixed onto `message` so the reason
+ * survives in `error.message` (logs, `toThrow` matchers) even when a detail string is given.
+ */
 export class TransferError extends Error {
   constructor(
     readonly reason: Fail['reason'],
     message?: string,
   ) {
-    super(message ?? reason);
+    super(message ? `${reason}: ${message}` : reason);
     this.name = 'TransferError';
   }
 }

--- a/packages/protocol/src/transfer-receiver.test.ts
+++ b/packages/protocol/src/transfer-receiver.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { deriveTransferKeys } from './keyschedule.js';
+import { open, seal, type FrameHeaderInput } from './aead.js';
+import { FrameType } from './transfer.js';
+import { FRAME_VERSION } from './constants.js';
+import { sha256 } from './webcrypto.js';
+import { bytesToHex } from './bytes.js';
+import { encodeControl } from './transfer-messages.js';
+import { MemorySink, type Digest } from './transfer-ports.js';
+import { TransferReceiver } from './transfer-receiver.js';
+
+function nodeDigest(): Digest {
+  const h = createHash('sha256');
+  return { update: (b) => void h.update(b), hexDigest: () => h.digest('hex') };
+}
+const master = new Uint8Array(32).fill(9);
+
+// Minimal sender-side frame builders over the o2j direction.
+async function build(keys: Awaited<ReturnType<typeof deriveTransferKeys>>) {
+  let ctr = 0;
+  const frames: Uint8Array[] = [];
+  const push = async (header: FrameHeaderInput, payload: Uint8Array) => {
+    frames.push(await seal(keys.o2j, ctr++, header, payload));
+  };
+  const ctrl = (type: FrameType, msg: Parameters<typeof encodeControl>[0]) =>
+    push(
+      { version: FRAME_VERSION, type, flags: 0, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      encodeControl(msg),
+    );
+  return { frames, push, ctrl };
+}
+
+describe('TransferReceiver', () => {
+  it('assembles blocks, verifies, writes the sink, and reports done', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array(20).map((_, i) => (i * 7) & 0xff); // block=8: blocks 0,1 (8B), block2 (4B)
+    const blockSize = 8;
+    const fileDigest = createHash('sha256').update(data).digest('hex');
+    const b = await build(keys);
+
+    await b.ctrl(FrameType.Manifest, {
+      type: FrameType.Manifest,
+      files: [
+        { idx: 0, name: 'f', size: 20, mime: '', lastModified: 0, blockSize, blocks: 3, fileDigest },
+      ],
+      totalSize: 20,
+    });
+    for (let blk = 0; blk * blockSize < data.length; blk++) {
+      const start = blk * blockSize;
+      const end = Math.min(start + blockSize, data.length);
+      const block = data.subarray(start, end);
+      // one frame per 4 bytes
+      for (let off = 0; off < block.length; off += 4) {
+        const frag = block.subarray(off, Math.min(off + 4, block.length));
+        const last = off + frag.length === block.length;
+        await b.push(
+          {
+            version: FRAME_VERSION,
+            type: FrameType.BlockData,
+            flags: last ? 1 : 0,
+            fileIdx: 0,
+            blockIdx: blk,
+            frameOff: off,
+          },
+          frag,
+        );
+      }
+      await b.ctrl(FrameType.BlockHash, {
+        type: FrameType.BlockHash,
+        fileIdx: 0,
+        blockIdx: blk,
+        sha256: bytesToHex(await sha256(block)),
+      });
+    }
+    await b.ctrl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
+
+    const sink = new MemorySink();
+    const backChannel: Uint8Array[] = [];
+    const receiver = new TransferReceiver({
+      send: (f) => void backChannel.push(f),
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+    });
+    for (const f of b.frames) receiver.handle(f);
+    const result = await receiver.done;
+
+    expect(result.digest).toBe(fileDigest);
+    expect([...sink.bytes()]).toEqual([...data]);
+    expect(sink.isClosed).toBe(true);
+    // Back-channel: block_recv ×3 then done.
+    let c = 0;
+    const backTypes: number[] = [];
+    for (const f of backChannel) backTypes.push((await open(keys.j2o, c++, f)).header.type);
+    expect(backTypes).toEqual([
+      FrameType.BlockRecv,
+      FrameType.BlockRecv,
+      FrameType.BlockRecv,
+      FrameType.Done,
+    ]);
+  });
+
+  it('aborts with integrity on a corrupted frame (GCM failure)', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array(8).map((_, i) => i);
+    const fileDigest = createHash('sha256').update(data).digest('hex');
+    const b = await build(keys);
+    await b.ctrl(FrameType.Manifest, {
+      type: FrameType.Manifest,
+      files: [
+        { idx: 0, name: 'f', size: 8, mime: '', lastModified: 0, blockSize: 8, blocks: 1, fileDigest },
+      ],
+      totalSize: 8,
+    });
+    await b.push(
+      { version: FRAME_VERSION, type: FrameType.BlockData, flags: 1, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      data,
+    );
+    b.frames.at(-1)![b.frames.at(-1)!.length - 1] ^= 0x01; // corrupt the tag
+
+    const sink = new MemorySink();
+    const receiver = new TransferReceiver({
+      send: () => {},
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+    });
+    for (const f of b.frames) receiver.handle(f);
+    await expect(receiver.done).rejects.toThrow(/integrity/);
+    expect(sink.abortReason).toBe('integrity');
+  });
+
+  it('fails digest_mismatch when complete disagrees', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array(8).map((_, i) => i);
+    const b = await build(keys);
+    await b.ctrl(FrameType.Manifest, {
+      type: FrameType.Manifest,
+      files: [
+        { idx: 0, name: 'f', size: 8, mime: '', lastModified: 0, blockSize: 8, blocks: 1, fileDigest: 'ff' },
+      ],
+      totalSize: 8,
+    });
+    await b.push(
+      { version: FRAME_VERSION, type: FrameType.BlockData, flags: 1, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      data,
+    );
+    await b.ctrl(FrameType.BlockHash, {
+      type: FrameType.BlockHash,
+      fileIdx: 0,
+      blockIdx: 0,
+      sha256: bytesToHex(await sha256(data)),
+    });
+    await b.ctrl(FrameType.Complete, { type: FrameType.Complete, fileDigest: 'deadbeef' });
+
+    const receiver = new TransferReceiver({
+      send: () => {},
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink: new MemorySink(),
+    });
+    for (const f of b.frames) receiver.handle(f);
+    await expect(receiver.done).rejects.toThrow(/digest_mismatch/);
+  });
+});

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -1,0 +1,188 @@
+/**
+ * TransferReceiver — the receiving half of the transfer engine (design §5, §6). Frames arrive
+ * over an ordered/reliable channel, so blocks assemble one at a time, in order. For each block
+ * the receiver verifies its SHA-256 (from `block_hash`) BEFORE writing to the sink, feeds the
+ * verified bytes into the whole-file streaming digest, then signals `block_recv` (the in-flight
+ * window). On `complete` it compares the recomputed digest to the sender's and returns `done`
+ * or `fail{digest_mismatch}`. A GCM `open` throw or any hash mismatch → `fail{integrity}` and
+ * abort — never a silent retry (design §5.5).
+ */
+
+import { open, seal, type FrameHeaderInput } from './aead.js';
+import type { DirectionalKey } from './keyschedule.js';
+import { FrameType, type FileEntry } from './transfer.js';
+import { FRAME_VERSION } from './constants.js';
+import { sha256 } from './webcrypto.js';
+import { bytesToHex } from './bytes.js';
+import { TransferError, type Digest, type Sink } from './transfer-ports.js';
+import { decodeControl, encodeControl } from './transfer-messages.js';
+
+export interface ReceiveResult {
+  file: FileEntry;
+  digest: string;
+}
+
+export interface TransferReceiverOptions {
+  send(frame: Uint8Array): void | Promise<void>;
+  sendDir: DirectionalKey;
+  recvDir: DirectionalKey;
+  sendCounterStart: number;
+  recvCounterStart: number;
+  createDigest(): Digest;
+  sink: Sink;
+  onProgress?(receivedBytes: number): void;
+}
+
+export class TransferReceiver {
+  private readonly o: TransferReceiverOptions;
+  private readonly digest: Digest;
+
+  private sendCounter: number;
+  private recvCounter: number;
+
+  private file?: FileEntry;
+  private curBlock = 0;
+  private blockBuf?: Uint8Array;
+  private blockLen = 0;
+  private received = 0;
+
+  private resolveDone!: (r: ReceiveResult) => void;
+  private rejectDone!: (e: Error) => void;
+  readonly done: Promise<ReceiveResult>;
+  private chain: Promise<void> = Promise.resolve();
+  private settled = false;
+
+  constructor(opts: TransferReceiverOptions) {
+    this.o = opts;
+    this.digest = opts.createDigest();
+    this.sendCounter = opts.sendCounterStart;
+    this.recvCounter = opts.recvCounterStart;
+    this.done = new Promise<ReceiveResult>((res, rej) => {
+      this.resolveDone = res;
+      this.rejectDone = rej;
+    });
+    this.done.catch(() => {});
+  }
+
+  /** Feed one inbound frame from the sender (manifest / block_data / block_hash / complete). */
+  handle(frame: Uint8Array): void {
+    this.chain = this.chain
+      .then(() => this.process(frame))
+      .catch((e: unknown) => {
+        void this.abortWith(
+          e instanceof TransferError ? e : new TransferError('integrity', String(e)),
+        );
+      });
+  }
+
+  // --- internal ---------------------------------------------------------------
+
+  private async process(frame: Uint8Array): Promise<void> {
+    if (this.settled) return;
+    const opened = await open(this.o.recvDir, this.recvCounter++, frame); // throw → integrity abort
+    switch (opened.header.type) {
+      case FrameType.Manifest:
+        return this.onManifest(opened.plaintext);
+      case FrameType.BlockData:
+        return this.onBlockData(opened.header.blockIdx, opened.header.frameOff, opened.plaintext);
+      case FrameType.BlockHash:
+        return this.onBlockHash(opened.plaintext);
+      case FrameType.Complete:
+        return this.onComplete(opened.plaintext);
+      default:
+        throw new TransferError(
+          'integrity',
+          `unexpected receiver-inbound type ${opened.header.type}`,
+        );
+    }
+  }
+
+  private onManifest(payload: Uint8Array): void {
+    const msg = decodeControl(payload);
+    if (msg.type !== FrameType.Manifest) throw new TransferError('integrity', 'expected manifest');
+    this.file = msg.files[0];
+  }
+
+  private onBlockData(blockIdx: number, frameOff: number, payload: Uint8Array): void {
+    if (!this.file) throw new TransferError('integrity', 'block_data before manifest');
+    if (blockIdx !== this.curBlock)
+      throw new TransferError('integrity', `out-of-order block ${blockIdx}`);
+    if (frameOff === 0) {
+      this.blockLen = Math.min(this.file.blockSize, this.file.size - blockIdx * this.file.blockSize);
+      this.blockBuf = new Uint8Array(this.blockLen);
+      this.received = 0;
+    }
+    this.blockBuf!.set(payload, frameOff);
+    this.received += payload.length;
+  }
+
+  private async onBlockHash(payload: Uint8Array): Promise<void> {
+    if (!this.file || !this.blockBuf)
+      throw new TransferError('integrity', 'block_hash without a block');
+    const msg = decodeControl(payload);
+    if (msg.type !== FrameType.BlockHash)
+      throw new TransferError('integrity', 'expected block_hash');
+    if (this.received !== this.blockLen) throw new TransferError('integrity', 'short block');
+    const got = bytesToHex(await sha256(this.blockBuf));
+    if (got !== msg.sha256)
+      throw new TransferError('integrity', `block ${msg.blockIdx} hash mismatch`);
+
+    await this.o.sink.write(this.curBlock * this.file.blockSize, this.blockBuf);
+    this.digest.update(this.blockBuf);
+    this.o.onProgress?.(this.curBlock * this.file.blockSize + this.blockLen);
+    await this.sendControl(FrameType.BlockRecv, {
+      type: FrameType.BlockRecv,
+      fileIdx: 0,
+      blockIdx: this.curBlock,
+    });
+    this.curBlock++;
+    this.blockBuf = undefined;
+  }
+
+  private async onComplete(payload: Uint8Array): Promise<void> {
+    if (!this.file) throw new TransferError('integrity', 'complete before manifest');
+    const msg = decodeControl(payload);
+    if (msg.type !== FrameType.Complete) throw new TransferError('integrity', 'expected complete');
+    const got = await this.digest.hexDigest();
+    if (got !== msg.fileDigest) {
+      await this.abortWith(new TransferError('digest_mismatch', 'whole-file digest mismatch'));
+      return;
+    }
+    await this.o.sink.close();
+    await this.sendControl(FrameType.Done, { type: FrameType.Done });
+    this.settled = true;
+    this.resolveDone({ file: this.file, digest: got });
+  }
+
+  private async abortWith(err: TransferError): Promise<void> {
+    if (this.settled) return;
+    this.settled = true;
+    try {
+      await this.sendControl(FrameType.Fail, { type: FrameType.Fail, reason: err.reason });
+    } catch {
+      // best-effort — the channel may already be gone
+    }
+    try {
+      await this.o.sink.abort(err.reason);
+    } catch {
+      // best-effort
+    }
+    this.rejectDone(err);
+  }
+
+  private async sendControl(
+    type: FrameType,
+    msg: Parameters<typeof encodeControl>[0],
+  ): Promise<void> {
+    const header: FrameHeaderInput = {
+      version: FRAME_VERSION,
+      type,
+      flags: 0,
+      fileIdx: 0,
+      blockIdx: 0,
+      frameOff: 0,
+    };
+    const frame = await seal(this.o.sendDir, this.sendCounter++, header, encodeControl(msg));
+    await this.o.send(frame);
+  }
+}


### PR DESCRIPTION
Prefix TransferError.reason onto the message so the wire-level fail reason
stays visible in error.message for logs and callers.