### PR TITLE
fix(protocol): make the transfer engine strict-typecheck and format clean

### DIFF
--- a/packages/protocol/src/transfer-chunker.test.ts
+++ b/packages/protocol/src/transfer-chunker.test.ts
@@ -5,7 +5,12 @@ async function* fromChunks(chunks: number[][]): AsyncGenerator<Uint8Array> {
   for (const c of chunks) yield new Uint8Array(c);
 }
 async function collect(stream: AsyncIterable<Uint8Array>, block: number, frame: number) {
-  const pieces: Array<{ blockIdx: number; frameOff: number; payload: number[]; lastInBlock: boolean }> = [];
+  const pieces: Array<{
+    blockIdx: number;
+    frameOff: number;
+    payload: number[];
+    lastInBlock: boolean;
+  }> = [];
   for await (const p of reChunk(stream, block, frame)) {
     pieces.push({
       blockIdx: p.blockIdx,
@@ -44,7 +49,11 @@ describe('reChunk', () => {
     // Same 16 bytes delivered as 3+7+6 — output must be identical to one 16-byte chunk.
     const data = Array.from({ length: 16 }, (_, i) => i);
     const pieces = await collect(
-      fromChunks([[0, 1, 2], [3, 4, 5, 6, 7, 8, 9], [10, 11, 12, 13, 14, 15]]),
+      fromChunks([
+        [0, 1, 2],
+        [3, 4, 5, 6, 7, 8, 9],
+        [10, 11, 12, 13, 14, 15],
+      ]),
       8,
       4,
     );

--- a/packages/protocol/src/transfer-chunker.ts
+++ b/packages/protocol/src/transfer-chunker.ts
@@ -22,7 +22,7 @@ export async function* reChunk(
   frameSize: number,
 ): AsyncGenerator<FramePiece> {
   let pos = 0; // absolute file offset of the next byte to emit
-  let buf = new Uint8Array(0);
+  let buf: Uint8Array = new Uint8Array(0);
   let start = 0; // consumed-prefix cursor into buf
 
   const avail = () => buf.length - start;

--- a/packages/protocol/src/transfer-messages.test.ts
+++ b/packages/protocol/src/transfer-messages.test.ts
@@ -37,9 +37,9 @@ describe('control-message codec', () => {
   it('rejects malformed JSON and unknown/invalid shapes', () => {
     expect(() => decodeControl(new Uint8Array([0x7b, 0x7b]))).toThrow(); // "{{"
     expect(() => decodeControl(encodeControl({ type: 999 } as never))).toThrow();
-    expect(() => decodeControl(encodeControl({ type: FrameType.Fail, reason: 'nope' } as never))).toThrow();
     expect(() =>
-      decodeControl(encodeControl({ type: FrameType.Complete } as never)),
-    ).toThrow(); // missing fileDigest
+      decodeControl(encodeControl({ type: FrameType.Fail, reason: 'nope' } as never)),
+    ).toThrow();
+    expect(() => decodeControl(encodeControl({ type: FrameType.Complete } as never))).toThrow(); // missing fileDigest
   });
 });

--- a/packages/protocol/src/transfer-messages.ts
+++ b/packages/protocol/src/transfer-messages.ts
@@ -52,7 +52,8 @@ export function decodeControl(payload: Uint8Array): TransferMsg {
 
 function num(m: Record<string, unknown>, k: string): number {
   const v = m[k];
-  if (typeof v !== 'number' || !Number.isFinite(v)) throw new Error(`control frame: ${k} not a number`);
+  if (typeof v !== 'number' || !Number.isFinite(v))
+    throw new Error(`control frame: ${k} not a number`);
   return v;
 }
 function str(m: Record<string, unknown>, k: string): string {
@@ -77,8 +78,13 @@ function asFileEntry(v: unknown): FileEntry {
 }
 
 function asManifest(m: Record<string, unknown>): Manifest {
-  if (!Array.isArray(m.files) || m.files.length === 0) throw new Error('control frame: manifest.files');
-  return { type: FrameType.Manifest, files: m.files.map(asFileEntry), totalSize: num(m, 'totalSize') };
+  if (!Array.isArray(m.files) || m.files.length === 0)
+    throw new Error('control frame: manifest.files');
+  return {
+    type: FrameType.Manifest,
+    files: m.files.map(asFileEntry),
+    totalSize: num(m, 'totalSize'),
+  };
 }
 function asBlockHash(m: Record<string, unknown>): BlockHash {
   return {

--- a/packages/protocol/src/transfer-receiver.test.ts
+++ b/packages/protocol/src/transfer-receiver.test.ts
@@ -42,7 +42,16 @@ describe('TransferReceiver', () => {
     await b.ctrl(FrameType.Manifest, {
       type: FrameType.Manifest,
       files: [
-        { idx: 0, name: 'f', size: 20, mime: '', lastModified: 0, blockSize, blocks: 3, fileDigest },
+        {
+          idx: 0,
+          name: 'f',
+          size: 20,
+          mime: '',
+          lastModified: 0,
+          blockSize,
+          blocks: 3,
+          fileDigest,
+        },
       ],
       totalSize: 20,
     });
@@ -112,12 +121,28 @@ describe('TransferReceiver', () => {
     await b.ctrl(FrameType.Manifest, {
       type: FrameType.Manifest,
       files: [
-        { idx: 0, name: 'f', size: 8, mime: '', lastModified: 0, blockSize: 8, blocks: 1, fileDigest },
+        {
+          idx: 0,
+          name: 'f',
+          size: 8,
+          mime: '',
+          lastModified: 0,
+          blockSize: 8,
+          blocks: 1,
+          fileDigest,
+        },
       ],
       totalSize: 8,
     });
     await b.push(
-      { version: FRAME_VERSION, type: FrameType.BlockData, flags: 1, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      {
+        version: FRAME_VERSION,
+        type: FrameType.BlockData,
+        flags: 1,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
       data,
     );
     b.frames.at(-1)![b.frames.at(-1)!.length - 1] ^= 0x01; // corrupt the tag
@@ -144,12 +169,28 @@ describe('TransferReceiver', () => {
     await b.ctrl(FrameType.Manifest, {
       type: FrameType.Manifest,
       files: [
-        { idx: 0, name: 'f', size: 8, mime: '', lastModified: 0, blockSize: 8, blocks: 1, fileDigest: 'ff' },
+        {
+          idx: 0,
+          name: 'f',
+          size: 8,
+          mime: '',
+          lastModified: 0,
+          blockSize: 8,
+          blocks: 1,
+          fileDigest: 'ff',
+        },
       ],
       totalSize: 8,
     });
     await b.push(
-      { version: FRAME_VERSION, type: FrameType.BlockData, flags: 1, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      {
+        version: FRAME_VERSION,
+        type: FrameType.BlockData,
+        flags: 1,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
       data,
     );
     await b.ctrl(FrameType.BlockHash, {

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -40,9 +40,9 @@ export class TransferReceiver {
   private sendCounter: number;
   private recvCounter: number;
 
-  private file?: FileEntry;
+  private file: FileEntry | undefined;
   private curBlock = 0;
-  private blockBuf?: Uint8Array;
+  private blockBuf: Uint8Array | undefined;
   private blockLen = 0;
   private received = 0;
 
@@ -108,7 +108,10 @@ export class TransferReceiver {
     if (blockIdx !== this.curBlock)
       throw new TransferError('integrity', `out-of-order block ${blockIdx}`);
     if (frameOff === 0) {
-      this.blockLen = Math.min(this.file.blockSize, this.file.size - blockIdx * this.file.blockSize);
+      this.blockLen = Math.min(
+        this.file.blockSize,
+        this.file.size - blockIdx * this.file.blockSize,
+      );
       this.blockBuf = new Uint8Array(this.blockLen);
       this.received = 0;
     }

--- a/packages/protocol/src/transfer-sender.test.ts
+++ b/packages/protocol/src/transfer-sender.test.ts
@@ -51,7 +51,14 @@ describe('TransferSender', () => {
       const frame = await seal(
         keys.j2o,
         ackCtr++,
-        { version: FRAME_VERSION, type: FrameType.BlockRecv, flags: 0, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+        {
+          version: FRAME_VERSION,
+          type: FrameType.BlockRecv,
+          flags: 0,
+          fileIdx: 0,
+          blockIdx: 0,
+          frameOff: 0,
+        },
         encodeControl({ type: FrameType.BlockRecv, fileIdx: 0, blockIdx }),
       );
       sender.handle(frame);
@@ -63,7 +70,14 @@ describe('TransferSender', () => {
     const done = await seal(
       keys.j2o,
       ackCtr++,
-      { version: FRAME_VERSION, type: FrameType.Done, flags: 0, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Done,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
       encodeControl({ type: FrameType.Done }),
     );
     sender.handle(done);
@@ -103,7 +117,14 @@ describe('TransferSender', () => {
     const fail = await seal(
       keys.j2o,
       0,
-      { version: FRAME_VERSION, type: FrameType.Fail, flags: 0, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Fail,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
       encodeControl({ type: FrameType.Fail, reason: 'integrity' }),
     );
     sender.handle(fail);


### PR DESCRIPTION
exactOptionalPropertyTypes rejects assigning a possibly-undefined value to a
non-optional field, so widen the receiver's file/blockBuf to `| undefined` and
annotate the chunker's rolling buffer as Uint8Array. Also bring the engine
sources under prettier.