### PR TITLE
feat(web): add hash-wasm streaming digest and CSP wasm-unsafe-eval

### DIFF
--- a/apps/server/internal/httpserver/headers.go
+++ b/apps/server/internal/httpserver/headers.go
@@ -14,7 +14,7 @@ func securityHeaders(next http.Handler) http.Handler {
 				"connect-src 'self' wss: https:; "+
 				"img-src 'self' data:; "+
 				"style-src 'self' 'unsafe-inline'; "+
-				"script-src 'self'; "+
+				"script-src 'self' 'wasm-unsafe-eval'; "+
 				"object-src 'none'; "+
 				"base-uri 'none'; "+
 				"frame-ancestors 'none'")

--- a/apps/server/internal/httpserver/server_test.go
+++ b/apps/server/internal/httpserver/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -49,6 +50,8 @@ func TestSecurityHeaders(t *testing.T) {
 	}
 	if got := rec.Header().Get("Content-Security-Policy"); got == "" {
 		t.Error("missing Content-Security-Policy")
+	} else if !strings.Contains(got, "wasm-unsafe-eval") {
+		t.Errorf("CSP missing wasm-unsafe-eval for hash-wasm: %q", got)
 	}
 	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
 		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint . --max-warnings 0"
   },
   "dependencies": {
-    "@sendarc/protocol": "workspace:*"
+    "@sendarc/protocol": "workspace:*",
+    "hash-wasm": "^4.12.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/apps/web/src/lib/transfer/digest.test.ts
+++ b/apps/web/src/lib/transfer/digest.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { sha256, bytesToHex } from '@sendarc/protocol';
+import { createSha256DigestFactory } from './digest.js';
+
+/** Reference digest via WebCrypto (available in node 22 and browsers) — an independent impl. */
+async function ref(bytes: Uint8Array): Promise<string> {
+  return bytesToHex(await sha256(bytes));
+}
+
+describe('createSha256DigestFactory', () => {
+  it('matches sha256sum for a multi-chunk stream', async () => {
+    const make = await createSha256DigestFactory();
+    const d = make();
+    const a = new Uint8Array(1000).fill(1);
+    const b = new Uint8Array(1500).fill(2);
+    d.update(a);
+    d.update(b);
+    const whole = new Uint8Array([...a, ...b]);
+    expect(await d.hexDigest()).toBe(await ref(whole));
+  });
+
+  it('produces independent, repeatable digests from one factory', async () => {
+    const make = await createSha256DigestFactory();
+    const d1 = make();
+    d1.update(new Uint8Array([1, 2, 3]));
+    const h1 = await d1.hexDigest();
+    const d2 = make();
+    d2.update(new Uint8Array([1, 2, 3]));
+    const h2 = await d2.hexDigest();
+    expect(h1).toBe(h2);
+    expect(h1).toBe(await ref(new Uint8Array([1, 2, 3])));
+  });
+
+  it('digests the empty input', async () => {
+    const make = await createSha256DigestFactory();
+    expect(await make().hexDigest()).toBe(await ref(new Uint8Array()));
+  });
+});

--- a/apps/web/src/lib/transfer/digest.ts
+++ b/apps/web/src/lib/transfer/digest.ts
@@ -1,0 +1,30 @@
+/**
+ * Streaming whole-file SHA-256 for the transfer worker. `hash-wasm` produces a
+ * `sha256sum`-identical hex string and hashes synchronously per `update`, so it runs inside
+ * the worker (never on the main thread). `createSHA256()` is async — we pay that once, then
+ * `init()` a fresh hasher per digest. Loading the wasm requires `'wasm-unsafe-eval'` in the CSP.
+ */
+
+import { createSHA256, type IHasher } from 'hash-wasm';
+import type { Digest } from '@sendarc/protocol';
+
+/**
+ * Resolve once the SHA-256 wasm is instantiated, returning a factory that yields a fresh,
+ * initialised {@link Digest} per call. The engine calls the factory once per transfer.
+ */
+export async function createSha256DigestFactory(): Promise<() => Digest> {
+  const hasher: IHasher = await createSHA256();
+  return () => new WasmDigest(hasher);
+}
+
+class WasmDigest implements Digest {
+  constructor(private readonly hasher: IHasher) {
+    this.hasher.init();
+  }
+  update(bytes: Uint8Array): void {
+    this.hasher.update(bytes);
+  }
+  hexDigest(): string {
+    return this.hasher.digest('hex');
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@sendarc/protocol':
         specifier: workspace:*
         version: link:../../packages/protocol
+      hash-wasm:
+        specifier: ^4.12.0
+        version: 4.12.0
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
@@ -1001,6 +1004,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hash-wasm@4.12.0:
+    resolution: {integrity: sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2236,6 +2242,8 @@ snapshots:
   globals@15.15.0: {}
 
   has-flag@4.0.0: {}
+
+  hash-wasm@4.12.0: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
The transfer worker needs a sha256sum-identical whole-file digest that
hashes synchronously off the main thread; hash-wasm provides it. Loading
its wasm module requires 'wasm-unsafe-eval' in script-src, so widen the
server CSP and assert the directive in the header test.