### PR TITLE
feat(web): add re-streamable FileSource over Blob

### DIFF
--- a/apps/web/src/lib/transfer/file-source.test.ts
+++ b/apps/web/src/lib/transfer/file-source.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { blobFileSource } from './file-source.js';
+
+async function collect(src: { stream(): AsyncIterable<Uint8Array> }): Promise<Uint8Array> {
+  const parts: Uint8Array[] = [];
+  for await (const c of src.stream()) parts.push(c);
+  let n = 0;
+  for (const p of parts) n += p.length;
+  const out = new Uint8Array(n);
+  let o = 0;
+  for (const p of parts) {
+    out.set(p, o);
+    o += p.length;
+  }
+  return out;
+}
+
+describe('blobFileSource', () => {
+  it('exposes File metadata', () => {
+    const f = new File([new Uint8Array([1, 2, 3])], 'a.bin', {
+      type: 'application/octet-stream',
+      lastModified: 42,
+    });
+    const src = blobFileSource(f);
+    expect(src.meta).toEqual({
+      name: 'a.bin',
+      size: 3,
+      mime: 'application/octet-stream',
+      lastModified: 42,
+    });
+  });
+
+  it('streams the exact bytes and is re-callable', async () => {
+    const bytes = new Uint8Array(5000).map((_, i) => i & 0xff);
+    const f = new File([bytes], 'big.bin');
+    const src = blobFileSource(f, 1024);
+    const first = await collect(src);
+    const second = await collect(src);
+    expect(first).toEqual(bytes);
+    expect(second).toEqual(bytes);
+  });
+
+  it('yields chunks no larger than the chunk size', async () => {
+    const f = new File([new Uint8Array(2500)], 'x');
+    const src = blobFileSource(f, 1000);
+    const sizes: number[] = [];
+    for await (const c of src.stream()) sizes.push(c.length);
+    expect(Math.max(...sizes)).toBeLessThanOrEqual(1000);
+    expect(sizes.reduce((a, b) => a + b, 0)).toBe(2500);
+  });
+});

--- a/apps/web/src/lib/transfer/file-source.ts
+++ b/apps/web/src/lib/transfer/file-source.ts
@@ -1,0 +1,32 @@
+/**
+ * A {@link FileSource} over a browser {@link File}/{@link Blob}. The sender streams twice — once
+ * for the whole-file digest, once to send blocks — so each `stream()` opens a fresh reader; Blob
+ * reads are repeatable. We slice into bounded pieces rather than iterating the ReadableStream,
+ * since async iteration over a ReadableStream is not supported across all target browsers.
+ */
+
+import type { FileMeta, FileSource } from '@sendarc/protocol';
+
+const DEFAULT_CHUNK = 64 * 1024;
+
+export function blobFileSource(file: File, chunk: number = DEFAULT_CHUNK): FileSource {
+  const meta: FileMeta = {
+    name: file.name,
+    size: file.size,
+    mime: file.type,
+    lastModified: file.lastModified,
+  };
+  return {
+    meta,
+    stream(): AsyncIterable<Uint8Array> {
+      return {
+        async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+          for (let off = 0; off < file.size; off += chunk) {
+            const slice = file.slice(off, Math.min(off + chunk, file.size));
+            yield new Uint8Array(await slice.arrayBuffer());
+          }
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
The sender reads a file twice — digest pass then send pass — so the source
must replay. Slice the picked File into bounded chunks on each stream().