### PR TITLE
feat(web): add positioned stream sink and OPFS receive sink

### DIFF
--- a/apps/web/src/lib/transfer/sink.ts
+++ b/apps/web/src/lib/transfer/sink.ts
@@ -1,0 +1,35 @@
+/**
+ * Opens an OPFS destination for a received file. OPFS needs no user gesture, so it works when the
+ * manifest arrives mid-connection. The worker writes verified blocks here; on completion the host
+ * reads the file back out for a download. Not unit-tested — exercised by the e2e transfer.
+ */
+
+import type { Sink } from '@sendarc/protocol';
+import { streamSink, type WritableFileLike } from './stream-sink.js';
+
+export interface OpenedSink {
+  sink: Sink;
+  /** Read the finished file back (after `sink.close()`), e.g. to trigger a download. */
+  file(): Promise<File>;
+}
+
+export async function openOpfsSink(name: string): Promise<OpenedSink> {
+  const root = await navigator.storage.getDirectory();
+  const handle = await root.getFileHandle(sanitize(name), { create: true });
+  const writable = (await handle.createWritable({
+    keepExistingData: false,
+  })) as unknown as WritableFileLike;
+  return {
+    sink: streamSink(writable),
+    async file() {
+      const f = await handle.getFile();
+      return new File([f], name, { type: f.type, lastModified: f.lastModified });
+    },
+  };
+}
+
+/** OPFS keys are path-like; strip separators so the manifest name can't escape the directory. */
+function sanitize(name: string): string {
+  const base = name.replace(/^.*[\\/]/, '').trim();
+  return base.length > 0 ? base : 'download';
+}

--- a/apps/web/src/lib/transfer/stream-sink.test.ts
+++ b/apps/web/src/lib/transfer/stream-sink.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { streamSink, type WritableFileLike } from './stream-sink.js';
+
+describe('streamSink', () => {
+  it('maps offsets to positioned writes and closes', async () => {
+    const writes: Array<{ position: number; len: number }> = [];
+    let closed = false;
+    const w: WritableFileLike = {
+      async write(d) {
+        writes.push({ position: d.position, len: (d.data as Uint8Array).length });
+      },
+      async close() {
+        closed = true;
+      },
+    };
+    const s = streamSink(w);
+    await s.write(0, new Uint8Array(10));
+    await s.write(10, new Uint8Array(5));
+    await s.close();
+    expect(writes).toEqual([
+      { position: 0, len: 10 },
+      { position: 10, len: 5 },
+    ]);
+    expect(closed).toBe(true);
+  });
+
+  it('aborts via the underlying stream when available', async () => {
+    let abortReason: unknown;
+    let closed = false;
+    const w: WritableFileLike = {
+      async write() {},
+      async close() {
+        closed = true;
+      },
+      async abort(r) {
+        abortReason = r;
+      },
+    };
+    const s = streamSink(w);
+    await s.abort('integrity');
+    expect(abortReason).toBe('integrity');
+    expect(closed).toBe(false);
+  });
+
+  it('falls back to close when abort is unavailable', async () => {
+    let closed = false;
+    const w: WritableFileLike = {
+      async write() {},
+      async close() {
+        closed = true;
+      },
+    };
+    const s = streamSink(w);
+    await s.abort('x');
+    expect(closed).toBe(true);
+  });
+});

--- a/apps/web/src/lib/transfer/stream-sink.ts
+++ b/apps/web/src/lib/transfer/stream-sink.ts
@@ -1,0 +1,31 @@
+/**
+ * Adapts a `FileSystemWritableFileStream`-shaped writable to the engine's {@link Sink}. Blocks
+ * arrive verified and in order, so each write is positioned. On abort we prefer the stream's own
+ * abort (discards the partial file) and finalise nothing; only if abort is unavailable do we close.
+ */
+
+import type { Sink } from '@sendarc/protocol';
+
+export interface WritableFileLike {
+  write(data: { type: 'write'; position: number; data: Uint8Array }): Promise<void>;
+  close(): Promise<void>;
+  abort?(reason?: unknown): Promise<void>;
+}
+
+export function streamSink(w: WritableFileLike): Sink {
+  return {
+    write(offset: number, bytes: Uint8Array): Promise<void> {
+      return w.write({ type: 'write', position: offset, data: bytes });
+    },
+    close(): Promise<void> {
+      return w.close();
+    },
+    async abort(reason?: string): Promise<void> {
+      if (w.abort) {
+        await w.abort(reason);
+      } else {
+        await w.close();
+      }
+    },
+  };
+}


### PR DESCRIPTION
Verified blocks land as positioned writes on a FileSystemWritableFileStream;
abort prefers the stream's own abort so a failed transfer leaves no partial
file. openOpfsSink resolves a gesture-free destination from the manifest name
and can read the file back for download.