### PR TITLE
feat(web): add worker transfer core and message protocol

### DIFF
--- a/apps/web/src/lib/transfer/transfer-core.test.ts
+++ b/apps/web/src/lib/transfer/transfer-core.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { deriveTransferKeys, sha256, bytesToHex, MemorySink } from '@sendarc/protocol';
+import { runTransferCore, type TransferCoreDeps } from './transfer-core.js';
+import { blobFileSource } from './file-source.js';
+import { createSha256DigestFactory } from './digest.js';
+import type { DuplexPort, HostToWorker, WorkerToHost } from './wire.js';
+
+/**
+ * A fake worker port. The core calls `postMessage` (worker → host, surfaced via `onWorkerOut`)
+ * and receives via the handler it registers (host → worker, driven by `toWorker`). Delivery is
+ * async and FIFO per direction, mirroring a real MessageChannel.
+ */
+class FakePort implements DuplexPort<HostToWorker, WorkerToHost> {
+  private handler: ((ev: { data: HostToWorker }) => void) | undefined;
+  onWorkerOut: (msg: WorkerToHost) => void = () => {};
+  postMessage(msg: WorkerToHost): void {
+    queueMicrotask(() => this.onWorkerOut(msg));
+  }
+  addEventListener(_type: 'message', handler: (ev: { data: HostToWorker }) => void): void {
+    this.handler = handler;
+  }
+  toWorker(msg: HostToWorker): void {
+    queueMicrotask(() => this.handler?.({ data: msg }));
+  }
+}
+
+describe('transfer-core loopback', () => {
+  it('completes a transfer through the worker message protocol', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(7));
+    const bytes = new Uint8Array(200 * 1024 + 7).map((_, i) => (i * 31) & 0xff);
+    const file = new File([bytes], 'loop.bin', { type: 'application/octet-stream' });
+
+    const sendPort = new FakePort();
+    const recvPort = new FakePort();
+    const sink = new MemorySink();
+
+    let senderDone: (WorkerToHost & { kind: 'done' }) | undefined;
+    let receiverDone: (WorkerToHost & { kind: 'done' }) | undefined;
+    let manifest: (WorkerToHost & { kind: 'manifest' }) | undefined;
+
+    sendPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') recvPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+      else if (m.kind === 'done') senderDone = m;
+    };
+    recvPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') sendPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+      else if (m.kind === 'done') receiverDone = m;
+      else if (m.kind === 'manifest') manifest = m;
+    };
+
+    const senderDeps: TransferCoreDeps = {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: (f) => blobFileSource(f),
+    };
+    const receiverDeps: TransferCoreDeps = {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => sink,
+      fileSource: () => {
+        throw new Error('receiver has no source');
+      },
+    };
+
+    const recvP = runTransferCore(recvPort, receiverDeps);
+    const sendP = runTransferCore(sendPort, senderDeps);
+
+    recvPort.toWorker({
+      kind: 'start-recv',
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounter: 1,
+      recvCounter: 1,
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      file,
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+      blockSize: 64 * 1024,
+      frameSize: 16 * 1024,
+    });
+
+    await Promise.all([recvP, sendP]);
+
+    const expected = bytesToHex(await sha256(bytes));
+    expect(sink.bytes()).toEqual(bytes);
+    expect(sink.isClosed).toBe(true);
+    expect(receiverDone?.digest).toBe(expected);
+    expect(senderDone?.digest).toBe(expected);
+    expect(receiverDone?.name).toBe('loop.bin');
+    expect(receiverDone?.size).toBe(bytes.length);
+    expect(manifest?.name).toBe('loop.bin');
+    expect(manifest?.size).toBe(bytes.length);
+  });
+
+  it('surfaces an integrity failure when a data frame is corrupted in flight', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(5));
+    const bytes = new Uint8Array(80 * 1024).map((_, i) => i & 0xff);
+    const file = new File([bytes], 'corrupt.bin');
+
+    const sendPort = new FakePort();
+    const recvPort = new FakePort();
+    const sink = new MemorySink();
+    let flipped = false;
+
+    sendPort.onWorkerOut = (m) => {
+      if (m.kind !== 'outbound-frame') return;
+      const view = new Uint8Array(m.frame);
+      // Corrupt the first non-manifest frame (a block_data frame) after the manifest.
+      const last = view.length - 1;
+      const b = view[last];
+      if (!flipped && view.length > 64 && b !== undefined) {
+        flipped = true;
+        view[last] = b ^ 0xff;
+      }
+      recvPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+    };
+    recvPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') sendPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+    };
+
+    const senderDeps: TransferCoreDeps = {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => sink,
+      fileSource: (f) => blobFileSource(f),
+    };
+    const receiverDeps: TransferCoreDeps = {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => sink,
+      fileSource: (f) => blobFileSource(f),
+    };
+
+    const recvP = runTransferCore(recvPort, receiverDeps);
+    const sendP = runTransferCore(sendPort, senderDeps);
+
+    recvPort.toWorker({
+      kind: 'start-recv',
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounter: 1,
+      recvCounter: 1,
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      file,
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+      blockSize: 64 * 1024,
+      frameSize: 16 * 1024,
+    });
+
+    await expect(Promise.all([recvP, sendP])).rejects.toThrow(/integrity/);
+  });
+});

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -1,0 +1,169 @@
+/**
+ * transfer-core — the transport-agnostic engine loop that runs inside the transfer Web Worker.
+ * It waits on a {@link DuplexPort} for one start message, drives a TransferSender or
+ * TransferReceiver against that port (forwarding outbound frames, progress, and completion to
+ * the host, feeding inbound frames into the engine), and resolves when the transfer settles.
+ * The receiver's sink is opened lazily from the manifest via a deferred wrapper, so the same
+ * core runs unchanged in the browser and in the Node loopback test with two fake ports wired
+ * together.
+ */
+
+import {
+  TransferSender,
+  TransferReceiver,
+  TransferError,
+  type Digest,
+  type FileEntry,
+  type FileSource,
+  type Sink,
+} from '@sendarc/protocol';
+import type { DuplexPort, HostToWorker, StartSendMsg, StartRecvMsg, WorkerToHost } from './wire.js';
+
+export interface TransferCoreDeps {
+  /** Fresh streaming whole-file hasher (matches `sha256sum`). One live digest per call. */
+  createDigest(): Digest;
+  /** Open the receive destination once the manifest names the file. */
+  createSink(file: FileEntry): Sink | Promise<Sink>;
+  /** Adapt the sender's File into a re-callable byte source. */
+  fileSource(file: File): FileSource;
+}
+
+type Port = DuplexPort<HostToWorker, WorkerToHost>;
+
+/** Drive one transfer to completion over `port`. Resolves on `done`, rejects on any failure. */
+export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let engine: { handle(frame: Uint8Array): void } | undefined;
+    let started = false;
+    const pending: Uint8Array[] = [];
+
+    const post = (msg: WorkerToHost): void => port.postMessage(msg);
+    const send = (frame: Uint8Array): void => {
+      const buf = transferable(frame);
+      port.postMessage({ kind: 'outbound-frame', frame: buf }, [buf]);
+    };
+    const bind = (e: { handle(frame: Uint8Array): void }): void => {
+      engine = e;
+      for (const f of pending) e.handle(f);
+      pending.length = 0;
+    };
+    const fail = (e: unknown): void => {
+      const reason = e instanceof TransferError ? e.reason : 'integrity';
+      const message = e instanceof Error ? e.message : String(e);
+      post({ kind: 'error', reason, message });
+      reject(e instanceof Error ? e : new Error(message));
+    };
+
+    port.addEventListener('message', (ev) => {
+      const msg = ev.data;
+      switch (msg.kind) {
+        case 'start-send':
+          if (!started) {
+            started = true;
+            void startSend(msg);
+          }
+          return;
+        case 'start-recv':
+          if (!started) {
+            started = true;
+            void startRecv(msg);
+          }
+          return;
+        case 'inbound-frame': {
+          const frame = new Uint8Array(msg.frame);
+          if (engine) engine.handle(frame);
+          else pending.push(frame);
+          return;
+        }
+        case 'cancel':
+          fail(new TransferError('canceled', msg.reason ?? 'canceled'));
+          return;
+      }
+    });
+
+    async function startSend(msg: StartSendMsg): Promise<void> {
+      try {
+        const source = deps.fileSource(msg.file);
+        const sender = new TransferSender({
+          file: source,
+          send,
+          sendDir: msg.sendDir,
+          recvDir: msg.recvDir,
+          sendCounterStart: msg.sendCounter,
+          recvCounterStart: msg.recvCounter,
+          createDigest: deps.createDigest,
+          onProgress: (bytes) => post({ kind: 'progress', bytes }),
+          ...(msg.blockSize !== undefined ? { blockSize: msg.blockSize } : {}),
+          ...(msg.frameSize !== undefined ? { frameSize: msg.frameSize } : {}),
+          ...(msg.window !== undefined ? { window: msg.window } : {}),
+        });
+        bind(sender);
+        const digest = await sender.run();
+        post({ kind: 'done', name: source.meta.name, size: source.meta.size, digest });
+        resolve();
+      } catch (e) {
+        fail(e);
+      }
+    }
+
+    async function startRecv(_msg: StartRecvMsg): Promise<void> {
+      try {
+        const deferred = new DeferredSink();
+        const receiver = new TransferReceiver({
+          send,
+          sendDir: _msg.sendDir,
+          recvDir: _msg.recvDir,
+          sendCounterStart: _msg.sendCounter,
+          recvCounterStart: _msg.recvCounter,
+          createDigest: deps.createDigest,
+          sink: deferred,
+          onProgress: (bytes) => post({ kind: 'progress', bytes }),
+          onManifest: async (file) => {
+            deferred.attach(await deps.createSink(file));
+            post({ kind: 'manifest', name: file.name, size: file.size, mime: file.mime });
+          },
+        });
+        bind(receiver);
+        const result = await receiver.done;
+        post({
+          kind: 'done',
+          name: result.file.name,
+          size: result.file.size,
+          digest: result.digest,
+        });
+        resolve();
+      } catch (e) {
+        fail(e);
+      }
+    }
+  });
+}
+
+/**
+ * A Sink whose destination is opened after construction — the receiver builds it before the
+ * manifest arrives, then `onManifest` attaches the real sink before the first verified write.
+ */
+class DeferredSink implements Sink {
+  private inner: Sink | undefined;
+  attach(sink: Sink): void {
+    this.inner = sink;
+  }
+  write(offset: number, bytes: Uint8Array): void | Promise<void> {
+    if (!this.inner) throw new TransferError('sink_error', 'sink not opened before write');
+    return this.inner.write(offset, bytes);
+  }
+  close(): void | Promise<void> {
+    return this.inner?.close();
+  }
+  abort(reason?: string): void | Promise<void> {
+    return this.inner?.abort(reason);
+  }
+}
+
+/** A sealed frame's own ArrayBuffer when it fits exactly (the common case), else a fresh copy. */
+function transferable(frame: Uint8Array): ArrayBuffer {
+  if (frame.byteOffset === 0 && frame.byteLength === frame.buffer.byteLength) {
+    return frame.buffer as ArrayBuffer;
+  }
+  return frame.slice().buffer;
+}

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -1,0 +1,69 @@
+/**
+ * Message protocol between the main thread and the transfer Web Worker. The worker owns crypto,
+ * per-block and whole-file hashing, and sink writes; the main thread owns the RTCDataChannel.
+ * Frame payloads cross the boundary as Transferable ArrayBuffers (zero-copy). Both directions of
+ * this protocol are exercised end-to-end by the Node loopback test, so the shapes are the contract.
+ */
+
+import type { DirectionalKey } from '@sendarc/protocol';
+
+/** Session crypto state handed to the worker at start — counters continue from M1, never reset. */
+export interface SessionCrypto {
+  sendDir: DirectionalKey;
+  recvDir: DirectionalKey;
+  sendCounter: number;
+  recvCounter: number;
+}
+
+export interface StartSendMsg extends SessionCrypto {
+  kind: 'start-send';
+  file: File;
+  blockSize?: number;
+  frameSize?: number;
+  window?: number;
+}
+export interface StartRecvMsg extends SessionCrypto {
+  kind: 'start-recv';
+}
+export interface InboundFrameMsg {
+  kind: 'inbound-frame';
+  frame: ArrayBuffer;
+}
+export interface CancelMsg {
+  kind: 'cancel';
+  reason?: string;
+}
+export type HostToWorker = StartSendMsg | StartRecvMsg | InboundFrameMsg | CancelMsg;
+
+export interface OutboundFrameMsg {
+  kind: 'outbound-frame';
+  frame: ArrayBuffer;
+}
+export interface ManifestMsg {
+  kind: 'manifest';
+  name: string;
+  size: number;
+  mime: string;
+}
+export interface ProgressMsg {
+  kind: 'progress';
+  bytes: number;
+}
+export interface DoneMsg {
+  kind: 'done';
+  name: string;
+  size: number;
+  digest: string;
+}
+export interface ErrorMsg {
+  kind: 'error';
+  reason: string;
+  message: string;
+}
+export type WorkerToHost = OutboundFrameMsg | ManifestMsg | ProgressMsg | DoneMsg | ErrorMsg;
+
+/** The slice of Worker / DedicatedWorkerGlobalScope the core needs, so a test can inject a fake. */
+export interface DuplexPort<In, Out> {
+  postMessage(msg: Out, transfer?: Transferable[]): void;
+  addEventListener(type: 'message', handler: (ev: { data: In }) => void): void;
+}

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -74,8 +74,12 @@ export class TransferSender {
     this.done.catch(() => {});
   }
 
-  /** Drive the whole send. Resolves when the receiver confirms `done`, rejects on `fail`. */
-  async run(): Promise<void> {
+  /**
+   * Drive the whole send. Resolves with the canonical whole-file digest (hex) when the receiver
+   * confirms `done`, rejects on `fail`. The digest is the same value carried in the manifest and
+   * `complete`, so a host can report it without recomputing.
+   */
+  async run(): Promise<string> {
     const { meta } = this.o.file;
 
     // Pass 1: whole-file digest (streamed; the file is never held).
@@ -105,7 +109,10 @@ export class TransferSender {
     let blockParts: Uint8Array[] = [];
     for await (const piece of reChunk(this.o.file.stream(), this.blockSize, this.frameSize)) {
       await this.gate(piece.blockIdx);
-      if (this.settled) return this.done; // aborted by an inbound fail
+      if (this.settled) {
+        await this.done; // aborted by an inbound fail → propagate the rejection
+        return fileDigest;
+      }
       await this.sendFrame(
         {
           version: FRAME_VERSION,
@@ -134,7 +141,8 @@ export class TransferSender {
     }
 
     await this.sendControl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
-    return this.done;
+    await this.done;
+    return fileDigest;
   }
 
   /** Feed one inbound frame from the receiver (block_recv / done / fail). */


### PR DESCRIPTION
Introduce the transport-agnostic engine loop that runs inside the transfer
Web Worker. `runTransferCore` waits on a DuplexPort for a single start
message, drives a TransferSender or TransferReceiver against it, forwards
outbound frames (as Transferable ArrayBuffers), progress, manifest, and
completion to the host, and feeds inbound frames back into the engine.

The receiver's sink is opened lazily from the manifest through a
DeferredSink filled by the receiver's onManifest hook, so OPFS can be named
after the incoming file without the engine knowing the destination. The
port abstraction lets a Node loopback test wire two cores together through
fake ports and assert both byte-identity and matching whole-file digests,
plus an integrity failure when a frame is corrupted in flight.

TransferSender.run now returns the canonical whole-file digest it already
computes, so the core can report it uniformly for both directions.