### PR TITLE
feat(web): authenticate SDP/ICE signaling with k_auth

### DIFF
--- a/apps/web/src/lib/transfer/authed-signaling.test.ts
+++ b/apps/web/src/lib/transfer/authed-signaling.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { authKeys, type Spake2Output } from '@sendarc/protocol';
+import { SignalAuthenticator } from './authed-signaling.js';
+
+function pairKeys() {
+  // KcA/KcB are confirmation keys; fabricate a Spake2Output-shaped value with distinct keys.
+  const KcA = new Uint8Array(32).fill(1);
+  const KcB = new Uint8Array(32).fill(2);
+  const spake2 = { KcA, KcB } as unknown as Spake2Output;
+  const offerer = authKeys('offerer', spake2);
+  const joiner = authKeys('joiner', spake2);
+  return { offerer, joiner };
+}
+
+describe('SignalAuthenticator', () => {
+  it('signs and verifies an SDP across the pair', async () => {
+    const { offerer, joiner } = pairKeys();
+    const room = 7;
+    const a = new SignalAuthenticator(room, offerer);
+    const b = new SignalAuthenticator(room, joiner);
+    const msg = await a.signSdp('v=0\r\n');
+    expect(await b.verify(msg)).toEqual({ ok: true });
+  });
+
+  it('rejects a tampered body', async () => {
+    const { offerer, joiner } = pairKeys();
+    const a = new SignalAuthenticator(3, offerer);
+    const b = new SignalAuthenticator(3, joiner);
+    const msg = await a.signSdp('v=0\r\n');
+    const bad = { ...msg, sdp: 'v=0\r\nmutated' };
+    const res = await b.verify(bad);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a room mismatch', async () => {
+    const { offerer, joiner } = pairKeys();
+    const a = new SignalAuthenticator(7, offerer);
+    const b = new SignalAuthenticator(8, joiner);
+    const msg = await a.signSdp('v=0\r\n');
+    const res = await b.verify(msg);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects replayed or non-increasing seq', async () => {
+    const { offerer, joiner } = pairKeys();
+    const a = new SignalAuthenticator(1, offerer);
+    const b = new SignalAuthenticator(1, joiner);
+    const first = await a.signSdp('a');
+    const second = await a.signIce('cand');
+    expect(await b.verify(second)).toEqual({ ok: true });
+    // `first` has a lower seq than the already-accepted `second`.
+    const res = await b.verify(first);
+    expect(res.ok).toBe(false);
+  });
+
+  it('uses one monotonic seq across sdp and ice', async () => {
+    const { offerer } = pairKeys();
+    const a = new SignalAuthenticator(1, offerer);
+    const m1 = await a.signSdp('a');
+    const m2 = await a.signIce('c');
+    const m3 = await a.signSdp('b');
+    expect([m1.seq, m2.seq, m3.seq]).toEqual([0, 1, 2]);
+  });
+
+  it('rejects a malformed mac without throwing', async () => {
+    const { offerer, joiner } = pairKeys();
+    const a = new SignalAuthenticator(1, offerer);
+    const b = new SignalAuthenticator(1, joiner);
+    const msg = await a.signSdp('a');
+    const res = await b.verify({ ...msg, mac: '!!!not base64url!!!' });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/apps/web/src/lib/transfer/authed-signaling.ts
+++ b/apps/web/src/lib/transfer/authed-signaling.ts
@@ -1,0 +1,68 @@
+/**
+ * Signs and verifies SDP/ICE signaling with the SPAKE2-derived k_auth (design authmac). The offerer
+ * signs with KcA and verifies KcB; the joiner mirrors. `seq` is monotonic per sender across both
+ * message kinds, and the verifier rejects any non-increasing seq to defeat replay and reorder. The
+ * MAC rides as base64url in the message `mac` field.
+ */
+
+import {
+  authKeys,
+  signSignal,
+  verifySignal,
+  bytesToBase64url,
+  base64urlToBytes,
+  type IceMsg,
+  type Role,
+  type SdpMsg,
+  type Spake2Output,
+} from '@sendarc/protocol';
+
+export interface AuthKeyPair {
+  sign: Uint8Array;
+  verify: Uint8Array;
+}
+
+export type VerifyResult = { ok: true } | { ok: false; error: string };
+
+export class SignalAuthenticator {
+  private outSeq = 0;
+  private inSeq = -1;
+
+  constructor(
+    private readonly room: number,
+    private readonly keys: AuthKeyPair,
+  ) {}
+
+  static fromSession(role: Role, room: number, spake2: Spake2Output): SignalAuthenticator {
+    return new SignalAuthenticator(room, authKeys(role, spake2));
+  }
+
+  async signSdp(sdp: string): Promise<SdpMsg> {
+    const seq = this.outSeq++;
+    const mac = await signSignal(this.keys.sign, 'sdp', this.room, seq, sdp);
+    return { type: 'sdp', sdp, seq, mac: bytesToBase64url(mac) };
+  }
+
+  async signIce(cand: string): Promise<IceMsg> {
+    const seq = this.outSeq++;
+    const mac = await signSignal(this.keys.sign, 'ice', this.room, seq, cand);
+    return { type: 'ice', cand, seq, mac: bytesToBase64url(mac) };
+  }
+
+  async verify(msg: SdpMsg | IceMsg): Promise<VerifyResult> {
+    if (!Number.isInteger(msg.seq) || msg.seq <= this.inSeq) {
+      return { ok: false, error: `non-increasing seq ${msg.seq}` };
+    }
+    let mac: Uint8Array;
+    try {
+      mac = base64urlToBytes(msg.mac);
+    } catch {
+      return { ok: false, error: 'malformed mac' };
+    }
+    const body = msg.type === 'sdp' ? msg.sdp : msg.cand;
+    const ok = await verifySignal(this.keys.verify, msg.type, this.room, msg.seq, body, mac);
+    if (!ok) return { ok: false, error: 'bad mac' };
+    this.inSeq = msg.seq;
+    return { ok: true };
+  }
+}


### PR DESCRIPTION
Sign every offer, answer, and candidate with the SPAKE2-derived key and
verify on receipt, rejecting any non-increasing seq so a relayed message
can't be replayed or reordered. One seq space spans SDP and ICE per sender.