### PR TITLE
feat(web): add data-channel backpressure writer

### DIFF
--- a/apps/web/src/lib/transfer/channel-writer.test.ts
+++ b/apps/web/src/lib/transfer/channel-writer.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { ChannelWriter, type ChannelLike } from './channel-writer.js';
+
+class FakeChannel implements ChannelLike {
+  bufferedAmount = 0;
+  bufferedAmountLowThreshold = 0;
+  onbufferedamountlow: ((this: unknown, ev: Event) => void) | null = null;
+  sent: number[] = [];
+  send(data: ArrayBuffer): void {
+    this.sent.push(data.byteLength);
+    this.bufferedAmount += data.byteLength;
+  }
+  /** Simulate the SCTP buffer draining below the low watermark. */
+  drainTo(n: number): void {
+    this.bufferedAmount = n;
+    if (n <= this.bufferedAmountLowThreshold && this.onbufferedamountlow) {
+      this.onbufferedamountlow.call(this, new Event('bufferedamountlow'));
+    }
+  }
+}
+
+describe('ChannelWriter', () => {
+  it('sends immediately while under the high watermark', () => {
+    const ch = new FakeChannel();
+    const w = new ChannelWriter(ch);
+    w.write(new ArrayBuffer(1000));
+    expect(ch.sent).toEqual([1000]);
+    expect(w.pending).toBe(0);
+  });
+
+  it('queues once bufferedAmount crosses the high watermark and drains on low', () => {
+    const ch = new FakeChannel();
+    const w = new ChannelWriter(ch);
+    ch.bufferedAmount = 9 * 1024 * 1024; // above 8 MiB high watermark
+    w.write(new ArrayBuffer(100));
+    w.write(new ArrayBuffer(200));
+    expect(ch.sent).toEqual([]);
+    expect(w.pending).toBe(2);
+    ch.drainTo(0);
+    expect(ch.sent).toEqual([100, 200]);
+    expect(w.pending).toBe(0);
+  });
+
+  it('preserves FIFO order once queuing has begun, even below the watermark', () => {
+    const ch = new FakeChannel();
+    const w = new ChannelWriter(ch);
+    ch.bufferedAmount = 9 * 1024 * 1024;
+    w.write(new ArrayBuffer(1)); // queued (over watermark)
+    ch.bufferedAmount = 0; // drops without firing the low event
+    w.write(new ArrayBuffer(2)); // must queue behind the first, not jump ahead
+    expect(ch.sent).toEqual([]);
+    expect(w.pending).toBe(2);
+    ch.drainTo(0);
+    expect(ch.sent).toEqual([1, 2]);
+  });
+
+  it('sets the low-watermark threshold on the channel', () => {
+    const ch = new FakeChannel();
+    new ChannelWriter(ch);
+    expect(ch.bufferedAmountLowThreshold).toBe(1 * 1024 * 1024);
+  });
+});

--- a/apps/web/src/lib/transfer/channel-writer.ts
+++ b/apps/web/src/lib/transfer/channel-writer.ts
@@ -1,0 +1,44 @@
+/**
+ * Best-effort SCTP-buffer guard over an RTCDataChannel. The worker's in-flight window is the real
+ * memory bound; this only keeps `bufferedAmount` from ballooning: queue while above the high
+ * watermark, flush in order when the channel signals it has drained below the low watermark.
+ */
+
+import { BUFFERED_AMOUNT_HIGH, BUFFERED_AMOUNT_LOW } from '@sendarc/protocol';
+
+export interface ChannelLike {
+  bufferedAmount: number;
+  bufferedAmountLowThreshold: number;
+  send(data: ArrayBuffer): void;
+  onbufferedamountlow: ((this: unknown, ev: Event) => void) | null;
+}
+
+export class ChannelWriter {
+  private queue: ArrayBuffer[] = [];
+
+  constructor(private readonly channel: ChannelLike) {
+    this.channel.bufferedAmountLowThreshold = BUFFERED_AMOUNT_LOW;
+    this.channel.onbufferedamountlow = () => this.flush();
+  }
+
+  get pending(): number {
+    return this.queue.length;
+  }
+
+  write(frame: ArrayBuffer): void {
+    // Once anything is queued, everything queues behind it — FIFO holds even if bufferedAmount
+    // has since dipped, since the low-watermark event is what authorises a drain.
+    if (this.queue.length === 0 && this.channel.bufferedAmount < BUFFERED_AMOUNT_HIGH) {
+      this.channel.send(frame);
+    } else {
+      this.queue.push(frame);
+    }
+  }
+
+  private flush(): void {
+    while (this.queue.length > 0 && this.channel.bufferedAmount < BUFFERED_AMOUNT_HIGH) {
+      const next = this.queue.shift()!;
+      this.channel.send(next);
+    }
+  }
+}


### PR DESCRIPTION
Queue frames while the data channel's bufferedAmount is above the high
watermark and flush in order on the low-watermark event, so a fast sender
can't balloon the SCTP send buffer past the in-flight window bound. FIFO
holds once queuing begins: later frames wait behind queued ones until the
low-watermark event authorises a drain.