### PR TITLE
feat(web): wire WebRTC peer, transfer worker, and orchestrator

### DIFF
--- a/apps/web/src/lib/session/rendezvous.ts
+++ b/apps/web/src/lib/session/rendezvous.ts
@@ -23,7 +23,7 @@ import {
   type SignalMsg,
 } from '@sendarc/protocol';
 
-import { SignalingClient, type BackoffOptions } from '../signaling/client.js';
+import { SignalingClient, type BackoffOptions, type SignalChannel } from '../signaling/client.js';
 
 export interface RendezvousControllerOptions {
   /** Signaling endpoint. Defaults to `/ws` on the current origin (ws/wss to match the page). */
@@ -45,6 +45,13 @@ export interface RendezvousController {
   readonly done: Promise<RendezvousResult>;
   /** Abort locally: notify the peer with `bye` and tear down the socket. Idempotent. */
   cancel(reason?: string): void;
+  /**
+   * Take over the still-open signaling socket for the M2 transfer, before it is auto-closed.
+   * Valid only after `done` resolves; the caller then owns teardown via the returned channel's
+   * `close()`. Swapping in a new `onMessage` handler reroutes inbound frames (SDP/ICE) away from
+   * the settled handshake session and into the transfer layer.
+   */
+  adoptSignaling(): SignalChannel;
 }
 
 /** Start as the offerer: allocate a room and display the generated invite code. */
@@ -84,6 +91,12 @@ function run(
 ): RendezvousController {
   const url = opts.url ?? defaultSignalingUrl();
 
+  // Inbound frames go to the handshake session until the transfer layer adopts the socket, at
+  // which point `route` is swapped to the transfer's own handler. `adopted` also suppresses the
+  // success auto-close, since the transfer layer then owns the socket's lifetime.
+  let route: (msg: SignalMsg) => void = (msg) => session.handle(msg);
+  let adopted = false;
+
   // The two layers reference each other, so one closure must name the other before it is
   // constructed: the session's sink calls `client.send`, but nothing sends until the socket
   // has opened (connect → start), by which point `client` below is initialized.
@@ -91,7 +104,7 @@ function run(
 
   const client = new SignalingClient({
     url,
-    onMessage: (msg) => session.handle(msg),
+    onMessage: (msg) => route(msg),
     onClose: (clean, code, reason) => {
       // A post-open drop is terminal; translate it into a session failure. If the session
       // already settled (the normal close we trigger on `done`), abort is a no-op.
@@ -101,10 +114,12 @@ function run(
     ...(opts.backoff !== undefined ? { backoff: opts.backoff } : {}),
   });
 
-  // Tear the socket down once the handshake settles either way — success frees the room on
-  // the server, failure stops a doomed retry loop.
+  // Tear the socket down once the handshake settles. Failure closes immediately (stop a doomed
+  // retry loop). Success defers to a macrotask so a caller can `adoptSignaling()` synchronously
+  // off `await done` and keep the socket for the M2 transfer; if nobody adopts, it still closes
+  // to free the room on the server.
   void session.done.then(
-    () => client.close(),
+    () => setTimeout(() => void (adopted || client.close()), 0),
     () => client.close(),
   );
 
@@ -124,6 +139,14 @@ function run(
     cancel: (reason = 'cancelled') => {
       session.abort(reason);
       client.close();
+    },
+    adoptSignaling: () => {
+      adopted = true;
+      return {
+        send: (msg) => client.send(msg),
+        onMessage: (handler) => (route = handler),
+        close: () => client.close(),
+      };
     },
   };
 }

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -1,0 +1,216 @@
+/**
+ * Transfer orchestrator — the main-thread conductor that turns a settled rendezvous into a running
+ * file transfer. It adopts the still-open signaling socket, brings up the authenticated WebRTC data
+ * channel ({@link createPeer}), spawns the transfer worker ({@link runTransferCore} host), and pumps
+ * frames between the two: worker → channel with SCTP backpressure ({@link ChannelWriter}), channel →
+ * worker as inbound frames. The worker owns crypto and disk; this module owns transport and the
+ * public {@link TransferController} the UI binds against (progress, a `done` promise, cancel).
+ *
+ * Browser-only (needs `Worker`, `RTCPeerConnection`); not unit-tested — the pieces it wires each
+ * have their own tests, and the whole path is covered by the e2e transfer.
+ */
+
+import type { RendezvousResult } from '@sendarc/protocol';
+import type { SignalChannel } from '../signaling/client.js';
+import { SignalAuthenticator } from '../transfer/authed-signaling.js';
+import { createPeer, type Peer } from '../transfer/peer.js';
+import { ChannelWriter } from '../transfer/channel-writer.js';
+import { readOpfsFile } from '../transfer/sink.js';
+import type { HostToWorker, SessionCrypto, WorkerToHost } from '../transfer/wire.js';
+
+/** Terminal outcome of a transfer. `file` is present on the receive side (the downloadable result). */
+export interface TransferOutcome {
+  name: string;
+  size: number;
+  digest: string;
+  file?: File;
+}
+
+/** A transfer in progress. `done` settles once; `progress` is polled by the UI for a live bar. */
+export interface TransferController {
+  /** Bytes moved so far (plaintext payload), updated as the worker reports progress. */
+  progress(): number;
+  /** The declared total size in bytes, once known (immediately when sending, on manifest when receiving). */
+  total(): number | undefined;
+  /** Resolves when the transfer completes and verifies; rejects on any failure. */
+  readonly done: Promise<TransferOutcome>;
+  /** Abort the transfer and tear down the worker, peer, and socket. Idempotent. */
+  cancel(reason?: string): void;
+}
+
+export interface SendOptions {
+  file: File;
+}
+
+/** Start sending `opts.file` to the peer over the adopted rendezvous socket. */
+export function runSend(
+  rendezvous: RendezvousResult,
+  signaling: SignalChannel,
+  opts: SendOptions,
+): TransferController {
+  return run(rendezvous, signaling, {
+    role: 'send',
+    total: opts.file.size,
+    start: () => ({ kind: 'start-send', file: opts.file, ...crypto(rendezvous) }),
+  });
+}
+
+/** Start receiving a file from the peer over the adopted rendezvous socket. */
+export function runReceive(
+  rendezvous: RendezvousResult,
+  signaling: SignalChannel,
+): TransferController {
+  return run(rendezvous, signaling, {
+    role: 'receive',
+    start: () => ({ kind: 'start-recv', ...crypto(rendezvous) }),
+  });
+}
+
+interface RunSpec {
+  role: 'send' | 'receive';
+  /** Known upfront only when sending. */
+  total?: number;
+  start: () => HostToWorker;
+}
+
+function run(
+  rendezvous: RendezvousResult,
+  signaling: SignalChannel,
+  spec: RunSpec,
+): TransferController {
+  let done = 0;
+  let total = spec.total;
+  let settled = false;
+  let peer: Peer | undefined;
+  let worker: Worker | undefined;
+
+  let resolveDone!: (o: TransferOutcome) => void;
+  let rejectDone!: (err: Error) => void;
+  const donePromise = new Promise<TransferOutcome>((resolve, reject) => {
+    resolveDone = resolve;
+    rejectDone = reject;
+  });
+
+  const cleanup = (): void => {
+    worker?.terminate();
+    peer?.close();
+    signaling.close();
+  };
+  const finish = (o: TransferOutcome): void => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    resolveDone(o);
+  };
+  const fail = (err: Error): void => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    rejectDone(err);
+  };
+
+  void (async () => {
+    try {
+      const auth = SignalAuthenticator.fromSession(
+        rendezvous.role,
+        rendezvous.room,
+        rendezvous.spake2,
+      );
+      const p = createPeer({ role: rendezvous.role, auth, send: (msg) => signaling.send(msg) });
+      peer = p;
+      signaling.onMessage((msg) => {
+        if (msg.type === 'sdp' || msg.type === 'ice') p.accept(msg);
+      });
+
+      const w = new Worker(new URL('../transfer/transfer.worker.ts', import.meta.url), {
+        type: 'module',
+      });
+      worker = w;
+      // Listen for `ready` before any await — the worker posts it as soon as its SHA-256 wasm loads,
+      // which can beat the channel negotiation; a late listener would miss it and hang forever.
+      const ready = workerReady(w);
+
+      const channel = await p.channel;
+      const writer = new ChannelWriter(channel);
+      await ready;
+
+      // Worker → host events.
+      w.addEventListener('message', (ev: MessageEvent) => {
+        const msg = ev.data as WorkerToHost;
+        switch (msg.kind) {
+          case 'outbound-frame':
+            writer.write(msg.frame);
+            return;
+          case 'progress':
+            done = msg.bytes;
+            return;
+          case 'manifest':
+            total = msg.size;
+            return;
+          case 'done':
+            void completeReceive(msg.name, msg.size, msg.digest);
+            return;
+          case 'error':
+            fail(new Error(msg.message));
+            return;
+          case 'ready':
+            return;
+        }
+      });
+
+      // Channel → worker: forward every inbound data frame as a Transferable.
+      p.onData((frame) =>
+        w.postMessage({ kind: 'inbound-frame', frame } satisfies HostToWorker, [frame]),
+      );
+
+      // Kick off the transfer in the worker.
+      const startMsg = spec.start();
+      w.postMessage(startMsg);
+    } catch (err) {
+      fail(err instanceof Error ? err : new Error(String(err)));
+    }
+  })();
+
+  async function completeReceive(name: string, size: number, digest: string): Promise<void> {
+    if (spec.role === 'receive') {
+      try {
+        const file = await readOpfsFile(name);
+        finish({ name, size, digest, file });
+      } catch (err) {
+        fail(err instanceof Error ? err : new Error(String(err)));
+      }
+    } else {
+      finish({ name, size, digest });
+    }
+  }
+
+  return {
+    progress: () => done,
+    total: () => total,
+    done: donePromise,
+    cancel: (reason = 'cancelled') => {
+      worker?.postMessage({ kind: 'cancel', reason } satisfies HostToWorker);
+      fail(new Error(reason));
+    },
+  };
+}
+
+/** Resolve once the worker posts its one-time `ready` handshake. */
+function workerReady(w: Worker): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const onReady = (ev: MessageEvent): void => {
+      if ((ev.data as WorkerToHost).kind === 'ready') {
+        w.removeEventListener('message', onReady);
+        resolve();
+      }
+    };
+    w.addEventListener('message', onReady);
+  });
+}
+
+/** Pull the directional keys and continuing counters out of the handshake result for the worker. */
+function crypto(r: RendezvousResult): SessionCrypto {
+  const sendDir = r.role === 'offerer' ? r.keys.o2j : r.keys.j2o;
+  const recvDir = r.role === 'offerer' ? r.keys.j2o : r.keys.o2j;
+  return { sendDir, recvDir, sendCounter: r.sendCounter, recvCounter: r.recvCounter };
+}

--- a/apps/web/src/lib/signaling/client.ts
+++ b/apps/web/src/lib/signaling/client.ts
@@ -15,6 +15,17 @@
 
 import type { SignalMsg } from '@sendarc/protocol';
 
+/**
+ * A live, bidirectional signaling channel with a swappable inbound handler. The rendezvous layer
+ * hands one of these to the M2 transfer layer (via `adoptSignaling`) once the handshake settles,
+ * so the SDP/ICE exchange can reuse the still-open socket instead of opening a second one.
+ */
+export interface SignalChannel {
+  send(msg: SignalMsg): void;
+  onMessage(handler: (msg: SignalMsg) => void): void;
+  close(): void;
+}
+
 /** Backoff schedule for the initial connect. Delays are `base * factor^n`, capped at `maxMs`. */
 export interface BackoffOptions {
   /** Number of retries after the first attempt before giving up. */

--- a/apps/web/src/lib/transfer/channel-writer.test.ts
+++ b/apps/web/src/lib/transfer/channel-writer.test.ts
@@ -4,7 +4,7 @@ import { ChannelWriter, type ChannelLike } from './channel-writer.js';
 class FakeChannel implements ChannelLike {
   bufferedAmount = 0;
   bufferedAmountLowThreshold = 0;
-  onbufferedamountlow: ((this: unknown, ev: Event) => void) | null = null;
+  onbufferedamountlow: ((ev: Event) => unknown) | null = null;
   sent: number[] = [];
   send(data: ArrayBuffer): void {
     this.sent.push(data.byteLength);

--- a/apps/web/src/lib/transfer/channel-writer.ts
+++ b/apps/web/src/lib/transfer/channel-writer.ts
@@ -10,7 +10,7 @@ export interface ChannelLike {
   bufferedAmount: number;
   bufferedAmountLowThreshold: number;
   send(data: ArrayBuffer): void;
-  onbufferedamountlow: ((this: unknown, ev: Event) => void) | null;
+  onbufferedamountlow: ((ev: Event) => unknown) | null;
 }
 
 export class ChannelWriter {

--- a/apps/web/src/lib/transfer/peer.ts
+++ b/apps/web/src/lib/transfer/peer.ts
@@ -1,0 +1,146 @@
+/**
+ * WebRTC peer for the M2 transfer: brings up an `RTCDataChannel` between the two paired clients
+ * over the already-authenticated signaling socket. Every SDP and ICE frame is signed and verified
+ * with the SPAKE2-derived key (see {@link SignalAuthenticator}); an unverifiable frame is dropped,
+ * so a malicious signaling server can pair sockets but cannot inject a peer or tamper with the
+ * negotiation. The offerer creates the channel and the offer; the joiner answers. Both trickle ICE.
+ *
+ * Browser-only (needs `RTCPeerConnection`); not unit-tested — exercised by the e2e transfer.
+ */
+
+import type { IceMsg, Role, SdpMsg } from '@sendarc/protocol';
+import type { SignalAuthenticator } from './authed-signaling.js';
+
+/** A public STUN server is enough for the common NAT case; TURN relay is a later milestone. */
+export const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
+
+export interface CreatePeerOptions {
+  role: Role;
+  auth: SignalAuthenticator;
+  /** Sign-and-forward an outbound signaling frame over the adopted socket. */
+  send: (msg: SdpMsg | IceMsg) => void;
+  iceServers?: RTCIceServer[];
+}
+
+export interface Peer {
+  /** Resolves with the data channel once it is open; rejects if negotiation fails. */
+  readonly channel: Promise<RTCDataChannel>;
+  /** Feed an inbound SDP/ICE frame (the orchestrator owns the socket's message routing). */
+  accept(msg: SdpMsg | IceMsg): void;
+  /**
+   * Register the inbound data-frame handler. Frames that arrive between channel-open and this
+   * call are buffered and flushed here, so the first blocks a fast sender emits are never lost.
+   */
+  onData(handler: (frame: ArrayBuffer) => void): void;
+  /** Tear down the peer connection. Idempotent. */
+  close(): void;
+}
+
+export function createPeer(opts: CreatePeerOptions): Peer {
+  const pc = new RTCPeerConnection({ iceServers: opts.iceServers ?? DEFAULT_ICE_SERVERS });
+
+  let resolveChannel!: (ch: RTCDataChannel) => void;
+  let rejectChannel!: (err: Error) => void;
+  const channel = new Promise<RTCDataChannel>((resolve, reject) => {
+    resolveChannel = resolve;
+    rejectChannel = reject;
+  });
+  let settled = false;
+
+  // Remote ICE can arrive before the remote description is set (network reorder, or the peer
+  // trickling early). Buffer such candidates and flush them once the description lands.
+  const pendingRemoteIce: RTCIceCandidateInit[] = [];
+  let remoteReady = false;
+
+  // Inbound data frames received before the orchestrator registers its handler are buffered here.
+  let dataHandler: ((frame: ArrayBuffer) => void) | undefined;
+  const dataBuffer: ArrayBuffer[] = [];
+
+  const fail = (err: Error): void => {
+    if (settled) return;
+    settled = true;
+    rejectChannel(err);
+    pc.close();
+  };
+
+  const wireChannel = (ch: RTCDataChannel): void => {
+    ch.binaryType = 'arraybuffer';
+    ch.onopen = () => {
+      if (settled) return;
+      settled = true;
+      resolveChannel(ch);
+    };
+    ch.onmessage = (ev: MessageEvent) => {
+      const frame = ev.data as ArrayBuffer;
+      if (dataHandler) dataHandler(frame);
+      else dataBuffer.push(frame);
+    };
+    ch.onerror = () => fail(new Error('data channel error'));
+  };
+
+  pc.onicecandidate = (ev) => {
+    if (ev.candidate) void opts.auth.signIce(JSON.stringify(ev.candidate)).then(opts.send);
+  };
+  pc.onconnectionstatechange = () => {
+    if (pc.connectionState === 'failed') fail(new Error('peer connection failed'));
+  };
+
+  if (opts.role === 'offerer') {
+    wireChannel(pc.createDataChannel('sendarc', { ordered: true }));
+    void (async () => {
+      try {
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+        opts.send(await opts.auth.signSdp(offer.sdp ?? ''));
+      } catch (err) {
+        fail(toError(err));
+      }
+    })();
+  } else {
+    pc.ondatachannel = (ev) => wireChannel(ev.channel);
+  }
+
+  const applyRemoteDescription = async (type: RTCSdpType, sdp: string): Promise<void> => {
+    await pc.setRemoteDescription({ type, sdp });
+    remoteReady = true;
+    for (const cand of pendingRemoteIce) await pc.addIceCandidate(cand);
+    pendingRemoteIce.length = 0;
+  };
+
+  const handle = async (msg: SdpMsg | IceMsg): Promise<void> => {
+    const verdict = await opts.auth.verify(msg);
+    if (!verdict.ok) return; // drop unverifiable frames
+    if (msg.type === 'sdp') {
+      if (opts.role === 'offerer') {
+        await applyRemoteDescription('answer', msg.sdp);
+      } else {
+        await applyRemoteDescription('offer', msg.sdp);
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        opts.send(await opts.auth.signSdp(answer.sdp ?? ''));
+      }
+    } else {
+      const cand: RTCIceCandidateInit = JSON.parse(msg.cand) as RTCIceCandidateInit;
+      if (remoteReady) await pc.addIceCandidate(cand);
+      else pendingRemoteIce.push(cand);
+    }
+  };
+
+  return {
+    channel,
+    accept: (msg) => void handle(msg).catch(fail),
+    onData: (handler) => {
+      dataHandler = handler;
+      for (const frame of dataBuffer) handler(frame);
+      dataBuffer.length = 0;
+    },
+    close: () => {
+      settled = true;
+      pc.close();
+    },
+  };
+}
+
+function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}

--- a/apps/web/src/lib/transfer/sink.ts
+++ b/apps/web/src/lib/transfer/sink.ts
@@ -33,3 +33,15 @@ function sanitize(name: string): string {
   const base = name.replace(/^.*[\\/]/, '').trim();
   return base.length > 0 ? base : 'download';
 }
+
+/**
+ * Read a finished OPFS file back by name, without opening a writable (which would truncate it).
+ * The orchestrator calls this after the worker reports `done` to hand a downloadable File to the
+ * UI. OPFS is origin-global, so the file the worker wrote is visible here on the main thread.
+ */
+export async function readOpfsFile(name: string): Promise<File> {
+  const root = await navigator.storage.getDirectory();
+  const handle = await root.getFileHandle(sanitize(name), { create: false });
+  const f = await handle.getFile();
+  return new File([f], name, { type: f.type, lastModified: f.lastModified });
+}

--- a/apps/web/src/lib/transfer/transfer.worker.ts
+++ b/apps/web/src/lib/transfer/transfer.worker.ts
@@ -1,0 +1,49 @@
+/**
+ * Transfer Web Worker entry. It hosts {@link runTransferCore} with the browser-backed deps —
+ * `hash-wasm` for the whole-file digest, an OPFS sink for the received file, a Blob-backed source
+ * for the sent file — so all crypto, hashing, and disk writes stay off the main thread. Loading
+ * the SHA-256 wasm is async; we post `{kind:'ready'}` only once it resolves, and the orchestrator
+ * waits for that before sending a start message.
+ *
+ * Browser-only (runs as a module worker); not unit-tested — the core it drives has its own
+ * loopback test, and the whole path is exercised by the e2e transfer.
+ */
+
+import { runTransferCore } from './transfer-core.js';
+import { createSha256DigestFactory } from './digest.js';
+import { blobFileSource } from './file-source.js';
+import { openOpfsSink } from './sink.js';
+import type { DuplexPort, HostToWorker, WorkerToHost } from './wire.js';
+
+/** The slice of the worker global we touch, typed narrowly to avoid the DOM/WebWorker lib clash. */
+interface WorkerScope {
+  postMessage(message: unknown, transfer?: Transferable[]): void;
+  addEventListener(type: 'message', handler: (ev: MessageEvent) => void): void;
+}
+const ctx = self as unknown as WorkerScope;
+
+const post = (msg: WorkerToHost, transfer?: Transferable[]): void => ctx.postMessage(msg, transfer);
+
+const port: DuplexPort<HostToWorker, WorkerToHost> = {
+  postMessage: (msg, transfer) => post(msg, transfer),
+  addEventListener: (_type, handler) =>
+    ctx.addEventListener('message', (ev) => handler({ data: ev.data as HostToWorker })),
+};
+
+async function main(): Promise<void> {
+  const createDigest = await createSha256DigestFactory();
+  post({ kind: 'ready' });
+  await runTransferCore(port, {
+    createDigest,
+    createSink: async (file) => (await openOpfsSink(file.name)).sink,
+    fileSource: (file) => blobFileSource(file),
+  });
+}
+
+void main().catch((err: unknown) => {
+  post({
+    kind: 'error',
+    reason: 'worker',
+    message: err instanceof Error ? err.message : String(err),
+  });
+});

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -39,6 +39,10 @@ export interface OutboundFrameMsg {
   kind: 'outbound-frame';
   frame: ArrayBuffer;
 }
+/** Worker → host, emitted once the core is wired and ready to accept a start message. */
+export interface ReadyMsg {
+  kind: 'ready';
+}
 export interface ManifestMsg {
   kind: 'manifest';
   name: string;
@@ -60,7 +64,8 @@ export interface ErrorMsg {
   reason: string;
   message: string;
 }
-export type WorkerToHost = OutboundFrameMsg | ManifestMsg | ProgressMsg | DoneMsg | ErrorMsg;
+export type WorkerToHost =
+  ReadyMsg | OutboundFrameMsg | ManifestMsg | ProgressMsg | DoneMsg | ErrorMsg;
 
 /** The slice of Worker / DedicatedWorkerGlobalScope the core needs, so a test can inject a fake. */
 export interface DuplexPort<In, Out> {


### PR DESCRIPTION
Bring up the M2 data path on top of the settled M1 handshake. The
rendezvous controller can now hand its still-open signaling socket to the
transfer layer (adoptSignaling) instead of closing it, so SDP/ICE reuse the
authenticated channel rather than opening a second one.

- peer.ts negotiates an RTCDataChannel, signing every SDP/ICE frame with the
  SPAKE2-derived key and dropping any that fail verification, so the
  signaling server can pair but never inject or tamper.
- transfer.worker.ts hosts runTransferCore with browser deps (hash-wasm
  digest, OPFS sink, Blob source) and a ready handshake gated on wasm load.
- session/transfer.ts pumps frames worker<->channel with backpressure,
  exposes a TransferController (progress, done, cancel), and reads the
  finished OPFS file back for download on the receive side.