### PR TITLE
feat(wire): add signaling authmac for the Go transport

### DIFF
--- a/packages/wire/authmac.go
+++ b/packages/wire/authmac.go
@@ -1,0 +1,76 @@
+package wire
+
+import (
+	"crypto/hmac"
+	"encoding/binary"
+)
+
+// Signaling-message authentication (M2 design §4.2). Each sdp/ice signaling message is
+// MAC'd so a malicious rendezvous server cannot substitute its own SDP to man-in-the-middle
+// the DataChannel:
+//
+//	mac = HMAC-SHA256(k_auth, utf8(type) || ":" || u32be(room) || ":" || u32be(seq) || ":" || body)
+//
+// k_auth is the SPAKE2 key-confirmation material M1 retains: each peer signs with its own
+// confirmation key and verifies with the peer's. This is defense-in-depth for the direct
+// path — confidentiality still rests on the AES-GCM frame layer keyed by K. This is the Go
+// twin of packages/protocol/src/authmac.ts and produces byte-identical MACs.
+
+// SignalMacType is the kind of signaling message being authenticated.
+type SignalMacType string
+
+const (
+	// SignalSDP authenticates an SDP offer/answer body.
+	SignalSDP SignalMacType = "sdp"
+	// SignalICE authenticates a trickled ICE-candidate body.
+	SignalICE SignalMacType = "ice"
+)
+
+// U32BE encodes n as 4 big-endian bytes — the fixed-width room/seq encoding in the MAC input.
+func U32BE(n uint32) []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, n)
+	return out
+}
+
+// SignalMacInput is the exact byte string the signaling MAC is computed over (design §4.2).
+func SignalMacInput(typ SignalMacType, room, seq uint32, body string) []byte {
+	const colon = ':'
+	out := make([]byte, 0, len(typ)+1+4+1+4+1+len(body))
+	out = append(out, string(typ)...)
+	out = append(out, colon)
+	out = append(out, U32BE(room)...)
+	out = append(out, colon)
+	out = append(out, U32BE(seq)...)
+	out = append(out, colon)
+	out = append(out, body...)
+	return out
+}
+
+// SignSignal computes the authentication MAC for a signaling message.
+func SignSignal(kAuth []byte, typ SignalMacType, room, seq uint32, body string) []byte {
+	return hmacSHA256(kAuth, SignalMacInput(typ, room, seq, body))
+}
+
+// VerifySignal recomputes the MAC and compares it in constant time. A false result means the
+// message is forged or corrupted and the session must abort.
+func VerifySignal(kAuth []byte, typ SignalMacType, room, seq uint32, body string, mac []byte) bool {
+	return hmac.Equal(SignSignal(kAuth, typ, room, seq, body), mac)
+}
+
+// SignalAuthKeys are one peer's signaling keys: it signs outgoing messages with Sign and
+// verifies the peer's messages with Verify.
+type SignalAuthKeys struct {
+	Sign   []byte
+	Verify []byte
+}
+
+// AuthKeys selects the signing/verifying confirmation keys for a role. The offerer (RFC party
+// "A") signs with KcA and verifies with KcB; the joiner is the mirror, so each peer's Sign
+// equals the other's Verify.
+func AuthKeys(role Role, out *Spake2Output) SignalAuthKeys {
+	if role == RoleOfferer {
+		return SignalAuthKeys{Sign: out.KcA, Verify: out.KcB}
+	}
+	return SignalAuthKeys{Sign: out.KcB, Verify: out.KcA}
+}

--- a/packages/wire/authmac_test.go
+++ b/packages/wire/authmac_test.go
@@ -1,0 +1,116 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestU32BE(t *testing.T) {
+	cases := []struct {
+		n    uint32
+		want string
+	}{
+		{0, "00000000"},
+		{1, "00000001"},
+		{7, "00000007"},
+		{0xffffffff, "ffffffff"},
+	}
+	for _, c := range cases {
+		if got := hex.EncodeToString(U32BE(c.n)); got != c.want {
+			t.Errorf("U32BE(%d) = %s, want %s", c.n, got, c.want)
+		}
+	}
+}
+
+func TestSignalMacInputShape(t *testing.T) {
+	// type || ":" || u32be(room) || ":" || u32be(seq) || ":" || body, colons as literal 0x3a.
+	got := SignalMacInput(SignalSDP, 7, 3, "hi")
+	want := bytes.Join([][]byte{
+		[]byte("sdp"), {':'}, {0, 0, 0, 7}, {':'}, {0, 0, 0, 3}, {':'}, []byte("hi"),
+	}, nil)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("SignalMacInput = %x, want %x", got, want)
+	}
+}
+
+// The committed cross-implementation vector: the Go MAC must equal the byte the TypeScript
+// codec produces for the same inputs, or a browser peer and a CLI peer cannot authenticate.
+func TestSignSignalVector(t *testing.T) {
+	var doc struct {
+		AuthMAC struct {
+			KAuthHex string `json:"kAuthHex"`
+			Type     string `json:"type"`
+			Room     uint32 `json:"room"`
+			Seq      uint32 `json:"seq"`
+			Body     string `json:"body"`
+			MAC      string `json:"mac"`
+		} `json:"authmac"`
+	}
+	loadVectors(t, "sendarc-crypto.json", &doc)
+	v := doc.AuthMAC
+	kAuth := mustHex(t, v.KAuthHex)
+
+	got := SignSignal(kAuth, SignalMacType(v.Type), v.Room, v.Seq, v.Body)
+	if hex.EncodeToString(got) != v.MAC {
+		t.Fatalf("SignSignal = %x, want %s", got, v.MAC)
+	}
+	if !VerifySignal(kAuth, SignalMacType(v.Type), v.Room, v.Seq, v.Body, mustHex(t, v.MAC)) {
+		t.Fatal("VerifySignal rejected the committed vector")
+	}
+}
+
+func TestVerifySignalRejectsTampering(t *testing.T) {
+	kAuth := mustHex(t, "000102030405060708090a0b0c0d0e0f")
+	mac := SignSignal(kAuth, SignalSDP, 7, 3, "body")
+
+	if !VerifySignal(kAuth, SignalSDP, 7, 3, "body", mac) {
+		t.Fatal("genuine MAC rejected")
+	}
+	// Every altered field must fail closed.
+	if VerifySignal(kAuth, SignalICE, 7, 3, "body", mac) {
+		t.Error("type change accepted")
+	}
+	if VerifySignal(kAuth, SignalSDP, 8, 3, "body", mac) {
+		t.Error("room change accepted")
+	}
+	if VerifySignal(kAuth, SignalSDP, 7, 4, "body", mac) {
+		t.Error("seq change accepted")
+	}
+	if VerifySignal(kAuth, SignalSDP, 7, 3, "body!", mac) {
+		t.Error("body change accepted")
+	}
+	// A flipped bit or a length change in the tag must be rejected.
+	bad := append([]byte(nil), mac...)
+	bad[0] ^= 0x01
+	if VerifySignal(kAuth, SignalSDP, 7, 3, "body", bad) {
+		t.Error("flipped MAC bit accepted")
+	}
+	if VerifySignal(kAuth, SignalSDP, 7, 3, "body", mac[:len(mac)-1]) {
+		t.Error("truncated MAC accepted")
+	}
+}
+
+func TestAuthKeysRolePairing(t *testing.T) {
+	out := &Spake2Output{
+		KcA: []byte("offerer-confirmation-key-A......."),
+		KcB: []byte("joiner-confirmation-key-B......."),
+	}
+	off := AuthKeys(RoleOfferer, out)
+	join := AuthKeys(RoleJoiner, out)
+
+	if !bytes.Equal(off.Sign, out.KcA) || !bytes.Equal(off.Verify, out.KcB) {
+		t.Error("offerer must sign with KcA and verify with KcB")
+	}
+	if !bytes.Equal(join.Sign, out.KcB) || !bytes.Equal(join.Verify, out.KcA) {
+		t.Error("joiner must sign with KcB and verify with KcA")
+	}
+	// The pairing must let each peer verify the other: one signs, the other verifies.
+	sign := func(k []byte) []byte { return SignSignal(k, SignalSDP, 1, 0, "x") }
+	if !VerifySignal(join.Verify, SignalSDP, 1, 0, "x", sign(off.Sign)) {
+		t.Error("joiner cannot verify the offerer's MAC")
+	}
+	if !VerifySignal(off.Verify, SignalSDP, 1, 0, "x", sign(join.Sign)) {
+		t.Error("offerer cannot verify the joiner's MAC")
+	}
+}


### PR DESCRIPTION
The browser transport authenticates every sdp/ice signaling message with
HMAC-SHA256 over k_auth (design 4.2) so the rendezvous server cannot swap in
its own SDP to MITM the DataChannel. The Go CLI needs the byte-identical
primitive before it can join the same signaling exchange, otherwise a browser
peer and a CLI peer could not verify each other's offers.

This is the Go twin of packages/protocol/src/authmac.ts: U32BE, SignalMacInput,
SignSignal, VerifySignal (constant-time via hmac.Equal), and AuthKeys role
pairing (offerer signs KcA/verifies KcB, joiner mirrored). A test reproduces
the committed cross-implementation vector and asserts every tampered field
fails closed.