### PR TITLE
feat(wire): add transfer IO ports and in-memory helpers

### DIFF
--- a/packages/wire/transfer_ports.go
+++ b/packages/wire/transfer_ports.go
@@ -1,0 +1,166 @@
+package wire
+
+import "errors"
+
+// IO ports for the transfer engine (M2 design §5.2, §7). The Sender/Receiver depend only on
+// these primitives, so the same core runs over an in-memory pipe in tests and over the real
+// pion DataChannel in the CLI. Concrete OS-backed implementations (file source, file sink)
+// live in apps/cli; this file defines the contracts plus in-memory helpers. It is the Go twin
+// of packages/protocol/src/transfer-ports.ts.
+
+// FileMeta is the minimal file metadata carried in the manifest.
+type FileMeta struct {
+	Name         string
+	Size         int64
+	Mime         string
+	LastModified int64
+}
+
+// FileSource is a streamable file. Stream yields the bytes in order and MUST be safe to call
+// more than once: the sender reads once to compute the whole-file digest, then again to emit
+// blocks. Each chunk is a view valid only for the duration of the callback — copy to retain.
+type FileSource interface {
+	Meta() FileMeta
+	Stream(fn func(chunk []byte) error) error
+}
+
+// Sink is a destination for verified, in-order block writes (design §7). offset is the byte
+// offset within the file. A non-nil error from any method aborts the transfer.
+type Sink interface {
+	Write(offset int64, bytes []byte) error
+	Close() error
+	Abort(reason string) error
+}
+
+// FailReason is the machine-readable tag for a transfer failure, sent on the wire in a fail
+// message. The set mirrors the TypeScript Fail['reason'] union exactly.
+type FailReason string
+
+const (
+	// FailDigestMismatch means the whole-file digest did not match the sender's Complete.
+	FailDigestMismatch FailReason = "digest_mismatch"
+	// FailIntegrity means a per-block hash did not match: a block was corrupted or forged.
+	FailIntegrity FailReason = "integrity"
+	// FailSinkError means the destination sink failed to write, close, or commit.
+	FailSinkError FailReason = "sink_error"
+	// FailCanceled means a peer canceled the transfer.
+	FailCanceled FailReason = "canceled"
+	// FailQuota means the destination ran out of space or quota.
+	FailQuota FailReason = "quota"
+)
+
+// TransferError carries one of the protocol's fail reasons. The reason is always prefixed
+// onto the message so it survives in Error() (logs, matchers) even when a detail is given,
+// matching the TypeScript TransferError.
+type TransferError struct {
+	Reason  FailReason
+	Message string
+}
+
+// NewTransferError builds a TransferError; an empty message yields the bare reason.
+func NewTransferError(reason FailReason, message string) *TransferError {
+	return &TransferError{Reason: reason, Message: message}
+}
+
+func (e *TransferError) Error() string {
+	if e.Message != "" {
+		return string(e.Reason) + ": " + e.Message
+	}
+	return string(e.Reason)
+}
+
+// errWriteAfterClose is returned by MemorySink when written to after close or abort.
+var errWriteAfterClose = errors.New("write after close/abort")
+
+// MemorySink is an in-memory Sink that reassembles writes into one buffer. For tests and the
+// loopback; it copies each write so callers may reuse their buffers.
+type MemorySink struct {
+	chunks  []memChunk
+	closed  bool
+	aborted bool
+	reason  string
+}
+
+type memChunk struct {
+	offset int64
+	bytes  []byte
+}
+
+// Write records bytes at offset. It fails once the sink is closed or aborted.
+func (s *MemorySink) Write(offset int64, bytes []byte) error {
+	if s.closed || s.aborted {
+		return errWriteAfterClose
+	}
+	s.chunks = append(s.chunks, memChunk{offset: offset, bytes: append([]byte(nil), bytes...)})
+	return nil
+}
+
+// Close marks the sink complete.
+func (s *MemorySink) Close() error {
+	s.closed = true
+	return nil
+}
+
+// Abort records a reason and stops accepting writes; an empty reason defaults to "aborted".
+func (s *MemorySink) Abort(reason string) error {
+	s.aborted = true
+	if reason == "" {
+		reason = "aborted"
+	}
+	s.reason = reason
+	return nil
+}
+
+// IsClosed reports whether Close has been called.
+func (s *MemorySink) IsClosed() bool { return s.closed }
+
+// AbortReason returns the reason passed to Abort, or "" if the sink was not aborted.
+func (s *MemorySink) AbortReason() string { return s.reason }
+
+// Bytes returns the assembled buffer; its size is the highest written offset plus length.
+func (s *MemorySink) Bytes() []byte {
+	var size int64
+	for _, c := range s.chunks {
+		if end := c.offset + int64(len(c.bytes)); end > size {
+			size = end
+		}
+	}
+	out := make([]byte, size)
+	for _, c := range s.chunks {
+		copy(out[c.offset:], c.bytes)
+	}
+	return out
+}
+
+// defaultSourceChunk is the streaming granularity of BytesSource when none is given (64 KiB).
+const defaultSourceChunk = 64 * 1024
+
+// BytesSource builds an in-memory FileSource over data, yielding chunk-sized pieces. A chunk
+// size of zero or less selects the 64 KiB default.
+func BytesSource(data []byte, meta FileMeta, chunk int) FileSource {
+	if chunk <= 0 {
+		chunk = defaultSourceChunk
+	}
+	return &bytesSource{data: data, meta: meta, chunk: chunk}
+}
+
+type bytesSource struct {
+	data  []byte
+	meta  FileMeta
+	chunk int
+}
+
+func (b *bytesSource) Meta() FileMeta { return b.meta }
+
+func (b *bytesSource) Stream(fn func(chunk []byte) error) error {
+	for i := 0; i < len(b.data); i += b.chunk {
+		end := i + b.chunk
+		if end > len(b.data) {
+			end = len(b.data)
+		}
+		if err := fn(b.data[i:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/packages/wire/transfer_ports_test.go
+++ b/packages/wire/transfer_ports_test.go
@@ -1,0 +1,132 @@
+package wire
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMemorySinkReassemblesOutOfOrder(t *testing.T) {
+	var s MemorySink
+	if err := s.Write(4, []byte{5, 6, 7, 8}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Write(0, []byte{1, 2, 3, 4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := s.Bytes(), []byte{1, 2, 3, 4, 5, 6, 7, 8}; !bytes.Equal(got, want) {
+		t.Errorf("Bytes() = %v, want %v", got, want)
+	}
+	if !s.IsClosed() {
+		t.Error("IsClosed() = false after Close()")
+	}
+}
+
+func TestMemorySinkCopiesWrites(t *testing.T) {
+	var s MemorySink
+	buf := []byte{1, 2, 3}
+	if err := s.Write(0, buf); err != nil {
+		t.Fatal(err)
+	}
+	buf[0] = 9 // mutate the caller's buffer; the sink must have copied.
+	if got := s.Bytes(); got[0] != 1 {
+		t.Errorf("sink retained caller buffer: got[0] = %d, want 1", got[0])
+	}
+}
+
+func TestMemorySinkAbortRefusesWrites(t *testing.T) {
+	var s MemorySink
+	if err := s.Abort("integrity"); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.AbortReason(); got != "integrity" {
+		t.Errorf("AbortReason() = %q, want %q", got, "integrity")
+	}
+	if err := s.Write(0, []byte{1}); err == nil {
+		t.Error("Write after Abort should fail")
+	}
+}
+
+func TestMemorySinkAbortDefaultReason(t *testing.T) {
+	var s MemorySink
+	if err := s.Abort(""); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.AbortReason(); got != "aborted" {
+		t.Errorf("AbortReason() = %q, want %q", got, "aborted")
+	}
+}
+
+func TestBytesSourceReStreamsInChunks(t *testing.T) {
+	data := make([]byte, 200)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	src := BytesSource(data, FileMeta{Name: "f", Size: 200}, 64)
+
+	// Re-callable: two independent passes must yield identical bytes and chunk sizes.
+	for pass := 0; pass < 2; pass++ {
+		var got []byte
+		var sizes []int
+		if err := src.Stream(func(c []byte) error {
+			sizes = append(sizes, len(c))
+			got = append(got, c...)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Errorf("pass %d: bytes mismatch", pass)
+		}
+		if want := []int{64, 64, 64, 8}; !equalInts(sizes, want) {
+			t.Errorf("pass %d: chunk sizes = %v, want %v", pass, sizes, want)
+		}
+	}
+}
+
+func TestBytesSourceEmpty(t *testing.T) {
+	src := BytesSource(nil, FileMeta{Name: "f"}, 0) // chunk 0 -> default; empty data.
+	calls := 0
+	if err := src.Stream(func([]byte) error { calls++; return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 {
+		t.Errorf("empty source yielded %d chunks, want 0", calls)
+	}
+}
+
+func TestBytesSourceStreamPropagatesError(t *testing.T) {
+	src := BytesSource([]byte{1, 2, 3, 4}, FileMeta{}, 2)
+	sentinel := NewTransferError(FailSinkError, "boom")
+	calls := 0
+	err := src.Stream(func([]byte) error { calls++; return sentinel })
+	if err != sentinel {
+		t.Errorf("Stream error = %v, want sentinel", err)
+	}
+	if calls != 1 {
+		t.Errorf("Stream kept going after error: %d calls, want 1", calls)
+	}
+}
+
+func TestTransferErrorMessage(t *testing.T) {
+	if got := NewTransferError(FailDigestMismatch, "").Error(); got != "digest_mismatch" {
+		t.Errorf("bare reason = %q, want %q", got, "digest_mismatch")
+	}
+	if got := NewTransferError(FailIntegrity, "block 3").Error(); got != "integrity: block 3" {
+		t.Errorf("reason+message = %q, want %q", got, "integrity: block 3")
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
The Go Sender and Receiver (coming next) must depend on the same narrow IO
contracts the TypeScript engine uses, so their core logic stays identical
across implementations and can be exercised over an in-memory pipe in tests
before any real DataChannel exists.

Port the transfer-ports module: FileMeta, FileSource (re-callable Stream so
the sender can hash then resend), Sink, and the FailReason set plus
TransferError with a reason-prefixed message, all matching the TS shapes.
MemorySink reassembles out-of-order writes and copies each buffer; BytesSource
re-streams fixed-size chunks. These are test/loopback fakes; OS-backed file
source and sink live in apps/cli.