### PR TITLE
feat(wire): add block-aligned frame re-chunker

### DIFF
--- a/packages/wire/transfer_chunker.go
+++ b/packages/wire/transfer_chunker.go
@@ -1,0 +1,87 @@
+package wire
+
+// Re-chunk an arbitrary byte stream into block-aligned frame pieces (design §5.4, §6).
+// Incoming chunk boundaries are irrelevant; output frames are frameSize bytes (a block's final
+// frame may be smaller), each tagged with its block index, its offset within the block, and
+// whether it is the block's last frame. Memory stays bounded to roughly one incoming chunk
+// plus one frame — the whole file is never held. Go twin of transfer-chunker.ts.
+
+// FramePiece is one frame's worth of file bytes, positioned within its block. Payload is a
+// view valid only until ReChunk emits the next piece; copy it to retain.
+type FramePiece struct {
+	BlockIdx    int
+	FrameOff    int // byte offset within the block
+	Payload     []byte
+	LastInBlock bool
+}
+
+// StreamFunc pushes a byte stream chunk by chunk; it is the shape of FileSource.Stream. It
+// must return the first error its callback returns, and be re-callable for the two sender
+// passes.
+type StreamFunc func(fn func(chunk []byte) error) error
+
+// ReChunk reads stream and calls emit once per block-aligned frame. A block boundary is never
+// crossed by a frame. emit's error (or the stream's) aborts and is returned.
+func ReChunk(stream StreamFunc, blockSize, frameSize int, emit func(FramePiece) error) error {
+	pos := 0           // absolute file offset of the next byte to emit
+	buf := []byte(nil) // unconsumed bytes, plus an already-consumed prefix up to start
+	start := 0         // consumed-prefix cursor into buf
+
+	avail := func() int { return len(buf) - start }
+	// A frame is capped at the block's remaining bytes so it never spans two blocks.
+	targetLen := func() int {
+		rem := blockSize - (pos % blockSize)
+		if frameSize < rem {
+			return frameSize
+		}
+		return rem
+	}
+	emitPiece := func(t int) FramePiece {
+		offsetInBlock := pos % blockSize
+		blockIdx := pos / blockSize
+		payload := buf[start : start+t]
+		start += t
+		pos += t
+		return FramePiece{
+			BlockIdx:    blockIdx,
+			FrameOff:    offsetInBlock,
+			Payload:     payload,
+			LastInBlock: offsetInBlock+t == blockSize,
+		}
+	}
+
+	if err := stream(func(chunk []byte) error {
+		// Drop the consumed prefix before growing, keeping the retained tail small. A fresh
+		// allocation means any payload view already emitted stays valid.
+		tail := buf[start:]
+		buf = make([]byte, 0, len(tail)+len(chunk))
+		buf = append(buf, tail...)
+		buf = append(buf, chunk...)
+		start = 0
+		for avail() >= targetLen() {
+			if err := emit(emitPiece(targetLen())); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Flush the trailing partial frame — also the file's final, possibly-partial block.
+	for avail() > 0 {
+		t := targetLen()
+		if a := avail(); a < t {
+			t = a
+		}
+		piece := emitPiece(t)
+		// At EOF the block is "last" whether it filled or the stream simply ended.
+		if avail() == 0 {
+			piece.LastInBlock = true
+		}
+		if err := emit(piece); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/packages/wire/transfer_chunker_test.go
+++ b/packages/wire/transfer_chunker_test.go
@@ -1,0 +1,139 @@
+package wire
+
+import "testing"
+
+// piece is a comparable snapshot of a FramePiece for table assertions.
+type piece struct {
+	block, off, plen int
+	last             bool
+	payload          string
+}
+
+// collect runs ReChunk over data delivered as the given chunk groups and records each piece.
+func collect(t *testing.T, chunks [][]byte, block, frame int) []piece {
+	t.Helper()
+	stream := func(fn func([]byte) error) error {
+		for _, c := range chunks {
+			if err := fn(c); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	var got []piece
+	err := ReChunk(stream, block, frame, func(p FramePiece) error {
+		got = append(got, piece{p.BlockIdx, p.FrameOff, len(p.Payload), p.LastInBlock, string(p.Payload)})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ReChunk: %v", err)
+	}
+	return got
+}
+
+func seq(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return b
+}
+
+func TestReChunkEmptyStream(t *testing.T) {
+	if got := collect(t, nil, 8, 4); len(got) != 0 {
+		t.Errorf("empty stream produced %d pieces, want 0", len(got))
+	}
+}
+
+func TestReChunkSubFrameFile(t *testing.T) {
+	got := collect(t, [][]byte{{1, 2, 3}}, 8, 4)
+	want := []piece{{0, 0, 3, true, string([]byte{1, 2, 3})}}
+	assertPieces(t, got, want)
+}
+
+func TestReChunkExactBlockMultiple(t *testing.T) {
+	// block=8, frame=4, 16 bytes = 2 blocks × 2 frames, all full.
+	got := collect(t, [][]byte{seq(16)}, 8, 4)
+	wantShape := [][4]int{{0, 0, 4, 0}, {0, 4, 4, 1}, {1, 0, 4, 0}, {1, 4, 4, 1}}
+	assertShape(t, got, wantShape)
+	assertBytes(t, got, seq(16))
+}
+
+func TestReChunkAwkwardBoundaries(t *testing.T) {
+	// Same 16 bytes delivered as 3+7+6 must produce output identical to one 16-byte chunk.
+	d := seq(16)
+	got := collect(t, [][]byte{d[0:3], d[3:10], d[10:16]}, 8, 4)
+	wantShape := [][4]int{{0, 0, 4, 0}, {0, 4, 4, 1}, {1, 0, 4, 0}, {1, 4, 4, 1}}
+	assertShape(t, got, wantShape)
+	assertBytes(t, got, d)
+}
+
+func TestReChunkFinalPartialBlock(t *testing.T) {
+	// block=8, frame=4, 10 bytes → block0 full (2 frames), block1 one 2-byte frame.
+	got := collect(t, [][]byte{seq(10)}, 8, 4)
+	assertShape(t, got, [][4]int{{0, 0, 4, 0}, {0, 4, 4, 1}, {1, 0, 2, 1}})
+}
+
+func TestReChunkFrameEqualsBlock(t *testing.T) {
+	// block=8, frame=8, 20 bytes → 8, 8, 4; one frame per block, each the block's last.
+	got := collect(t, [][]byte{seq(20)}, 8, 8)
+	assertShape(t, got, [][4]int{{0, 0, 8, 1}, {1, 0, 8, 1}, {2, 0, 4, 1}})
+}
+
+func TestReChunkPropagatesEmitError(t *testing.T) {
+	stream := func(fn func([]byte) error) error { return fn(seq(16)) }
+	sentinel := NewTransferError(FailSinkError, "stop")
+	calls := 0
+	err := ReChunk(stream, 8, 4, func(FramePiece) error {
+		calls++
+		return sentinel
+	})
+	if err != sentinel {
+		t.Errorf("ReChunk error = %v, want sentinel", err)
+	}
+	if calls != 1 {
+		t.Errorf("kept emitting after error: %d calls, want 1", calls)
+	}
+}
+
+func assertPieces(t *testing.T, got, want []piece) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d pieces, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("piece %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// assertShape checks [blockIdx, frameOff, payloadLen, lastInBlock(0/1)] per piece.
+func assertShape(t *testing.T, got []piece, want [][4]int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d pieces, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		last := 0
+		if got[i].last {
+			last = 1
+		}
+		if got[i].block != w[0] || got[i].off != w[1] || got[i].plen != w[2] || last != w[3] {
+			t.Errorf("piece %d = [%d %d %d %d], want %v",
+				i, got[i].block, got[i].off, got[i].plen, last, w)
+		}
+	}
+}
+
+// assertBytes checks the concatenated payloads equal want.
+func assertBytes(t *testing.T, got []piece, want []byte) {
+	t.Helper()
+	var all []byte
+	for _, p := range got {
+		all = append(all, []byte(p.payload)...)
+	}
+	if string(all) != string(want) {
+		t.Errorf("reassembled bytes = %v, want %v", all, want)
+	}
+}


### PR DESCRIPTION
Ports the transfer engine's re-chunking stage (`transfer-chunker.ts`) to the Go `wire` module.

`ReChunk` reads an arbitrary byte stream and emits fixed-size `FramePiece`s that never cross a block boundary, each tagged with block index, in-block offset, and last-in-block. This is the shared input for the sender's windowed block emission and the receiver's per-block hashing.

**Memory:** buffers only the unconsumed tail plus one frame; a fresh backing allocation per incoming chunk keeps already-emitted payload views valid until the next piece.

**Tests** mirror the TS suite — empty stream, sub-frame file, exact block multiple, awkward delivery splits (3+7+6), trailing partial block, frame-equals-block, and emit-error propagation.

Gates run locally with `GOWORK=off GOFLAGS=-mod=readonly`: gofmt, `go vet`, `go test -race`, `golangci-lint` — all clean.