### PR TITLE
feat(wire): add windowed transfer sender

### DIFF
--- a/packages/wire/frame.go
+++ b/packages/wire/frame.go
@@ -7,6 +7,11 @@ import (
 
 const frameHeaderBytes = 16
 
+// FrameVersion is the frame-header format version (the header's first byte). It mirrors
+// FRAME_VERSION in packages/protocol/src/constants.ts and is bumped only if the header
+// layout changes.
+const FrameVersion uint8 = 1
+
 // FrameHeader is the 16-byte frame header (plan.md §6.3). Its encoded bytes are the
 // AES-GCM additional authenticated data, so the codec must be exact and stable.
 //

--- a/packages/wire/transfer_ports.go
+++ b/packages/wire/transfer_ports.go
@@ -1,6 +1,11 @@
 package wire
 
-import "errors"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"hash"
+)
 
 // IO ports for the transfer engine (M2 design §5.2, §7). The Sender/Receiver depend only on
 // these primitives, so the same core runs over an in-memory pipe in tests and over the real
@@ -32,9 +37,40 @@ type Sink interface {
 	Abort(reason string) error
 }
 
+// Digest is a streaming whole-file hasher producing a sha256sum-identical hex string. The
+// sender computes it in a first pass so the file is never buffered whole; a fresh Digest is
+// requested per transfer so implementations may be stateful. It is the Go twin of the TS
+// Digest port.
+type Digest interface {
+	Update(bytes []byte)
+	HexDigest() string
+}
+
+// sha256Digest is the default Digest, backed by the standard library.
+type sha256Digest struct{ h hash.Hash }
+
+// NewSHA256Digest returns a streaming SHA-256 Digest — the CLI's default whole-file hasher.
+func NewSHA256Digest() Digest { return &sha256Digest{h: sha256.New()} }
+
+func (d *sha256Digest) Update(b []byte) { d.h.Write(b) }
+
+func (d *sha256Digest) HexDigest() string { return hex.EncodeToString(d.h.Sum(nil)) }
+
 // FailReason is the machine-readable tag for a transfer failure, sent on the wire in a fail
 // message. The set mirrors the TypeScript Fail['reason'] union exactly.
 type FailReason string
+
+// Transfer sizing defaults, mirroring packages/protocol/src/constants.ts. They are the
+// negotiation starting point; a caps exchange may lower them within the header field widths.
+const (
+	// DefaultBlockBytes is the logical block size — the unit of ack, retry, and resume.
+	DefaultBlockBytes = 1024 * 1024
+	// DefaultFrameBytes is the default DataChannel/relay payload size.
+	DefaultFrameBytes = 16 * 1024
+	// DefaultInflightBlocks bounds how many blocks the sender may run ahead of the
+	// receiver's block_recv, capping receiver memory regardless of sink speed.
+	DefaultInflightBlocks = 8
+)
 
 const (
 	// FailDigestMismatch means the whole-file digest did not match the sender's Complete.

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -1,0 +1,280 @@
+package wire
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Sender is the sending half of the transport-agnostic transfer engine (design §5). It
+// streams a file without ever buffering it whole:
+//
+//	Pass 1  read the file once → whole-file streaming digest → manifest (with fileDigest).
+//	Pass 2  re-chunk into block_data frames; at each block boundary send block_hash.
+//	Finish  send complete{fileDigest}; return when the receiver replies done.
+//
+// Outbound frames are AES-GCM sealed with a per-direction counter that continues from the
+// handshake and is never reset. The sender never runs more than Window blocks ahead of the
+// receiver's block_recv signal, bounding the outbound queue. It is the Go twin of
+// packages/protocol/src/transfer-sender.ts.
+//
+// Run executes on the caller's goroutine; Handle is called from the transport's read loop as
+// inbound frames (block_recv / done / fail) arrive. Shared state is guarded by a mutex and a
+// condition variable: window-gating in Run waits on the receiver's acks delivered by Handle.
+
+// FrameFlagLastInBlock is the header flag marking a frame as the last of its block.
+const FrameFlagLastInBlock uint8 = 0x01
+
+// SenderOptions configures a Sender. Zero-valued sizing fields select the protocol defaults.
+type SenderOptions struct {
+	File             FileSource
+	Send             func(frame []byte) error
+	SendDir          DirectionalKey
+	RecvDir          DirectionalKey
+	SendCounterStart uint64
+	RecvCounterStart uint64
+	CreateDigest     func() Digest // nil selects a streaming SHA-256 digest
+	BlockSize        int           // 0 selects DefaultBlockBytes
+	FrameSize        int           // 0 selects DefaultFrameBytes
+	Window           int           // 0 selects DefaultInflightBlocks
+	OnProgress       func(sentBytes int64)
+}
+
+// Sender drives one file send. Construct it with NewSender.
+type Sender struct {
+	o         SenderOptions
+	blockSize int
+	frameSize int
+	window    int
+
+	sendCounter uint64 // touched only by Run's goroutine
+	sent        int64  // touched only by Run's goroutine
+
+	mu            sync.Mutex
+	cond          *sync.Cond
+	recvCounter   uint64
+	lastRecvBlock int
+	settled       bool
+	err           error // non-nil once a fail has been observed
+}
+
+// errSenderSettled breaks out of the pass-2 stream when the transfer settles mid-flight; it
+// never escapes Run, which converts it into the stored fail (or nil on an early done).
+var errSenderSettled = errors.New("sender settled")
+
+// NewSender builds a Sender, applying protocol defaults for any zero-valued sizing option.
+func NewSender(opts SenderOptions) *Sender {
+	if opts.BlockSize <= 0 {
+		opts.BlockSize = DefaultBlockBytes
+	}
+	if opts.FrameSize <= 0 {
+		opts.FrameSize = DefaultFrameBytes
+	}
+	if opts.Window <= 0 {
+		opts.Window = DefaultInflightBlocks
+	}
+	if opts.CreateDigest == nil {
+		opts.CreateDigest = NewSHA256Digest
+	}
+	s := &Sender{
+		o:             opts,
+		blockSize:     opts.BlockSize,
+		frameSize:     opts.FrameSize,
+		window:        opts.Window,
+		sendCounter:   opts.SendCounterStart,
+		recvCounter:   opts.RecvCounterStart,
+		lastRecvBlock: -1,
+	}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// Run drives the whole send. It returns the canonical whole-file digest (hex) once the
+// receiver confirms done, or an error on fail or an IO failure. The digest is the same value
+// carried in the manifest and complete, so a host can report it without recomputing.
+func (s *Sender) Run() (string, error) {
+	meta := s.o.File.Meta()
+
+	// Pass 1: whole-file digest, streamed so the file is never held.
+	digest := s.o.CreateDigest()
+	if err := s.o.File.Stream(func(chunk []byte) error {
+		digest.Update(chunk)
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	fileDigest := digest.HexDigest()
+
+	blocks := 0
+	if meta.Size > 0 {
+		blocks = int((meta.Size + int64(s.blockSize) - 1) / int64(s.blockSize)) // ceil
+	}
+	if err := s.sendControl(NewManifest([]FileEntry{{
+		Idx: 0, Name: meta.Name, Size: meta.Size, Mime: meta.Mime,
+		LastModified: meta.LastModified, BlockSize: s.blockSize, Blocks: blocks,
+		FileDigest: fileDigest,
+	}}, meta.Size)); err != nil {
+		return "", err
+	}
+
+	// Pass 2: block data + per-block hash, gated to the in-flight window.
+	var blockParts []byte
+	streamErr := ReChunk(StreamFunc(s.o.File.Stream), s.blockSize, s.frameSize, func(p FramePiece) error {
+		s.gate(p.BlockIdx)
+		if s.isSettled() {
+			return errSenderSettled // aborted by an inbound fail (or early done)
+		}
+		flags := uint8(0)
+		if p.LastInBlock {
+			flags = FrameFlagLastInBlock
+		}
+		if err := s.sendFrame(FrameHeaderInput{
+			Version:  FrameVersion,
+			Type:     FrameBlockData,
+			Flags:    flags,
+			FileIdx:  0,
+			BlockIdx: uint32(p.BlockIdx),
+			FrameOff: uint16(p.FrameOff),
+		}, p.Payload); err != nil {
+			return err
+		}
+		s.sent += int64(len(p.Payload))
+		if s.o.OnProgress != nil {
+			s.o.OnProgress(s.sent)
+		}
+		blockParts = append(blockParts, p.Payload...)
+		if p.LastInBlock {
+			sum := sha256.Sum256(blockParts)
+			blockParts = blockParts[:0]
+			if err := s.sendControl(NewBlockHash(0, p.BlockIdx, hex.EncodeToString(sum[:]))); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if streamErr != nil {
+		if errors.Is(streamErr, errSenderSettled) {
+			// Settled mid-stream: propagate the fail, or return the digest on an early done.
+			return fileDigest, s.waitDone()
+		}
+		return "", streamErr
+	}
+
+	if err := s.sendControl(NewComplete(fileDigest)); err != nil {
+		return "", err
+	}
+	if err := s.waitDone(); err != nil {
+		return "", err
+	}
+	return fileDigest, nil
+}
+
+// Handle feeds one inbound frame from the receiver (block_recv / done / fail). It must be
+// called serially — the ordered DataChannel read loop satisfies this — because each frame
+// consumes the next receive counter.
+func (s *Sender) Handle(frame []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.settled {
+		return
+	}
+	ctr := s.recvCounter
+	s.recvCounter++
+	opened, err := Open(s.o.RecvDir, ctr, frame)
+	if err != nil {
+		s.failLocked(err)
+		return
+	}
+	msg, err := DecodeControl(opened.Plaintext)
+	if err != nil {
+		s.failLocked(err)
+		return
+	}
+	switch m := msg.(type) {
+	case *BlockRecv:
+		if m.BlockIdx > s.lastRecvBlock {
+			s.lastRecvBlock = m.BlockIdx
+		}
+		s.cond.Broadcast()
+	case *Done:
+		s.settleLocked()
+	case *Fail:
+		s.failLocked(NewTransferError(m.Reason, "receiver failed: "+string(m.Reason)))
+	default:
+		s.failLocked(NewTransferError(FailIntegrity,
+			fmt.Sprintf("unexpected sender-inbound type %d", msg.FrameType())))
+	}
+}
+
+// --- internal ---------------------------------------------------------------
+
+// gate blocks until the block is within the in-flight window of the receiver's last ack, or
+// the transfer settles.
+func (s *Sender) gate(blockIdx int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for !s.settled && blockIdx-s.lastRecvBlock > s.window {
+		s.cond.Wait()
+	}
+}
+
+func (s *Sender) isSettled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.settled
+}
+
+// waitDone blocks until the transfer settles and returns the fail error, or nil on done.
+func (s *Sender) waitDone() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for !s.settled {
+		s.cond.Wait()
+	}
+	return s.err
+}
+
+// settleLocked marks a successful finish; the caller holds the mutex.
+func (s *Sender) settleLocked() {
+	if s.settled {
+		return
+	}
+	s.settled = true
+	s.cond.Broadcast()
+}
+
+// failLocked records the first failure and wakes every waiter; the caller holds the mutex.
+func (s *Sender) failLocked(err error) {
+	if s.settled {
+		return
+	}
+	s.settled = true
+	s.err = err
+	s.cond.Broadcast()
+}
+
+// sendControl seals and sends a control message; its frame-header type is the message's tag.
+func (s *Sender) sendControl(msg ControlMsg) error {
+	payload, err := EncodeControl(msg)
+	if err != nil {
+		return err
+	}
+	return s.sendFrame(FrameHeaderInput{
+		Version: FrameVersion,
+		Type:    msg.FrameType(),
+		Flags:   0,
+		FileIdx: 0, BlockIdx: 0, FrameOff: 0,
+	}, payload)
+}
+
+// sendFrame seals payload under the next send counter and hands the frame to the transport.
+func (s *Sender) sendFrame(header FrameHeaderInput, payload []byte) error {
+	frame, err := Seal(s.o.SendDir, s.sendCounter, header, payload)
+	if err != nil {
+		return err
+	}
+	s.sendCounter++
+	return s.o.Send(frame)
+}

--- a/packages/wire/transfer_sender_test.go
+++ b/packages/wire/transfer_sender_test.go
@@ -1,0 +1,225 @@
+package wire
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// senderMaster is the fixed 32-byte master key both sender tests derive their keys from.
+func senderMaster() []byte {
+	m := make([]byte, 32)
+	for i := range m {
+		m[i] = 9
+	}
+	return m
+}
+
+// outbox is a concurrency-safe capture of the frames a Sender emits from its Run goroutine.
+type outbox struct {
+	mu     sync.Mutex
+	frames [][]byte
+}
+
+func (o *outbox) push(f []byte) error {
+	o.mu.Lock()
+	o.frames = append(o.frames, append([]byte(nil), f...))
+	o.mu.Unlock()
+	return nil
+}
+
+func (o *outbox) len() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.frames)
+}
+
+func (o *outbox) snapshot() [][]byte {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([][]byte(nil), o.frames...)
+}
+
+// waitStable blocks until the outbox has held want frames unchanged across a few polls,
+// i.e. the sender has stalled on its window gate rather than merely being between sends.
+func waitStable(t *testing.T, o *outbox, want int) {
+	t.Helper()
+	stable := 0
+	for i := 0; i < 2000; i++ {
+		if o.len() == want {
+			if stable++; stable >= 5 {
+				return
+			}
+		} else {
+			stable = 0
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("outbox never stabilized at %d frames (saw %d)", want, o.len())
+}
+
+func TestSenderEmitsGrammarGatedByBlockRecv(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := seq(20) // block=8 → blocks 0,1 full, block 2 = 4 bytes
+	var out outbox
+
+	s := NewSender(SenderOptions{
+		File:      BytesSource(data, FileMeta{Name: "f", Size: 20}, 0),
+		Send:      out.push,
+		SendDir:   keys.O2J,
+		RecvDir:   keys.J2O,
+		BlockSize: 8,
+		FrameSize: 4,
+		Window:    1, // force gating after block 0
+	})
+
+	type result struct {
+		digest string
+		err    error
+	}
+	res := make(chan result, 1)
+	go func() {
+		d, err := s.Run()
+		res <- result{d, err}
+	}()
+
+	// manifest + block 0's two frames + block 0 hash = 4 frames, then it stalls on window=1.
+	waitStable(t, &out, 4)
+	peek := 0
+	for _, f := range out.snapshot() {
+		o, err := Open(keys.O2J, uint64(peek), f)
+		if err != nil {
+			t.Fatalf("open frame %d: %v", peek, err)
+		}
+		if peek == 0 && o.Header.Type != FrameManifest {
+			t.Fatalf("frame 0 type = %d, want manifest", o.Header.Type)
+		}
+		if o.Header.Type == FrameComplete {
+			t.Fatalf("complete sent before receiver acked the window")
+		}
+		peek++
+	}
+
+	// Ack every block so the window drains, then send done.
+	ackCtr := uint64(0)
+	ack := func(blockIdx int) {
+		payload, err := EncodeControl(NewBlockRecv(0, blockIdx))
+		if err != nil {
+			t.Fatal(err)
+		}
+		frame, err := Seal(keys.J2O, ackCtr, FrameHeaderInput{Version: FrameVersion, Type: FrameBlockRecv}, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ackCtr++
+		s.Handle(frame)
+	}
+	ack(0)
+	ack(1)
+	ack(2)
+
+	// Let pass 2 drain all blocks and send complete before we confirm done — otherwise done
+	// would settle the sender mid-stream and complete would never be sent. The final 4-byte
+	// block lands on a frame boundary, so like the TS reference it carries no block_hash:
+	// manifest + (block0: 2 data + hash) + (block1: 2 data + hash) + (block2: 1 data) +
+	// complete = 9 frames.
+	waitStable(t, &out, 9)
+
+	donePayload, err := EncodeControl(NewDone())
+	if err != nil {
+		t.Fatal(err)
+	}
+	doneFrame, err := Seal(keys.J2O, ackCtr, FrameHeaderInput{Version: FrameVersion, Type: FrameDone}, donePayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Handle(doneFrame)
+
+	got := <-res
+	if got.err != nil {
+		t.Fatalf("Run: %v", got.err)
+	}
+	sum := sha256.Sum256(data)
+	wantDigest := hex.EncodeToString(sum[:])
+	if got.digest != wantDigest {
+		t.Errorf("digest = %s, want %s", got.digest, wantDigest)
+	}
+
+	// Decode the full outbound sequence: last frame must be complete with the file digest, and
+	// the block_data payloads must reassemble to the original bytes in order.
+	var body []byte
+	var lastType uint8
+	var lastPayload []byte
+	c := 0
+	for _, f := range out.snapshot() {
+		o, err := Open(keys.O2J, uint64(c), f)
+		if err != nil {
+			t.Fatalf("open frame %d: %v", c, err)
+		}
+		if o.Header.Type == FrameBlockData {
+			body = append(body, o.Plaintext...)
+		}
+		lastType, lastPayload = o.Header.Type, o.Plaintext
+		c++
+	}
+	if lastType != FrameComplete {
+		t.Fatalf("last frame type = %d, want complete", lastType)
+	}
+	msg, err := DecodeControl(lastPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	complete, ok := msg.(*Complete)
+	if !ok || complete.FileDigest != wantDigest {
+		t.Fatalf("complete = %#v, want digest %s", msg, wantDigest)
+	}
+	if string(body) != string(data) {
+		t.Errorf("reassembled body = %v, want %v", body, data)
+	}
+}
+
+func TestSenderRejectsOnReceiverFail(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewSender(SenderOptions{
+		File:      BytesSource(make([]byte, 4), FileMeta{Name: "f", Size: 4}, 0),
+		Send:      func([]byte) error { return nil },
+		SendDir:   keys.O2J,
+		RecvDir:   keys.J2O,
+		BlockSize: 8,
+		FrameSize: 4,
+	})
+
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run()
+		res <- err
+	}()
+
+	payload, err := EncodeControl(NewFail(FailIntegrity))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failFrame, err := Seal(keys.J2O, 0, FrameHeaderInput{Version: FrameVersion, Type: FrameFail}, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Handle(failFrame)
+
+	select {
+	case err := <-res:
+		if err == nil || !strings.Contains(err.Error(), "integrity") {
+			t.Fatalf("Run error = %v, want one mentioning integrity", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after receiver fail")
+	}
+}


### PR DESCRIPTION
Ports the sending half of the transport-agnostic transfer engine (`transfer-sender.ts`) to the Go `wire` module.

**Two streaming passes** — never buffers the file whole:
1. hash the file → manifest `fileDigest`
2. re-chunk into sealed `block_data` frames, emit a `block_hash` at each block boundary; finish with `complete{fileDigest}`, return on the receiver's `done`.

**Concurrency:** where the TS engine uses promises, the Go port uses a goroutine + `sync.Cond`. `Run` drives both passes and blocks on the in-flight-window gate; `Handle` (called from the transport read loop) advances the receiver's `block_recv` high-water mark and wakes the gate. The sender never runs more than `Window` blocks ahead of the last ack. `done` resolves `Run`; `fail` rejects it.

**Supporting additions:** `FrameVersion` and `FrameFlagLastInBlock` constants, transfer sizing defaults (block/frame/window), and a streaming `Digest` port with a stdlib SHA-256 default.

**Tests** mirror the TS suite — manifest → block_data/block_hash → complete gated by `block_recv`, and `Run` rejecting on receiver `fail`.

Gates run locally with `GOWORK=off GOFLAGS=-mod=readonly`: gofmt, `go vet`, `go test -race`, `golangci-lint` — all clean.