### PR TITLE
feat(wire): add verify-before-write transfer receiver

### DIFF
--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -1,0 +1,284 @@
+package wire
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Receiver is the receiving half of the transfer engine (design §5, §6). Frames arrive over an
+// ordered, reliable channel, so blocks assemble one at a time, in order. For each block the
+// receiver verifies its SHA-256 (from block_hash) BEFORE writing to the sink, feeds the verified
+// bytes into the whole-file streaming digest, then signals block_recv (the in-flight window). On
+// complete it compares the recomputed digest to the sender's and replies done, or
+// fail{digest_mismatch}. A GCM open failure or any hash mismatch yields fail{integrity} and an
+// abort — never a silent retry (design §5.5). It is the Go twin of
+// packages/protocol/src/transfer-receiver.ts.
+//
+// Handle is called from the transport read loop and MUST be called serially — the ordered
+// DataChannel satisfies this, and each frame consumes the next receive counter. Wait blocks a
+// separate goroutine until the transfer settles.
+
+// ReceiveResult is the outcome of a successful receive: the manifest entry and the verified
+// whole-file digest (hex).
+type ReceiveResult struct {
+	File   FileEntry
+	Digest string
+}
+
+// ReceiverOptions configures a Receiver.
+type ReceiverOptions struct {
+	Send             func(frame []byte) error
+	SendDir          DirectionalKey
+	RecvDir          DirectionalKey
+	SendCounterStart uint64
+	RecvCounterStart uint64
+	CreateDigest     func() Digest // nil selects a streaming SHA-256 digest
+	Sink             Sink
+	OnProgress       func(receivedBytes int64)
+	// OnManifest is called once when the manifest decodes, before any block is written — it lets
+	// the host open a destination named after the file without the engine knowing about it. A
+	// non-nil error aborts the transfer.
+	OnManifest func(file FileEntry) error
+}
+
+// Receiver drives one file receive. Construct it with NewReceiver.
+type Receiver struct {
+	o      ReceiverOptions
+	digest Digest
+
+	// Counters and assembly state are touched only by Handle's (serial) goroutine.
+	sendCounter uint64
+	recvCounter uint64
+	file        *FileEntry
+	curBlock    int
+	blockBuf    []byte
+	blockLen    int
+	received    int
+
+	mu      sync.Mutex
+	done    chan struct{}
+	settled bool
+	result  ReceiveResult
+	err     error
+}
+
+// NewReceiver builds a Receiver, defaulting to a streaming SHA-256 digest when none is given.
+func NewReceiver(opts ReceiverOptions) *Receiver {
+	if opts.CreateDigest == nil {
+		opts.CreateDigest = NewSHA256Digest
+	}
+	return &Receiver{
+		o:           opts,
+		digest:      opts.CreateDigest(),
+		sendCounter: opts.SendCounterStart,
+		recvCounter: opts.RecvCounterStart,
+		done:        make(chan struct{}),
+	}
+}
+
+// Wait blocks until the transfer settles, returning the result on done or the error on fail.
+func (r *Receiver) Wait() (ReceiveResult, error) {
+	<-r.done
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.result, r.err
+}
+
+// Handle feeds one inbound frame from the sender (manifest / block_data / block_hash / complete).
+// Any error aborts the transfer with the appropriate fail reason (integrity unless the error
+// already carries one).
+func (r *Receiver) Handle(frame []byte) {
+	if err := r.process(frame); err != nil {
+		var te *TransferError
+		if !errors.As(err, &te) {
+			te = NewTransferError(FailIntegrity, err.Error())
+		}
+		r.abortWith(te)
+	}
+}
+
+// --- internal ---------------------------------------------------------------
+
+func (r *Receiver) process(frame []byte) error {
+	if r.isSettled() {
+		return nil
+	}
+	ctr := r.recvCounter
+	r.recvCounter++
+	opened, err := Open(r.o.RecvDir, ctr, frame) // open failure → integrity abort
+	if err != nil {
+		return NewTransferError(FailIntegrity, err.Error())
+	}
+	switch opened.Header.Type {
+	case FrameManifest:
+		return r.applyManifest(opened.Plaintext)
+	case FrameBlockData:
+		return r.onBlockData(opened.Header.BlockIdx, opened.Header.FrameOff, opened.Plaintext)
+	case FrameBlockHash:
+		return r.onBlockHash(opened.Plaintext)
+	case FrameComplete:
+		return r.onComplete(opened.Plaintext)
+	default:
+		return NewTransferError(FailIntegrity,
+			fmt.Sprintf("unexpected receiver-inbound type %d", opened.Header.Type))
+	}
+}
+
+func (r *Receiver) applyManifest(payload []byte) error {
+	msg, err := DecodeControl(payload)
+	if err != nil {
+		return NewTransferError(FailIntegrity, err.Error())
+	}
+	m, ok := msg.(*Manifest)
+	if !ok {
+		return NewTransferError(FailIntegrity, "expected manifest")
+	}
+	if len(m.Files) == 0 {
+		return NewTransferError(FailIntegrity, "manifest has no files")
+	}
+	f := m.Files[0]
+	r.file = &f
+	if r.o.OnManifest != nil {
+		return r.o.OnManifest(f)
+	}
+	return nil
+}
+
+func (r *Receiver) onBlockData(blockIdx uint32, frameOff uint16, payload []byte) error {
+	if r.file == nil {
+		return NewTransferError(FailIntegrity, "block_data before manifest")
+	}
+	if int(blockIdx) != r.curBlock {
+		return NewTransferError(FailIntegrity, fmt.Sprintf("out-of-order block %d", blockIdx))
+	}
+	if frameOff == 0 {
+		// The final block is short: cap its buffer at the file's remaining bytes.
+		r.blockLen = r.file.BlockSize
+		if rem := r.file.Size - int64(blockIdx)*int64(r.file.BlockSize); int64(r.blockLen) > rem {
+			r.blockLen = int(rem)
+		}
+		r.blockBuf = make([]byte, r.blockLen)
+		r.received = 0
+	}
+	copy(r.blockBuf[frameOff:], payload)
+	r.received += len(payload)
+	return nil
+}
+
+func (r *Receiver) onBlockHash(payload []byte) error {
+	if r.file == nil || r.blockBuf == nil {
+		return NewTransferError(FailIntegrity, "block_hash without a block")
+	}
+	msg, err := DecodeControl(payload)
+	if err != nil {
+		return NewTransferError(FailIntegrity, err.Error())
+	}
+	bh, ok := msg.(*BlockHash)
+	if !ok {
+		return NewTransferError(FailIntegrity, "expected block_hash")
+	}
+	if r.received != r.blockLen {
+		return NewTransferError(FailIntegrity, "short block")
+	}
+	sum := sha256.Sum256(r.blockBuf)
+	if hex.EncodeToString(sum[:]) != bh.SHA256 {
+		return NewTransferError(FailIntegrity, fmt.Sprintf("block %d hash mismatch", bh.BlockIdx))
+	}
+
+	// Verified: write, fold into the whole-file digest, then open the window one more block. A
+	// sink error propagates as-is, so a sink returning a TransferError keeps its reason.
+	offset := int64(r.curBlock) * int64(r.file.BlockSize)
+	if err := r.o.Sink.Write(offset, r.blockBuf); err != nil {
+		return err
+	}
+	r.digest.Update(r.blockBuf)
+	if r.o.OnProgress != nil {
+		r.o.OnProgress(offset + int64(r.blockLen))
+	}
+	if err := r.sendControl(NewBlockRecv(0, r.curBlock)); err != nil {
+		return err
+	}
+	r.curBlock++
+	r.blockBuf = nil
+	return nil
+}
+
+func (r *Receiver) onComplete(payload []byte) error {
+	if r.file == nil {
+		return NewTransferError(FailIntegrity, "complete before manifest")
+	}
+	msg, err := DecodeControl(payload)
+	if err != nil {
+		return NewTransferError(FailIntegrity, err.Error())
+	}
+	c, ok := msg.(*Complete)
+	if !ok {
+		return NewTransferError(FailIntegrity, "expected complete")
+	}
+	got := r.digest.HexDigest()
+	if got != c.FileDigest {
+		return NewTransferError(FailDigestMismatch, "whole-file digest mismatch")
+	}
+	if err := r.o.Sink.Close(); err != nil {
+		return err
+	}
+	if err := r.sendControl(NewDone()); err != nil {
+		return err
+	}
+	r.settle(ReceiveResult{File: *r.file, Digest: got})
+	return nil
+}
+
+// abortWith settles the transfer as failed and, best-effort, tells the peer and the sink. Only
+// the first abort (or a prior settle) takes effect.
+func (r *Receiver) abortWith(err *TransferError) {
+	r.mu.Lock()
+	if r.settled {
+		r.mu.Unlock()
+		return
+	}
+	r.settled = true
+	r.err = err
+	r.mu.Unlock()
+
+	_ = r.sendControl(NewFail(err.Reason)) // best-effort — the channel may already be gone
+	_ = r.o.Sink.Abort(string(err.Reason)) // best-effort
+	close(r.done)
+}
+
+// settle records a successful finish; only the first settle (or a prior abort) takes effect.
+func (r *Receiver) settle(res ReceiveResult) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.settled {
+		return
+	}
+	r.settled = true
+	r.result = res
+	close(r.done)
+}
+
+func (r *Receiver) isSettled() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.settled
+}
+
+// sendControl seals and sends a control message under the next send counter.
+func (r *Receiver) sendControl(msg ControlMsg) error {
+	payload, err := EncodeControl(msg)
+	if err != nil {
+		return err
+	}
+	frame, err := Seal(r.o.SendDir, r.sendCounter, FrameHeaderInput{
+		Version: FrameVersion, Type: msg.FrameType(),
+	}, payload)
+	if err != nil {
+		return err
+	}
+	r.sendCounter++
+	return r.o.Send(frame)
+}

--- a/packages/wire/transfer_receiver_test.go
+++ b/packages/wire/transfer_receiver_test.go
@@ -1,0 +1,248 @@
+package wire
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// senderFrames builds sender-side (o2j) frames the way the real Sender would, for driving a
+// Receiver under test. ctr advances one seal counter per frame.
+type senderFrames struct {
+	t      *testing.T
+	keys   TransferKeys
+	ctr    uint64
+	frames [][]byte
+}
+
+func newSenderFrames(t *testing.T, keys TransferKeys) *senderFrames {
+	return &senderFrames{t: t, keys: keys}
+}
+
+func (s *senderFrames) push(h FrameHeaderInput, payload []byte) {
+	f, err := Seal(s.keys.O2J, s.ctr, h, payload)
+	if err != nil {
+		s.t.Fatalf("seal: %v", err)
+	}
+	s.ctr++
+	s.frames = append(s.frames, f)
+}
+
+func (s *senderFrames) ctrl(msg ControlMsg) {
+	payload, err := EncodeControl(msg)
+	if err != nil {
+		s.t.Fatalf("encode: %v", err)
+	}
+	s.push(FrameHeaderInput{Version: FrameVersion, Type: msg.FrameType()}, payload)
+}
+
+// blockData splits data into frames of frameSize, tagging each with its block/offset and the
+// last-in-block flag, followed by the block's block_hash — the sender's on-wire grammar.
+func (s *senderFrames) blockData(data []byte, blockSize, frameSize int) {
+	for blk := 0; blk*blockSize < len(data); blk++ {
+		start := blk * blockSize
+		end := start + blockSize
+		if end > len(data) {
+			end = len(data)
+		}
+		block := data[start:end]
+		for off := 0; off < len(block); off += frameSize {
+			fe := off + frameSize
+			if fe > len(block) {
+				fe = len(block)
+			}
+			frag := block[off:fe]
+			flags := uint8(0)
+			if off+len(frag) == len(block) {
+				flags = FrameFlagLastInBlock
+			}
+			s.push(FrameHeaderInput{
+				Version: FrameVersion, Type: FrameBlockData, Flags: flags,
+				BlockIdx: uint32(blk), FrameOff: uint16(off),
+			}, frag)
+		}
+		sum := sha256.Sum256(block)
+		s.ctrl(NewBlockHash(0, blk, hex.EncodeToString(sum[:])))
+	}
+}
+
+func hexSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestReceiverAssemblesVerifiesWritesDone(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, 20)
+	for i := range data {
+		data[i] = byte((i * 7) & 0xff) // block=8: blocks 0,1 (8B), block2 (4B)
+	}
+	const blockSize, frameSize = 8, 4
+	fileDigest := hexSHA256(data)
+
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(NewManifest([]FileEntry{{
+		Idx: 0, Name: "f", Size: 20, BlockSize: blockSize, Blocks: 3, FileDigest: fileDigest,
+	}}, 20))
+	sf.blockData(data, blockSize, frameSize)
+	sf.ctrl(NewComplete(fileDigest))
+
+	sink := &MemorySink{}
+	var back outbox
+	r := NewReceiver(ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+	})
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	res, err := r.Wait()
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if res.Digest != fileDigest {
+		t.Errorf("digest = %s, want %s", res.Digest, fileDigest)
+	}
+	if string(sink.Bytes()) != string(data) {
+		t.Errorf("sink bytes = %v, want %v", sink.Bytes(), data)
+	}
+	if !sink.IsClosed() {
+		t.Error("sink not closed on done")
+	}
+
+	// Back-channel: block_recv ×3 then done.
+	wantBack := []uint8{FrameBlockRecv, FrameBlockRecv, FrameBlockRecv, FrameDone}
+	got := back.snapshot()
+	if len(got) != len(wantBack) {
+		t.Fatalf("back-channel has %d frames, want %d", len(got), len(wantBack))
+	}
+	for i, f := range got {
+		o, err := Open(keys.J2O, uint64(i), f)
+		if err != nil {
+			t.Fatalf("open back frame %d: %v", i, err)
+		}
+		if o.Header.Type != wantBack[i] {
+			t.Errorf("back frame %d type = %d, want %d", i, o.Header.Type, wantBack[i])
+		}
+	}
+}
+
+func TestReceiverAbortsIntegrityOnCorruptFrame(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := seq(8)
+	fileDigest := hexSHA256(data)
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(NewManifest([]FileEntry{{
+		Idx: 0, Name: "f", Size: 8, BlockSize: 8, Blocks: 1, FileDigest: fileDigest,
+	}}, 8))
+	sf.push(FrameHeaderInput{Version: FrameVersion, Type: FrameBlockData, Flags: FrameFlagLastInBlock}, data)
+	// Corrupt the GCM tag of the last frame.
+	last := sf.frames[len(sf.frames)-1]
+	last[len(last)-1] ^= 0x01
+
+	sink := &MemorySink{}
+	r := NewReceiver(ReceiverOptions{
+		Send: func([]byte) error { return nil }, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+	})
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	_, err = r.Wait()
+	if err == nil || !strings.Contains(err.Error(), "integrity") {
+		t.Fatalf("Wait error = %v, want one mentioning integrity", err)
+	}
+	if sink.AbortReason() != "integrity" {
+		t.Errorf("sink abort reason = %q, want integrity", sink.AbortReason())
+	}
+}
+
+// recordingSink records the order of its calls so a test can assert onManifest ran first.
+type recordingSink struct{ events *[]string }
+
+func (s recordingSink) Write(int64, []byte) error { *s.events = append(*s.events, "write"); return nil }
+func (s recordingSink) Close() error              { return nil }
+func (s recordingSink) Abort(string) error        { return nil }
+
+func TestReceiverOnManifestBeforeFirstWrite(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := seq(8)
+	fileDigest := hexSHA256(data)
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(NewManifest([]FileEntry{{
+		Idx: 0, Name: "note.txt", Size: 8, Mime: "text/plain", BlockSize: 8, Blocks: 1, FileDigest: fileDigest,
+	}}, 8))
+	sf.push(FrameHeaderInput{Version: FrameVersion, Type: FrameBlockData, Flags: FrameFlagLastInBlock}, data)
+	sf.ctrl(NewBlockHash(0, 0, fileDigest))
+	sf.ctrl(NewComplete(fileDigest))
+
+	var events []string
+	var seen []string
+	r := NewReceiver(ReceiverOptions{
+		Send: func([]byte) error { return nil }, SendDir: keys.J2O, RecvDir: keys.O2J,
+		Sink: recordingSink{events: &events},
+		OnManifest: func(f FileEntry) error {
+			events = append(events, "manifest")
+			seen = append(seen, f.Name)
+			return nil
+		},
+	})
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	if _, err := r.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if len(seen) != 1 || seen[0] != "note.txt" {
+		t.Errorf("onManifest saw %v, want [note.txt]", seen)
+	}
+	if len(events) == 0 || events[0] != "manifest" {
+		t.Fatalf("first event = %v, want manifest first", events)
+	}
+	if idxOf(events, "manifest") >= idxOf(events, "write") {
+		t.Errorf("manifest did not precede write: %v", events)
+	}
+}
+
+func TestReceiverFailsDigestMismatch(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := seq(8)
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(NewManifest([]FileEntry{{
+		Idx: 0, Name: "f", Size: 8, BlockSize: 8, Blocks: 1, FileDigest: "ff",
+	}}, 8))
+	sf.push(FrameHeaderInput{Version: FrameVersion, Type: FrameBlockData, Flags: FrameFlagLastInBlock}, data)
+	sf.ctrl(NewBlockHash(0, 0, hexSHA256(data)))
+	sf.ctrl(NewComplete("deadbeef"))
+
+	r := NewReceiver(ReceiverOptions{
+		Send: func([]byte) error { return nil }, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: &MemorySink{},
+	})
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	_, err = r.Wait()
+	if err == nil || !strings.Contains(err.Error(), "digest_mismatch") {
+		t.Fatalf("Wait error = %v, want one mentioning digest_mismatch", err)
+	}
+}
+
+func idxOf(xs []string, want string) int {
+	for i, x := range xs {
+		if x == want {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Ports the receiving half of the transfer engine (`transfer-receiver.ts`) to the Go `wire` module.

Frames arrive over an ordered, reliable channel, so blocks assemble one at a time, in order. For each block the receiver verifies its SHA-256 against the sender's `block_hash` **before** touching the sink, folds the verified bytes into the whole-file streaming digest, then signals `block_recv` to advance the in-flight window. On `complete` it compares the recomputed digest to the sender's and replies `done`, or `fail{digest_mismatch}`.

**Fail-closed integrity:** a GCM open failure, a per-block hash mismatch, an out-of-order block, or any malformed control frame aborts with `fail{integrity}` — the sink is aborted, the peer told, `Wait` returns the error. No silent retry (design §5.5).

**Concurrency:** swaps the TS promise chain for a serial `Handle` (driven by the transport read loop, one receive counter per frame) plus a `done` channel that `Wait` blocks on. `OnManifest` fires once before the first write so a host can open a destination named after the file.

**Tests** mirror the TS suite — full assemble/verify/write/done with the `block_recv`×N + `done` back-channel, integrity abort on a corrupted frame, `onManifest` ordering before the first write, and `digest_mismatch` when `complete` disagrees.

Gates run locally with `GOWORK=off GOFLAGS=-mod=readonly`: gofmt, `go vet`, `go test -race`, `golangci-lint` — all clean.