### PR TITLE
feat(cli): extend rendezvous envelope with sdp/ice messages

### DIFF
--- a/apps/cli/internal/rendezvous/message.go
+++ b/apps/cli/internal/rendezvous/message.go
@@ -24,6 +24,8 @@ const (
 	typePake       = "pake"
 	typeConfirm    = "confirm"
 	typeCaps       = "caps"
+	typeSDP        = "sdp"
+	typeICE        = "ice"
 	typeBye        = "bye"
 	typeError      = "error"
 )
@@ -40,10 +42,19 @@ type Message struct {
 	Role string `json:"role,omitempty"`
 	// Msg carries the base64url SPAKE2 share on pake, and the human text on error.
 	Msg string `json:"msg,omitempty"`
-	// Mac is the base64url RFC 9382 key-confirmation MAC on confirm.
+	// Mac is the base64url RFC 9382 key-confirmation MAC on confirm, and the
+	// authmac tag over the body on sdp/ice (plan.md §6.1, M2).
 	Mac string `json:"mac,omitempty"`
 	// Frame is the base64url AEAD-sealed frame on caps.
 	Frame string `json:"frame,omitempty"`
+	// Sdp carries the SDP offer/answer text on sdp (M2 peer→peer).
+	Sdp string `json:"sdp,omitempty"`
+	// Cand carries the ICE candidate string on ice (M2 peer→peer).
+	Cand string `json:"cand,omitempty"`
+	// Seq is the sender-monotonic sequence number authenticated on sdp/ice. It is a
+	// pointer so seq:0 — the first message — still serializes, while every non-M2
+	// message omits the field entirely.
+	Seq *int `json:"seq,omitempty"`
 	// Reason is the optional detail on bye.
 	Reason string `json:"reason,omitempty"`
 	// Code is the machine-readable error code on error.
@@ -63,6 +74,19 @@ func (f SinkFunc) Send(m Message) error { return f(m) }
 
 // MarshalMessage encodes a signaling message to its JSON wire form.
 func MarshalMessage(m Message) ([]byte, error) { return json.Marshal(m) }
+
+// NewSDP builds an authenticated sdp message. seq is the sender-monotonic sequence
+// number and mac the base64url authmac tag over the body (plan.md §6.1, M2). It is
+// exported because the RTC layer, not the handshake session, emits these.
+func NewSDP(seq int, sdp, mac string) Message {
+	return Message{Type: typeSDP, Sdp: sdp, Seq: &seq, Mac: mac}
+}
+
+// NewICE builds an authenticated ice message carrying one candidate string, sequenced
+// and tagged exactly like [NewSDP].
+func NewICE(seq int, cand, mac string) Message {
+	return Message{Type: typeICE, Cand: cand, Seq: &seq, Mac: mac}
+}
 
 // UnmarshalMessage decodes a JSON signaling frame. A frame missing a type is rejected so
 // the session can fail cleanly rather than act on an empty tag.

--- a/apps/cli/internal/rendezvous/message_test.go
+++ b/apps/cli/internal/rendezvous/message_test.go
@@ -1,0 +1,101 @@
+package rendezvous
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSDPMessageWireShape pins the sdp envelope, including that seq:0 — the first
+// message a sender emits — is present on the wire. A dropped seq:0 would let a peer
+// silently accept a replayed first offer, so this guards the pointer-with-omitempty
+// choice that keeps the field for M2 messages while omitting it everywhere else.
+func TestSDPMessageWireShape(t *testing.T) {
+	b, err := MarshalMessage(NewSDP(0, "v=0\r\no=- 1 1 IN IP4 0.0.0.0\r\n", "dGFn"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"type": "sdp",
+		"sdp":  "v=0\r\no=- 1 1 IN IP4 0.0.0.0\r\n",
+		"seq":  float64(0),
+		"mac":  "dGFn",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("sdp has fields %v, want exactly %v", keysOf(got), keysOf(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("sdp[%q] = %v, want %v", k, got[k], v)
+		}
+	}
+}
+
+// TestICEMessageWireShape pins the ice envelope and a non-zero seq.
+func TestICEMessageWireShape(t *testing.T) {
+	b, err := MarshalMessage(NewICE(7, "candidate:1 1 udp 2130706431 192.0.2.1 54321 typ host", "bWFj"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"type": "ice",
+		"cand": "candidate:1 1 udp 2130706431 192.0.2.1 54321 typ host",
+		"seq":  float64(7),
+		"mac":  "bWFj",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ice has fields %v, want exactly %v", keysOf(got), keysOf(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("ice[%q] = %v, want %v", k, got[k], v)
+		}
+	}
+}
+
+// TestNonM2MessagesOmitM2Fields confirms sdp/cand/seq never leak onto a handshake
+// message: a create carries only its type, nothing from the M2 extension.
+func TestNonM2MessagesOmitM2Fields(t *testing.T) {
+	b, err := MarshalMessage(Message{Type: typeCreate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := string(b); s != `{"type":"create"}` {
+		t.Errorf("create = %s, want {\"type\":\"create\"}", s)
+	}
+}
+
+// TestMessageRoundTrip confirms an sdp message survives marshal→unmarshal intact,
+// including the pointer seq.
+func TestMessageRoundTrip(t *testing.T) {
+	orig := NewSDP(3, "sdp-body", "mac-tag")
+	b, err := MarshalMessage(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := UnmarshalMessage(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != typeSDP || got.Sdp != "sdp-body" || got.Mac != "mac-tag" {
+		t.Errorf("round-trip = %#v", got)
+	}
+	if got.Seq == nil || *got.Seq != 3 {
+		t.Errorf("round-trip seq = %v, want 3", got.Seq)
+	}
+}
+
+func keysOf(m map[string]any) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}


### PR DESCRIPTION
Add the M2 peer→peer signaling messages to the CLI's rendezvous envelope: `sdp` (SDP offer/answer) and `ice` (a single ICE candidate), each carrying a sender-monotonic `seq` and an authmac `mac` over the body. The server already relays both types blindly (`forwardable`), so this teaches the CLI peer to speak them and interoperate with a browser peer's WebRTC negotiation.

Design notes:
- `seq` is `*int` with `omitempty` so `seq:0` — the first message a sender emits — still serializes, while every handshake message keeps omitting the field. Dropping `seq:0` would let a peer accept a replayed first offer.
- `NewSDP`/`NewICE` are exported constructors because the RTC layer (Task 10), not the handshake session, emits these from another package; they own the type tag and pointer-seq detail.

Tests pin the exact wire shape of both messages (field set + `seq:0` present), that non-M2 messages stay minimal (`{"type":"create"}`), and a marshal→unmarshal round-trip.

Field tags mirror `packages/protocol/src/signaling.ts` (`SdpMsg`/`IceMsg`) exactly for browser↔CLI interop. Gates green locally: gofmt, `go vet`, `go test -race`, `golangci-lint` (0 issues).