### PR TITLE
feat(cli): add authenticated SDP/ICE signaling for the RTC leg

### DIFF
--- a/apps/cli/internal/rtc/auth.go
+++ b/apps/cli/internal/rtc/auth.go
@@ -1,0 +1,119 @@
+// Package rtc drives the CLI peer's WebRTC leg of a direct transfer (design §4): it
+// authenticates the SDP/ICE signaling with the SPAKE2-derived confirmation keys, negotiates a
+// pion PeerConnection, and exposes the ordered, reliable "sendarc" DataChannel the transfer
+// engine rides on.
+//
+// This file is the signaling authenticator — the Go twin of
+// apps/web/src/lib/transfer/authed-signaling.ts. A blind rendezvous server relays sdp/ice
+// bodies verbatim, so a malicious server could otherwise substitute its own SDP and
+// man-in-the-middle the DataChannel. Every sdp/ice message therefore carries an authmac tag
+// keyed by k_auth: a peer signs with its own confirmation key and verifies with the peer's, so
+// a substituted body is rejected before it reaches pion. seq is monotonic per sender across
+// both message kinds, and the verifier rejects any non-increasing seq, defeating replay and
+// reorder. Confidentiality still rests on the AES-GCM frame layer; this is defense-in-depth for
+// the negotiation itself.
+package rtc
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/sendarc/cli/internal/rendezvous"
+	"github.com/sendarc/wire"
+)
+
+// SignalAuthenticator signs one peer's outbound sdp/ice messages and verifies the peer's
+// inbound ones. It is safe for concurrent use: pion delivers local ICE candidates on its own
+// goroutine while an answer is being signed, and inbound messages arrive on the signaling read
+// loop, so the per-sender counters are mutex-guarded (the TypeScript original relies on the
+// single-threaded event loop instead).
+type SignalAuthenticator struct {
+	room uint32
+	keys wire.SignalAuthKeys
+
+	mu     sync.Mutex
+	outSeq int // next sequence number to sign
+	inSeq  int // highest sequence number accepted; -1 before the first message
+}
+
+// NewSignalAuthenticator builds an authenticator for a room from an already-selected signing
+// and verifying key pair.
+func NewSignalAuthenticator(room int, keys wire.SignalAuthKeys) *SignalAuthenticator {
+	return &SignalAuthenticator{room: uint32(room), keys: keys, inSeq: -1}
+}
+
+// FromSession derives the authenticator from a completed M1 handshake, selecting the peer's
+// confirmation keys by role (the offerer signs with KcA and verifies with KcB; the joiner is
+// the mirror). It is the twin of SignalAuthenticator.fromSession.
+func FromSession(role wire.Role, room int, spake2 *wire.Spake2Output) *SignalAuthenticator {
+	return NewSignalAuthenticator(room, wire.AuthKeys(role, spake2))
+}
+
+// SignSDP returns a signed sdp message carrying the offer/answer, consuming the next sequence
+// number.
+func (a *SignalAuthenticator) SignSDP(sdp string) rendezvous.Message {
+	seq, mac := a.sign(wire.SignalSDP, sdp)
+	return rendezvous.NewSDP(seq, sdp, mac)
+}
+
+// SignICE returns a signed ice message carrying one trickled candidate, consuming the next
+// sequence number.
+func (a *SignalAuthenticator) SignICE(cand string) rendezvous.Message {
+	seq, mac := a.sign(wire.SignalICE, cand)
+	return rendezvous.NewICE(seq, cand, mac)
+}
+
+// sign computes the tag over body under the next outbound sequence number and returns both.
+func (a *SignalAuthenticator) sign(typ wire.SignalMacType, body string) (int, string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	seq := a.outSeq
+	a.outSeq++
+	mac := wire.SignSignal(a.keys.Sign, typ, a.room, uint32(seq), body)
+	return seq, base64.RawURLEncoding.EncodeToString(mac)
+}
+
+// Verify authenticates an inbound sdp/ice message and enforces strictly increasing seq. It
+// returns nil when the message is genuine and in order; otherwise a descriptive error and no
+// state change, so a forged message at seq N never blocks the genuine one. On success the
+// sender's window advances past seq, so a replay or an out-of-order delivery is rejected.
+func (a *SignalAuthenticator) Verify(msg rendezvous.Message) error {
+	typ, body, err := signalBody(msg)
+	if err != nil {
+		return err
+	}
+	if msg.Seq == nil {
+		return errors.New("missing seq")
+	}
+	seq := *msg.Seq
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if seq <= a.inSeq {
+		return fmt.Errorf("non-increasing seq %d", seq)
+	}
+	mac, err := base64.RawURLEncoding.DecodeString(msg.Mac)
+	if err != nil {
+		return errors.New("malformed mac")
+	}
+	if !wire.VerifySignal(a.keys.Verify, typ, a.room, uint32(seq), body, mac) {
+		return errors.New("bad mac")
+	}
+	a.inSeq = seq
+	return nil
+}
+
+// signalBody maps a message to its authmac type and the body the tag covers, rejecting
+// anything that is not an sdp/ice signaling message.
+func signalBody(msg rendezvous.Message) (wire.SignalMacType, string, error) {
+	switch msg.Type {
+	case string(wire.SignalSDP):
+		return wire.SignalSDP, msg.Sdp, nil
+	case string(wire.SignalICE):
+		return wire.SignalICE, msg.Cand, nil
+	default:
+		return "", "", fmt.Errorf("not a signaling message: %q", msg.Type)
+	}
+}

--- a/apps/cli/internal/rtc/auth_test.go
+++ b/apps/cli/internal/rtc/auth_test.go
@@ -1,0 +1,161 @@
+package rtc
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/sendarc/cli/internal/rendezvous"
+	"github.com/sendarc/wire"
+)
+
+const testRoom = 42
+
+// newPair builds an offerer/joiner authenticator sharing a room and confirmation keys, the way
+// a completed handshake would. KcA and KcB are distinct so a peer cannot verify its own
+// signatures — the crux of the man-in-the-middle defense.
+func newPair(room int) (offerer, joiner *SignalAuthenticator) {
+	out := &wire.Spake2Output{
+		KcA: bytes.Repeat([]byte{0xA1}, 32),
+		KcB: bytes.Repeat([]byte{0xB2}, 32),
+	}
+	return FromSession(wire.RoleOfferer, room, out), FromSession(wire.RoleJoiner, room, out)
+}
+
+func TestSignVerifyRoundTripAcrossPeers(t *testing.T) {
+	offerer, joiner := newPair(testRoom)
+
+	offer := offerer.SignSDP("v=0\r\no=offer\r\n")
+	if offer.Seq == nil || *offer.Seq != 0 {
+		t.Fatalf("first sdp seq = %v, want 0", offer.Seq)
+	}
+	if err := joiner.Verify(offer); err != nil {
+		t.Fatalf("joiner rejected genuine offer: %v", err)
+	}
+
+	cand := offerer.SignICE("candidate:1 1 udp 1 192.0.2.1 5000 typ host")
+	if cand.Seq == nil || *cand.Seq != 1 {
+		t.Fatalf("ice seq = %v, want 1 (monotonic across kinds)", cand.Seq)
+	}
+	if err := joiner.Verify(cand); err != nil {
+		t.Fatalf("joiner rejected genuine candidate: %v", err)
+	}
+
+	// The reverse direction authenticates under the mirrored keys.
+	answer := joiner.SignSDP("v=0\r\no=answer\r\n")
+	if err := offerer.Verify(answer); err != nil {
+		t.Fatalf("offerer rejected genuine answer: %v", err)
+	}
+}
+
+func TestVerifyRejectsReplay(t *testing.T) {
+	offerer, joiner := newPair(testRoom)
+	offer := offerer.SignSDP("v=0\r\n")
+	if err := joiner.Verify(offer); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	if err := joiner.Verify(offer); err == nil || !strings.Contains(err.Error(), "non-increasing") {
+		t.Fatalf("replay accepted: err = %v", err)
+	}
+}
+
+func TestVerifyRejectsReorder(t *testing.T) {
+	offerer, joiner := newPair(testRoom)
+	m0 := offerer.SignSDP("a")
+	m1 := offerer.SignICE("b")
+	m2 := offerer.SignICE("c")
+
+	if err := joiner.Verify(m0); err != nil {
+		t.Fatalf("verify m0: %v", err)
+	}
+	if err := joiner.Verify(m2); err != nil {
+		t.Fatalf("verify m2: %v", err)
+	}
+	// m1 arrives after m2 — strictly-increasing seq rejects the late message.
+	if err := joiner.Verify(m1); err == nil || !strings.Contains(err.Error(), "non-increasing") {
+		t.Fatalf("out-of-order message accepted: err = %v", err)
+	}
+}
+
+func TestVerifyRejectsTamperedBody(t *testing.T) {
+	offerer, joiner := newPair(testRoom)
+	offer := offerer.SignSDP("v=0\r\noriginal\r\n")
+	offer.Sdp = "v=0\r\ntampered\r\n" // server swaps the SDP, keeps the tag
+	if err := joiner.Verify(offer); err == nil || !strings.Contains(err.Error(), "bad mac") {
+		t.Fatalf("tampered body accepted: err = %v", err)
+	}
+}
+
+func TestVerifyRejectsTamperedMac(t *testing.T) {
+	offerer, joiner := newPair(testRoom)
+	offer := offerer.SignSDP("v=0\r\n")
+	raw, err := base64.RawURLEncoding.DecodeString(offer.Mac)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw[0] ^= 0x01
+	offer.Mac = base64.RawURLEncoding.EncodeToString(raw)
+	if err := joiner.Verify(offer); err == nil || !strings.Contains(err.Error(), "bad mac") {
+		t.Fatalf("tampered mac accepted: err = %v", err)
+	}
+}
+
+func TestVerifyRejectsMalformedMac(t *testing.T) {
+	offerer, joiner := newPair(testRoom)
+	offer := offerer.SignSDP("v=0\r\n")
+	offer.Mac = "not*valid*base64url"
+	if err := joiner.Verify(offer); err == nil || !strings.Contains(err.Error(), "malformed mac") {
+		t.Fatalf("malformed mac accepted: err = %v", err)
+	}
+}
+
+// TestVerifyRejectsTypeConfusion pins that the message type is bound into the MAC: relabeling a
+// signed sdp as ice (reusing body, seq, and tag) does not verify.
+func TestVerifyRejectsTypeConfusion(t *testing.T) {
+	offerer, joiner := newPair(testRoom)
+	offer := offerer.SignSDP("shared-body")
+	forged := rendezvous.NewICE(*offer.Seq, "shared-body", offer.Mac)
+	if err := joiner.Verify(forged); err == nil || !strings.Contains(err.Error(), "bad mac") {
+		t.Fatalf("type-confused message accepted: err = %v", err)
+	}
+}
+
+// TestVerifyRejectsForeignRoom pins that the room is bound into the MAC: a tag minted for one
+// room does not verify against a verifier scoped to another.
+func TestVerifyRejectsForeignRoom(t *testing.T) {
+	offerer, _ := newPair(testRoom)
+	_, otherJoiner := newPair(testRoom + 1)
+	offer := offerer.SignSDP("v=0\r\n")
+	if err := otherJoiner.Verify(offer); err == nil || !strings.Contains(err.Error(), "bad mac") {
+		t.Fatalf("cross-room message accepted: err = %v", err)
+	}
+}
+
+// TestVerifyRejectsOwnSignature pins that a peer cannot verify its own messages — the offerer
+// verifies with KcB but signs with KcA — which is what stops a server from looping a peer's
+// SDP back as if it came from the other side.
+func TestVerifyRejectsOwnSignature(t *testing.T) {
+	offerer, _ := newPair(testRoom)
+	offer := offerer.SignSDP("v=0\r\n")
+	if err := offerer.Verify(offer); err == nil || !strings.Contains(err.Error(), "bad mac") {
+		t.Fatalf("self-signed message accepted: err = %v", err)
+	}
+}
+
+func TestVerifyRejectsMissingSeq(t *testing.T) {
+	_, joiner := newPair(testRoom)
+	msg := rendezvous.Message{Type: "sdp", Sdp: "x", Mac: "AAAA"}
+	if err := joiner.Verify(msg); err == nil || !strings.Contains(err.Error(), "missing seq") {
+		t.Fatalf("message without seq accepted: err = %v", err)
+	}
+}
+
+func TestVerifyRejectsNonSignalingType(t *testing.T) {
+	_, joiner := newPair(testRoom)
+	seq := 0
+	msg := rendezvous.Message{Type: "caps", Seq: &seq, Mac: "AAAA"}
+	if err := joiner.Verify(msg); err == nil || !strings.Contains(err.Error(), "not a signaling message") {
+		t.Fatalf("non-signaling message accepted: err = %v", err)
+	}
+}


### PR DESCRIPTION
Introduce `apps/cli/internal/rtc` with the signaling authenticator that guards the direct-transfer negotiation — the Go twin of `apps/web/src/lib/transfer/authed-signaling.ts`.

A blind rendezvous server relays `sdp`/`ice` bodies verbatim, so without this a malicious server could substitute its own SDP and man-in-the-middle the DataChannel. Each message now carries an authmac tag keyed by the SPAKE2 confirmation material (`packages/wire`): a peer signs with its own key (KcA for the offerer, KcB for the joiner) and verifies with the peer's.

Guarantees, each pinned by a test:
- **Tamper** — a swapped SDP/ICE body or a flipped tag fails (`bad mac`); a non-base64url tag is `malformed mac`.
- **Replay / reorder** — `seq` is monotonic per sender across both kinds; the verifier requires strictly increasing `seq`.
- **Type & room binding** — relabeling an `sdp` as `ice`, or replaying a tag into another room, fails because both are folded into the MAC input.
- **No self-verify** — a peer cannot verify its own messages (distinct KcA/KcB), which stops a server looping a peer's SDP back as the other side.
- On any rejection the verifier leaves `inSeq` untouched, so a forged message at seq N never blocks the genuine one.

Unlike the single-threaded TS original, the Go authenticator is mutex-guarded (pion emits local ICE candidates on its own goroutine while an answer is being signed); the race detector exercises this.

Gates green locally: gofmt, `go vet`, `go test -race`, `golangci-lint` (0 issues).