### PR TITLE
fix(protocol): widen frame header frameOff to u32

### DIFF
--- a/packages/protocol/src/frame.test.ts
+++ b/packages/protocol/src/frame.test.ts
@@ -37,8 +37,15 @@ describe('frame header codec', () => {
     expect(decodeFrameHeader(view)).toEqual(sample);
   });
 
-  it('rejects a file offset that would overflow u16 (guards the multi-GB bug)', () => {
-    expect(() => encodeFrameHeader({ ...sample, frameOff: 0x10000 })).toThrow(RangeError);
+  it('carries a within-block byte offset past u16 (a 1 MiB block needs u32)', () => {
+    // The default 1 MiB block framed at 16 KiB reaches offsets well past 0xffff; the
+    // field is u32, so such an offset must round-trip rather than throw.
+    const off = 1_000_000;
+    expect(decodeFrameHeader(encodeFrameHeader({ ...sample, frameOff: off })).frameOff).toBe(off);
+  });
+
+  it('rejects a frame offset that would overflow u32 (guards the multi-GB bug)', () => {
+    expect(() => encodeFrameHeader({ ...sample, frameOff: 0x1_0000_0000 })).toThrow(RangeError);
   });
 
   it('rejects out-of-range block index', () => {

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -4,7 +4,12 @@
  *
  * Layout (big-endian):
  *   version(u8) type(u8) flags(u8) reserved(u8)
- *   fileIdx(u16) blockIdx(u32) frameOff(u16) len(u16)
+ *   fileIdx(u16) blockIdx(u32) frameOff(u32) len(u16)
+ *
+ * frameOff is a byte offset within the block, so it must span the whole block: at the
+ * default 1 MiB block a 16 KiB frame reaches offset ~1 MiB, far past u16. It is u32
+ * (an earlier draft miscalculated it as u16), absorbed by dropping the former trailing
+ * reserved(u16) — the header stays a fixed 16 bytes.
  */
 
 import { FRAME_HEADER_BYTES } from './constants.js';
@@ -27,7 +32,7 @@ export function encodeFrameHeader(h: FrameHeader): Uint8Array {
   assertRange('flags', h.flags, U8_MAX);
   assertRange('fileIdx', h.fileIdx, U16_MAX);
   assertRange('blockIdx', h.blockIdx, U32_MAX);
-  assertRange('frameOff', h.frameOff, U16_MAX);
+  assertRange('frameOff', h.frameOff, U32_MAX);
   assertRange('len', h.len, U16_MAX);
 
   const buf = new Uint8Array(FRAME_HEADER_BYTES);
@@ -38,9 +43,8 @@ export function encodeFrameHeader(h: FrameHeader): Uint8Array {
   dv.setUint8(3, 0); // reserved
   dv.setUint16(4, h.fileIdx, false);
   dv.setUint32(6, h.blockIdx, false);
-  dv.setUint16(10, h.frameOff, false);
-  dv.setUint16(12, h.len, false);
-  dv.setUint16(14, 0, false); // reserved tail — keeps header at a fixed 16 bytes
+  dv.setUint32(10, h.frameOff, false);
+  dv.setUint16(14, h.len, false);
   return buf;
 }
 
@@ -56,7 +60,7 @@ export function decodeFrameHeader(buf: Uint8Array): FrameHeader {
     flags: dv.getUint8(2),
     fileIdx: dv.getUint16(4, false),
     blockIdx: dv.getUint32(6, false),
-    frameOff: dv.getUint16(10, false),
-    len: dv.getUint16(12, false),
+    frameOff: dv.getUint32(10, false),
+    len: dv.getUint16(14, false),
   };
 }

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -10,7 +10,7 @@ export interface FrameHeader {
   flags: number;
   fileIdx: number; // u16
   blockIdx: number; // u32
-  frameOff: number; // u16 — byte offset WITHIN the block (not the file)
+  frameOff: number; // u32 — byte offset WITHIN the block (not the file)
   len: number; // u16 — ciphertext payload length
 }
 

--- a/packages/wire/aead.go
+++ b/packages/wire/aead.go
@@ -17,7 +17,7 @@ type FrameHeaderInput struct {
 	Flags    uint8
 	FileIdx  uint16
 	BlockIdx uint32
-	FrameOff uint16
+	FrameOff uint32
 }
 
 // nonce builds the 12-byte GCM nonce: the direction's 4-byte salt followed by a

--- a/packages/wire/frame.go
+++ b/packages/wire/frame.go
@@ -18,14 +18,19 @@ const FrameVersion uint8 = 1
 // Layout (big-endian):
 //
 //	version(u8) type(u8) flags(u8) reserved(u8)
-//	fileIdx(u16) blockIdx(u32) frameOff(u16) len(u16) reserved(u16)
+//	fileIdx(u16) blockIdx(u32) frameOff(u32) len(u16)
+//
+// FrameOff is a byte offset within the block, so it must span the whole block: at the
+// default 1 MiB block a 16 KiB frame reaches offset ~1 MiB, far past u16. It is u32
+// (not u16, as an earlier draft miscalculated), which the header absorbs by dropping the
+// former trailing reserved(u16) — the header stays a fixed 16 bytes.
 type FrameHeader struct {
 	Version  uint8
 	Type     uint8
 	Flags    uint8
 	FileIdx  uint16
 	BlockIdx uint32
-	FrameOff uint16 // byte offset within the block, not the file
+	FrameOff uint32 // byte offset within the block, not the file
 	Len      uint16 // ciphertext payload length
 }
 
@@ -53,9 +58,8 @@ func encodeFrameHeader(h FrameHeader) []byte {
 	buf[3] = 0 // reserved
 	binary.BigEndian.PutUint16(buf[4:6], h.FileIdx)
 	binary.BigEndian.PutUint32(buf[6:10], h.BlockIdx)
-	binary.BigEndian.PutUint16(buf[10:12], h.FrameOff)
-	binary.BigEndian.PutUint16(buf[12:14], h.Len)
-	// buf[14:16] reserved tail — keeps the header at a fixed 16 bytes
+	binary.BigEndian.PutUint32(buf[10:14], h.FrameOff)
+	binary.BigEndian.PutUint16(buf[14:16], h.Len)
 	return buf
 }
 
@@ -70,7 +74,7 @@ func decodeFrameHeader(buf []byte) (FrameHeader, error) {
 		Flags:    buf[2],
 		FileIdx:  binary.BigEndian.Uint16(buf[4:6]),
 		BlockIdx: binary.BigEndian.Uint32(buf[6:10]),
-		FrameOff: binary.BigEndian.Uint16(buf[10:12]),
-		Len:      binary.BigEndian.Uint16(buf[12:14]),
+		FrameOff: binary.BigEndian.Uint32(buf[10:14]),
+		Len:      binary.BigEndian.Uint16(buf[14:16]),
 	}, nil
 }

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -147,7 +147,7 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	return nil
 }
 
-func (r *Receiver) onBlockData(blockIdx uint32, frameOff uint16, payload []byte) error {
+func (r *Receiver) onBlockData(blockIdx uint32, frameOff uint32, payload []byte) error {
 	if r.file == nil {
 		return NewTransferError(FailIntegrity, "block_data before manifest")
 	}

--- a/packages/wire/transfer_receiver_test.go
+++ b/packages/wire/transfer_receiver_test.go
@@ -59,7 +59,7 @@ func (s *senderFrames) blockData(data []byte, blockSize, frameSize int) {
 			}
 			s.push(FrameHeaderInput{
 				Version: FrameVersion, Type: FrameBlockData, Flags: flags,
-				BlockIdx: uint32(blk), FrameOff: uint16(off),
+				BlockIdx: uint32(blk), FrameOff: uint32(off),
 			}, frag)
 		}
 		sum := sha256.Sum256(block)

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -136,7 +136,7 @@ func (s *Sender) Run() (string, error) {
 			Flags:    flags,
 			FileIdx:  0,
 			BlockIdx: uint32(p.BlockIdx),
-			FrameOff: uint16(p.FrameOff),
+			FrameOff: uint32(p.FrameOff),
 		}, p.Payload); err != nil {
 			return err
 		}

--- a/test-vectors/sendarc-crypto.json
+++ b/test-vectors/sendarc-crypto.json
@@ -26,9 +26,9 @@
   "aead": {
     "direction": "o2j",
     "counter": 0,
-    "headerHex": "010100000000000000000000001b0000",
+    "headerHex": "0101000000000000000000000000001b",
     "plaintextUtf8": "sendarc caps vector payload",
-    "frameHex": "010100000000000000000000001b00009888677ac00c856a25561506dc2ee2f89b4b7fb356920d6819299deb894321e18c92c9123133f0b77b6a4c"
+    "frameHex": "0101000000000000000000000000001b9888677ac00c856a25561506dc2ee2f89b4b7fb356920d6819299d66f7a7cd4171213328dea32e0962fe5b"
   },
   "authmac": {
     "note": "mac = HMAC-SHA256(kAuth, type || ':' || u32be(room) || ':' || u32be(seq) || ':' || body). Self-contained kAuth (not derived from spake2 above).",


### PR DESCRIPTION
The frame header's `frameOff` field encodes a byte offset **within the block**, not the file. At the default 1 MiB block framed at 16 KiB, offsets climb to ~1 MiB — far past u16's 64 KiB ceiling.

## The bug

At offset 65536 the u16 field wraps to 0. The receiver treats `frameOff == 0` as the start of a new block, so a mid-block frame resets the assembly cursor. The block then finishes short of its expected length and fails integrity as a `"short block"`.

The defect existed identically in the TS reference and the Go port. It never fired because every existing test used tiny blocks (≤ 1 KiB), so no offset ever reached 64 KiB. The Task 11 loopback (payload `1<<20 + 40000`, crossing a 1 MiB boundary) is the first case to exercise it.

## The fix

Widen `frameOff` from u16 to u32. The header stays a fixed 16 bytes by consuming the former trailing `reserved(u16)`. New big-endian layout:

```
version(u8) type(u8) flags(u8) reserved(u8)
fileIdx(u16) blockIdx(u32) frameOff(u32) len(u16)
```

`len` stays u16 (payload ≤ 64 KiB, guarded). Updated in lockstep so TS and Go stay byte-identical:

- TS `frame.ts` encoder/decoder + range check; `transfer.ts` field doc; `frame.test.ts` (round-trips a >u16 within-block offset, rejects >u32).
- Go `frame.go`, `aead.go`, `transfer_sender.go`, `transfer_receiver.go`, and the receiver test.
- Shared `test-vectors/sendarc-crypto.json`: the GCM tag changed because the header (AAD) changed; the ciphertext is unchanged.

## Verification

- `packages/wire`: `go test -race ./...` green.
- `packages/protocol`: vitest 107 passing, typecheck / lint / format / build green.