### PR TITLE
feat(cli): drive the direct file transfer end to end

### DIFF
--- a/apps/cli/cmd/sendarc/main.go
+++ b/apps/cli/cmd/sendarc/main.go
@@ -1,12 +1,14 @@
-// Command sendarc is the terminal client for a SendArc transfer. It drives one M1
-// rendezvous over the blind signaling server:
+// Command sendarc is the terminal client for a SendArc transfer. It runs one M1
+// rendezvous over the blind signaling server and then, over the same socket, an M2
+// end-to-end-encrypted direct file transfer:
 //
-//	sendarc send            # allocate a room, print the invite code + link, wait
-//	sendarc receive <code>  # join with a code (or a pasted invite link)
+//	sendarc send <file>     # allocate a room, print the invite code + link, send the file
+//	sendarc receive <code>  # join with a code (or a pasted invite link), receive the file
 //
 // Both ends run SPAKE2 over the invite code, confirm the key (failing closed on a
-// mismatch), and exchange sealed capabilities — the point where the M2 encrypted file
-// transfer will begin. The word half of the code never reaches the server.
+// mismatch), exchange sealed capabilities, then bring up an authenticated WebRTC channel
+// and stream the file sealed under the session key. The word half of the code never
+// reaches the server, and the server never sees the file bytes.
 package main
 
 import (
@@ -21,7 +23,9 @@ import (
 	"syscall"
 
 	"github.com/sendarc/cli/internal/rendezvous"
+	"github.com/sendarc/cli/internal/transfer"
 	"github.com/sendarc/cli/internal/wsclient"
+	"github.com/sendarc/wire"
 )
 
 const defaultServer = "wss://localhost:8443/ws"
@@ -50,13 +54,14 @@ func usage(w *os.File) {
 	_, _ = fmt.Fprint(w, `sendarc — secure peer-to-peer file transfer
 
 Usage:
-  sendarc send [flags]
+  sendarc send <file> [flags]
   sendarc receive <code|link> [flags]
 
 Flags:
   --server URL             signaling server (default `+defaultServer+`)
   --insecure-skip-verify   skip TLS verification; self-signed dev certs only
   --words N                number of words in the invite code (send only; 0 = default)
+  --out DIR                directory to write the received file into (receive only; default .)
 `)
 }
 
@@ -65,33 +70,57 @@ func runSend(args []string) int {
 	server := fs.String("server", defaultServer, "signaling server URL")
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
 	words := fs.Int("words", 0, "number of words in the invite code (0 = default)")
-	parseArgs(fs, args)
+	positionals := parseArgs(fs, args)
+
+	if len(positionals) == 0 {
+		fmt.Fprintln(os.Stderr, "sendarc send: a file to send is required")
+		return 2
+	}
+	src, err := transfer.NewOSFileSource(positionals[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sendarc send: %s\n", err)
+		return 1
+	}
+	meta := src.Meta()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	fmt.Fprintf(os.Stderr, "Connecting to %s …\n", *server)
-	res, err := wsclient.Rendezvous(ctx, *server, wsclient.DialOptions{InsecureSkipVerify: *insecure},
-		rendezvous.Options{
+	client, err := dial(ctx, *server, *insecure)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nFailed: %s\n", handshakeError(err))
+		return 1
+	}
+	defer client.Close()
+
+	progress := newProgress(meta.Size)
+	out, err := transfer.Run(ctx, client, transfer.Spec{
+		Session: rendezvous.Options{
 			Role:      rendezvous.RoleOfferer,
 			WordCount: *words,
-			OnCode: func(code string) {
-				fmt.Println()
-				fmt.Printf("  Invite code:  %s\n", code)
-				if link := inviteLink(*server, code); link != "" {
-					fmt.Printf("  Invite link:  %s\n", link)
-				}
-				fmt.Println()
-			},
-			OnPhase: phasePrinter(rendezvous.RoleOfferer),
-		})
-	return report("receiver", res, err)
+			OnCode:    codePrinter(*server),
+			OnPhase:   phasePrinter(rendezvous.RoleOfferer),
+		},
+		Source:     src,
+		OnConnect:  connectPrinter(fmt.Sprintf("Sending %s (%s) …", meta.Name, humanBytes(meta.Size))),
+		OnProgress: progress.report,
+	})
+	progress.finish()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nFailed: %s\n", handshakeError(err))
+		return 1
+	}
+	fmt.Printf("\n✓ Sent %s (%s).\n", out.Name, humanBytes(out.Size))
+	fmt.Printf("  Fingerprint:  %s\n", fingerprint(out.Handshake.Master))
+	fmt.Printf("  SHA-256:      %s\n", out.Digest)
+	return 0
 }
 
 func runReceive(args []string) int {
 	fs := flag.NewFlagSet("receive", flag.ExitOnError)
 	server := fs.String("server", defaultServer, "signaling server URL")
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
+	outDir := fs.String("out", ".", "directory to write the received file into")
 	positionals := parseArgs(fs, args)
 
 	code := ""
@@ -102,19 +131,52 @@ func runReceive(args []string) int {
 		fmt.Fprintln(os.Stderr, "sendarc receive: an invite code (or link) is required")
 		return 2
 	}
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "sendarc receive: %s\n", err)
+		return 1
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	fmt.Fprintf(os.Stderr, "Connecting to %s …\n", *server)
+	client, err := dial(ctx, *server, *insecure)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nFailed: %s\n", handshakeError(err))
+		return 1
+	}
+	defer client.Close()
+
 	fmt.Fprintf(os.Stderr, "Joining %s …\n", code)
-	res, err := wsclient.Rendezvous(ctx, *server, wsclient.DialOptions{InsecureSkipVerify: *insecure},
-		rendezvous.Options{
+	progress := newProgress(0)
+	out, err := transfer.Run(ctx, client, transfer.Spec{
+		Session: rendezvous.Options{
 			Role:    rendezvous.RoleJoiner,
 			Code:    code,
 			OnPhase: phasePrinter(rendezvous.RoleJoiner),
-		})
-	return report("sender", res, err)
+		},
+		DestDir: *outDir,
+		OnManifest: func(file wire.FileEntry) {
+			progress.setTotal(file.Size)
+			connectPrinter(fmt.Sprintf("Receiving %s (%s) …", file.Name, humanBytes(file.Size)))()
+		},
+		OnProgress: progress.report,
+	})
+	progress.finish()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nFailed: %s\n", handshakeError(err))
+		return 1
+	}
+	fmt.Printf("\n✓ Received %s (%s) → %s\n", out.Name, humanBytes(out.Size), out.Path)
+	fmt.Printf("  Fingerprint:  %s\n", fingerprint(out.Handshake.Master))
+	fmt.Printf("  SHA-256:      %s\n", out.Digest)
+	return 0
+}
+
+// dial opens the signaling socket, reporting the server it is contacting. The transfer
+// driver adopts the returned client for the whole exchange and closes it when done.
+func dial(ctx context.Context, server string, insecure bool) (*wsclient.Client, error) {
+	fmt.Fprintf(os.Stderr, "Connecting to %s …\n", server)
+	return wsclient.Dial(ctx, server, wsclient.DialOptions{InsecureSkipVerify: insecure})
 }
 
 // parseArgs parses flags that may appear before or after positional arguments. Go's flag
@@ -134,6 +196,19 @@ func parseArgs(fs *flag.FlagSet, args []string) []string {
 	return positionals
 }
 
+// codePrinter shows the invite code and the matching web-app link once the room is
+// allocated, so the sender can hand either to the recipient.
+func codePrinter(server string) func(string) {
+	return func(code string) {
+		fmt.Println()
+		fmt.Printf("  Invite code:  %s\n", code)
+		if link := inviteLink(server, code); link != "" {
+			fmt.Printf("  Invite link:  %s\n", link)
+		}
+		fmt.Println()
+	}
+}
+
 // phasePrinter surfaces the two transitions worth a human's attention — waiting for the
 // peer (offerer only) and the start of the key handshake — and stays quiet for the rest so
 // the output reads as progress, not a state-machine trace.
@@ -150,22 +225,52 @@ func phasePrinter(role rendezvous.Role) func(rendezvous.Phase) {
 	}
 }
 
-// report prints the outcome and returns the process exit code. peer names the other side
-// for the success line ("receiver" for a sender, "sender" for a receiver).
-func report(peer string, res *rendezvous.Result, err error) int {
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "\nFailed: %s\n", handshakeError(err))
-		return 1
-	}
-	fmt.Printf("\n✓ Secure channel established with the %s.\n", peer)
-	fmt.Printf("  Fingerprint:  %s\n", fingerprint(res.Master))
-	fmt.Printf("  Peer:         %s\n", describeCaps(res.RemoteCaps))
-	fmt.Fprintln(os.Stderr, "\nBoth sides should see the same fingerprint. File transfer arrives in the next milestone.")
-	return 0
+// connectPrinter returns a one-shot callback that prints line once the direct channel is
+// open, just before the bytes begin to move.
+func connectPrinter(line string) func() {
+	return func() { fmt.Fprintln(os.Stderr, line) }
 }
 
-// handshakeError renders a rendezvous failure as a human-readable line, translating the
-// stable codes into plain guidance where it helps.
+// progress renders a single, rewriting transfer-progress line on stderr. The total may be
+// unknown at first (the receiver learns it from the manifest), in which case only the byte
+// count is shown until setTotal is called.
+type progress struct {
+	total    int64
+	lastPct  int
+	reported bool
+}
+
+func newProgress(total int64) *progress { return &progress{total: total, lastPct: -1} }
+
+func (p *progress) setTotal(total int64) { p.total = total }
+
+// report prints cumulative bytes. It is invoked from the engine goroutine while the main
+// goroutine blocks in transfer.Run, so it needs no locking; it throttles to whole-percent
+// changes to keep the terminal quiet.
+func (p *progress) report(n int64) {
+	p.reported = true
+	if p.total <= 0 {
+		fmt.Fprintf(os.Stderr, "\r  %s", humanBytes(n))
+		return
+	}
+	pct := int(n * 100 / p.total)
+	if pct == p.lastPct {
+		return
+	}
+	p.lastPct = pct
+	fmt.Fprintf(os.Stderr, "\r  %s / %s (%d%%)", humanBytes(n), humanBytes(p.total), pct)
+}
+
+// finish terminates the progress line with a newline if anything was printed on it.
+func (p *progress) finish() {
+	if p.reported {
+		fmt.Fprintln(os.Stderr)
+	}
+}
+
+// handshakeError renders a transfer failure as a human-readable line, translating the
+// stable rendezvous codes into plain guidance where it helps and falling back to the raw
+// message for transport and transfer errors.
 func handshakeError(err error) string {
 	var re *rendezvous.Error
 	if errorsAs(err, &re) {
@@ -198,11 +303,7 @@ func fingerprint(master []byte) string {
 	return fmt.Sprintf("%02x%02x %02x%02x", sum[0], sum[1], sum[2], sum[3])
 }
 
-func describeCaps(c rendezvous.Caps) string {
-	return fmt.Sprintf("%s (frame %s, block %s)", c.Version, humanBytes(c.MaxFrame), humanBytes(c.BlockSize))
-}
-
-func humanBytes(n int) string {
+func humanBytes(n int64) string {
 	switch {
 	case n >= 1<<20 && n%(1<<20) == 0:
 		return fmt.Sprintf("%d MiB", n>>20)

--- a/apps/cli/internal/rtc/conn.go
+++ b/apps/cli/internal/rtc/conn.go
@@ -3,6 +3,7 @@ package rtc
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/pion/webrtc/v4"
 )
@@ -99,8 +100,23 @@ func (c *DataConn) OnData(handler func(frame []byte)) {
 	close(c.handlerReady)
 }
 
-// Close closes the underlying channel. It is idempotent and unblocks any waiting Send.
+// Close closes the underlying channel. It drains the SCTP send buffer (bounded) so a final
+// frame reaches the wire before teardown, then closes the channel. It is idempotent and unblocks
+// any waiting Send.
 func (c *DataConn) Close() error {
+	// Drain the SCTP send buffer so the final frame (receiver's done, or sender's complete)
+	// actually flushes to the wire before pc.Close() aborts the association — otherwise a
+	// graceful close from the first-finishing peer can starve the last frame. Wait for
+	// BufferedAmount→0 with a timeout so a genuinely stalled transport cannot block forever.
+	deadline := time.Now().Add(5 * time.Second)
+	c.mu.Lock()
+	for !c.closed && c.dc.BufferedAmount() > 0 && time.Now().Before(deadline) {
+		c.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+		c.mu.Lock()
+	}
+	c.mu.Unlock()
+
 	c.shutdown()
 	return c.dc.Close()
 }

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -1,0 +1,278 @@
+// Package transfer wires a completed M1 rendezvous into an M2 direct file transfer: it adopts
+// the open signaling socket, brings up the authenticated WebRTC DataChannel (internal/rtc), and
+// runs the transport-agnostic transfer engine (packages/wire) over it — the offerer sends the
+// file, the joiner writes it to disk. It is the CLI counterpart of
+// apps/web/src/lib/transfer/transfer-core.ts, adapted to Go concurrency and OS files.
+package transfer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/sendarc/cli/internal/rendezvous"
+	"github.com/sendarc/cli/internal/rtc"
+	"github.com/sendarc/wire"
+)
+
+// Signal is the live signaling connection the driver adopts for the whole exchange — first the
+// handshake, then the sdp/ice negotiation. *wsclient.Client satisfies it; tests supply an
+// in-memory relay.
+type Signal interface {
+	Send(rendezvous.Message) error
+	Run(ctx context.Context, onMessage func(rendezvous.Message)) error
+	Close()
+}
+
+// Spec configures one side of a transfer. Session carries the handshake inputs (role, code,
+// caps, progress callbacks); the driver supplies its Transport. A sending (offerer) spec sets
+// Source; a receiving (joiner) spec sets DestDir.
+type Spec struct {
+	Session rendezvous.Options
+	// Source is the file to send; required for an offerer, ignored for a joiner.
+	Source wire.FileSource
+	// DestDir is the directory the received file is written into; used by a joiner.
+	DestDir string
+	// ICEServers overrides rtc.DefaultICEServers. An explicit empty slice uses host candidates
+	// only (loopback tests); nil takes the default STUN server.
+	ICEServers []webrtc.ICEServer
+	// OnConnect fires once the DataChannel opens, before the first byte moves.
+	OnConnect func()
+	// OnManifest fires on the receiver when the sender's manifest arrives (file named and sized).
+	OnManifest func(wire.FileEntry)
+	// OnProgress reports cumulative bytes transferred.
+	OnProgress func(int64)
+}
+
+// Outcome is the result of a completed transfer.
+type Outcome struct {
+	Handshake *rendezvous.Result
+	Name      string
+	Size      int64
+	Digest    string // whole-file SHA-256 (hex); identical on both peers
+	Path      string // receiver: the written file; empty for a sender
+}
+
+// Run performs the handshake over sig and then the file transfer, returning when the transfer
+// settles. It adopts sig for the whole exchange: the same socket that carries the SPAKE2
+// handshake carries the sdp/ice signaling afterwards, so the read loop switches from feeding the
+// session to feeding the peer once the key is established.
+func Run(ctx context.Context, sig Signal, spec Spec) (*Outcome, error) {
+	d := &driver{sig: sig, spec: spec, peerCh: make(chan *rtc.Peer, 1)}
+	return d.run(ctx)
+}
+
+type driver struct {
+	sig  Signal
+	spec Spec
+
+	mu   sync.Mutex // serializes every socket write (session, sendOffer, pion's ICE goroutine)
+	sess *rendezvous.Session
+
+	// peer and res are set once, by the read-loop goroutine, at establishment; peerCh publishes
+	// the peer to run once it exists.
+	peer   *rtc.Peer
+	res    *rendezvous.Result
+	peerCh chan *rtc.Peer
+}
+
+// Send implements rendezvous.Sink for the handshake session and doubles as the peer's send
+// callback. It serializes every socket write: during M2 the read loop (relaying an answer),
+// the offerer's sendOffer goroutine, and pion's ICE-candidate goroutine can all write at once,
+// and coder/websocket permits only one writer at a time.
+func (d *driver) Send(m rendezvous.Message) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sig.Send(m)
+}
+
+func (d *driver) run(ctx context.Context) (*Outcome, error) {
+	opts := d.spec.Session
+	opts.Transport = d
+	d.sess = rendezvous.New(opts)
+
+	// On a handshake failure, close the socket so the read loop unblocks; on success keep it
+	// open — the M2 signaling still needs it.
+	go func() {
+		<-d.sess.Done()
+		if _, err := d.sess.Result(); err != nil {
+			d.sig.Close()
+		}
+	}()
+
+	readErr := make(chan error, 1)
+	go func() { readErr <- d.sig.Run(ctx, d.route) }()
+
+	d.sess.Start()
+
+	var peer *rtc.Peer
+	select {
+	case peer = <-d.peerCh:
+	case err := <-readErr:
+		// The socket ended before the peer was built: surface the handshake failure, or a raw
+		// transport error if it dropped mid-handshake.
+		if _, herr := d.sess.Result(); herr != nil {
+			return nil, herr
+		}
+		if err == nil {
+			err = errors.New("transfer: signaling closed before the channel opened")
+		}
+		return nil, err
+	case <-ctx.Done():
+		d.sess.Abort("cancelled")
+		return nil, ctx.Err()
+	}
+
+	res := d.res
+	conn, err := peer.Channel(ctx)
+	if err != nil {
+		_ = peer.Close()
+		d.sig.Close()
+		return nil, fmt.Errorf("transfer: data channel: %w", err)
+	}
+	if d.spec.OnConnect != nil {
+		d.spec.OnConnect()
+	}
+
+	out, terr := d.transfer(conn, res)
+
+	_ = peer.Close()
+	d.sig.Close()
+	<-readErr // let the read loop drain once the socket is closed
+
+	if terr != nil {
+		return nil, terr
+	}
+	out.Handshake = res
+	return out, nil
+}
+
+// route is the single inbound dispatch. Before establishment it feeds the handshake session;
+// the instant the session establishes it builds the peer — synchronously, so the peer exists
+// before the next frame (the offer, for a joiner) is read — and thereafter feeds the peer.
+// Running entirely on the read-loop goroutine makes the switch race-free.
+func (d *driver) route(m rendezvous.Message) {
+	if d.peer != nil {
+		d.peer.Accept(m)
+		return
+	}
+	d.sess.Handle(m)
+	if d.peer != nil {
+		return
+	}
+	select {
+	case <-d.sess.Done():
+	default:
+		return // still handshaking
+	}
+	res, err := d.sess.Result()
+	if err != nil {
+		return // handshake failed; the watcher goroutine closes the socket
+	}
+	peer, perr := rtc.NewPeer(rtc.PeerOptions{
+		Role:       res.Role,
+		Auth:       rtc.FromSession(res.Role, res.Room, res.Spake2),
+		Send:       d.Send,
+		ICEServers: d.spec.ICEServers,
+	})
+	if perr != nil {
+		d.sig.Close() // unrecoverable; run's readErr branch reports it
+		return
+	}
+	d.res = res
+	d.peer = peer
+	d.peerCh <- peer
+}
+
+// transfer runs the engine over the open channel: the offerer sends its file, the joiner
+// receives one. Counters continue from the handshake so the AES-GCM nonce is never reused, and
+// block/frame sizes are the min of the two peers' announced caps.
+func (d *driver) transfer(conn *rtc.DataConn, res *rendezvous.Result) (*Outcome, error) {
+	sendDir, recvDir := directionalKeys(res)
+	if res.Role == wire.RoleOfferer {
+		return d.send(conn, res, sendDir, recvDir)
+	}
+	return d.receive(conn, res, sendDir, recvDir)
+}
+
+func (d *driver) send(conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+	if d.spec.Source == nil {
+		return nil, errors.New("transfer: a file source is required to send")
+	}
+	sender := wire.NewSender(wire.SenderOptions{
+		File:             d.spec.Source,
+		Send:             conn.Send,
+		SendDir:          sendDir,
+		RecvDir:          recvDir,
+		SendCounterStart: res.SendCounter,
+		RecvCounterStart: res.RecvCounter,
+		BlockSize:        negotiate(res.LocalCaps.BlockSize, res.RemoteCaps.BlockSize, wire.DefaultBlockBytes),
+		FrameSize:        negotiate(res.LocalCaps.MaxFrame, res.RemoteCaps.MaxFrame, wire.DefaultFrameBytes),
+		OnProgress:       d.spec.OnProgress,
+	})
+	conn.OnData(sender.Handle)
+	digest, err := sender.Run()
+	if err != nil {
+		return nil, err
+	}
+	meta := d.spec.Source.Meta()
+	return &Outcome{Name: meta.Name, Size: meta.Size, Digest: digest}, nil
+}
+
+func (d *driver) receive(conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+	deferred := &deferredSink{}
+	var sinkPath string
+	receiver := wire.NewReceiver(wire.ReceiverOptions{
+		Send:             conn.Send,
+		SendDir:          sendDir,
+		RecvDir:          recvDir,
+		SendCounterStart: res.SendCounter,
+		RecvCounterStart: res.RecvCounter,
+		Sink:             deferred,
+		OnProgress:       d.spec.OnProgress,
+		OnManifest: func(file wire.FileEntry) error {
+			// Open the destination lazily, named after the (sanitized) manifest file, before the
+			// first block is written — the browser DeferredSink pattern.
+			sink, err := NewOSFileSink(d.spec.DestDir, file.Name)
+			if err != nil {
+				return wire.NewTransferError(wire.FailSinkError, err.Error())
+			}
+			deferred.attach(sink)
+			sinkPath = sink.Path()
+			if d.spec.OnManifest != nil {
+				d.spec.OnManifest(file)
+			}
+			return nil
+		},
+	})
+	conn.OnData(receiver.Handle)
+	result, err := receiver.Wait()
+	if err != nil {
+		return nil, err
+	}
+	return &Outcome{Name: result.File.Name, Size: result.File.Size, Digest: result.Digest, Path: sinkPath}, nil
+}
+
+// directionalKeys selects the seal/open keys for this peer's role, mirroring the session's
+// sendDir/recvDir: the offerer sends on O2J and receives on J2O; the joiner is the mirror.
+func directionalKeys(res *rendezvous.Result) (send, recv wire.DirectionalKey) {
+	if res.Role == wire.RoleOfferer {
+		return res.Keys.O2J, res.Keys.J2O
+	}
+	return res.Keys.J2O, res.Keys.O2J
+}
+
+// negotiate picks the smaller of the two announced sizes, falling back to def if either side did
+// not announce a positive value. Both peers compute the same result from the same caps.
+func negotiate(local, remote, def int) int {
+	m := local
+	if remote < m {
+		m = remote
+	}
+	if m <= 0 {
+		return def
+	}
+	return m
+}

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -136,8 +136,12 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 		d.spec.OnConnect()
 	}
 
-	out, terr := d.transfer(conn, res)
+	out, terr := d.transfer(ctx, conn, res)
 
+	// Drain the data channel before tearing down the peer: the first side to finish (the
+	// receiver, once it has sent done) must let that final frame reach the wire, or closing the
+	// PeerConnection aborts SCTP and the waiting sender never learns the transfer completed.
+	_ = conn.Close()
 	_ = peer.Close()
 	d.sig.Close()
 	<-readErr // let the read loop drain once the socket is closed
@@ -188,16 +192,17 @@ func (d *driver) route(m rendezvous.Message) {
 
 // transfer runs the engine over the open channel: the offerer sends its file, the joiner
 // receives one. Counters continue from the handshake so the AES-GCM nonce is never reused, and
-// block/frame sizes are the min of the two peers' announced caps.
-func (d *driver) transfer(conn *rtc.DataConn, res *rendezvous.Result) (*Outcome, error) {
+// block/frame sizes are the min of the two peers' announced caps. Canceling ctx aborts the
+// in-flight transfer.
+func (d *driver) transfer(ctx context.Context, conn *rtc.DataConn, res *rendezvous.Result) (*Outcome, error) {
 	sendDir, recvDir := directionalKeys(res)
 	if res.Role == wire.RoleOfferer {
-		return d.send(conn, res, sendDir, recvDir)
+		return d.send(ctx, conn, res, sendDir, recvDir)
 	}
-	return d.receive(conn, res, sendDir, recvDir)
+	return d.receive(ctx, conn, res, sendDir, recvDir)
 }
 
-func (d *driver) send(conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+func (d *driver) send(ctx context.Context, conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
 	if d.spec.Source == nil {
 		return nil, errors.New("transfer: a file source is required to send")
 	}
@@ -213,7 +218,7 @@ func (d *driver) send(conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvD
 		OnProgress:       d.spec.OnProgress,
 	})
 	conn.OnData(sender.Handle)
-	digest, err := sender.Run()
+	digest, err := sender.Run(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +226,7 @@ func (d *driver) send(conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvD
 	return &Outcome{Name: meta.Name, Size: meta.Size, Digest: digest}, nil
 }
 
-func (d *driver) receive(conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+func (d *driver) receive(ctx context.Context, conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
 	deferred := &deferredSink{}
 	var sinkPath string
 	receiver := wire.NewReceiver(wire.ReceiverOptions{
@@ -248,7 +253,7 @@ func (d *driver) receive(conn *rtc.DataConn, res *rendezvous.Result, sendDir, re
 		},
 	})
 	conn.OnData(receiver.Handle)
-	result, err := receiver.Wait()
+	result, err := receiver.Wait(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/internal/transfer/driver_test.go
+++ b/apps/cli/internal/transfer/driver_test.go
@@ -1,0 +1,236 @@
+package transfer
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/sendarc/cli/internal/rendezvous"
+	"github.com/sendarc/wire"
+)
+
+// relay is an in-memory stand-in for the signaling server, faithful to apps/server's peer
+// loop: it allocates a room on create, pairs on join (notifying each side with its own
+// role, exactly as peerJoinedFrame does), and forwards every other message verbatim to the
+// partner. It lets a complete offerer↔joiner exchange — SPAKE2 handshake, authenticated
+// SDP/ICE, and the sealed file transfer — run in one process with no sockets.
+type relay struct {
+	off     *relayEnd
+	join    *relayEnd
+	room    int
+	created chan struct{} // closed once the offerer has created the room
+	once    sync.Once
+}
+
+func newRelay() *relay {
+	r := &relay{room: 7, created: make(chan struct{})}
+	r.off = newRelayEnd(r, "offerer")
+	r.join = newRelayEnd(r, "joiner")
+	return r
+}
+
+func (r *relay) partner(e *relayEnd) *relayEnd {
+	if e == r.off {
+		return r.join
+	}
+	return r.off
+}
+
+// route reproduces the server's dispatch: create allocates the room and answers the sender,
+// join pairs and tells each peer its own role, and anything else is relayed to the partner. A
+// join blocks until the room has been created, mirroring the server guarantee that a joiner
+// cannot pair before the offerer exists (it needs the code, which needs the room) — without
+// this, the two drivers start concurrently and a join can race ahead of create, delivering
+// peer-joined to the offerer while it is still allocating.
+func (r *relay) route(from *relayEnd, m rendezvous.Message) {
+	switch m.Type {
+	case "create":
+		room := r.room
+		from.enqueue(rendezvous.Message{Type: "created", Room: &room})
+		r.once.Do(func() { close(r.created) })
+	case "join":
+		<-r.created
+		r.off.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.off.role})
+		r.join.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.join.role})
+	default:
+		r.partner(from).enqueue(m)
+	}
+}
+
+// relayEnd is one side of the relay. It satisfies transfer.Signal, so a driver adopts it
+// exactly as it would a real *wsclient.Client.
+type relayEnd struct {
+	hub  *relay
+	role string
+	in   chan rendezvous.Message
+	once sync.Once
+	done chan struct{}
+}
+
+func newRelayEnd(hub *relay, role string) *relayEnd {
+	return &relayEnd{hub: hub, role: role, in: make(chan rendezvous.Message, 256), done: make(chan struct{})}
+}
+
+func (e *relayEnd) Send(m rendezvous.Message) error {
+	e.hub.route(e, m)
+	return nil
+}
+
+func (e *relayEnd) Run(ctx context.Context, onMessage func(rendezvous.Message)) error {
+	for {
+		select {
+		case m := <-e.in:
+			onMessage(m)
+		case <-e.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (e *relayEnd) Close() { e.once.Do(func() { close(e.done) }) }
+
+// enqueue delivers to this end unless it has closed, in which case the frame is dropped —
+// a late trickled candidate arriving after teardown must not panic on a closed channel.
+func (e *relayEnd) enqueue(m rendezvous.Message) {
+	select {
+	case e.in <- m:
+	case <-e.done:
+	}
+}
+
+// TestDriverLoopbackTransfersFile is the M2c capstone: two drivers, wired only through the
+// in-memory relay, complete the whole pipeline — SPAKE2 rendezvous, an authenticated pion
+// DataChannel over host candidates, and a sealed file transfer — and the receiver writes a
+// file byte-identical to the sender's, with matching whole-file digests and session keys.
+func TestDriverLoopbackTransfersFile(t *testing.T) {
+	hub := newRelay()
+
+	// A payload that crosses a 1 MiB block boundary and does not divide evenly into frames,
+	// so the run exercises real chunking, windowing, and multi-block reassembly.
+	payload := make([]byte, 1<<20+40000)
+	for i := range payload {
+		payload[i] = byte(i*31 + 7)
+	}
+	meta := wire.FileMeta{
+		Name:         "payload.bin",
+		Size:         int64(len(payload)),
+		Mime:         "application/octet-stream",
+		LastModified: 1_700_000_000_000,
+	}
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *Outcome
+		err error
+	}
+	sendDone := make(chan result, 1)
+	recvDone := make(chan result, 1)
+
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{}, // host candidates only; loopback needs no STUN
+		})
+		sendDone <- result{out, err}
+	}()
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:    dir,
+			ICEServers: []webrtc.ICEServer{},
+		})
+		recvDone <- result{out, err}
+	}()
+
+	send := <-sendDone
+	recv := <-recvDone
+
+	if recv.err != nil {
+		t.Fatalf("receiver: %v", recv.err)
+	}
+	if send.err != nil {
+		t.Fatalf("sender: %v", send.err)
+	}
+
+	if send.out.Digest != recv.out.Digest {
+		t.Errorf("digests differ: sender %s, receiver %s", send.out.Digest, recv.out.Digest)
+	}
+	if recv.out.Name != "payload.bin" {
+		t.Errorf("received name = %q, want payload.bin", recv.out.Name)
+	}
+	if recv.out.Size != meta.Size {
+		t.Errorf("received size = %d, want %d", recv.out.Size, meta.Size)
+	}
+	if want := filepath.Join(dir, "payload.bin"); recv.out.Path != want {
+		t.Errorf("written path = %q, want %q", recv.out.Path, want)
+	}
+
+	got, err := os.ReadFile(recv.out.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("received %d bytes, want %d byte-identical to the source", len(got), len(payload))
+	}
+
+	// Both peers derived the same session key, so their SAS fingerprints would match.
+	if !bytes.Equal(send.out.Handshake.Master, recv.out.Handshake.Master) {
+		t.Error("master keys differ across peers")
+	}
+}
+
+// TestDriverReceiverRejectsMismatchedCode proves the handshake still fails closed when
+// adopted by the driver: a joiner with the wrong code never reaches a channel, and both
+// sides surface a confirmation failure rather than hanging or transferring.
+func TestDriverReceiverRejectsMismatchedCode(t *testing.T) {
+	hub := newRelay()
+	payload := []byte("must never be sent under a bad code")
+	meta := wire.FileMeta{Name: "secret.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	errs := make(chan error, 2)
+	go func() {
+		_, err := Run(ctx, hub.off, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		})
+		errs <- err
+	}()
+	go func() {
+		_, err := Run(ctx, hub.join, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-wrong-words"},
+			DestDir:    dir,
+			ICEServers: []webrtc.ICEServer{},
+		})
+		errs <- err
+	}()
+
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err == nil {
+			t.Fatal("expected a handshake failure under a mismatched code, got nil")
+		}
+	}
+	// No file should have been created from a failed handshake.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("destination dir has %d entries, want 0 after a failed handshake", len(entries))
+	}
+}

--- a/apps/cli/internal/transfer/ports_test.go
+++ b/apps/cli/internal/transfer/ports_test.go
@@ -1,0 +1,216 @@
+package transfer
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sendarc/wire"
+)
+
+func TestOSFileSourceMetaAndStream(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "greeting.txt")
+	// Larger than sourceChunkBytes so Stream must loop and reassemble across reads.
+	content := bytes.Repeat([]byte("sendarc-"), 20000) // 160000 bytes
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src, err := NewOSFileSource(path)
+	if err != nil {
+		t.Fatalf("NewOSFileSource: %v", err)
+	}
+
+	meta := src.Meta()
+	if meta.Name != "greeting.txt" {
+		t.Errorf("Name = %q, want greeting.txt", meta.Name)
+	}
+	if meta.Size != int64(len(content)) {
+		t.Errorf("Size = %d, want %d", meta.Size, len(content))
+	}
+	if meta.Mime == "" {
+		t.Error("Mime is empty; want a resolved or fallback type")
+	}
+	if meta.LastModified <= 0 {
+		t.Errorf("LastModified = %d, want a positive epoch-millis value", meta.LastModified)
+	}
+
+	// Stream must be repeatable: the sender reads once for the whole-file digest and again
+	// for the block stream, both from the start.
+	for pass := 1; pass <= 2; pass++ {
+		var got bytes.Buffer
+		if err := src.Stream(func(chunk []byte) error {
+			got.Write(chunk)
+			return nil
+		}); err != nil {
+			t.Fatalf("pass %d Stream: %v", pass, err)
+		}
+		if !bytes.Equal(got.Bytes(), content) {
+			t.Fatalf("pass %d streamed %d bytes, want %d identical", pass, got.Len(), len(content))
+		}
+	}
+}
+
+func TestOSFileSourceStreamPropagatesError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.bin")
+	if err := os.WriteFile(path, bytes.Repeat([]byte{0xab}, 200000), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src, err := NewOSFileSource(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sentinel := errors.New("consumer stop")
+	err = src.Stream(func([]byte) error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Stream error = %v, want the consumer's error propagated", err)
+	}
+}
+
+func TestNewOSFileSourceRejectsMissingAndDir(t *testing.T) {
+	if _, err := NewOSFileSource(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Error("expected an error for a missing file")
+	}
+	if _, err := NewOSFileSource(t.TempDir()); err == nil {
+		t.Error("expected an error for a directory")
+	}
+}
+
+func TestOSFileSinkWritesAndCommits(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewOSFileSink(dir, "out.bin")
+	if err != nil {
+		t.Fatalf("NewOSFileSink: %v", err)
+	}
+	if want := filepath.Join(dir, "out.bin"); sink.Path() != want {
+		t.Errorf("Path = %q, want %q", sink.Path(), want)
+	}
+	// WriteAt semantics: the second block lands at its offset regardless of order.
+	if err := sink.Write(5, []byte("world")); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Write(0, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Errorf("second Close = %v, want nil (idempotent)", err)
+	}
+	got, err := os.ReadFile(sink.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "helloworld" {
+		t.Errorf("file = %q, want helloworld", got)
+	}
+}
+
+func TestOSFileSinkWriteAfterCloseFails(t *testing.T) {
+	sink, err := NewOSFileSink(t.TempDir(), "out.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Write(0, []byte("late")); !errors.Is(err, errSinkClosed) {
+		t.Fatalf("Write after Close = %v, want errSinkClosed", err)
+	}
+}
+
+func TestOSFileSinkAbortRemovesPartial(t *testing.T) {
+	sink, err := NewOSFileSink(t.TempDir(), "out.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Write(0, []byte("partial")); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Abort("digest mismatch"); err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if _, err := os.Stat(sink.Path()); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("partial file still present after Abort: stat err = %v", err)
+	}
+	if err := sink.Abort("again"); err != nil {
+		t.Errorf("second Abort = %v, want nil (idempotent)", err)
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	cases := map[string]string{
+		"report.pdf":       "report.pdf",
+		"a/b/c.txt":        "c.txt",
+		`dir\sub\win.dat`:  "win.dat",
+		"../../etc/passwd": "passwd",
+		"  spaced.bin  ":   "spaced.bin",
+		"":                 "download",
+		".":                "download",
+		"..":               "download",
+		"/":                "download",
+		`trailing\`:        "download",
+	}
+	for in, want := range cases {
+		if got := sanitizeName(in); got != want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNewOSFileSinkContainsTraversalName(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewOSFileSink(dir, "../escape.txt")
+	if err != nil {
+		t.Fatalf("NewOSFileSink: %v", err)
+	}
+	defer func() { _ = sink.Abort("cleanup") }()
+	if got, want := sink.Path(), filepath.Join(dir, "escape.txt"); got != want {
+		t.Errorf("traversal name escaped dir: Path = %q, want %q", got, want)
+	}
+}
+
+func TestDeferredSinkBeforeAttach(t *testing.T) {
+	d := &deferredSink{}
+
+	// A write before the manifest is a protocol error surfaced as a sink failure.
+	err := d.Write(0, []byte("early"))
+	var te *wire.TransferError
+	if !errors.As(err, &te) || te.Reason != wire.FailSinkError {
+		t.Fatalf("Write before attach = %v, want a FailSinkError TransferError", err)
+	}
+	// Close and Abort are no-ops until a real sink is attached.
+	if err := d.Close(); err != nil {
+		t.Errorf("Close before attach = %v, want nil", err)
+	}
+	if err := d.Abort("x"); err != nil {
+		t.Errorf("Abort before attach = %v, want nil", err)
+	}
+}
+
+func TestDeferredSinkDelegatesAfterAttach(t *testing.T) {
+	d := &deferredSink{}
+	inner, err := NewOSFileSink(t.TempDir(), "out.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.attach(inner)
+	if err := d.Write(0, []byte("data")); err != nil {
+		t.Fatalf("Write after attach: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(inner.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "data" {
+		t.Errorf("delegated file = %q, want data", got)
+	}
+}

--- a/apps/cli/internal/transfer/sink.go
+++ b/apps/cli/internal/transfer/sink.go
@@ -1,0 +1,140 @@
+package transfer
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/sendarc/wire"
+)
+
+// errSinkClosed is returned when a block is written after the sink has been closed or aborted.
+// The engine never does this, so it only guards against a misuse or a late concurrent abort.
+var errSinkClosed = errors.New("transfer: write after sink closed")
+
+// OSFileSink is a [wire.Sink] that writes verified, in-order blocks to a file on disk. The
+// receiver hands it a block only after that block's SHA-256 checks out, so a committed file is
+// exactly the sender's bytes; a failed transfer aborts and removes the partial file rather than
+// leave truncated output behind. It is the CLI counterpart of the browser sink.
+type OSFileSink struct {
+	path string
+
+	mu     sync.Mutex
+	f      *os.File
+	closed bool
+}
+
+// NewOSFileSink creates (truncating) the destination file named after the manifest inside dir.
+// name is reduced to its base component so a hostile manifest name cannot escape dir (see
+// [sanitizeName]); the resolved path is available via Path.
+func NewOSFileSink(dir, name string) (*OSFileSink, error) {
+	path := filepath.Join(dir, sanitizeName(name))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return &OSFileSink{path: path, f: f}, nil
+}
+
+// Path is the destination path the sink writes to.
+func (s *OSFileSink) Path() string { return s.path }
+
+// Write places bytes at offset. Blocks arrive in order, but WriteAt keeps the sink correct for
+// whatever offset the engine chooses.
+func (s *OSFileSink) Write(offset int64, bytes []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return errSinkClosed
+	}
+	_, err := s.f.WriteAt(bytes, offset)
+	return err
+}
+
+// Close flushes and closes the file, committing the received bytes. It is idempotent.
+func (s *OSFileSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.f.Close()
+}
+
+// Abort discards a partial transfer: it closes the descriptor and removes the file so no
+// truncated output survives. It is idempotent and best-effort on the removal. The reason is
+// unused here — the sink simply discards; the peer already learned it via fail.
+func (s *OSFileSink) Abort(_ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	_ = s.f.Close()
+	return os.Remove(s.path)
+}
+
+// deferredSink lets the receiver be constructed before its destination file exists: the real
+// sink is attached from OnManifest, once the file name is known. It mirrors the browser
+// DeferredSink — a write before attach is a programming error, since the engine always delivers
+// the manifest before the first block.
+type deferredSink struct {
+	mu    sync.Mutex
+	inner wire.Sink
+}
+
+func (d *deferredSink) attach(inner wire.Sink) {
+	d.mu.Lock()
+	d.inner = inner
+	d.mu.Unlock()
+}
+
+func (d *deferredSink) get() wire.Sink {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.inner
+}
+
+func (d *deferredSink) Write(offset int64, bytes []byte) error {
+	inner := d.get()
+	if inner == nil {
+		return wire.NewTransferError(wire.FailSinkError, "sink written before manifest")
+	}
+	return inner.Write(offset, bytes)
+}
+
+func (d *deferredSink) Close() error {
+	inner := d.get()
+	if inner == nil {
+		return nil
+	}
+	return inner.Close()
+}
+
+func (d *deferredSink) Abort(reason string) error {
+	inner := d.get()
+	if inner == nil {
+		return nil
+	}
+	return inner.Abort(reason)
+}
+
+// sanitizeName reduces a manifest-supplied file name to a safe base name for the local
+// filesystem: it strips any directory component (either separator style, so a name authored on
+// Windows cannot smuggle a path through a backslash on a POSIX host) and rejects the empty and
+// dot names, falling back to "download". It matches the browser sink's sanitize().
+func sanitizeName(name string) string {
+	name = strings.TrimSpace(name)
+	if i := strings.LastIndexAny(name, `/\`); i >= 0 {
+		name = name[i+1:]
+	}
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." {
+		return "download"
+	}
+	return name
+}

--- a/apps/cli/internal/transfer/source.go
+++ b/apps/cli/internal/transfer/source.go
@@ -1,0 +1,80 @@
+package transfer
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"os"
+	"path/filepath"
+
+	"github.com/sendarc/wire"
+)
+
+// sourceChunkBytes is the streaming granularity when reading a file from disk. It mirrors the
+// browser blobFileSource's 64 KiB slice; the sender re-chunks into frames regardless, so this
+// only bounds how much is read per syscall.
+const sourceChunkBytes = 64 * 1024
+
+// OSFileSource is a [wire.FileSource] backed by a regular file on disk. Stream opens the file
+// fresh on each call, so the sender's two passes — the whole-file digest, then the block
+// stream — each read from the start, satisfying the "safe to call more than once" contract the
+// engine relies on. It is the CLI counterpart of apps/web/src/lib/transfer/file-source.ts.
+type OSFileSource struct {
+	path string
+	meta wire.FileMeta
+}
+
+// NewOSFileSource stats path and prepares a repeatable streaming source. It errors if the path
+// is missing or is a directory.
+func NewOSFileSource(path string) (*OSFileSource, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("transfer: %s is a directory, not a file", path)
+	}
+	mimeType := mime.TypeByExtension(filepath.Ext(path))
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	return &OSFileSource{
+		path: path,
+		meta: wire.FileMeta{
+			Name:         filepath.Base(path),
+			Size:         info.Size(),
+			Mime:         mimeType,
+			LastModified: info.ModTime().UnixMilli(),
+		},
+	}, nil
+}
+
+// Meta returns the file's manifest metadata, captured at construction.
+func (s *OSFileSource) Meta() wire.FileMeta { return s.meta }
+
+// Stream reads the file from the beginning, handing successive chunks to fn. Each chunk is only
+// valid for the duration of the call — the engine copies what it retains. Opening per call keeps
+// Stream repeatable and avoids holding a descriptor open between the sender's two passes.
+func (s *OSFileSource) Stream(fn func(chunk []byte) error) error {
+	f, err := os.Open(s.path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, sourceChunkBytes)
+	for {
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			if err := fn(buf[:n]); err != nil {
+				return err
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}

--- a/packages/wire/transfer_loopback_test.go
+++ b/packages/wire/transfer_loopback_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -81,9 +82,9 @@ func runLoopback(t *testing.T, data []byte, blockSize, frameSize, window int, co
 	}()
 
 	runErrCh := make(chan error, 1)
-	go func() { _, e := sender.Run(); runErrCh <- e }()
+	go func() { _, e := sender.Run(context.Background()); runErrCh <- e }()
 
-	recvRes, recvErr := receiver.Wait()
+	recvRes, recvErr := receiver.Wait(context.Background())
 	var runErr error
 	select {
 	case runErr = <-runErrCh:

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -80,8 +81,17 @@ func NewReceiver(opts ReceiverOptions) *Receiver {
 }
 
 // Wait blocks until the transfer settles, returning the result on done or the error on fail.
-func (r *Receiver) Wait() (ReceiveResult, error) {
-	<-r.done
+// Canceling ctx aborts the receive with FailCanceled in bounded time, so a dropped peer never
+// parks Wait forever.
+func (r *Receiver) Wait(ctx context.Context) (ReceiveResult, error) {
+	select {
+	case <-r.done:
+	case <-ctx.Done():
+		// abortWith is idempotent and closes r.done; if the receive already settled it is a
+		// no-op and the <-r.done below returns immediately with the real result.
+		r.abortWith(NewTransferError(FailCanceled, ctx.Err().Error()))
+		<-r.done
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.result, r.err

--- a/packages/wire/transfer_receiver_test.go
+++ b/packages/wire/transfer_receiver_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
@@ -99,7 +100,7 @@ func TestReceiverAssemblesVerifiesWritesDone(t *testing.T) {
 	for _, f := range sf.frames {
 		r.Handle(f)
 	}
-	res, err := r.Wait()
+	res, err := r.Wait(context.Background())
 	if err != nil {
 		t.Fatalf("Wait: %v", err)
 	}
@@ -153,7 +154,7 @@ func TestReceiverAbortsIntegrityOnCorruptFrame(t *testing.T) {
 	for _, f := range sf.frames {
 		r.Handle(f)
 	}
-	_, err = r.Wait()
+	_, err = r.Wait(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "integrity") {
 		t.Fatalf("Wait error = %v, want one mentioning integrity", err)
 	}
@@ -198,7 +199,7 @@ func TestReceiverOnManifestBeforeFirstWrite(t *testing.T) {
 	for _, f := range sf.frames {
 		r.Handle(f)
 	}
-	if _, err := r.Wait(); err != nil {
+	if _, err := r.Wait(context.Background()); err != nil {
 		t.Fatalf("Wait: %v", err)
 	}
 	if len(seen) != 1 || seen[0] != "note.txt" {
@@ -232,7 +233,7 @@ func TestReceiverFailsDigestMismatch(t *testing.T) {
 	for _, f := range sf.frames {
 		r.Handle(f)
 	}
-	_, err = r.Wait()
+	_, err = r.Wait(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "digest_mismatch") {
 		t.Fatalf("Wait error = %v, want one mentioning digest_mismatch", err)
 	}

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -93,8 +94,22 @@ func NewSender(opts SenderOptions) *Sender {
 
 // Run drives the whole send. It returns the canonical whole-file digest (hex) once the
 // receiver confirms done, or an error on fail or an IO failure. The digest is the same value
-// carried in the manifest and complete, so a host can report it without recomputing.
-func (s *Sender) Run() (string, error) {
+// carried in the manifest and complete, so a host can report it without recomputing. Canceling
+// ctx aborts the transfer in bounded time.
+func (s *Sender) Run(ctx context.Context) (string, error) {
+	// Watch ctx so a canceled transfer (peer dropped, host aborted) settles in bounded time
+	// rather than parking forever on the window gate or waitDone. stop retires the watcher when
+	// Run returns so it never outlives the send.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.cancel(ctx.Err())
+		case <-stop:
+		}
+	}()
+
 	meta := s.o.File.Meta()
 
 	// Pass 1: whole-file digest, streamed so the file is never held.
@@ -253,6 +268,15 @@ func (s *Sender) failLocked(err error) {
 	s.settled = true
 	s.err = err
 	s.cond.Broadcast()
+}
+
+// cancel settles the send as canceled unless it has already finished. It is the ctx-cancellation
+// path: it only touches local state and wakes the waiters (gate/waitDone), never the transport,
+// so it cannot block on a peer that has already gone away.
+func (s *Sender) cancel(cause error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failLocked(NewTransferError(FailCanceled, cause.Error()))
 }
 
 // sendControl seals and sends a control message; its frame-header type is the message's tag.

--- a/packages/wire/transfer_sender_test.go
+++ b/packages/wire/transfer_sender_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
@@ -85,7 +86,7 @@ func TestSenderEmitsGrammarGatedByBlockRecv(t *testing.T) {
 	}
 	res := make(chan result, 1)
 	go func() {
-		d, err := s.Run()
+		d, err := s.Run(context.Background())
 		res <- result{d, err}
 	}()
 
@@ -200,7 +201,7 @@ func TestSenderRejectsOnReceiverFail(t *testing.T) {
 
 	res := make(chan error, 1)
 	go func() {
-		_, err := s.Run()
+		_, err := s.Run(context.Background())
 		res <- err
 	}()
 


### PR DESCRIPTION
Completes **M2c**. Wires a finished M1 rendezvous into an M2 direct transfer and exposes it through the CLI — the offerer sends a file, the joiner verifies each block and writes it to disk, both over an authenticated WebRTC DataChannel.

## What lands

- **`internal/transfer/driver.go`** — adopts the open signaling socket for the whole exchange (SPAKE2 handshake, then the sdp/ice negotiation), brings up the peer via `internal/rtc`, and runs the transport-agnostic `packages/wire` engine over the channel. Inbound dispatch runs entirely on the read-loop goroutine: it feeds the handshake session until the key is established, then builds the peer **synchronously** and switches to feeding it, so the handshake→transfer handoff is race-free. Block/frame sizes are the min of the two peers' announced caps; AES-GCM counters continue from the handshake so a nonce is never reused.
- **`internal/transfer/sink.go`** — an OS file sink that writes verified, in-order blocks and removes the partial file on abort, plus a deferred sink so the destination is opened lazily from the manifest (named and path-sanitized).
- **`internal/transfer/source.go`** — the sending file source over the engine's `FileSource`.
- **`cmd/sendarc/main.go`** — `send <file>` and `receive <code|link>`, with `--server`, `--out`, `--words`, progress, and a SAS fingerprint derived from the master key for out-of-band confirmation.

## Tests

`driver_test.go` runs a full offerer↔joiner exchange in one process over an in-memory relay — SPAKE2 rendezvous, an authenticated pion DataChannel on host candidates, and a sealed transfer — asserting the received file is byte-identical, digests and session keys match, and a mismatched code fails closed with no file written. The payload (`1<<20 + 40000`) deliberately crosses a 1 MiB block boundary and does not divide evenly into frames, exercising real multi-block chunking, windowing, and reassembly.

The relay holds `join` until the room is `created`, mirroring the server's guarantee that a joiner cannot pair before the offerer exists (it cannot hold the code until the room does). Without this, the two concurrently-started drivers race and a `join` can deliver `peer-joined` to an offerer still allocating.

## Verification

`gofmt` clean · `go vet` clean · `golangci-lint` 0 issues · `go test -race ./...` green · `go build ./...` green.