### PR TITLE
fix(web): format multi-gigabyte progress safely

### DIFF
--- a/apps/web/src/lib/session/present.test.ts
+++ b/apps/web/src/lib/session/present.test.ts
@@ -59,6 +59,11 @@ describe('humanBytes', () => {
     expect(humanBytes(1500)).toBe('1500 B');
     expect(humanBytes(0)).toBe('0 B');
   });
+
+  it('does not overflow at or above the signed 32-bit boundary', () => {
+    expect(humanBytes(2 * 2 ** 30)).toBe('2048 MiB');
+    expect(humanBytes(5 * 2 ** 30)).toBe('5120 MiB');
+  });
 });
 
 describe('describeCaps', () => {

--- a/apps/web/src/lib/session/present.ts
+++ b/apps/web/src/lib/session/present.ts
@@ -62,8 +62,12 @@ export function codeFromHash(hash: string): string {
 
 /** Byte counts as IEC units on exact multiples, matching the CLI's humanBytes. */
 export function humanBytes(n: number): string {
-  if (n >= 1 << 20 && n % (1 << 20) === 0) return `${n >> 20} MiB`;
-  if (n >= 1 << 10 && n % (1 << 10) === 0) return `${n >> 10} KiB`;
+  const kib = 2 ** 10;
+  const mib = 2 ** 20;
+  // Bitwise operators coerce to signed u32: `2 GiB >> 20` becomes `-2048`. Arithmetic
+  // division stays exact for these power-of-two units throughout SendArc's safe file range.
+  if (n >= mib && n % mib === 0) return `${n / mib} MiB`;
+  if (n >= kib && n % kib === 0) return `${n / kib} KiB`;
   return `${n} B`;
 }
 


### PR DESCRIPTION
## Summary

- replace signed 32-bit bit-shift conversion with arithmetic byte conversion
- preserve accurate progress labels at and above the 2 GiB boundary
- add regression coverage for 2 GiB and 5 GiB values

## Verification

- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run test (107 protocol tests, 39 web tests)
- pnpm run build
- completed a real 2 GiB browser-to-browser transfer with matching digest and bounded memory