### PR TITLE
docs: present SendArc without internal roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,141 @@
 # SendArc
 
-SendArc is a self-hostable, end-to-end-encrypted, peer-to-peer file transfer. Two peers
-share a short invite code; SendArc establishes an authenticated rendezvous, negotiates a
-direct WebRTC connection, and streams the file encrypted, with bounded memory on both
-ends and a verified digest at completion. It ships as a browser app and a terminal client
-that speak the same protocol.
+[![CI](https://github.com/Akshay7273/sendarc/actions/workflows/ci.yml/badge.svg)](https://github.com/Akshay7273/sendarc/actions/workflows/ci.yml)
 
-The server is a blind rendezvous point and will gain a fallback relay in M5. It pairs two
-peers by a room number and forwards their messages untouched; it never sees the invite
-words, the file bytes, filenames, or the encryption keys.
+**Send files directly. Share only a short code. Keep the server out of your data.**
 
-## Status
+SendArc is a self-hostable, end-to-end-encrypted file-transfer application for the browser
+and terminal. It authenticates two peers with a short invite code, establishes a direct
+WebRTC connection, and streams the file without loading it all into memory.
 
-Early development. The foundation (M0), authenticated rendezvous (M1), and direct-transfer
-vertical slice (M2) are complete. Browser and CLI peers can establish an authenticated
-WebRTC DataChannel and stream one encrypted file with bounded memory, per-block integrity,
-and a verified whole-file digest. Active work moves to M3 — acknowledgements,
-retransmission, pause/resume, and cancellation.
+> [!NOTE]
+> SendArc is pre-release software. Direct single-file transfers are working, but there is
+> no stable release or compatibility guarantee yet.
+
+## Why SendArc
+
+- **End-to-end encrypted.** File contents, names, digests, and session keys are encrypted
+  between the two peers. The rendezvous server cannot read them.
+- **Authenticated by a human-friendly code.** SPAKE2 binds the cryptographic handshake to
+  the invite code and fails closed when the code is wrong.
+- **Direct peer-to-peer transport.** Files travel over an authenticated WebRTC DataChannel
+  instead of being uploaded to server-side storage.
+- **Streams large files with bounded memory.** Fixed-size blocks, transport backpressure,
+  and a bounded in-flight window keep memory use independent of file size.
+- **Verifiable completion.** Every block is authenticated and hashed; the final streaming
+  SHA-256 digest is compatible with `sha256sum`.
+- **Browser and CLI interoperability.** Send or receive with either client using the same
+  protocol and invite code.
 
 ## How it works
 
-- **Invite code.** The sender asks the server for a room and mints a few random words,
-  e.g. `4-brave-otter`. The room number routes the two sockets; the words are generated
-  and checked entirely on the clients. In the browser the code travels in the URL
-  fragment (`#…`), which is never put on the wire, so the words never reach the server.
-- **Authenticated handshake.** Both ends run SPAKE2 (RFC 9382, over P-256) with the full
-  invite code as the shared password, then exchange RFC 9382 key-confirmation MACs. A
-  wrong code fails closed, so a malicious or compromised server cannot man-in-the-middle
-  the connection. Both peers also derive the same short fingerprint, which the two humans
-  can read to each other as an out-of-band check.
-- **Encrypted transfer.** Files are streamed as AES-256-GCM frames keyed by the handshake
-  output. The 16-byte frame header is the AEAD's associated data, binding each frame to
-  its position. The same frame layer is used on the direct WebRTC path and on the relay
-  fallback, so recovery is transport-agnostic. Integrity is checked per block (SHA-256)
-  and for the whole file with a streaming digest that matches `sha256sum`.
-- **Bounded memory.** The sender streams from disk, in-flight data is capped by a fixed
-  window, and the receiver writes verified blocks to its sink and drops them — neither
-  side buffers the whole file in RAM.
-
-## Repository layout
-
-```
-apps/web            Svelte 5 + Vite single-page app (UI, WebRTC, crypto, transfer)
-apps/cli            Go terminal client (sendarc send / receive)
-apps/server         Go signaling + relay server (sendarcd)
-packages/protocol   Wire types and constants shared by the web app and CLI (TypeScript)
-packages/wire       Go mirror of the wire protocol, shared by the server and CLI
-infra/certs         Local mkcert TLS material (gitignored)
+```text
+ Sender                      Blind rendezvous                     Receiver
+   │  create room ─────────────────▶│                                │
+   │◀──────────── room number       │◀────────────── join room ─────│
+   │                                │                                │
+   │  SPAKE2 + key confirmation ◀───┼───▶ SPAKE2 + key confirmation │
+   │  authenticated SDP / ICE   ◀───┼───▶ authenticated SDP / ICE   │
+   │                                │                                │
+   └════════ encrypted WebRTC DataChannel, peer to peer ════════════┘
 ```
 
-## Quick start (development)
+The room number is only a routing token. The random words stay on the clients—in browser
+links they live after `#`, which is not sent in HTTP requests. Both peers use the complete
+code as the SPAKE2 password, confirm the derived key, and authenticate WebRTC signaling
+before transferring encrypted frames.
 
-Requires Node ≥ 22, Go ≥ 1.24, [pnpm](https://pnpm.io) (via `corepack enable`),
-[mkcert](https://github.com/FiloSottile/mkcert), and
-[just](https://github.com/casey/just).
+The rendezvous server can observe connection metadata and WebRTC signaling required to
+connect the peers. It cannot derive the session key or decrypt file metadata and content.
+The security section below summarizes the trust boundary.
+
+## Supported paths
+
+| Sender  | Receiver | Transfer path          |
+| ------- | -------- | ---------------------- |
+| Browser | Browser  | Direct WebRTC          |
+| Browser | CLI      | Direct WebRTC          |
+| CLI     | Browser  | Direct WebRTC          |
+| CLI     | CLI      | Direct WebRTC via Pion |
+
+## Run locally
+
+### Requirements
+
+- Node.js 22 or newer
+- Go 1.24 or newer
+- [pnpm](https://pnpm.io/) through Corepack
+- [just](https://github.com/casey/just)
+- [mkcert](https://github.com/FiloSottile/mkcert)
+
+### Browser application
 
 ```bash
-just install     # install JS and Go dependencies
-just dev         # Vite HMR + Go server at https://localhost
+git clone https://github.com/Akshay7273/sendarc.git
+cd sendarc
+corepack enable
+just install
+just dev
 ```
 
-`just dev` generates a local certificate on first run. If the browser distrusts it,
-run `mkcert -install` once to add the local CA to your system trust store.
+Open `https://localhost:8443` on both peers. The first run creates a local TLS certificate.
+Run `mkcert -install` once if your browser does not trust the development certificate.
 
-Other recipes:
+### Terminal client
+
+With the local server running, build the CLI:
 
 ```bash
-just build       # build the web bundle and the sendarcd binary
-just serve       # serve the production build over TLS
-just lint        # lint the web app and every Go module
-just typecheck   # TypeScript + Svelte
-just test        # unit tests (web + Go modules)
+(cd apps/cli && go build -o ../../bin/sendarc ./cmd/sendarc)
+```
+
+Send a file:
+
+```bash
+bin/sendarc send ./example.zip --insecure-skip-verify
+```
+
+Receive it from another terminal:
+
+```bash
+bin/sendarc receive 4-brave-otter --out ./downloads --insecure-skip-verify
+```
+
+`--insecure-skip-verify` is only for the self-signed local development certificate. Do not
+use it with a deployed server. Run `bin/sendarc help` for all options.
+
+## Development
+
+```bash
+just build       # build the web application and server binary
+just lint        # lint TypeScript, Svelte, and every Go module
+just typecheck   # run TypeScript and Svelte diagnostics
+just test        # run JavaScript and Go test suites
+just serve       # serve a production-style local build over TLS
+```
+
+The repository is a pnpm and Go workspace:
+
+```text
+apps/web            Svelte web application, WebRTC client, and transfer worker
+apps/cli            Go terminal client
+apps/server         Go HTTPS and blind rendezvous server
+packages/protocol   TypeScript protocol, cryptography, and transfer engine
+packages/wire       Go implementation of the shared wire protocol
 ```
 
 ## Security
 
-SendArc treats the server and the network as untrusted for confidentiality and
-integrity. Encryption is end-to-end on both the direct and relay paths, and peer
-authentication is bound to the invite code.
+SendArc treats the rendezvous server and network as untrusted for confidentiality and
+integrity. Bulk encryption uses AES-256-GCM with monotonic per-direction nonces; the frame
+header is authenticated as associated data. SPAKE2 with RFC 9382 key confirmation protects
+the short invite code from offline guessing by the server and prevents an undetected
+man-in-the-middle handshake.
+
+SendArc has not yet received an independent security audit. Please do not use pre-release
+builds for irreplaceable or highly sensitive data.
 
 ## License
 
-Not yet chosen. Until a license is added, no rights are granted beyond viewing the
-source; do not assume any license. A license will be selected before the first public
-release.
+No license has been granted yet. Until a `LICENSE` file is added, the source is available
+for inspection only; do not assume permission to copy, modify, or distribute it.

--- a/apps/cli/cmd/sendarc/main.go
+++ b/apps/cli/cmd/sendarc/main.go
@@ -1,6 +1,6 @@
-// Command sendarc is the terminal client for a SendArc transfer. It runs one M1
-// rendezvous over the blind signaling server and then, over the same socket, an M2
-// end-to-end-encrypted direct file transfer:
+// Command sendarc is the terminal client for SendArc. It authenticates through the blind
+// rendezvous server, then uses the same socket to negotiate an end-to-end-encrypted direct
+// file transfer:
 //
 //	sendarc send <file>     # allocate a room, print the invite code + link, send the file
 //	sendarc receive <code>  # join with a code (or a pasted invite link), receive the file

--- a/apps/cli/internal/rendezvous/message.go
+++ b/apps/cli/internal/rendezvous/message.go
@@ -1,5 +1,5 @@
-// Package rendezvous drives one CLI peer through the SendArc M1 handshake over the blind
-// signaling channel (plan.md §5.2): create/join → peer-joined → pake → confirm → an
+// Package rendezvous drives one CLI peer through the SendArc handshake over the blind
+// signaling channel: create/join → peer-joined → pake → confirm → an
 // AEAD-sealed caps round-trip, ending with a shared master key and both directional
 // transfer keys.
 //
@@ -13,7 +13,7 @@ package rendezvous
 
 import "encoding/json"
 
-// Signaling message type tags (plan.md §6.1). These match the string tags in
+// Signaling message type tags. These match the string tags in
 // packages/protocol/src/signaling.ts exactly; the server forwards the peer→peer bodies
 // verbatim, so a mismatch here would break interop with a browser peer.
 const (
@@ -43,16 +43,16 @@ type Message struct {
 	// Msg carries the base64url SPAKE2 share on pake, and the human text on error.
 	Msg string `json:"msg,omitempty"`
 	// Mac is the base64url RFC 9382 key-confirmation MAC on confirm, and the
-	// authmac tag over the body on sdp/ice (plan.md §6.1, M2).
+	// authmac tag over the body on sdp/ice.
 	Mac string `json:"mac,omitempty"`
 	// Frame is the base64url AEAD-sealed frame on caps.
 	Frame string `json:"frame,omitempty"`
-	// Sdp carries the SDP offer/answer text on sdp (M2 peer→peer).
+	// Sdp carries the SDP offer/answer text on sdp.
 	Sdp string `json:"sdp,omitempty"`
-	// Cand carries the ICE candidate string on ice (M2 peer→peer).
+	// Cand carries the ICE candidate string on ice.
 	Cand string `json:"cand,omitempty"`
 	// Seq is the sender-monotonic sequence number authenticated on sdp/ice. It is a
-	// pointer so seq:0 — the first message — still serializes, while every non-M2
+	// pointer so seq:0 — the first message — still serializes, while every non-SDP/ICE
 	// message omits the field entirely.
 	Seq *int `json:"seq,omitempty"`
 	// Reason is the optional detail on bye.
@@ -76,7 +76,7 @@ func (f SinkFunc) Send(m Message) error { return f(m) }
 func MarshalMessage(m Message) ([]byte, error) { return json.Marshal(m) }
 
 // NewSDP builds an authenticated sdp message. seq is the sender-monotonic sequence
-// number and mac the base64url authmac tag over the body (plan.md §6.1, M2). It is
+// number and mac the base64url authmac tag over the body. It is
 // exported because the RTC layer, not the handshake session, emits these.
 func NewSDP(seq int, sdp, mac string) Message {
 	return Message{Type: typeSDP, Sdp: sdp, Seq: &seq, Mac: mac}

--- a/apps/cli/internal/rendezvous/message_test.go
+++ b/apps/cli/internal/rendezvous/message_test.go
@@ -8,7 +8,7 @@ import (
 // TestSDPMessageWireShape pins the sdp envelope, including that seq:0 — the first
 // message a sender emits — is present on the wire. A dropped seq:0 would let a peer
 // silently accept a replayed first offer, so this guards the pointer-with-omitempty
-// choice that keeps the field for M2 messages while omitting it everywhere else.
+// choice that keeps the field for authenticated signaling while omitting it elsewhere.
 func TestSDPMessageWireShape(t *testing.T) {
 	b, err := MarshalMessage(NewSDP(0, "v=0\r\no=- 1 1 IN IP4 0.0.0.0\r\n", "dGFn"))
 	if err != nil {
@@ -60,9 +60,9 @@ func TestICEMessageWireShape(t *testing.T) {
 	}
 }
 
-// TestNonM2MessagesOmitM2Fields confirms sdp/cand/seq never leak onto a handshake
-// message: a create carries only its type, nothing from the M2 extension.
-func TestNonM2MessagesOmitM2Fields(t *testing.T) {
+// TestHandshakeMessagesOmitSignalingFields confirms sdp/cand/seq never leak onto a
+// handshake message: a create carries only its type.
+func TestHandshakeMessagesOmitSignalingFields(t *testing.T) {
 	b, err := MarshalMessage(Message{Type: typeCreate})
 	if err != nil {
 		t.Fatal(err)

--- a/apps/cli/internal/rendezvous/session.go
+++ b/apps/cli/internal/rendezvous/session.go
@@ -54,7 +54,7 @@ const (
 	RoleJoiner  = wire.RoleJoiner
 )
 
-// Result is everything a completed handshake yields — enough to run the M2 transfer under
+// Result is everything a completed handshake yields — enough to run the transfer under
 // the same key. The caps exchange consumed frame counter 0 in each direction, so both
 // counters are 1: the transfer must continue from here without resetting, or it would
 // reuse an AES-GCM nonce.
@@ -64,7 +64,7 @@ type Result struct {
 	Code        string // the full normalized invite code (<room>-<words>); the SPAKE2 password
 	Master      []byte
 	Keys        wire.TransferKeys
-	Spake2      *wire.Spake2Output // retained for the M2 SDP/ICE MAC keys (KcA/KcB)
+	Spake2      *wire.Spake2Output // retained for the SDP/ICE MAC keys (KcA/KcB)
 	LocalCaps   Caps
 	RemoteCaps  Caps
 	SendCounter uint64
@@ -352,7 +352,7 @@ func (s *Session) onConfirm(msg Message) {
 		expected = s.spake2.ConfirmA
 	}
 	if !hmac.Equal(got, expected) {
-		// Wrong code or a MITM: fail closed (RFC 9382 §4). This is the core M1 guarantee.
+		// Wrong code or a MITM: fail closed (RFC 9382 §4).
 		s.fail(&Error{CodeConfirmationFailed, "key confirmation failed"})
 		return
 	}

--- a/apps/cli/internal/rtc/auth.go
+++ b/apps/cli/internal/rtc/auth.go
@@ -44,7 +44,7 @@ func NewSignalAuthenticator(room int, keys wire.SignalAuthKeys) *SignalAuthentic
 	return &SignalAuthenticator{room: uint32(room), keys: keys, inSeq: -1}
 }
 
-// FromSession derives the authenticator from a completed M1 handshake, selecting the peer's
+// FromSession derives the authenticator from a completed handshake, selecting the peer's
 // confirmation keys by role (the offerer signs with KcA and verifies with KcB; the joiner is
 // the mirror). It is the twin of SignalAuthenticator.fromSession.
 func FromSession(role wire.Role, room int, spake2 *wire.Spake2Output) *SignalAuthenticator {

--- a/apps/cli/internal/rtc/peer.go
+++ b/apps/cli/internal/rtc/peer.go
@@ -20,8 +20,8 @@ import (
 // signaling server can pair sockets but can neither inject a peer nor tamper with the
 // negotiation. Confidentiality still rests on the AES-GCM frame layer that rides the channel.
 
-// DefaultICEServers is enough for the common NAT case; a TURN relay is a later milestone. It
-// matches DEFAULT_ICE_SERVERS in the browser peer so both ends gather comparably.
+// DefaultICEServers covers the common NAT case. It matches DEFAULT_ICE_SERVERS in the browser
+// peer so both ends gather comparably.
 var DefaultICEServers = []webrtc.ICEServer{{URLs: []string{"stun:stun.l.google.com:19302"}}}
 
 // PeerOptions configures a Peer.

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -1,4 +1,4 @@
-// Package transfer wires a completed M1 rendezvous into an M2 direct file transfer: it adopts
+// Package transfer wires a completed rendezvous into a direct file transfer: it adopts
 // the open signaling socket, brings up the authenticated WebRTC DataChannel (internal/rtc), and
 // runs the transport-agnostic transfer engine (packages/wire) over it — the offerer sends the
 // file, the joiner writes it to disk. It is the CLI counterpart of
@@ -79,7 +79,7 @@ type driver struct {
 }
 
 // Send implements rendezvous.Sink for the handshake session and doubles as the peer's send
-// callback. It serializes every socket write: during M2 the read loop (relaying an answer),
+// callback. It serializes every socket write: the read loop (relaying an answer),
 // the offerer's sendOffer goroutine, and pion's ICE-candidate goroutine can all write at once,
 // and coder/websocket permits only one writer at a time.
 func (d *driver) Send(m rendezvous.Message) error {
@@ -94,7 +94,7 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	d.sess = rendezvous.New(opts)
 
 	// On a handshake failure, close the socket so the read loop unblocks; on success keep it
-	// open — the M2 signaling still needs it.
+	// open — WebRTC signaling still needs it.
 	go func() {
 		<-d.sess.Done()
 		if _, err := d.sess.Result(); err != nil {

--- a/apps/cli/internal/wsclient/client.go
+++ b/apps/cli/internal/wsclient/client.go
@@ -6,8 +6,8 @@
 //
 // As in the browser, reconnection is limited to the initial connect. Once the socket is
 // open the server holds this session's room on this connection; a drop tears the room
-// down and notifies the peer with bye, so a fresh socket cannot resume it (recovery under
-// the same code is deferred to M6). A post-open drop is surfaced as a terminal failure.
+// down and notifies the peer with bye, so a fresh socket cannot resume it. A post-open drop
+// is surfaced as a terminal failure.
 package wsclient
 
 import (

--- a/apps/server/cmd/sendarcd/main.go
+++ b/apps/server/cmd/sendarcd/main.go
@@ -1,6 +1,5 @@
-// Command sendarcd is the SendArc signaling + relay server. In M0 it serves the web
-// bundle over TLS (or reverse-proxies the Vite dev server) and exposes /healthz.
-// Signaling and relay are added in M1/M5.
+// Command sendarcd serves the SendArc web bundle over TLS (or reverse-proxies the Vite
+// development server), exposes /healthz, and hosts the blind signaling endpoint.
 package main
 
 import (

--- a/apps/server/internal/httpserver/headers.go
+++ b/apps/server/internal/httpserver/headers.go
@@ -2,10 +2,10 @@ package httpserver
 
 import "net/http"
 
-// securityHeaders applies the baseline hardening from plan.md §14. The CSP is
+// securityHeaders applies the baseline HTTP hardening. The CSP is
 // deliberately strict; connect-src stays 'self' because signaling runs same-origin
 // (wss to the same host). Referrer-Policy is an extra guard so the URL fragment
-// secret can never leak via Referer. Tightened further for release in M7.
+// secret cannot leak via Referer.
 func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()

--- a/apps/server/internal/httpserver/server.go
+++ b/apps/server/internal/httpserver/server.go
@@ -1,7 +1,6 @@
 // Package httpserver wires the HTTP surface for sendarcd: health, security headers,
 // and serving the web app — either from a built directory (prod) or by proxying the
-// Vite dev server (dev). Signaling/relay handlers mount onto this router in later
-// milestones.
+// Vite dev server (dev). The signaling handler mounts on the same router.
 package httpserver
 
 import (
@@ -112,7 +111,7 @@ func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler,
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	// Signaling endpoint: origin-checked WebSocket rendezvous (plan.md §6.1).
+	// Signaling endpoint: origin-checked WebSocket rendezvous.
 	hub := signal.NewHub(ctx, cfg.Signal, logger)
 	r.Handle("/ws", hub.Handler(ctx))
 

--- a/apps/server/internal/signal/hub.go
+++ b/apps/server/internal/signal/hub.go
@@ -114,7 +114,7 @@ func (h *Hub) partner(p *peer) *peer {
 }
 
 // remove drops p from its room. If a partner remains it is returned so the caller can
-// notify it; the room is then deleted (M1 tears down on either peer leaving).
+// notify it; the room is then deleted when either peer leaves.
 func (h *Hub) remove(p *peer) *peer {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/apps/server/internal/signal/message.go
+++ b/apps/server/internal/signal/message.go
@@ -2,7 +2,7 @@
 // forwarder and pairer. It allocates room numbers, links exactly two sockets per
 // room, and relays the peers' SPAKE2 handshake and encrypted capability frames
 // without inspecting them. It never sees the word code, any key, or any plaintext —
-// only room numbers and connection metadata (plan.md §5.5, §6.1).
+// only room numbers and connection metadata.
 package signal
 
 import (
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-// Wire message types (plan.md §6.1). Control types are handled by the server; the
+// Wire message types. Control types are handled by the server; the
 // forwardable types are relayed peer-to-peer as opaque bytes.
 const (
 	typeCreate     = "create"
@@ -39,8 +39,7 @@ const (
 )
 
 // forwardable is the set of peer→peer types the server relays without inspection.
-// sdp and ice are unused until M2 but are relayed now so the handshake path is
-// complete; their bodies are never parsed.
+// SDP and ICE bodies are forwarded without being parsed.
 var forwardable = map[string]bool{
 	typePake:    true,
 	typeConfirm: true,

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -34,7 +34,7 @@
   let peerCaps = $state<CapsPayload | undefined>(undefined);
   let errorText = $state('');
 
-  // M2 transfer state, live once the handshake settles and the socket is adopted.
+  // Transfer state, live once the handshake settles and the socket is adopted.
   let role = $state<Role | undefined>(undefined);
   let pickedFile = $state<File | null>(null);
   // TransferController is an imperative identity-bearing object (methods + a terminal Promise),

--- a/apps/web/src/lib/session/rendezvous.ts
+++ b/apps/web/src/lib/session/rendezvous.ts
@@ -46,7 +46,7 @@ export interface RendezvousController {
   /** Abort locally: notify the peer with `bye` and tear down the socket. Idempotent. */
   cancel(reason?: string): void;
   /**
-   * Take over the still-open signaling socket for the M2 transfer, before it is auto-closed.
+   * Take over the still-open signaling socket for the transfer, before it is auto-closed.
    * Valid only after `done` resolves; the caller then owns teardown via the returned channel's
    * `close()`. Swapping in a new `onMessage` handler reroutes inbound frames (SDP/ICE) away from
    * the settled handshake session and into the transfer layer.
@@ -116,7 +116,7 @@ function run(
 
   // Tear the socket down once the handshake settles. Failure closes immediately (stop a doomed
   // retry loop). Success defers to a macrotask so a caller can `adoptSignaling()` synchronously
-  // off `await done` and keep the socket for the M2 transfer; if nobody adopts, it still closes
+  // off `await done` and keep the socket for the transfer; if nobody adopts, it still closes
   // to free the room on the server.
   void session.done.then(
     () => setTimeout(() => void (adopted || client.close()), 0),

--- a/apps/web/src/lib/signaling/client.ts
+++ b/apps/web/src/lib/signaling/client.ts
@@ -8,16 +8,15 @@
  * Reconnection is deliberately limited to that first connect. Once the socket has opened,
  * the server holds this session's room and pairing on *this* connection; a drop tears the
  * room down and notifies the peer with `bye`, so a fresh socket cannot resume it — it
- * would only allocate a new, unrelated room. Recovering a dropped session by
- * re-handshaking under the same code is a later milestone (plan.md §M6); here a
- * post-open close is surfaced as a terminal event for the caller to handle.
+ * would only allocate a new, unrelated room. A post-open close is surfaced as a terminal
+ * event for the caller to handle.
  */
 
 import type { SignalMsg } from '@sendarc/protocol';
 
 /**
  * A live, bidirectional signaling channel with a swappable inbound handler. The rendezvous layer
- * hands one of these to the M2 transfer layer (via `adoptSignaling`) once the handshake settles,
+ * hands one of these to the transfer layer (via `adoptSignaling`) once the handshake settles,
  * so the SDP/ICE exchange can reuse the still-open socket instead of opening a second one.
  */
 export interface SignalChannel {

--- a/apps/web/src/lib/transfer/peer.ts
+++ b/apps/web/src/lib/transfer/peer.ts
@@ -1,5 +1,5 @@
 /**
- * WebRTC peer for the M2 transfer: brings up an `RTCDataChannel` between the two paired clients
+ * WebRTC peer: brings up an `RTCDataChannel` between the two paired clients
  * over the already-authenticated signaling socket. Every SDP and ICE frame is signed and verified
  * with the SPAKE2-derived key (see {@link SignalAuthenticator}); an unverifiable frame is dropped,
  * so a malicious signaling server can pair sockets but cannot inject a peer or tamper with the
@@ -11,7 +11,7 @@
 import type { IceMsg, Role, SdpMsg } from '@sendarc/protocol';
 import type { SignalAuthenticator } from './authed-signaling.js';
 
-/** A public STUN server is enough for the common NAT case; TURN relay is a later milestone. */
+/** A public STUN server is sufficient for the common NAT case. */
 export const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
 
 export interface CreatePeerOptions {

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -7,7 +7,7 @@
 
 import type { DirectionalKey } from '@sendarc/protocol';
 
-/** Session crypto state handed to the worker at start — counters continue from M1, never reset. */
+/** Session crypto state handed to the worker at start — counters continue, never reset. */
 export interface SessionCrypto {
   sendDir: DirectionalKey;
   recvDir: DirectionalKey;

--- a/packages/protocol/src/aead.ts
+++ b/packages/protocol/src/aead.ts
@@ -1,5 +1,5 @@
 /**
- * AES-256-GCM frame codec (plan.md §6.3). Each frame is a fixed 16-byte header followed
+ * AES-256-GCM frame codec. Each frame is a fixed 16-byte header followed
  * by the GCM output (ciphertext with appended 16-byte tag). The encoded header is the
  * GCM additional authenticated data, so any header tampering fails decryption.
  *

--- a/packages/protocol/src/authmac.test.ts
+++ b/packages/protocol/src/authmac.test.ts
@@ -42,7 +42,7 @@ describe('authmac', () => {
     expect(await verifySignal(k, 'sdp', 8, 3, 'hello', mac)).toBe(false); // room bound
   });
 
-  it('domain-separates from the M1 confirm MAC (type prefix present)', () => {
+  it('domain-separates from the confirm MAC (type prefix present)', () => {
     const input = signalMacInput('sdp', 7, 3, 'x');
     expect(new TextDecoder().decode(input.slice(0, 4))).toBe('sdp:');
   });

--- a/packages/protocol/src/authmac.ts
+++ b/packages/protocol/src/authmac.ts
@@ -1,10 +1,10 @@
 /**
- * SDP/ICE authentication (M2 design §4.2). Each `sdp`/`ice` signaling message is
+ * SDP/ICE authentication. Each `sdp`/`ice` signaling message is
  * authenticated so a malicious server cannot swap in its own SDP to MITM the DataChannel:
  *
  *   mac = HMAC-SHA256(k_auth, utf8(type) || ":" || u32be(room) || ":" || u32be(seq) || ":" || body)
  *
- * `k_auth` is the SPAKE2 key-confirmation material M1 retains: each peer signs with its own
+ * `k_auth` is retained SPAKE2 key-confirmation material: each peer signs with its own
  * confirmation key and verifies with the peer's. This is defense-in-depth for the direct
  * path — confidentiality still rests on the AES-GCM frame layer keyed by K.
  */

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -17,7 +17,7 @@ export const DEFAULT_WORD_COUNT = 2; // 2 words × 8 bits = 16 bits; configurabl
 export const WORDLIST_SIZE = 256; // one byte of entropy per word
 export const CODE_SEPARATOR = '-';
 
-/** Framing (see plan.md §6.3). Header is fixed-size and used as AES-GCM AAD. */
+/** Framing constants. The header is fixed-size and used as AES-GCM AAD. */
 export const FRAME_HEADER_BYTES = 16;
 
 /** Frame-header format version (the header's first byte). Bumped only if the header layout changes. */
@@ -32,7 +32,7 @@ export const DEFAULT_BLOCK_BYTES = 1024 * 1024;
 
 /**
  * Receiver memory bound: how many blocks the sender may have in flight ahead of the
- * receiver's confirmation. Bounds receiver RAM regardless of sink speed (plan.md M2/M3).
+ * receiver's confirmation. Bounds receiver RAM regardless of sink speed.
  */
 export const DEFAULT_INFLIGHT_BLOCKS = 8;
 
@@ -40,7 +40,7 @@ export const DEFAULT_INFLIGHT_BLOCKS = 8;
 export const BUFFERED_AMOUNT_HIGH = 8 * 1024 * 1024;
 export const BUFFERED_AMOUNT_LOW = 1 * 1024 * 1024;
 
-/** Structural caps implied by the wire header field widths (plan.md §6.3). */
+/** Structural caps implied by the wire header field widths. */
 export const MAX_FILES_PER_TRANSFER = 0xffff + 1; // fileIdx is u16
 export const MAX_BLOCKS_PER_FILE = 0xffffffff + 1; // blockIdx is u32
 

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -1,5 +1,5 @@
 /**
- * Binary codec for the 16-byte frame header (plan.md §6.3). The encoded header bytes
+ * Binary codec for the 16-byte frame header. The encoded header bytes
  * are used verbatim as the AES-GCM AAD, so encode/decode must be exact and stable.
  *
  * Layout (big-endian):

--- a/packages/protocol/src/rendezvous.ts
+++ b/packages/protocol/src/rendezvous.ts
@@ -1,6 +1,6 @@
 /**
- * Rendezvous state machine — drives one peer through the M1 handshake over the blind
- * signaling channel (plan.md §5.2): `create`/`join` → `peer-joined` → `pake` → `confirm`
+ * Rendezvous state machine — drives one peer through the handshake over the blind
+ * signaling channel: `create`/`join` → `peer-joined` → `pake` → `confirm`
  * → an encrypted `caps` round-trip, ending with a shared master key and both directional
  * transfer keys.
  *
@@ -62,7 +62,7 @@ export interface CapsPayload {
   sinkHints: SinkHint[];
 }
 
-/** Everything a completed handshake yields — enough to run the M2 transfer under the same key. */
+/** Everything a completed handshake yields — enough to run the transfer under the same key. */
 export interface RendezvousResult {
   readonly role: Role;
   readonly room: number;
@@ -72,14 +72,14 @@ export interface RendezvousResult {
   readonly master: Uint8Array;
   /** Both directional AEAD keys + nonce salts. */
   readonly keys: TransferKeys;
-  /** Raw SPAKE2 output, retained for the M2 SDP/ICE MAC keys (KcA/KcB). */
+  /** Raw SPAKE2 output, retained for the SDP/ICE MAC keys (KcA/KcB). */
   readonly spake2: Spake2Output;
   readonly localCaps: CapsPayload;
   readonly remoteCaps: CapsPayload;
   /**
    * Next per-direction frame counters. The caps exchange consumed counter 0 in each
    * direction, so both are 1: the transfer must continue from here without resetting,
-   * or it would reuse an AES-GCM nonce (plan.md §5.3 counter-continuity invariant).
+   * or it would reuse an AES-GCM nonce.
    */
   readonly sendCounter: number;
   readonly recvCounter: number;
@@ -330,7 +330,7 @@ export class RendezvousSession {
     }
     const expected = this.role === 'offerer' ? this.spake2.confirmB : this.spake2.confirmA;
     if (!constantTimeEqual(got, expected)) {
-      // Wrong code or a MITM: fail closed (RFC 9382 §4). This is the core M1 guarantee.
+      // Wrong code or a MITM: fail closed (RFC 9382 §4).
       return this.fail(new RendezvousError('confirmation_failed', 'key confirmation failed'));
     }
     // Confirmed. Derive the transfer keys and send our encrypted caps.

--- a/packages/protocol/src/signaling.ts
+++ b/packages/protocol/src/signaling.ts
@@ -1,5 +1,5 @@
 /**
- * Signaling protocol — JSON messages over the WebSocket (plan.md §6.1, M1 design §4).
+ * Signaling protocol — JSON messages over the WebSocket.
  *
  * The server is a blind pairer + forwarder: it allocates a room number, links the two
  * sockets, and forwards `pake`/`confirm`/`caps`/`sdp`/`ice`/`bye` between them without
@@ -51,7 +51,7 @@ export interface ConfirmMsg {
 
 /**
  * Peer → peer (forwarded): an opaque AES-256-GCM frame (base64url). First use of the
- * transfer codec — carries the encrypted `caps` in M1.
+ * transfer codec — carries the encrypted `caps` handshake payload.
  */
 export interface CapsMsg {
   type: 'caps';
@@ -59,7 +59,7 @@ export interface CapsMsg {
 }
 
 /**
- * Peer → peer (forwarded): SDP offer/answer, authenticated by the session key (M2).
+ * Peer → peer (forwarded): SDP offer/answer, authenticated by the session key.
  * `mac` = HMAC(k_auth, "sdp" | room | seq | body); `seq` is monotonic per sender.
  */
 export interface SdpMsg {
@@ -69,7 +69,7 @@ export interface SdpMsg {
   mac: string;
 }
 
-/** Peer → peer (forwarded): ICE candidate, authenticated like SdpMsg (M2). */
+/** Peer → peer (forwarded): ICE candidate, authenticated like SdpMsg. */
 export interface IceMsg {
   type: 'ice';
   cand: string;

--- a/packages/protocol/src/transfer-ports.ts
+++ b/packages/protocol/src/transfer-ports.ts
@@ -1,5 +1,5 @@
 /**
- * IO ports for the transfer engine (M2 design §5.2, §7). The engine depends only on these
+ * IO ports for the transfer engine. The engine depends only on these
  * async primitives, so the same core runs inline in Node and inside the browser worker with
  * no forked logic. Concrete implementations (OPFS sink, hash-wasm digest, File source) live
  * in the host; this module defines the contracts plus in-memory helpers for tests.

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -4,7 +4,7 @@
  *   Pass 1  read the file once → whole-file streaming digest → manifest (with fileDigest).
  *   Pass 2  re-chunk into `block_data` frames; at each block boundary send `block_hash`.
  *   Finish  send `complete{fileDigest}`; resolve when the receiver returns `done`.
- * Outbound frames are AES-GCM sealed with a per-direction counter that continues from M1
+ * Outbound frames are AES-GCM sealed with a per-direction counter that continues from the handshake
  * (never reset). The sender never runs more than `window` blocks ahead of the receiver's
  * `block_recv` signal, bounding the outbound queue.
  */

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -1,9 +1,9 @@
 /**
  * Transfer protocol — messages carried as plaintext INSIDE AES-GCM frames, over the
- * DataChannel or the relay (plan.md §6.2). The frame header (§6.3) is the GCM AAD.
+ * DataChannel or another binary transport. The frame header is the GCM AAD.
  */
 
-/** One frame's binary header fields (plan.md §6.3). `frameOff` is within-block. */
+/** One frame's binary header fields. `frameOff` is within-block. */
 export interface FrameHeader {
   version: number;
   type: FrameType;
@@ -20,7 +20,7 @@ export enum FrameType {
   Manifest = 2,
   BlockData = 3,
   BlockHash = 4,
-  BlockRecv = 5, // lightweight M2 in-flight-window signal
+  BlockRecv = 5, // lightweight in-flight-window signal
   Ack = 6,
   Nack = 7,
   Control = 8,
@@ -32,7 +32,7 @@ export enum FrameType {
 /** Feature flags negotiated in caps. */
 export type Feature = 'folders' | 'resume' | 'relay' | 'archive';
 
-/** Hints about which receiver sink is available (plan.md M4). */
+/** Hints about which receiver sink is available. */
 export type SinkHint = 'direct-file' | 'opfs' | 'archive';
 
 /** First encrypted message after the handshake. */
@@ -48,7 +48,7 @@ export interface Caps {
 /** One file's metadata within a manifest. */
 export interface FileEntry {
   idx: number;
-  name: string; // sanitized on receipt (plan.md M4)
+  name: string; // sanitized on receipt
   size: number;
   mime: string;
   lastModified: number;
@@ -72,21 +72,21 @@ export interface BlockHash {
   sha256: string; // hex
 }
 
-/** M2 window signal: receiver has taken delivery of a block (pre-ack). */
+/** Window signal: receiver has taken delivery of a block (pre-ack). */
 export interface BlockRecv {
   type: FrameType.BlockRecv;
   fileIdx: number;
   blockIdx: number;
 }
 
-/** M3: receiver confirms a block was verified and written to the sink. */
+/** Receiver confirms a block was verified and written to the sink. */
 export interface Ack {
   type: FrameType.Ack;
   fileIdx: number;
   blockIdx: number;
 }
 
-/** M3: receiver requests retransmission of a missing block (not for integrity fails). */
+/** Receiver requests retransmission of a missing block (not for integrity failures). */
 export interface Nack {
   type: FrameType.Nack;
   fileIdx: number;

--- a/packages/wire/authmac.go
+++ b/packages/wire/authmac.go
@@ -5,13 +5,13 @@ import (
 	"encoding/binary"
 )
 
-// Signaling-message authentication (M2 design §4.2). Each sdp/ice signaling message is
+// Signaling-message authentication. Each sdp/ice signaling message is
 // MAC'd so a malicious rendezvous server cannot substitute its own SDP to man-in-the-middle
 // the DataChannel:
 //
 //	mac = HMAC-SHA256(k_auth, utf8(type) || ":" || u32be(room) || ":" || u32be(seq) || ":" || body)
 //
-// k_auth is the SPAKE2 key-confirmation material M1 retains: each peer signs with its own
+// k_auth is retained SPAKE2 key-confirmation material: each peer signs with its own
 // confirmation key and verifies with the peer's. This is defense-in-depth for the direct
 // path — confidentiality still rests on the AES-GCM frame layer keyed by K. This is the Go
 // twin of packages/protocol/src/authmac.ts and produces byte-identical MACs.

--- a/packages/wire/frame.go
+++ b/packages/wire/frame.go
@@ -12,7 +12,7 @@ const frameHeaderBytes = 16
 // layout changes.
 const FrameVersion uint8 = 1
 
-// FrameHeader is the 16-byte frame header (plan.md §6.3). Its encoded bytes are the
+// FrameHeader is the 16-byte frame header. Its encoded bytes are the
 // AES-GCM additional authenticated data, so the codec must be exact and stable.
 //
 // Layout (big-endian):

--- a/packages/wire/transfer_messages.go
+++ b/packages/wire/transfer_messages.go
@@ -23,7 +23,7 @@ type ControlMsg interface {
 // FileEntry is one file's metadata within a manifest.
 type FileEntry struct {
 	Idx          int    `json:"idx"`
-	Name         string `json:"name"` // sanitized on receipt (plan.md M4)
+	Name         string `json:"name"` // sanitized on receipt
 	Size         int64  `json:"size"`
 	Mime         string `json:"mime"`
 	LastModified int64  `json:"lastModified"`
@@ -47,7 +47,7 @@ type BlockHash struct {
 	SHA256   string `json:"sha256"`
 }
 
-// BlockRecv is the M2 window signal: the receiver has taken delivery of a block (pre-ack).
+// BlockRecv is the window signal: the receiver has taken delivery of a block (pre-ack).
 type BlockRecv struct {
 	Type     uint8 `json:"type"`
 	FileIdx  int   `json:"fileIdx"`

--- a/packages/wire/transfer_ports.go
+++ b/packages/wire/transfer_ports.go
@@ -7,7 +7,7 @@ import (
 	"hash"
 )
 
-// IO ports for the transfer engine (M2 design §5.2, §7). The Sender/Receiver depend only on
+// IO ports for the transfer engine. The Sender/Receiver depend only on
 // these primitives, so the same core runs over an in-memory pipe in tests and over the real
 // pion DataChannel in the CLI. Concrete OS-backed implementations (file source, file sink)
 // live in apps/cli; this file defines the contracts plus in-memory helpers. It is the Go twin


### PR DESCRIPTION
## Summary

- replace the milestone-oriented README with a product-first project introduction
- document current browser and CLI interoperability, local setup, architecture, and security posture
- remove internal milestone names and private planning-document references from the repository tree
- avoid roadmap promises and distinguish current functionality from pre-release limitations

## Verification

- confirmed no milestone or private-plan references remain in the current tree
- pnpm run format:check
- just lint
- just typecheck
- just test
- just build