### PR TITLE
feat(protocol): define reliable transfer controls

### DIFF
--- a/packages/protocol/src/transfer-messages.test.ts
+++ b/packages/protocol/src/transfer-messages.test.ts
@@ -23,13 +23,20 @@ describe('control-message codec', () => {
     expect(decodeControl(encodeControl(manifest))).toEqual(manifest);
   });
 
-  it('round-trips block_hash / block_recv / complete / done / fail', () => {
+  it('round-trips block and terminal messages', () => {
     const msgs = [
       { type: FrameType.BlockHash, fileIdx: 0, blockIdx: 1, sha256: 'ff' },
       { type: FrameType.BlockRecv, fileIdx: 0, blockIdx: 1 },
+      { type: FrameType.Ack, fileIdx: 0, blockIdx: 1 },
+      { type: FrameType.Nack, fileIdx: 0, blockIdx: 2, reason: 'missing' },
+      { type: FrameType.Nack, fileIdx: 0, blockIdx: 3, reason: 'timeout' },
+      { type: FrameType.Control, op: 'pause' },
+      { type: FrameType.Control, op: 'resume' },
+      { type: FrameType.Control, op: 'cancel' },
       { type: FrameType.Complete, fileDigest: 'deadbeef' },
       { type: FrameType.Done },
       { type: FrameType.Fail, reason: 'digest_mismatch' },
+      { type: FrameType.Fail, reason: 'retry_exhausted' },
     ] as const;
     for (const m of msgs) expect(decodeControl(encodeControl(m))).toEqual(m);
   });
@@ -39,6 +46,14 @@ describe('control-message codec', () => {
     expect(() => decodeControl(encodeControl({ type: 999 } as never))).toThrow();
     expect(() =>
       decodeControl(encodeControl({ type: FrameType.Fail, reason: 'nope' } as never)),
+    ).toThrow();
+    expect(() =>
+      decodeControl(
+        encodeControl({ type: FrameType.Nack, fileIdx: 0, blockIdx: 1, reason: 'bad' } as never),
+      ),
+    ).toThrow();
+    expect(() =>
+      decodeControl(encodeControl({ type: FrameType.Control, op: 'stop' } as never)),
     ).toThrow();
     expect(() => decodeControl(encodeControl({ type: FrameType.Complete } as never))).toThrow(); // missing fileDigest
   });

--- a/packages/protocol/src/transfer-messages.ts
+++ b/packages/protocol/src/transfer-messages.ts
@@ -7,12 +7,15 @@
 
 import {
   FrameType,
+  type Ack,
   type BlockHash,
   type BlockRecv,
   type Complete,
+  type Control,
   type Fail,
   type FileEntry,
   type Manifest,
+  type Nack,
   type TransferMsg,
 } from './transfer.js';
 import { utf8 } from './bytes.js';
@@ -39,6 +42,12 @@ export function decodeControl(payload: Uint8Array): TransferMsg {
       return asBlockHash(m);
     case FrameType.BlockRecv:
       return asBlockRecv(m);
+    case FrameType.Ack:
+      return asAck(m);
+    case FrameType.Nack:
+      return asNack(m);
+    case FrameType.Control:
+      return asControl(m);
     case FrameType.Complete:
       return asComplete(m);
     case FrameType.Done:
@@ -97,12 +106,41 @@ function asBlockHash(m: Record<string, unknown>): BlockHash {
 function asBlockRecv(m: Record<string, unknown>): BlockRecv {
   return { type: FrameType.BlockRecv, fileIdx: num(m, 'fileIdx'), blockIdx: num(m, 'blockIdx') };
 }
+function asAck(m: Record<string, unknown>): Ack {
+  return { type: FrameType.Ack, fileIdx: num(m, 'fileIdx'), blockIdx: num(m, 'blockIdx') };
+}
+function asNack(m: Record<string, unknown>): Nack {
+  const reason = str(m, 'reason');
+  if (reason !== 'missing' && reason !== 'timeout') {
+    throw new Error(`control frame: bad nack reason ${reason}`);
+  }
+  return {
+    type: FrameType.Nack,
+    fileIdx: num(m, 'fileIdx'),
+    blockIdx: num(m, 'blockIdx'),
+    reason,
+  };
+}
+function asControl(m: Record<string, unknown>): Control {
+  const op = str(m, 'op');
+  if (op !== 'pause' && op !== 'resume' && op !== 'cancel') {
+    throw new Error(`control frame: bad control op ${op}`);
+  }
+  return { type: FrameType.Control, op };
+}
 function asComplete(m: Record<string, unknown>): Complete {
   return { type: FrameType.Complete, fileDigest: str(m, 'fileDigest') };
 }
 function asFail(m: Record<string, unknown>): Fail {
   const reason = str(m, 'reason');
-  const allowed = ['digest_mismatch', 'integrity', 'sink_error', 'canceled', 'quota'];
+  const allowed = [
+    'digest_mismatch',
+    'integrity',
+    'sink_error',
+    'canceled',
+    'quota',
+    'retry_exhausted',
+  ];
   if (!allowed.includes(reason)) throw new Error(`control frame: bad fail reason ${reason}`);
   return { type: FrameType.Fail, reason: reason as Fail['reason'] };
 }

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -114,7 +114,7 @@ export interface Done {
 
 export interface Fail {
   type: FrameType.Fail;
-  reason: 'digest_mismatch' | 'integrity' | 'sink_error' | 'canceled' | 'quota';
+  reason: 'digest_mismatch' | 'integrity' | 'sink_error' | 'canceled' | 'quota' | 'retry_exhausted';
 }
 
 export type TransferMsg =

--- a/packages/wire/transfer_messages.go
+++ b/packages/wire/transfer_messages.go
@@ -54,6 +54,49 @@ type BlockRecv struct {
 	BlockIdx int   `json:"blockIdx"`
 }
 
+// Ack confirms that a block was verified and committed to the destination sink.
+type Ack struct {
+	Type     uint8 `json:"type"`
+	FileIdx  int   `json:"fileIdx"`
+	BlockIdx int   `json:"blockIdx"`
+}
+
+// Nack requests a fresh transmission of a block that did not arrive.
+type Nack struct {
+	Type     uint8      `json:"type"`
+	FileIdx  int        `json:"fileIdx"`
+	BlockIdx int        `json:"blockIdx"`
+	Reason   NackReason `json:"reason"`
+}
+
+// NackReason describes why a block is being requested again.
+type NackReason string
+
+const (
+	// NackMissing means a later block exposed a gap in the ordered block sequence.
+	NackMissing NackReason = "missing"
+	// NackTimeout means the acknowledgement deadline expired.
+	NackTimeout NackReason = "timeout"
+)
+
+// Control changes the live transfer state in either direction.
+type Control struct {
+	Type uint8     `json:"type"`
+	Op   ControlOp `json:"op"`
+}
+
+// ControlOp is one bidirectional transfer action.
+type ControlOp string
+
+const (
+	// ControlPause stops creation of new outbound data frames.
+	ControlPause ControlOp = "pause"
+	// ControlResume allows outbound data frames again.
+	ControlResume ControlOp = "resume"
+	// ControlCancel terminates the transfer.
+	ControlCancel ControlOp = "cancel"
+)
+
 // Complete tells the receiver every block was sent and gives the canonical digest to verify.
 type Complete struct {
 	Type       uint8  `json:"type"`
@@ -81,6 +124,15 @@ func (m BlockHash) FrameType() uint8 { return m.Type }
 // FrameType reports the block_recv frame tag.
 func (m BlockRecv) FrameType() uint8 { return m.Type }
 
+// FrameType reports the ack frame tag.
+func (m Ack) FrameType() uint8 { return m.Type }
+
+// FrameType reports the nack frame tag.
+func (m Nack) FrameType() uint8 { return m.Type }
+
+// FrameType reports the control frame tag.
+func (m Control) FrameType() uint8 { return m.Type }
+
 // FrameType reports the complete frame tag.
 func (m Complete) FrameType() uint8 { return m.Type }
 
@@ -104,6 +156,19 @@ func NewBlockHash(fileIdx, blockIdx int, sha256 string) *BlockHash {
 func NewBlockRecv(fileIdx, blockIdx int) *BlockRecv {
 	return &BlockRecv{Type: FrameBlockRecv, FileIdx: fileIdx, BlockIdx: blockIdx}
 }
+
+// NewAck builds a verified-block acknowledgement.
+func NewAck(fileIdx, blockIdx int) *Ack {
+	return &Ack{Type: FrameAck, FileIdx: fileIdx, BlockIdx: blockIdx}
+}
+
+// NewNack builds a missing-block request.
+func NewNack(fileIdx, blockIdx int, reason NackReason) *Nack {
+	return &Nack{Type: FrameNack, FileIdx: fileIdx, BlockIdx: blockIdx, Reason: reason}
+}
+
+// NewControl builds a bidirectional transfer control message.
+func NewControl(op ControlOp) *Control { return &Control{Type: FrameControl, Op: op} }
 
 // NewComplete builds a complete message carrying the canonical file digest.
 func NewComplete(fileDigest string) *Complete {
@@ -140,6 +205,9 @@ func DecodeControl(payload []byte) (ControlMsg, error) {
 	if head.Type == nil {
 		return nil, errors.New("control frame: missing type")
 	}
+	if *head.Type < 0 || *head.Type > 0xff {
+		return nil, fmt.Errorf("control frame: invalid type %d", *head.Type)
+	}
 	switch uint8(*head.Type) {
 	case FrameManifest:
 		return decodeManifest(payload)
@@ -147,6 +215,12 @@ func DecodeControl(payload []byte) (ControlMsg, error) {
 		return decodeBlockHash(payload)
 	case FrameBlockRecv:
 		return decodeBlockRecv(payload)
+	case FrameAck:
+		return decodeAck(payload)
+	case FrameNack:
+		return decodeNack(payload)
+	case FrameControl:
+		return decodeControlMessage(payload)
 	case FrameComplete:
 		return decodeComplete(payload)
 	case FrameDone:
@@ -237,6 +311,56 @@ func decodeBlockRecv(payload []byte) (ControlMsg, error) {
 	return &BlockRecv{Type: FrameBlockRecv, FileIdx: *raw.FileIdx, BlockIdx: *raw.BlockIdx}, nil
 }
 
+func decodeAck(payload []byte) (ControlMsg, error) {
+	var raw struct {
+		FileIdx  *int `json:"fileIdx"`
+		BlockIdx *int `json:"blockIdx"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil, errors.New("control frame: invalid ack")
+	}
+	if raw.FileIdx == nil || raw.BlockIdx == nil {
+		return nil, errors.New("control frame: incomplete ack")
+	}
+	return &Ack{Type: FrameAck, FileIdx: *raw.FileIdx, BlockIdx: *raw.BlockIdx}, nil
+}
+
+func decodeNack(payload []byte) (ControlMsg, error) {
+	var raw struct {
+		FileIdx  *int    `json:"fileIdx"`
+		BlockIdx *int    `json:"blockIdx"`
+		Reason   *string `json:"reason"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil, errors.New("control frame: invalid nack")
+	}
+	if raw.FileIdx == nil || raw.BlockIdx == nil || raw.Reason == nil {
+		return nil, errors.New("control frame: incomplete nack")
+	}
+	reason := NackReason(*raw.Reason)
+	if reason != NackMissing && reason != NackTimeout {
+		return nil, fmt.Errorf("control frame: bad nack reason %q", *raw.Reason)
+	}
+	return &Nack{Type: FrameNack, FileIdx: *raw.FileIdx, BlockIdx: *raw.BlockIdx, Reason: reason}, nil
+}
+
+func decodeControlMessage(payload []byte) (ControlMsg, error) {
+	var raw struct {
+		Op *string `json:"op"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil, errors.New("control frame: invalid control")
+	}
+	if raw.Op == nil {
+		return nil, errors.New("control frame: control.op missing")
+	}
+	op := ControlOp(*raw.Op)
+	if op != ControlPause && op != ControlResume && op != ControlCancel {
+		return nil, fmt.Errorf("control frame: bad control op %q", *raw.Op)
+	}
+	return &Control{Type: FrameControl, Op: op}, nil
+}
+
 func decodeComplete(payload []byte) (ControlMsg, error) {
 	var raw struct {
 		FileDigest *string `json:"fileDigest"`
@@ -261,7 +385,7 @@ func decodeFail(payload []byte) (ControlMsg, error) {
 		return nil, errors.New("control frame: fail.reason missing")
 	}
 	switch FailReason(*raw.Reason) {
-	case FailDigestMismatch, FailIntegrity, FailSinkError, FailCanceled, FailQuota:
+	case FailDigestMismatch, FailIntegrity, FailSinkError, FailCanceled, FailQuota, FailRetryExhausted:
 		return &Fail{Type: FrameFail, Reason: FailReason(*raw.Reason)}, nil
 	default:
 		return nil, fmt.Errorf("control frame: bad fail reason %q", *raw.Reason)

--- a/packages/wire/transfer_messages_test.go
+++ b/packages/wire/transfer_messages_test.go
@@ -21,6 +21,11 @@ func TestEncodeControlWireBytes(t *testing.T) {
 		},
 		{"block_hash", NewBlockHash(0, 1, "ff"), `{"type":4,"fileIdx":0,"blockIdx":1,"sha256":"ff"}`},
 		{"block_recv", NewBlockRecv(0, 1), `{"type":5,"fileIdx":0,"blockIdx":1}`},
+		{"ack", NewAck(0, 1), `{"type":6,"fileIdx":0,"blockIdx":1}`},
+		{"nack", NewNack(0, 2, NackMissing), `{"type":7,"fileIdx":0,"blockIdx":2,"reason":"missing"}`},
+		{"pause", NewControl(ControlPause), `{"type":8,"op":"pause"}`},
+		{"resume", NewControl(ControlResume), `{"type":8,"op":"resume"}`},
+		{"cancel", NewControl(ControlCancel), `{"type":8,"op":"cancel"}`},
 		{"complete", NewComplete("deadbeef"), `{"type":9,"fileDigest":"deadbeef"}`},
 		{"done", NewDone(), `{"type":10}`},
 		{"fail", NewFail(FailDigestMismatch), `{"type":11,"reason":"digest_mismatch"}`},
@@ -57,6 +62,12 @@ func TestDecodeControlRoundTrip(t *testing.T) {
 		}}, 10),
 		NewBlockHash(0, 1, "ff"),
 		NewBlockRecv(0, 1),
+		NewAck(0, 1),
+		NewNack(0, 2, NackMissing),
+		NewNack(0, 3, NackTimeout),
+		NewControl(ControlPause),
+		NewControl(ControlResume),
+		NewControl(ControlCancel),
 		NewComplete("deadbeef"),
 		NewDone(),
 		NewFail(FailDigestMismatch),
@@ -82,25 +93,28 @@ func TestDecodeControlRoundTrip(t *testing.T) {
 
 // A payload the TS decoder produced must decode here to the same values (decode-side interop).
 func TestDecodeControlFromTSShapes(t *testing.T) {
-	m, err := DecodeControl([]byte(`{"type":5,"fileIdx":2,"blockIdx":7}`))
+	m, err := DecodeControl([]byte(`{"type":7,"fileIdx":2,"blockIdx":7,"reason":"timeout"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	br, ok := m.(*BlockRecv)
-	if !ok || br.FileIdx != 2 || br.BlockIdx != 7 {
-		t.Fatalf("decoded block_recv = %#v", m)
+	nack, ok := m.(*Nack)
+	if !ok || nack.FileIdx != 2 || nack.BlockIdx != 7 || nack.Reason != NackTimeout {
+		t.Fatalf("decoded nack = %#v", m)
 	}
 }
 
 func TestDecodeControlRejectsMalformed(t *testing.T) {
 	bad := []string{
-		`{{`,                                  // invalid JSON
-		`{"type":999}`,                        // unknown type
-		`{"type":11,"reason":"nope"}`,         // bad fail reason
-		`{"type":9}`,                          // complete missing fileDigest
-		`{"type":2,"files":[],"totalSize":0}`, // empty manifest files
-		`{"type":4,"fileIdx":0}`,              // block_hash missing sha256/blockIdx
-		`{"fileIdx":0}`,                       // missing type
+		`{{`,           // invalid JSON
+		`{"type":999}`, // out-of-range type
+		`{"type":263,"fileIdx":0,"blockIdx":1,"reason":"missing"}`, // must not wrap to nack
+		`{"type":11,"reason":"nope"}`,                              // bad fail reason
+		`{"type":7,"fileIdx":0,"blockIdx":1,"reason":"bad"}`,       // bad nack reason
+		`{"type":8,"op":"stop"}`,                                   // bad control operation
+		`{"type":9}`,                                               // complete missing fileDigest
+		`{"type":2,"files":[],"totalSize":0}`,                      // empty manifest files
+		`{"type":4,"fileIdx":0}`,                                   // block_hash missing sha256/blockIdx
+		`{"fileIdx":0}`,                                            // missing type
 	}
 	for _, s := range bad {
 		if _, err := DecodeControl([]byte(s)); err == nil {

--- a/packages/wire/transfer_ports.go
+++ b/packages/wire/transfer_ports.go
@@ -83,6 +83,8 @@ const (
 	FailCanceled FailReason = "canceled"
 	// FailQuota means the destination ran out of space or quota.
 	FailQuota FailReason = "quota"
+	// FailRetryExhausted means a missing block remained unacknowledged after bounded retries.
+	FailRetryExhausted FailReason = "retry_exhausted"
 )
 
 // TransferError carries one of the protocol's fail reasons. The reason is always prefixed


### PR DESCRIPTION
## Summary

- complete ACK and NACK control-message support in TypeScript and Go
- add pause, resume, and cancel wire controls in both implementations
- define a bounded retry-exhaustion failure reason
- preserve byte-identical JSON encoding across browser and CLI peers
- reject malformed operations, reasons, and out-of-range frame types

## Verification

- pnpm run format:check
- just lint
- just typecheck
- just test
- just build