### PR TITLE
feat(transfer): add acknowledged block recovery

### DIFF
--- a/packages/protocol/src/transfer-receiver.test.ts
+++ b/packages/protocol/src/transfer-receiver.test.ts
@@ -6,7 +6,7 @@ import { FrameType } from './transfer.js';
 import { FRAME_VERSION } from './constants.js';
 import { sha256 } from './webcrypto.js';
 import { bytesToHex } from './bytes.js';
-import { encodeControl } from './transfer-messages.js';
+import { decodeControl, encodeControl } from './transfer-messages.js';
 import { MemorySink, type Digest, type Sink } from './transfer-ports.js';
 import { TransferReceiver } from './transfer-receiver.js';
 
@@ -101,16 +101,11 @@ describe('TransferReceiver', () => {
     expect(result.digest).toBe(fileDigest);
     expect([...sink.bytes()]).toEqual([...data]);
     expect(sink.isClosed).toBe(true);
-    // Back-channel: block_recv ×3 then done.
+    // Back-channel: verified ACK ×3 then done.
     let c = 0;
     const backTypes: number[] = [];
     for (const f of backChannel) backTypes.push((await open(keys.j2o, c++, f)).header.type);
-    expect(backTypes).toEqual([
-      FrameType.BlockRecv,
-      FrameType.BlockRecv,
-      FrameType.BlockRecv,
-      FrameType.Done,
-    ]);
+    expect(backTypes).toEqual([FrameType.Ack, FrameType.Ack, FrameType.Ack, FrameType.Done]);
   });
 
   it('aborts with integrity on a corrupted frame (GCM failure)', async () => {
@@ -148,8 +143,9 @@ describe('TransferReceiver', () => {
     b.frames.at(-1)![b.frames.at(-1)!.length - 1] ^= 0x01; // corrupt the tag
 
     const sink = new MemorySink();
+    const backChannel: Uint8Array[] = [];
     const receiver = new TransferReceiver({
-      send: () => {},
+      send: (frame) => void backChannel.push(frame),
       sendDir: keys.j2o,
       recvDir: keys.o2j,
       sendCounterStart: 0,
@@ -160,6 +156,8 @@ describe('TransferReceiver', () => {
     for (const f of b.frames) receiver.handle(f);
     await expect(receiver.done).rejects.toThrow(/integrity/);
     expect(sink.abortReason).toBe('integrity');
+    expect(backChannel).toHaveLength(1);
+    expect((await open(keys.j2o, 0, backChannel[0]!)).header.type).toBe(FrameType.Fail);
   });
 
   it('invokes onManifest with the file entry before writing the first block', async () => {
@@ -281,5 +279,85 @@ describe('TransferReceiver', () => {
     });
     for (const f of b.frames) receiver.handle(f);
     await expect(receiver.done).rejects.toThrow(/digest_mismatch/);
+  });
+
+  it('requests a missing block, reorders by retransmission, and verifies the file', async () => {
+    const keys = await deriveTransferKeys(master);
+    const first = new Uint8Array([1, 2, 3, 4]);
+    const second = new Uint8Array([5, 6, 7, 8]);
+    const data = new Uint8Array([...first, ...second]);
+    const fileDigest = createHash('sha256').update(data).digest('hex');
+    const b = await build(keys);
+    await b.ctrl(FrameType.Manifest, {
+      type: FrameType.Manifest,
+      files: [
+        {
+          idx: 0,
+          name: 'reordered.bin',
+          size: data.length,
+          mime: '',
+          lastModified: 0,
+          blockSize: 4,
+          blocks: 2,
+          fileDigest,
+        },
+      ],
+      totalSize: data.length,
+    });
+    const addBlock = async (blockIdx: number, block: Uint8Array) => {
+      await b.push(
+        {
+          version: FRAME_VERSION,
+          type: FrameType.BlockData,
+          flags: 1,
+          fileIdx: 0,
+          blockIdx,
+          frameOff: 0,
+        },
+        block,
+      );
+      await b.ctrl(FrameType.BlockHash, {
+        type: FrameType.BlockHash,
+        fileIdx: 0,
+        blockIdx,
+        sha256: bytesToHex(await sha256(block)),
+      });
+    };
+
+    // A transport transition exposes block 1 before block 0. The first copy of block 1 is
+    // authenticated but not committed; both blocks then arrive in the requested order.
+    await addBlock(1, second);
+    await addBlock(0, first);
+    await addBlock(1, second);
+    await b.ctrl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
+
+    const sink = new MemorySink();
+    const backChannel: Uint8Array[] = [];
+    const receiver = new TransferReceiver({
+      send: (frame) => void backChannel.push(frame),
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+    });
+    for (const frame of b.frames) receiver.handle(frame);
+    const result = await receiver.done;
+
+    expect(result.digest).toBe(fileDigest);
+    expect(sink.bytes()).toEqual(data);
+    let counter = 0;
+    const controls = [];
+    for (const frame of backChannel) {
+      controls.push(decodeControl((await open(keys.j2o, counter++, frame)).plaintext));
+    }
+    expect(controls).toEqual([
+      { type: FrameType.Nack, fileIdx: 0, blockIdx: 0, reason: 'missing' },
+      { type: FrameType.Ack, fileIdx: 0, blockIdx: 0 },
+      { type: FrameType.Nack, fileIdx: 0, blockIdx: 1, reason: 'missing' },
+      { type: FrameType.Ack, fileIdx: 0, blockIdx: 1 },
+      { type: FrameType.Done },
+    ]);
   });
 });

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -1,21 +1,21 @@
 /**
- * TransferReceiver — the receiving half of the transfer engine (design §5, §6). Frames arrive
- * over an ordered/reliable channel, so blocks assemble one at a time, in order. For each block
- * the receiver verifies its SHA-256 (from `block_hash`) BEFORE writing to the sink, feeds the
- * verified bytes into the whole-file streaming digest, then signals `block_recv` (the in-flight
- * window). On `complete` it compares the recomputed digest to the sender's and returns `done`
- * or `fail{digest_mismatch}`. A GCM `open` throw or any hash mismatch → `fail{integrity}` and
- * abort — never a silent retry (design §5.5).
+ * Receiving half of the transport-agnostic transfer engine.
+ *
+ * Blocks are authenticated, hashed, and committed before acknowledgement. A valid block arriving
+ * ahead of the next required index exposes a gap: it is deliberately not committed, and the
+ * receiver requests the missing block. Duplicate retransmissions are reverified and acknowledged
+ * without being written or hashed twice. Any AEAD or block-hash failure aborts immediately.
  */
 
 import { open, seal, type FrameHeaderInput } from './aead.js';
 import type { DirectionalKey } from './keyschedule.js';
-import { FrameType, type FileEntry } from './transfer.js';
-import { FRAME_VERSION } from './constants.js';
+import { FrameType, type ControlOp, type FileEntry } from './transfer.js';
+import { DEFAULT_INFLIGHT_BLOCKS, FRAME_VERSION } from './constants.js';
 import { sha256 } from './webcrypto.js';
 import { bytesToHex } from './bytes.js';
 import { TransferError, type Digest, type Sink } from './transfer-ports.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
+import type { TransferRunState } from './transfer-sender.js';
 
 export interface ReceiveResult {
   file: FileEntry;
@@ -30,11 +30,10 @@ export interface TransferReceiverOptions {
   recvCounterStart: number;
   createDigest(): Digest;
   sink: Sink;
-  onProgress?(receivedBytes: number): void;
-  /**
-   * Called once when the manifest decodes, before any block is written — lets the host open a
-   * destination named after the file (e.g. an OPFS sink) without the engine knowing about it.
-   */
+  /** Reports bytes only after verify-and-sink. */
+  onProgress?(acknowledgedBytes: number): void;
+  onStateChange?(state: TransferRunState): void;
+  /** Called once after the manifest is validated and before the first sink write. */
   onManifest?(file: FileEntry): void | Promise<void>;
 }
 
@@ -44,17 +43,20 @@ export class TransferReceiver {
 
   private sendCounter: number;
   private recvCounter: number;
-
   private file: FileEntry | undefined;
-  private curBlock = 0;
+  private nextBlock = 0;
+  private assemblingBlock = -1;
   private blockBuf: Uint8Array | undefined;
-  private blockLen = 0;
-  private received = 0;
+  private blockReceived = 0;
+  private readonly seenAhead = new Set<number>();
+  private nackOutstanding: number | undefined;
+  private paused = false;
 
   private resolveDone!: (r: ReceiveResult) => void;
   private rejectDone!: (e: Error) => void;
   readonly done: Promise<ReceiveResult>;
-  private chain: Promise<void> = Promise.resolve();
+  private inbound: Promise<void> = Promise.resolve();
+  private outbound: Promise<void> = Promise.resolve();
   private settled = false;
 
   constructor(opts: TransferReceiverOptions) {
@@ -69,31 +71,77 @@ export class TransferReceiver {
     this.done.catch(() => {});
   }
 
-  /** Feed one inbound frame from the sender (manifest / block_data / block_hash / complete). */
+  /** Feed one inbound encrypted frame from the sender. */
   handle(frame: Uint8Array): void {
-    this.chain = this.chain
+    this.inbound = this.inbound
       .then(() => this.process(frame))
       .catch((e: unknown) => {
         void this.abortWith(
-          e instanceof TransferError ? e : new TransferError('integrity', String(e)),
+          e instanceof TransferError
+            ? e
+            : new TransferError('integrity', e instanceof Error ? e.message : String(e)),
         );
       });
   }
 
-  // --- internal ---------------------------------------------------------------
+  /** Ask the sender to stop producing data frames. Buffered transport bytes may still drain. */
+  pause(): void {
+    if (this.settled || this.paused) return;
+    this.setPaused(true);
+    void this.sendControl(FrameType.Control, { type: FrameType.Control, op: 'pause' }).catch(
+      (e: unknown) => void this.abortWith(asIntegrityError(e)),
+    );
+  }
+
+  /** Ask the sender to continue. */
+  resume(): void {
+    if (this.settled || !this.paused) return;
+    this.setPaused(false);
+    void this.sendControl(FrameType.Control, { type: FrameType.Control, op: 'resume' }).catch(
+      (e: unknown) => void this.abortWith(asIntegrityError(e)),
+    );
+  }
+
+  /** Best-effort peer notification followed by terminal local cancellation. */
+  cancel(reason = 'canceled'): void {
+    if (this.settled) return;
+    this.o.onStateChange?.('canceled');
+    void this.sendControl(FrameType.Control, { type: FrameType.Control, op: 'cancel' })
+      .catch(() => {})
+      .finally(
+        () => void this.abortWith(new TransferError('canceled', reason), { notifyPeer: false }),
+      );
+  }
 
   private async process(frame: Uint8Array): Promise<void> {
     if (this.settled) return;
-    const opened = await open(this.o.recvDir, this.recvCounter++, frame); // throw → integrity abort
+    let opened;
+    try {
+      opened = await open(this.o.recvDir, this.recvCounter++, frame);
+    } catch (e) {
+      throw new TransferError(
+        'integrity',
+        e instanceof Error ? e.message : 'unable to authenticate transfer frame',
+      );
+    }
     switch (opened.header.type) {
       case FrameType.Manifest:
         return this.applyManifest(opened.plaintext);
       case FrameType.BlockData:
-        return this.onBlockData(opened.header.blockIdx, opened.header.frameOff, opened.plaintext);
+        return this.onBlockData(
+          opened.header.fileIdx,
+          opened.header.blockIdx,
+          opened.header.frameOff,
+          opened.plaintext,
+        );
       case FrameType.BlockHash:
         return this.onBlockHash(opened.plaintext);
+      case FrameType.Control:
+        return this.onControl(opened.plaintext);
       case FrameType.Complete:
         return this.onComplete(opened.plaintext);
+      case FrameType.Fail:
+        return this.onPeerFail(opened.plaintext);
       default:
         throw new TransferError(
           'integrity',
@@ -103,80 +151,204 @@ export class TransferReceiver {
   }
 
   private async applyManifest(payload: Uint8Array): Promise<void> {
+    if (this.file) throw new TransferError('integrity', 'duplicate manifest');
     const msg = decodeControl(payload);
     if (msg.type !== FrameType.Manifest) throw new TransferError('integrity', 'expected manifest');
     const file = msg.files[0];
-    if (!file) throw new TransferError('integrity', 'manifest has no files');
+    if (!file || msg.files.length !== 1) {
+      throw new TransferError('integrity', 'single-file manifest required');
+    }
+    if (
+      file.idx !== 0 ||
+      file.size < 0 ||
+      file.blockSize <= 0 ||
+      file.blocks !== Math.ceil(file.size / file.blockSize)
+    ) {
+      throw new TransferError('integrity', 'invalid manifest geometry');
+    }
     this.file = file;
-    await this.o.onManifest?.(file);
+    try {
+      await this.o.onManifest?.(file);
+    } catch (e) {
+      throw e instanceof TransferError
+        ? e
+        : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
+    }
   }
 
-  private onBlockData(blockIdx: number, frameOff: number, payload: Uint8Array): void {
-    if (!this.file) throw new TransferError('integrity', 'block_data before manifest');
-    if (blockIdx !== this.curBlock)
-      throw new TransferError('integrity', `out-of-order block ${blockIdx}`);
-    if (frameOff === 0) {
-      this.blockLen = Math.min(
-        this.file.blockSize,
-        this.file.size - blockIdx * this.file.blockSize,
-      );
-      this.blockBuf = new Uint8Array(this.blockLen);
-      this.received = 0;
+  private onBlockData(
+    fileIdx: number,
+    blockIdx: number,
+    frameOff: number,
+    payload: Uint8Array,
+  ): void {
+    const file = this.file;
+    if (!file) throw new TransferError('integrity', 'block_data before manifest');
+    if (fileIdx !== 0 || blockIdx < 0 || blockIdx >= file.blocks) {
+      throw new TransferError('integrity', `block_data outside manifest: ${blockIdx}`);
     }
-    this.blockBuf!.set(payload, frameOff);
-    this.received += payload.length;
+    if (frameOff === 0) {
+      if (this.blockBuf) throw new TransferError('integrity', 'new block before block_hash');
+      const blockLen = Math.min(file.blockSize, file.size - blockIdx * file.blockSize);
+      this.assemblingBlock = blockIdx;
+      this.blockBuf = new Uint8Array(blockLen);
+      this.blockReceived = 0;
+    }
+    if (!this.blockBuf || this.assemblingBlock !== blockIdx) {
+      throw new TransferError('integrity', `unexpected block fragment ${blockIdx}`);
+    }
+    if (frameOff !== this.blockReceived || frameOff + payload.length > this.blockBuf.length) {
+      throw new TransferError('integrity', `invalid frame offset in block ${blockIdx}`);
+    }
+    this.blockBuf.set(payload, frameOff);
+    this.blockReceived += payload.length;
   }
 
   private async onBlockHash(payload: Uint8Array): Promise<void> {
-    if (!this.file || !this.blockBuf)
-      throw new TransferError('integrity', 'block_hash without a block');
+    const file = this.file;
+    const block = this.blockBuf;
+    if (!file || !block) throw new TransferError('integrity', 'block_hash without a block');
     const msg = decodeControl(payload);
-    if (msg.type !== FrameType.BlockHash)
+    if (msg.type !== FrameType.BlockHash) {
       throw new TransferError('integrity', 'expected block_hash');
-    if (this.received !== this.blockLen) throw new TransferError('integrity', 'short block');
-    const got = bytesToHex(await sha256(this.blockBuf));
-    if (got !== msg.sha256)
+    }
+    if (msg.fileIdx !== 0 || msg.blockIdx !== this.assemblingBlock) {
+      throw new TransferError('integrity', 'block_hash does not match assembled block');
+    }
+    if (this.blockReceived !== block.length) throw new TransferError('integrity', 'short block');
+    const got = bytesToHex(await sha256(block));
+    if (got !== msg.sha256) {
       throw new TransferError('integrity', `block ${msg.blockIdx} hash mismatch`);
+    }
 
-    await this.o.sink.write(this.curBlock * this.file.blockSize, this.blockBuf);
-    this.digest.update(this.blockBuf);
-    this.o.onProgress?.(this.curBlock * this.file.blockSize + this.blockLen);
-    await this.sendControl(FrameType.BlockRecv, {
-      type: FrameType.BlockRecv,
-      fileIdx: 0,
-      blockIdx: this.curBlock,
-    });
-    this.curBlock++;
     this.blockBuf = undefined;
+    this.blockReceived = 0;
+    this.assemblingBlock = -1;
+
+    if (msg.blockIdx < this.nextBlock) {
+      await this.sendAck(msg.blockIdx); // verified duplicate; acknowledgement was likely lost
+      return;
+    }
+    if (msg.blockIdx > this.nextBlock) {
+      if (this.seenAhead.size < DEFAULT_INFLIGHT_BLOCKS) this.seenAhead.add(msg.blockIdx);
+      await this.requestMissing();
+      return;
+    }
+
+    const offset = this.nextBlock * file.blockSize;
+    try {
+      await this.o.sink.write(offset, block);
+    } catch (e) {
+      throw e instanceof TransferError
+        ? e
+        : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
+    }
+    this.digest.update(block);
+    this.nextBlock++;
+    this.nackOutstanding = undefined;
+    this.o.onProgress?.(offset + block.length);
+    await this.sendAck(msg.blockIdx);
+
+    if (this.seenAhead.delete(this.nextBlock)) await this.requestMissing();
+  }
+
+  private async sendAck(blockIdx: number): Promise<void> {
+    await this.sendControl(FrameType.Ack, {
+      type: FrameType.Ack,
+      fileIdx: 0,
+      blockIdx,
+    });
+  }
+
+  private async requestMissing(): Promise<void> {
+    if (this.nackOutstanding === this.nextBlock) return;
+    this.nackOutstanding = this.nextBlock;
+    await this.sendControl(FrameType.Nack, {
+      type: FrameType.Nack,
+      fileIdx: 0,
+      blockIdx: this.nextBlock,
+      reason: 'missing',
+    });
+  }
+
+  private onControl(payload: Uint8Array): void {
+    const msg = decodeControl(payload);
+    if (msg.type !== FrameType.Control) throw new TransferError('integrity', 'expected control');
+    this.applyRemoteControl(msg.op);
+  }
+
+  private applyRemoteControl(op: ControlOp): void {
+    switch (op) {
+      case 'pause':
+        this.setPaused(true);
+        return;
+      case 'resume':
+        this.setPaused(false);
+        return;
+      case 'cancel':
+        this.o.onStateChange?.('canceled');
+        void this.abortWith(new TransferError('canceled', 'peer canceled the transfer'), {
+          notifyPeer: false,
+        });
+    }
+  }
+
+  private setPaused(paused: boolean): void {
+    if (this.paused === paused || this.settled) return;
+    this.paused = paused;
+    this.o.onStateChange?.(paused ? 'paused' : 'running');
+  }
+
+  private async onPeerFail(payload: Uint8Array): Promise<void> {
+    const msg = decodeControl(payload);
+    if (msg.type !== FrameType.Fail) throw new TransferError('integrity', 'expected fail');
+    await this.abortWith(new TransferError(msg.reason, `sender failed: ${msg.reason}`), {
+      notifyPeer: false,
+    });
   }
 
   private async onComplete(payload: Uint8Array): Promise<void> {
-    if (!this.file) throw new TransferError('integrity', 'complete before manifest');
+    const file = this.file;
+    if (!file) throw new TransferError('integrity', 'complete before manifest');
     const msg = decodeControl(payload);
     if (msg.type !== FrameType.Complete) throw new TransferError('integrity', 'expected complete');
-    const got = await this.digest.hexDigest();
-    if (got !== msg.fileDigest) {
-      await this.abortWith(new TransferError('digest_mismatch', 'whole-file digest mismatch'));
+    if (this.nextBlock !== file.blocks) {
+      await this.requestMissing();
       return;
     }
-    await this.o.sink.close();
+    const got = await this.digest.hexDigest();
+    if (msg.fileDigest !== file.fileDigest || got !== msg.fileDigest) {
+      throw new TransferError('digest_mismatch', 'whole-file digest mismatch');
+    }
+    try {
+      await this.o.sink.close();
+    } catch (e) {
+      throw e instanceof TransferError
+        ? e
+        : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
+    }
     await this.sendControl(FrameType.Done, { type: FrameType.Done });
     this.settled = true;
-    this.resolveDone({ file: this.file, digest: got });
+    this.resolveDone({ file, digest: got });
   }
 
-  private async abortWith(err: TransferError): Promise<void> {
+  private async abortWith(
+    err: TransferError,
+    options: { notifyPeer?: boolean } = {},
+  ): Promise<void> {
     if (this.settled) return;
     this.settled = true;
-    try {
-      await this.sendControl(FrameType.Fail, { type: FrameType.Fail, reason: err.reason });
-    } catch {
-      // best-effort — the channel may already be gone
+    if (options.notifyPeer !== false) {
+      try {
+        await this.sendControl(FrameType.Fail, { type: FrameType.Fail, reason: err.reason });
+      } catch {
+        // The channel may already be unavailable.
+      }
     }
     try {
       await this.o.sink.abort(err.reason);
     } catch {
-      // best-effort
+      // Sink abort is best-effort after the first terminal failure.
     }
     this.rejectDone(err);
   }
@@ -193,7 +365,22 @@ export class TransferReceiver {
       blockIdx: 0,
       frameOff: 0,
     };
-    const frame = await seal(this.o.sendDir, this.sendCounter++, header, encodeControl(msg));
-    await this.o.send(frame);
+    await this.sendFrame(header, encodeControl(msg));
   }
+
+  /** Serialize sealing so UI controls and acknowledgements cannot reuse a nonce. */
+  private sendFrame(header: FrameHeaderInput, payload: Uint8Array): Promise<void> {
+    const task = this.outbound.then(async () => {
+      const frame = await seal(this.o.sendDir, this.sendCounter++, header, payload);
+      await this.o.send(frame);
+    });
+    this.outbound = task.catch(() => {});
+    return task;
+  }
+}
+
+function asIntegrityError(e: unknown): TransferError {
+  return e instanceof TransferError
+    ? e
+    : new TransferError('integrity', e instanceof Error ? e.message : String(e));
 }

--- a/packages/protocol/src/transfer-sender.test.ts
+++ b/packages/protocol/src/transfer-sender.test.ts
@@ -14,11 +14,20 @@ function nodeDigest(): Digest {
 }
 const master = new Uint8Array(32).fill(9);
 
+async function waitFor(check: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error('timed out waiting for sender state');
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
 describe('TransferSender', () => {
-  it('emits manifest → block_data/block_hash → complete, gated by block_recv', async () => {
+  it('emits manifest → block_data/block_hash → complete, gated by verified acknowledgements', async () => {
     const keys = await deriveTransferKeys(master);
     const data = new Uint8Array(20).map((_, i) => i); // block=8 → blocks 0,1 full, block2 = 4B
     const outbound: Uint8Array[] = [];
+    const progress: number[] = [];
 
     const sender = new TransferSender({
       file: bytesSource(data, { name: 'f', size: 20, mime: '', lastModified: 0 }),
@@ -31,6 +40,7 @@ describe('TransferSender', () => {
       blockSize: 8,
       frameSize: 4,
       window: 1, // force gating after block 0
+      onProgress: (bytes) => progress.push(bytes),
     });
 
     const runP = sender.run();
@@ -45,7 +55,7 @@ describe('TransferSender', () => {
     // With window=1 the sender may run 1 block ahead; it must NOT have sent `complete` yet.
     expect(types).not.toContain(FrameType.Complete);
 
-    // Feed block_recv for every block so it drains, then `done`.
+    // Feed a verified acknowledgement for each block so the window drains, then `done`.
     let ackCtr = 0;
     const ack = async (blockIdx: number) => {
       const frame = await seal(
@@ -53,18 +63,20 @@ describe('TransferSender', () => {
         ackCtr++,
         {
           version: FRAME_VERSION,
-          type: FrameType.BlockRecv,
+          type: FrameType.Ack,
           flags: 0,
           fileIdx: 0,
           blockIdx: 0,
           frameOff: 0,
         },
-        encodeControl({ type: FrameType.BlockRecv, fileIdx: 0, blockIdx }),
+        encodeControl({ type: FrameType.Ack, fileIdx: 0, blockIdx }),
       );
       sender.handle(frame);
     };
     await ack(0);
+    await new Promise((r) => setTimeout(r, 10));
     await ack(1);
+    await new Promise((r) => setTimeout(r, 10));
     await ack(2);
     await new Promise((r) => setTimeout(r, 10));
     const done = await seal(
@@ -82,6 +94,7 @@ describe('TransferSender', () => {
     );
     sender.handle(done);
     await runP;
+    expect(progress).toEqual([8, 16, 20]);
 
     // Decode the full outbound sequence and check the message grammar + digest.
     let c = 0;
@@ -114,6 +127,7 @@ describe('TransferSender', () => {
       frameSize: 4,
     });
     const runP = sender.run();
+    await new Promise((r) => setTimeout(r, 0));
     const fail = await seal(
       keys.j2o,
       0,
@@ -129,5 +143,157 @@ describe('TransferSender', () => {
     );
     sender.handle(fail);
     await expect(runP).rejects.toThrow(/integrity/);
+  });
+
+  it('reseals a nacked block with fresh counters and advances progress only on ack', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const outbound: Uint8Array[] = [];
+    const progress: number[] = [];
+    const sender = new TransferSender({
+      file: bytesSource(data, { name: 'f', size: data.length, mime: '', lastModified: 0 }),
+      send: (frame) => void outbound.push(frame),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 8,
+      frameSize: 4,
+      window: 1,
+      ackTimeoutMs: 1000,
+      onProgress: (bytes) => progress.push(bytes),
+    });
+
+    const runP = sender.run();
+    await waitFor(() => outbound.length === 3); // manifest, block_data, block_hash
+    expect(progress).toEqual([]);
+
+    const nack = await seal(
+      keys.j2o,
+      0,
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Nack,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      encodeControl({ type: FrameType.Nack, fileIdx: 0, blockIdx: 0, reason: 'missing' }),
+    );
+    sender.handle(nack);
+    await waitFor(() => outbound.length === 5); // freshly sealed data + hash
+
+    const ack = await seal(
+      keys.j2o,
+      1,
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Ack,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      encodeControl({ type: FrameType.Ack, fileIdx: 0, blockIdx: 0 }),
+    );
+    sender.handle(ack);
+    await waitFor(() => outbound.length === 6); // complete
+    expect(progress).toEqual([4]);
+
+    const done = await seal(
+      keys.j2o,
+      2,
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Done,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      encodeControl({ type: FrameType.Done }),
+    );
+    sender.handle(done);
+    await runP;
+
+    let counter = 0;
+    const opened = [];
+    for (const frame of outbound) opened.push(await open(keys.o2j, counter++, frame));
+    expect(opened.map((item) => item.header.type)).toEqual([
+      FrameType.Manifest,
+      FrameType.BlockData,
+      FrameType.BlockHash,
+      FrameType.BlockData,
+      FrameType.BlockHash,
+      FrameType.Complete,
+    ]);
+    expect(opened[1]?.plaintext).toEqual(data);
+    expect(opened[3]?.plaintext).toEqual(data);
+    expect(outbound[1]).not.toEqual(outbound[3]); // retransmission uses a fresh GCM nonce
+  });
+
+  it('halts new data while paused and resumes without losing the window', async () => {
+    const keys = await deriveTransferKeys(master);
+    const outbound: Uint8Array[] = [];
+    const states: string[] = [];
+    const sender = new TransferSender({
+      file: bytesSource(new Uint8Array([1, 2, 3, 4]), {
+        name: 'f',
+        size: 4,
+        mime: '',
+        lastModified: 0,
+      }),
+      send: (frame) => void outbound.push(frame),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 8,
+      frameSize: 4,
+      onStateChange: (state) => states.push(state),
+    });
+
+    sender.pause();
+    const runP = sender.run();
+    await waitFor(() => outbound.length === 2); // pause control + manifest
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(outbound).toHaveLength(2);
+
+    sender.resume();
+    await waitFor(() => outbound.length === 5); // resume + block_data + block_hash
+    const ack = await seal(
+      keys.j2o,
+      0,
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Ack,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      encodeControl({ type: FrameType.Ack, fileIdx: 0, blockIdx: 0 }),
+    );
+    sender.handle(ack);
+    await waitFor(() => outbound.length === 6);
+    const done = await seal(
+      keys.j2o,
+      1,
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Done,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      encodeControl({ type: FrameType.Done }),
+    );
+    sender.handle(done);
+    await runP;
+    expect(states).toEqual(['paused', 'running']);
   });
 });

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -1,17 +1,15 @@
 /**
- * TransferSender — the sending half of the transport-agnostic transfer engine (design §5).
- * It streams the file without ever buffering it whole:
- *   Pass 1  read the file once → whole-file streaming digest → manifest (with fileDigest).
- *   Pass 2  re-chunk into `block_data` frames; at each block boundary send `block_hash`.
- *   Finish  send `complete{fileDigest}`; resolve when the receiver returns `done`.
- * Outbound frames are AES-GCM sealed with a per-direction counter that continues from the handshake
- * (never reset). The sender never runs more than `window` blocks ahead of the receiver's
- * `block_recv` signal, bounding the outbound queue.
+ * Sending half of the transport-agnostic transfer engine.
+ *
+ * The source is read once for the canonical digest and once for data. During the data pass the
+ * sender retains only the bounded window of unacknowledged plaintext blocks. A block leaves that
+ * window only after the receiver confirms it was verified and written to its sink. Missing blocks
+ * are resealed with fresh AEAD counters; integrity failures remain terminal.
  */
 
-import { seal, open, type FrameHeaderInput } from './aead.js';
+import { open, seal, type FrameHeaderInput } from './aead.js';
 import type { DirectionalKey } from './keyschedule.js';
-import { FrameType } from './transfer.js';
+import { FrameType, type ControlOp, type Fail } from './transfer.js';
 import {
   DEFAULT_BLOCK_BYTES,
   DEFAULT_FRAME_BYTES,
@@ -19,13 +17,15 @@ import {
   FRAME_VERSION,
 } from './constants.js';
 import { sha256 } from './webcrypto.js';
-import { bytesToHex, concatBytes } from './bytes.js';
+import { bytesToHex } from './bytes.js';
 import { TransferError, type Digest, type FileSource } from './transfer-ports.js';
 import { reChunk } from './transfer-chunker.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
 
 /** Header flag: this frame is the last of its block. */
 export const FRAME_FLAG_LAST_IN_BLOCK = 0x01;
+
+export type TransferRunState = 'running' | 'paused' | 'canceled';
 
 export interface TransferSenderOptions {
   file: FileSource;
@@ -38,26 +38,48 @@ export interface TransferSenderOptions {
   blockSize?: number;
   frameSize?: number;
   window?: number;
-  onProgress?(sentBytes: number): void;
+  /** Milliseconds without an acknowledgement before a block is resent. */
+  ackTimeoutMs?: number;
+  /** Retransmissions allowed per block after its initial send. */
+  maxRetries?: number;
+  /** Reports bytes acknowledged after verify-and-sink. */
+  onProgress?(acknowledgedBytes: number): void;
+  onStateChange?(state: TransferRunState): void;
 }
+
+interface InflightBlock {
+  readonly bytes: Uint8Array;
+  retries: number;
+  timer: ReturnType<typeof setTimeout> | undefined;
+}
+
+const DEFAULT_ACK_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_RETRIES = 3;
 
 export class TransferSender {
   private readonly o: TransferSenderOptions;
   private readonly blockSize: number;
   private readonly frameSize: number;
   private readonly window: number;
+  private readonly ackTimeoutMs: number;
+  private readonly maxRetries: number;
 
   private sendCounter: number;
   private recvCounter: number;
-  private sent = 0;
+  private acknowledged = 0;
+  private paused = false;
+  private completeSent = false;
 
-  private lastRecvBlock = -1;
-  private windowWaiters: Array<() => void> = [];
+  private readonly inflight = new Map<number, InflightBlock>();
+  private readonly retryQueue: number[] = [];
+  private readonly retryQueued = new Set<number>();
+  private waiters: Array<() => void> = [];
 
   private resolveDone!: () => void;
   private rejectDone!: (e: Error) => void;
   private readonly done: Promise<void>;
   private inbound: Promise<void> = Promise.resolve();
+  private outbound: Promise<void> = Promise.resolve();
   private settled = false;
 
   constructor(opts: TransferSenderOptions) {
@@ -65,6 +87,8 @@ export class TransferSender {
     this.blockSize = opts.blockSize ?? DEFAULT_BLOCK_BYTES;
     this.frameSize = opts.frameSize ?? DEFAULT_FRAME_BYTES;
     this.window = opts.window ?? DEFAULT_INFLIGHT_BLOCKS;
+    this.ackTimeoutMs = opts.ackTimeoutMs ?? DEFAULT_ACK_TIMEOUT_MS;
+    this.maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.sendCounter = opts.sendCounterStart;
     this.recvCounter = opts.recvCounterStart;
     this.done = new Promise<void>((res, rej) => {
@@ -75,19 +99,63 @@ export class TransferSender {
   }
 
   /**
-   * Drive the whole send. Resolves with the canonical whole-file digest (hex) when the receiver
-   * confirms `done`, rejects on `fail`. The digest is the same value carried in the manifest and
-   * `complete`, so a host can report it without recomputing.
+   * Drive the complete send. The returned digest is reported only after every block is
+   * acknowledged and the receiver confirms the whole-file digest.
    */
   async run(): Promise<string> {
+    try {
+      return await this.drive();
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      this.fail(err);
+      throw err;
+    }
+  }
+
+  /** Feed one inbound encrypted control frame from the receiver. */
+  handle(frame: Uint8Array): void {
+    this.inbound = this.inbound
+      .then(() => this.processInbound(frame))
+      .catch((e: unknown) => {
+        this.fail(e instanceof Error ? e : new Error(String(e)));
+      });
+  }
+
+  /** Pause locally and ask the peer to reflect the paused state. */
+  pause(): void {
+    if (this.settled || this.paused) return;
+    this.setPaused(true);
+    void this.sendControl(FrameType.Control, { type: FrameType.Control, op: 'pause' }).catch(
+      (e: unknown) => this.fail(e instanceof Error ? e : new Error(String(e))),
+    );
+  }
+
+  /** Resume locally and notify the peer. */
+  resume(): void {
+    if (this.settled || !this.paused) return;
+    this.setPaused(false);
+    void this.sendControl(FrameType.Control, { type: FrameType.Control, op: 'resume' }).catch(
+      (e: unknown) => this.fail(e instanceof Error ? e : new Error(String(e))),
+    );
+  }
+
+  /** Best-effort peer notification followed by terminal local cancellation. */
+  cancel(reason = 'canceled'): void {
+    if (this.settled) return;
+    const err = new TransferError('canceled', reason);
+    void this.sendControl(FrameType.Control, { type: FrameType.Control, op: 'cancel' })
+      .catch(() => {})
+      .finally(() => this.fail(err));
+  }
+
+  private async drive(): Promise<string> {
     const { meta } = this.o.file;
 
-    // Pass 1: whole-file digest (streamed; the file is never held).
     const digest = this.o.createDigest();
     for await (const chunk of this.o.file.stream()) digest.update(chunk);
     const fileDigest = await digest.hexDigest();
 
-    const blocks = Math.ceil(meta.size / this.blockSize); // 0 for an empty file
+    const blocks = Math.ceil(meta.size / this.blockSize);
     await this.sendControl(FrameType.Manifest, {
       type: FrameType.Manifest,
       files: [
@@ -105,87 +173,181 @@ export class TransferSender {
       totalSize: meta.size,
     });
 
-    // Pass 2: block data + per-block hash, gated to the in-flight window.
-    let blockParts: Uint8Array[] = [];
-    for await (const piece of reChunk(this.o.file.stream(), this.blockSize, this.frameSize)) {
-      await this.gate(piece.blockIdx);
-      if (this.settled) {
-        await this.done; // aborted by an inbound fail → propagate the rejection
-        return fileDigest;
-      }
-      await this.sendFrame(
-        {
-          version: FRAME_VERSION,
-          type: FrameType.BlockData,
-          flags: piece.lastInBlock ? FRAME_FLAG_LAST_IN_BLOCK : 0,
-          fileIdx: 0,
-          blockIdx: piece.blockIdx,
-          frameOff: piece.frameOff,
-        },
-        piece.payload,
-      );
-      this.sent += piece.payload.length;
-      this.o.onProgress?.(this.sent);
-      blockParts.push(piece.payload.slice());
-      if (piece.lastInBlock) {
-        const blockBytes = concatBytes(...blockParts);
-        blockParts = [];
-        const hashHex = bytesToHex(await sha256(blockBytes));
-        await this.sendControl(FrameType.BlockHash, {
-          type: FrameType.BlockHash,
-          fileIdx: 0,
-          blockIdx: piece.blockIdx,
-          sha256: hashHex,
-        });
-      }
+    // Asking reChunk for block-sized pieces yields one retained buffer per logical block. The
+    // block is then split into transport-sized frames by sendBlock.
+    for await (const piece of reChunk(this.o.file.stream(), this.blockSize, this.blockSize)) {
+      await this.beforeNewBlock();
+      await this.propagateSettlement();
+      const bytes = piece.payload.slice();
+      this.inflight.set(piece.blockIdx, { bytes, retries: 0, timer: undefined });
+      await this.sendBlock(piece.blockIdx, bytes);
+      this.armTimeout(piece.blockIdx);
     }
 
+    while (this.inflight.size > 0) {
+      await this.propagateSettlement();
+      await this.serviceRetriesOrWait();
+    }
+
+    this.completeSent = true;
     await this.sendControl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
     await this.done;
     return fileDigest;
   }
 
-  /** Feed one inbound frame from the receiver (block_recv / done / fail). */
-  handle(frame: Uint8Array): void {
-    this.inbound = this.inbound
-      .then(() => this.processInbound(frame))
-      .catch((e: unknown) => {
-        this.fail(e instanceof Error ? e : new Error(String(e)));
-      });
-  }
-
-  // --- internal ---------------------------------------------------------------
-
   private async processInbound(frame: Uint8Array): Promise<void> {
     if (this.settled) return;
-    const opened = await open(this.o.recvDir, this.recvCounter++, frame);
+    let opened;
+    try {
+      opened = await open(this.o.recvDir, this.recvCounter++, frame);
+    } catch (e) {
+      throw new TransferError(
+        'integrity',
+        e instanceof Error ? e.message : 'unable to authenticate control frame',
+      );
+    }
     const msg = decodeControl(opened.plaintext);
+    if (opened.header.type !== msg.type) {
+      throw new TransferError('integrity', 'control frame header/payload type mismatch');
+    }
     switch (msg.type) {
-      case FrameType.BlockRecv:
-        this.lastRecvBlock = Math.max(this.lastRecvBlock, msg.blockIdx);
-        this.wakeWindow();
+      case FrameType.Ack: {
+        if (msg.fileIdx !== 0) throw new TransferError('integrity', 'ack for unknown file');
+        const state = this.inflight.get(msg.blockIdx);
+        if (!state) return; // duplicate acknowledgement
+        if (state.timer) clearTimeout(state.timer);
+        this.inflight.delete(msg.blockIdx);
+        this.retryQueued.delete(msg.blockIdx);
+        this.acknowledged += state.bytes.length;
+        this.o.onProgress?.(this.acknowledged);
+        this.wake();
+        return;
+      }
+      case FrameType.Nack:
+        if (msg.fileIdx !== 0) throw new TransferError('integrity', 'nack for unknown file');
+        this.queueRetry(msg.blockIdx);
+        return;
+      case FrameType.Control:
+        this.applyRemoteControl(msg.op);
         return;
       case FrameType.Done:
+        if (!this.completeSent || this.inflight.size !== 0) {
+          throw new TransferError('integrity', 'done before every block was acknowledged');
+        }
         this.settle();
         return;
       case FrameType.Fail:
         this.fail(new TransferError(msg.reason, `receiver failed: ${msg.reason}`));
         return;
       default:
-        this.fail(new TransferError('integrity', `unexpected sender-inbound type ${msg.type}`));
+        throw new TransferError('integrity', `unexpected sender-inbound type ${msg.type}`);
     }
   }
 
-  private async gate(blockIdx: number): Promise<void> {
-    while (!this.settled && blockIdx - this.lastRecvBlock > this.window) {
-      await new Promise<void>((r) => this.windowWaiters.push(r));
+  private applyRemoteControl(op: ControlOp): void {
+    switch (op) {
+      case 'pause':
+        this.setPaused(true);
+        return;
+      case 'resume':
+        this.setPaused(false);
+        return;
+      case 'cancel':
+        this.o.onStateChange?.('canceled');
+        this.fail(new TransferError('canceled', 'peer canceled the transfer'));
     }
   }
 
-  private wakeWindow(): void {
-    const waiters = this.windowWaiters;
-    this.windowWaiters = [];
-    for (const w of waiters) w();
+  private setPaused(paused: boolean): void {
+    if (this.paused === paused || this.settled) return;
+    this.paused = paused;
+    for (const [blockIdx, state] of this.inflight) {
+      if (state.timer) clearTimeout(state.timer);
+      state.timer = undefined;
+      if (!paused) this.armTimeout(blockIdx);
+    }
+    this.o.onStateChange?.(paused ? 'paused' : 'running');
+    this.wake();
+  }
+
+  private async beforeNewBlock(): Promise<void> {
+    while (!this.settled) {
+      if (this.paused) {
+        await this.wait();
+        continue;
+      }
+      if (this.retryQueue.length > 0) {
+        await this.resendNext();
+        continue;
+      }
+      if (this.inflight.size < this.window) return;
+      await this.wait();
+    }
+  }
+
+  private async serviceRetriesOrWait(): Promise<void> {
+    if (this.paused || this.retryQueue.length === 0) {
+      await this.wait();
+      return;
+    }
+    await this.resendNext();
+  }
+
+  private queueRetry(blockIdx: number): void {
+    const state = this.inflight.get(blockIdx);
+    if (!state || this.retryQueued.has(blockIdx)) return;
+    if (state.timer) clearTimeout(state.timer);
+    state.timer = undefined;
+    this.retryQueued.add(blockIdx);
+    this.retryQueue.push(blockIdx);
+    this.wake();
+  }
+
+  private async resendNext(): Promise<void> {
+    const blockIdx = this.retryQueue.shift();
+    if (blockIdx === undefined) return;
+    this.retryQueued.delete(blockIdx);
+    const state = this.inflight.get(blockIdx);
+    if (!state) return;
+    if (state.retries >= this.maxRetries) {
+      const err = new TransferError('retry_exhausted', `block ${blockIdx} remained unacknowledged`);
+      await this.bestEffortFail(err.reason);
+      this.fail(err);
+      return;
+    }
+    state.retries++;
+    await this.sendBlock(blockIdx, state.bytes);
+    this.armTimeout(blockIdx);
+  }
+
+  private armTimeout(blockIdx: number): void {
+    const state = this.inflight.get(blockIdx);
+    if (!state || this.paused || this.ackTimeoutMs <= 0) return;
+    if (state.timer) clearTimeout(state.timer);
+    state.timer = setTimeout(() => this.queueRetry(blockIdx), this.ackTimeoutMs);
+  }
+
+  private async sendBlock(blockIdx: number, bytes: Uint8Array): Promise<void> {
+    for (let off = 0; off < bytes.length; off += this.frameSize) {
+      const end = Math.min(off + this.frameSize, bytes.length);
+      await this.sendFrame(
+        {
+          version: FRAME_VERSION,
+          type: FrameType.BlockData,
+          flags: end === bytes.length ? FRAME_FLAG_LAST_IN_BLOCK : 0,
+          fileIdx: 0,
+          blockIdx,
+          frameOff: off,
+        },
+        bytes.subarray(off, end),
+      );
+    }
+    await this.sendControl(FrameType.BlockHash, {
+      type: FrameType.BlockHash,
+      fileIdx: 0,
+      blockIdx,
+      sha256: bytesToHex(await sha256(bytes)),
+    });
   }
 
   private async sendControl(
@@ -198,22 +360,58 @@ export class TransferSender {
     );
   }
 
-  private async sendFrame(header: FrameHeaderInput, payload: Uint8Array): Promise<void> {
-    const frame = await seal(this.o.sendDir, this.sendCounter++, header, payload);
-    await this.o.send(frame);
+  /** Serialize sealing so external controls can never race the data path for a nonce. */
+  private sendFrame(header: FrameHeaderInput, payload: Uint8Array): Promise<void> {
+    const task = this.outbound.then(async () => {
+      const frame = await seal(this.o.sendDir, this.sendCounter++, header, payload);
+      await this.o.send(frame);
+    });
+    this.outbound = task.catch(() => {});
+    return task;
+  }
+
+  private async bestEffortFail(reason: Fail['reason']): Promise<void> {
+    try {
+      await this.sendControl(FrameType.Fail, { type: FrameType.Fail, reason });
+    } catch {
+      // The transport may already be unavailable.
+    }
+  }
+
+  private wait(): Promise<void> {
+    if (this.settled) return Promise.resolve();
+    return new Promise<void>((resolve) => this.waiters.push(resolve));
+  }
+
+  private wake(): void {
+    const waiters = this.waiters;
+    this.waiters = [];
+    for (const resolve of waiters) resolve();
+  }
+
+  private async propagateSettlement(): Promise<void> {
+    if (this.settled) await this.done;
+  }
+
+  private clearTimers(): void {
+    for (const state of this.inflight.values()) {
+      if (state.timer) clearTimeout(state.timer);
+    }
   }
 
   private settle(): void {
     if (this.settled) return;
     this.settled = true;
+    this.clearTimers();
     this.resolveDone();
-    this.wakeWindow();
+    this.wake();
   }
 
   private fail(err: Error): void {
     if (this.settled) return;
     this.settled = true;
+    this.clearTimers();
     this.rejectDone(err);
-    this.wakeWindow();
+    this.wake();
   }
 }

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -20,7 +20,7 @@ export enum FrameType {
   Manifest = 2,
   BlockData = 3,
   BlockHash = 4,
-  BlockRecv = 5, // lightweight in-flight-window signal
+  BlockRecv = 5, // legacy pre-verification receipt tag; retained for decoder compatibility
   Ack = 6,
   Nack = 7,
   Control = 8,
@@ -72,7 +72,7 @@ export interface BlockHash {
   sha256: string; // hex
 }
 
-/** Window signal: receiver has taken delivery of a block (pre-ack). */
+/** Legacy pre-verification receipt. Reliable engines use Ack after verify-and-sink. */
 export interface BlockRecv {
   type: FrameType.BlockRecv;
   fileIdx: number;

--- a/packages/wire/transfer_messages.go
+++ b/packages/wire/transfer_messages.go
@@ -47,7 +47,7 @@ type BlockHash struct {
 	SHA256   string `json:"sha256"`
 }
 
-// BlockRecv is the window signal: the receiver has taken delivery of a block (pre-ack).
+// BlockRecv is the legacy pre-verification receipt retained for decoder compatibility.
 type BlockRecv struct {
 	Type     uint8 `json:"type"`
 	FileIdx  int   `json:"fileIdx"`
@@ -152,7 +152,7 @@ func NewBlockHash(fileIdx, blockIdx int, sha256 string) *BlockHash {
 	return &BlockHash{Type: FrameBlockHash, FileIdx: fileIdx, BlockIdx: blockIdx, SHA256: sha256}
 }
 
-// NewBlockRecv builds a block_recv window signal.
+// NewBlockRecv builds a legacy pre-verification receipt.
 func NewBlockRecv(fileIdx, blockIdx int) *BlockRecv {
 	return &BlockRecv{Type: FrameBlockRecv, FileIdx: fileIdx, BlockIdx: blockIdx}
 }

--- a/packages/wire/transfer_ports.go
+++ b/packages/wire/transfer_ports.go
@@ -60,6 +60,18 @@ func (d *sha256Digest) HexDigest() string { return hex.EncodeToString(d.h.Sum(ni
 // message. The set mirrors the TypeScript Fail['reason'] union exactly.
 type FailReason string
 
+// TransferState is the user-visible live state shared by sender and receiver controls.
+type TransferState string
+
+const (
+	// TransferRunning means new data frames may be produced.
+	TransferRunning TransferState = "running"
+	// TransferPaused means new data frames are halted while buffered transport bytes drain.
+	TransferPaused TransferState = "paused"
+	// TransferCanceled means one peer terminated the transfer.
+	TransferCanceled TransferState = "canceled"
+)
+
 // Transfer sizing defaults, mirroring packages/protocol/src/constants.ts. They are the
 // negotiation starting point; a caps exchange may lower them within the header field widths.
 const (
@@ -67,8 +79,8 @@ const (
 	DefaultBlockBytes = 1024 * 1024
 	// DefaultFrameBytes is the default DataChannel/relay payload size.
 	DefaultFrameBytes = 16 * 1024
-	// DefaultInflightBlocks bounds how many blocks the sender may run ahead of the
-	// receiver's block_recv, capping receiver memory regardless of sink speed.
+	// DefaultInflightBlocks bounds how many unacknowledged blocks the sender retains,
+	// capping receiver pressure and retry memory regardless of sink speed.
 	DefaultInflightBlocks = 8
 )
 

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -9,21 +9,11 @@ import (
 	"sync"
 )
 
-// Receiver is the receiving half of the transfer engine (design §5, §6). Frames arrive over an
-// ordered, reliable channel, so blocks assemble one at a time, in order. For each block the
-// receiver verifies its SHA-256 (from block_hash) BEFORE writing to the sink, feeds the verified
-// bytes into the whole-file streaming digest, then signals block_recv (the in-flight window). On
-// complete it compares the recomputed digest to the sender's and replies done, or
-// fail{digest_mismatch}. A GCM open failure or any hash mismatch yields fail{integrity} and an
-// abort — never a silent retry (design §5.5). It is the Go twin of
-// packages/protocol/src/transfer-receiver.ts.
-//
-// Handle is called from the transport read loop and MUST be called serially — the ordered
-// DataChannel satisfies this, and each frame consumes the next receive counter. Wait blocks a
-// separate goroutine until the transfer settles.
+// Receiver verifies and commits blocks before acknowledging them. A valid block that arrives
+// ahead of the next required index exposes a gap: it is not committed, and the missing block is
+// requested. Duplicate retransmissions are reverified and acknowledged without a second write.
 
-// ReceiveResult is the outcome of a successful receive: the manifest entry and the verified
-// whole-file digest (hex).
+// ReceiveResult is the successful manifest entry and canonical whole-file digest.
 type ReceiveResult struct {
 	File   FileEntry
 	Digest string
@@ -36,60 +26,63 @@ type ReceiverOptions struct {
 	RecvDir          DirectionalKey
 	SendCounterStart uint64
 	RecvCounterStart uint64
-	CreateDigest     func() Digest // nil selects a streaming SHA-256 digest
+	CreateDigest     func() Digest
 	Sink             Sink
-	OnProgress       func(receivedBytes int64)
-	// OnManifest is called once when the manifest decodes, before any block is written — it lets
-	// the host open a destination named after the file without the engine knowing about it. A
-	// non-nil error aborts the transfer.
-	OnManifest func(file FileEntry) error
+	// OnProgress reports bytes only after verify-and-sink.
+	OnProgress    func(acknowledgedBytes int64)
+	OnStateChange func(TransferState)
+	OnManifest    func(file FileEntry) error
 }
 
-// Receiver drives one file receive. Construct it with NewReceiver.
+// Receiver drives one file receive. Handle calls must remain ordered.
 type Receiver struct {
 	o      ReceiverOptions
 	digest Digest
 
-	// Counters and assembly state are touched only by Handle's (serial) goroutine.
+	sendMu      sync.Mutex
 	sendCounter uint64
-	recvCounter uint64
-	file        *FileEntry
-	curBlock    int
-	blockBuf    []byte
-	blockLen    int
-	received    int
+
+	// Assembly state belongs to the serial Handle path.
+	recvCounter     uint64
+	file            *FileEntry
+	nextBlock       int
+	assembling      int
+	blockBuf        []byte
+	blockReceived   int
+	seenAhead       map[int]bool
+	nackOutstanding int
 
 	mu      sync.Mutex
 	done    chan struct{}
 	settled bool
+	paused  bool
 	result  ReceiveResult
 	err     error
 }
 
-// NewReceiver builds a Receiver, defaulting to a streaming SHA-256 digest when none is given.
+// NewReceiver builds a Receiver.
 func NewReceiver(opts ReceiverOptions) *Receiver {
 	if opts.CreateDigest == nil {
 		opts.CreateDigest = NewSHA256Digest
 	}
 	return &Receiver{
-		o:           opts,
-		digest:      opts.CreateDigest(),
-		sendCounter: opts.SendCounterStart,
-		recvCounter: opts.RecvCounterStart,
-		done:        make(chan struct{}),
+		o:               opts,
+		digest:          opts.CreateDigest(),
+		sendCounter:     opts.SendCounterStart,
+		recvCounter:     opts.RecvCounterStart,
+		assembling:      -1,
+		seenAhead:       make(map[int]bool),
+		nackOutstanding: -1,
+		done:            make(chan struct{}),
 	}
 }
 
-// Wait blocks until the transfer settles, returning the result on done or the error on fail.
-// Canceling ctx aborts the receive with FailCanceled in bounded time, so a dropped peer never
-// parks Wait forever.
+// Wait blocks until completion or cancellation.
 func (r *Receiver) Wait(ctx context.Context) (ReceiveResult, error) {
 	select {
 	case <-r.done:
 	case <-ctx.Done():
-		// abortWith is idempotent and closes r.done; if the receive already settled it is a
-		// no-op and the <-r.done below returns immediately with the real result.
-		r.abortWith(NewTransferError(FailCanceled, ctx.Err().Error()))
+		r.abortWith(NewTransferError(FailCanceled, ctx.Err().Error()), true)
 		<-r.done
 	}
 	r.mu.Lock()
@@ -97,20 +90,48 @@ func (r *Receiver) Wait(ctx context.Context) (ReceiveResult, error) {
 	return r.result, r.err
 }
 
-// Handle feeds one inbound frame from the sender (manifest / block_data / block_hash / complete).
-// Any error aborts the transfer with the appropriate fail reason (integrity unless the error
-// already carries one).
+// Handle consumes one encrypted sender frame. Any malformed or unauthenticated frame aborts.
 func (r *Receiver) Handle(frame []byte) {
 	if err := r.process(frame); err != nil {
 		var te *TransferError
 		if !errors.As(err, &te) {
 			te = NewTransferError(FailIntegrity, err.Error())
 		}
-		r.abortWith(te)
+		r.abortWith(te, true)
 	}
 }
 
-// --- internal ---------------------------------------------------------------
+// Pause asks the sender to stop producing data frames.
+func (r *Receiver) Pause() error {
+	if !r.setPaused(true) {
+		return nil
+	}
+	return r.sendControl(NewControl(ControlPause))
+}
+
+// Resume asks the sender to continue.
+func (r *Receiver) Resume() error {
+	if !r.setPaused(false) {
+		return nil
+	}
+	return r.sendControl(NewControl(ControlResume))
+}
+
+// Cancel notifies the sender and terminates the receive.
+func (r *Receiver) Cancel(reason string) error {
+	r.mu.Lock()
+	settled := r.settled
+	r.mu.Unlock()
+	if settled {
+		return nil
+	}
+	if r.o.OnStateChange != nil {
+		r.o.OnStateChange(TransferCanceled)
+	}
+	err := r.sendControl(NewControl(ControlCancel))
+	r.abortWith(NewTransferError(FailCanceled, reason), false)
+	return err
+}
 
 func (r *Receiver) process(frame []byte) error {
 	if r.isSettled() {
@@ -118,7 +139,7 @@ func (r *Receiver) process(frame []byte) error {
 	}
 	ctr := r.recvCounter
 	r.recvCounter++
-	opened, err := Open(r.o.RecvDir, ctr, frame) // open failure → integrity abort
+	opened, err := Open(r.o.RecvDir, ctr, frame)
 	if err != nil {
 		return NewTransferError(FailIntegrity, err.Error())
 	}
@@ -126,11 +147,16 @@ func (r *Receiver) process(frame []byte) error {
 	case FrameManifest:
 		return r.applyManifest(opened.Plaintext)
 	case FrameBlockData:
-		return r.onBlockData(opened.Header.BlockIdx, opened.Header.FrameOff, opened.Plaintext)
+		return r.onBlockData(opened.Header.FileIdx, opened.Header.BlockIdx,
+			opened.Header.FrameOff, opened.Plaintext)
 	case FrameBlockHash:
 		return r.onBlockHash(opened.Plaintext)
+	case FrameControl:
+		return r.onControl(opened.Plaintext)
 	case FrameComplete:
 		return r.onComplete(opened.Plaintext)
+	case FrameFail:
+		return r.onPeerFail(opened.Plaintext)
 	default:
 		return NewTransferError(FailIntegrity,
 			fmt.Sprintf("unexpected receiver-inbound type %d", opened.Header.Type))
@@ -138,6 +164,9 @@ func (r *Receiver) process(frame []byte) error {
 }
 
 func (r *Receiver) applyManifest(payload []byte) error {
+	if r.file != nil {
+		return NewTransferError(FailIntegrity, "duplicate manifest")
+	}
 	msg, err := DecodeControl(payload)
 	if err != nil {
 		return NewTransferError(FailIntegrity, err.Error())
@@ -146,35 +175,55 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	if !ok {
 		return NewTransferError(FailIntegrity, "expected manifest")
 	}
-	if len(m.Files) == 0 {
-		return NewTransferError(FailIntegrity, "manifest has no files")
+	if len(m.Files) != 1 {
+		return NewTransferError(FailIntegrity, "single-file manifest required")
 	}
 	f := m.Files[0]
+	wantBlocks := 0
+	if f.Size > 0 && f.BlockSize > 0 {
+		wantBlocks = int((f.Size + int64(f.BlockSize) - 1) / int64(f.BlockSize))
+	}
+	if f.Idx != 0 || f.Size < 0 || f.BlockSize <= 0 || f.Blocks != wantBlocks {
+		return NewTransferError(FailIntegrity, "invalid manifest geometry")
+	}
 	r.file = &f
 	if r.o.OnManifest != nil {
-		return r.o.OnManifest(f)
+		if err := r.o.OnManifest(f); err != nil {
+			return asTransferError(err, FailSinkError)
+		}
 	}
 	return nil
 }
 
-func (r *Receiver) onBlockData(blockIdx uint32, frameOff uint32, payload []byte) error {
+func (r *Receiver) onBlockData(fileIdx uint16, blockIdx uint32, frameOff uint32, payload []byte) error {
 	if r.file == nil {
 		return NewTransferError(FailIntegrity, "block_data before manifest")
 	}
-	if int(blockIdx) != r.curBlock {
-		return NewTransferError(FailIntegrity, fmt.Sprintf("out-of-order block %d", blockIdx))
+	idx := int(blockIdx)
+	if fileIdx != 0 || idx < 0 || idx >= r.file.Blocks {
+		return NewTransferError(FailIntegrity, fmt.Sprintf("block_data outside manifest: %d", idx))
 	}
 	if frameOff == 0 {
-		// The final block is short: cap its buffer at the file's remaining bytes.
-		r.blockLen = r.file.BlockSize
-		if rem := r.file.Size - int64(blockIdx)*int64(r.file.BlockSize); int64(r.blockLen) > rem {
-			r.blockLen = int(rem)
+		if r.blockBuf != nil {
+			return NewTransferError(FailIntegrity, "new block before block_hash")
 		}
-		r.blockBuf = make([]byte, r.blockLen)
-		r.received = 0
+		blockLen := r.file.BlockSize
+		if rem := r.file.Size - int64(idx)*int64(r.file.BlockSize); int64(blockLen) > rem {
+			blockLen = int(rem)
+		}
+		r.assembling = idx
+		r.blockBuf = make([]byte, blockLen)
+		r.blockReceived = 0
 	}
-	copy(r.blockBuf[frameOff:], payload)
-	r.received += len(payload)
+	if r.blockBuf == nil || r.assembling != idx {
+		return NewTransferError(FailIntegrity, fmt.Sprintf("unexpected block fragment %d", idx))
+	}
+	off := int(frameOff)
+	if off != r.blockReceived || off+len(payload) > len(r.blockBuf) {
+		return NewTransferError(FailIntegrity, fmt.Sprintf("invalid frame offset in block %d", idx))
+	}
+	copy(r.blockBuf[off:], payload)
+	r.blockReceived += len(payload)
 	return nil
 }
 
@@ -190,7 +239,10 @@ func (r *Receiver) onBlockHash(payload []byte) error {
 	if !ok {
 		return NewTransferError(FailIntegrity, "expected block_hash")
 	}
-	if r.received != r.blockLen {
+	if bh.FileIdx != 0 || bh.BlockIdx != r.assembling {
+		return NewTransferError(FailIntegrity, "block_hash does not match assembled block")
+	}
+	if r.blockReceived != len(r.blockBuf) {
 		return NewTransferError(FailIntegrity, "short block")
 	}
 	sum := sha256.Sum256(r.blockBuf)
@@ -198,21 +250,82 @@ func (r *Receiver) onBlockHash(payload []byte) error {
 		return NewTransferError(FailIntegrity, fmt.Sprintf("block %d hash mismatch", bh.BlockIdx))
 	}
 
-	// Verified: write, fold into the whole-file digest, then open the window one more block. A
-	// sink error propagates as-is, so a sink returning a TransferError keeps its reason.
-	offset := int64(r.curBlock) * int64(r.file.BlockSize)
-	if err := r.o.Sink.Write(offset, r.blockBuf); err != nil {
-		return err
-	}
-	r.digest.Update(r.blockBuf)
-	if r.o.OnProgress != nil {
-		r.o.OnProgress(offset + int64(r.blockLen))
-	}
-	if err := r.sendControl(NewBlockRecv(0, r.curBlock)); err != nil {
-		return err
-	}
-	r.curBlock++
+	block := r.blockBuf
 	r.blockBuf = nil
+	r.blockReceived = 0
+	r.assembling = -1
+
+	if bh.BlockIdx < r.nextBlock {
+		return r.sendControl(NewAck(0, bh.BlockIdx))
+	}
+	if bh.BlockIdx > r.nextBlock {
+		if len(r.seenAhead) < DefaultInflightBlocks {
+			r.seenAhead[bh.BlockIdx] = true
+		}
+		return r.requestMissing()
+	}
+
+	offset := int64(r.nextBlock) * int64(r.file.BlockSize)
+	if err := r.o.Sink.Write(offset, block); err != nil {
+		return asTransferError(err, FailSinkError)
+	}
+	r.digest.Update(block)
+	r.nextBlock++
+	r.nackOutstanding = -1
+	if r.o.OnProgress != nil {
+		r.o.OnProgress(offset + int64(len(block)))
+	}
+	if err := r.sendControl(NewAck(0, bh.BlockIdx)); err != nil {
+		return err
+	}
+	if r.seenAhead[r.nextBlock] {
+		delete(r.seenAhead, r.nextBlock)
+		return r.requestMissing()
+	}
+	return nil
+}
+
+func (r *Receiver) requestMissing() error {
+	if r.nackOutstanding == r.nextBlock {
+		return nil
+	}
+	r.nackOutstanding = r.nextBlock
+	return r.sendControl(NewNack(0, r.nextBlock, NackMissing))
+}
+
+func (r *Receiver) onControl(payload []byte) error {
+	msg, err := DecodeControl(payload)
+	if err != nil {
+		return NewTransferError(FailIntegrity, err.Error())
+	}
+	control, ok := msg.(*Control)
+	if !ok {
+		return NewTransferError(FailIntegrity, "expected control")
+	}
+	switch control.Op {
+	case ControlPause:
+		r.setPaused(true)
+	case ControlResume:
+		r.setPaused(false)
+	case ControlCancel:
+		if r.o.OnStateChange != nil {
+			r.o.OnStateChange(TransferCanceled)
+		}
+		r.abortWith(NewTransferError(FailCanceled, "peer canceled the transfer"), false)
+	}
+	return nil
+}
+
+func (r *Receiver) onPeerFail(payload []byte) error {
+	msg, err := DecodeControl(payload)
+	if err != nil {
+		return NewTransferError(FailIntegrity, err.Error())
+	}
+	fail, ok := msg.(*Fail)
+	if !ok {
+		return NewTransferError(FailIntegrity, "expected fail")
+	}
+	r.abortWith(NewTransferError(fail.Reason, "sender failed: "+string(fail.Reason)), false)
 	return nil
 }
 
@@ -224,16 +337,19 @@ func (r *Receiver) onComplete(payload []byte) error {
 	if err != nil {
 		return NewTransferError(FailIntegrity, err.Error())
 	}
-	c, ok := msg.(*Complete)
+	complete, ok := msg.(*Complete)
 	if !ok {
 		return NewTransferError(FailIntegrity, "expected complete")
 	}
+	if r.nextBlock != r.file.Blocks {
+		return r.requestMissing()
+	}
 	got := r.digest.HexDigest()
-	if got != c.FileDigest {
+	if complete.FileDigest != r.file.FileDigest || got != complete.FileDigest {
 		return NewTransferError(FailDigestMismatch, "whole-file digest mismatch")
 	}
 	if err := r.o.Sink.Close(); err != nil {
-		return err
+		return asTransferError(err, FailSinkError)
 	}
 	if err := r.sendControl(NewDone()); err != nil {
 		return err
@@ -242,9 +358,25 @@ func (r *Receiver) onComplete(payload []byte) error {
 	return nil
 }
 
-// abortWith settles the transfer as failed and, best-effort, tells the peer and the sink. Only
-// the first abort (or a prior settle) takes effect.
-func (r *Receiver) abortWith(err *TransferError) {
+func (r *Receiver) setPaused(paused bool) bool {
+	r.mu.Lock()
+	if r.settled || r.paused == paused {
+		r.mu.Unlock()
+		return false
+	}
+	r.paused = paused
+	r.mu.Unlock()
+	if r.o.OnStateChange != nil {
+		if paused {
+			r.o.OnStateChange(TransferPaused)
+		} else {
+			r.o.OnStateChange(TransferRunning)
+		}
+	}
+	return true
+}
+
+func (r *Receiver) abortWith(err *TransferError, notifyPeer bool) {
 	r.mu.Lock()
 	if r.settled {
 		r.mu.Unlock()
@@ -253,21 +385,21 @@ func (r *Receiver) abortWith(err *TransferError) {
 	r.settled = true
 	r.err = err
 	r.mu.Unlock()
-
-	_ = r.sendControl(NewFail(err.Reason)) // best-effort — the channel may already be gone
-	_ = r.o.Sink.Abort(string(err.Reason)) // best-effort
+	if notifyPeer {
+		_ = r.sendControl(NewFail(err.Reason))
+	}
+	_ = r.o.Sink.Abort(string(err.Reason))
 	close(r.done)
 }
 
-// settle records a successful finish; only the first settle (or a prior abort) takes effect.
-func (r *Receiver) settle(res ReceiveResult) {
+func (r *Receiver) settle(result ReceiveResult) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.settled {
 		return
 	}
 	r.settled = true
-	r.result = res
+	r.result = result
 	close(r.done)
 }
 
@@ -277,18 +409,26 @@ func (r *Receiver) isSettled() bool {
 	return r.settled
 }
 
-// sendControl seals and sends a control message under the next send counter.
 func (r *Receiver) sendControl(msg ControlMsg) error {
 	payload, err := EncodeControl(msg)
 	if err != nil {
 		return err
 	}
-	frame, err := Seal(r.o.SendDir, r.sendCounter, FrameHeaderInput{
-		Version: FrameVersion, Type: msg.FrameType(),
-	}, payload)
+	r.sendMu.Lock()
+	defer r.sendMu.Unlock()
+	frame, err := Seal(r.o.SendDir, r.sendCounter,
+		FrameHeaderInput{Version: FrameVersion, Type: msg.FrameType()}, payload)
 	if err != nil {
 		return err
 	}
 	r.sendCounter++
 	return r.o.Send(frame)
+}
+
+func asTransferError(err error, fallback FailReason) *TransferError {
+	var transferErr *TransferError
+	if errors.As(err, &transferErr) {
+		return transferErr
+	}
+	return NewTransferError(fallback, err.Error())
 }

--- a/packages/wire/transfer_receiver_test.go
+++ b/packages/wire/transfer_receiver_test.go
@@ -68,6 +68,24 @@ func (s *senderFrames) blockData(data []byte, blockSize, frameSize int) {
 	}
 }
 
+func (s *senderFrames) oneBlock(blockIdx int, block []byte, frameSize int) {
+	for off := 0; off < len(block); off += frameSize {
+		end := off + frameSize
+		if end > len(block) {
+			end = len(block)
+		}
+		flags := uint8(0)
+		if end == len(block) {
+			flags = FrameFlagLastInBlock
+		}
+		s.push(FrameHeaderInput{
+			Version: FrameVersion, Type: FrameBlockData, Flags: flags,
+			BlockIdx: uint32(blockIdx), FrameOff: uint32(off),
+		}, block[off:end])
+	}
+	s.ctrl(NewBlockHash(0, blockIdx, hexSHA256(block)))
+}
+
 func hexSHA256(data []byte) string {
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])
@@ -114,8 +132,8 @@ func TestReceiverAssemblesVerifiesWritesDone(t *testing.T) {
 		t.Error("sink not closed on done")
 	}
 
-	// Back-channel: block_recv ×3 then done.
-	wantBack := []uint8{FrameBlockRecv, FrameBlockRecv, FrameBlockRecv, FrameDone}
+	// Back-channel: verified ACK ×3 then done.
+	wantBack := []uint8{FrameAck, FrameAck, FrameAck, FrameDone}
 	got := back.snapshot()
 	if len(got) != len(wantBack) {
 		t.Fatalf("back-channel has %d frames, want %d", len(got), len(wantBack))
@@ -148,8 +166,9 @@ func TestReceiverAbortsIntegrityOnCorruptFrame(t *testing.T) {
 	last[len(last)-1] ^= 0x01
 
 	sink := &MemorySink{}
+	var back outbox
 	r := NewReceiver(ReceiverOptions{
-		Send: func([]byte) error { return nil }, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
 	})
 	for _, f := range sf.frames {
 		r.Handle(f)
@@ -160,6 +179,17 @@ func TestReceiverAbortsIntegrityOnCorruptFrame(t *testing.T) {
 	}
 	if sink.AbortReason() != "integrity" {
 		t.Errorf("sink abort reason = %q, want integrity", sink.AbortReason())
+	}
+	frames := back.snapshot()
+	if len(frames) != 1 {
+		t.Fatalf("back-channel has %d frames, want one terminal fail", len(frames))
+	}
+	opened, openErr := Open(keys.J2O, 0, frames[0])
+	if openErr != nil {
+		t.Fatal(openErr)
+	}
+	if opened.Header.Type != FrameFail {
+		t.Fatalf("corruption response type = %d, want fail", opened.Header.Type)
 	}
 }
 
@@ -236,6 +266,72 @@ func TestReceiverFailsDigestMismatch(t *testing.T) {
 	_, err = r.Wait(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "digest_mismatch") {
 		t.Fatalf("Wait error = %v, want one mentioning digest_mismatch", err)
+	}
+}
+
+func TestReceiverRequestsMissingAndRecoversReorderedBlocks(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := []byte{1, 2, 3, 4}
+	second := []byte{5, 6, 7, 8}
+	data := append(append([]byte(nil), first...), second...)
+	fileDigest := hexSHA256(data)
+
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(NewManifest([]FileEntry{{
+		Idx: 0, Name: "reordered.bin", Size: int64(len(data)), BlockSize: 4,
+		Blocks: 2, FileDigest: fileDigest,
+	}}, int64(len(data))))
+	// A transport transition exposes block 1 first. It is authenticated but not committed;
+	// the requested sequence then arrives under fresh counters.
+	sf.oneBlock(1, second, 4)
+	sf.oneBlock(0, first, 4)
+	sf.oneBlock(1, second, 4)
+	sf.ctrl(NewComplete(fileDigest))
+
+	sink := &MemorySink{}
+	var back outbox
+	r := NewReceiver(ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+	})
+	for _, frame := range sf.frames {
+		r.Handle(frame)
+	}
+	result, err := r.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if result.Digest != fileDigest || string(sink.Bytes()) != string(data) {
+		t.Fatalf("recovered result digest=%s bytes=%v", result.Digest, sink.Bytes())
+	}
+
+	want := []ControlMsg{
+		NewNack(0, 0, NackMissing),
+		NewAck(0, 0),
+		NewNack(0, 1, NackMissing),
+		NewAck(0, 1),
+		NewDone(),
+	}
+	frames := back.snapshot()
+	if len(frames) != len(want) {
+		t.Fatalf("back-channel has %d frames, want %d", len(frames), len(want))
+	}
+	for i, frame := range frames {
+		opened, openErr := Open(keys.J2O, uint64(i), frame)
+		if openErr != nil {
+			t.Fatalf("open back frame %d: %v", i, openErr)
+		}
+		got, decodeErr := DecodeControl(opened.Plaintext)
+		if decodeErr != nil {
+			t.Fatalf("decode back frame %d: %v", i, decodeErr)
+		}
+		gotJSON, _ := EncodeControl(got)
+		wantJSON, _ := EncodeControl(want[i])
+		if string(gotJSON) != string(wantJSON) {
+			t.Errorf("back frame %d = %s, want %s", i, gotJSON, wantJSON)
+		}
 	}
 }
 

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -7,28 +7,24 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 )
 
-// Sender is the sending half of the transport-agnostic transfer engine (design §5). It
-// streams a file without ever buffering it whole:
-//
-//	Pass 1  read the file once → whole-file streaming digest → manifest (with fileDigest).
-//	Pass 2  re-chunk into block_data frames; at each block boundary send block_hash.
-//	Finish  send complete{fileDigest}; return when the receiver replies done.
-//
-// Outbound frames are AES-GCM sealed with a per-direction counter that continues from the
-// handshake and is never reset. The sender never runs more than Window blocks ahead of the
-// receiver's block_recv signal, bounding the outbound queue. It is the Go twin of
-// packages/protocol/src/transfer-sender.ts.
-//
-// Run executes on the caller's goroutine; Handle is called from the transport's read loop as
-// inbound frames (block_recv / done / fail) arrive. Shared state is guarded by a mutex and a
-// condition variable: window-gating in Run waits on the receiver's acks delivered by Handle.
+// Sender streams one file while retaining only a bounded window of unacknowledged blocks.
+// A block leaves the window after the receiver has verified and committed it. NACK and timeout
+// retransmissions are sealed under fresh AEAD counters; integrity failures remain terminal.
 
-// FrameFlagLastInBlock is the header flag marking a frame as the last of its block.
+// FrameFlagLastInBlock marks the final data frame in a logical block.
 const FrameFlagLastInBlock uint8 = 0x01
 
-// SenderOptions configures a Sender. Zero-valued sizing fields select the protocol defaults.
+const (
+	// DefaultAckTimeout is the acknowledgement deadline before a block is retransmitted.
+	DefaultAckTimeout = 15 * time.Second
+	// DefaultMaxBlockRetries bounds retransmissions after the initial block send.
+	DefaultMaxBlockRetries = 3
+)
+
+// SenderOptions configures a Sender. Zero-valued sizing and retry fields select defaults.
 type SenderOptions struct {
 	File             FileSource
 	Send             func(frame []byte) error
@@ -36,36 +32,51 @@ type SenderOptions struct {
 	RecvDir          DirectionalKey
 	SendCounterStart uint64
 	RecvCounterStart uint64
-	CreateDigest     func() Digest // nil selects a streaming SHA-256 digest
-	BlockSize        int           // 0 selects DefaultBlockBytes
-	FrameSize        int           // 0 selects DefaultFrameBytes
-	Window           int           // 0 selects DefaultInflightBlocks
-	OnProgress       func(sentBytes int64)
+	CreateDigest     func() Digest
+	BlockSize        int
+	FrameSize        int
+	Window           int
+	AckTimeout       time.Duration
+	MaxRetries       int
+	// OnProgress reports bytes acknowledged after verify-and-sink.
+	OnProgress    func(acknowledgedBytes int64)
+	OnStateChange func(TransferState)
+}
+
+type inflightBlock struct {
+	bytes   []byte
+	retries int
+	timer   *time.Timer
 }
 
 // Sender drives one file send. Construct it with NewSender.
 type Sender struct {
-	o         SenderOptions
-	blockSize int
-	frameSize int
-	window    int
+	o          SenderOptions
+	blockSize  int
+	frameSize  int
+	window     int
+	ackTimeout time.Duration
+	maxRetries int
 
-	sendCounter uint64 // touched only by Run's goroutine
-	sent        int64  // touched only by Run's goroutine
+	sendMu      sync.Mutex
+	sendCounter uint64
 
-	mu            sync.Mutex
-	cond          *sync.Cond
-	recvCounter   uint64
-	lastRecvBlock int
-	settled       bool
-	err           error // non-nil once a fail has been observed
+	mu           sync.Mutex
+	cond         *sync.Cond
+	recvCounter  uint64
+	inflight     map[int]*inflightBlock
+	retryQueue   []int
+	retryQueued  map[int]bool
+	acknowledged int64
+	paused       bool
+	completeSent bool
+	settled      bool
+	err          error
 }
 
-// errSenderSettled breaks out of the pass-2 stream when the transfer settles mid-flight; it
-// never escapes Run, which converts it into the stored fail (or nil on an early done).
 var errSenderSettled = errors.New("sender settled")
 
-// NewSender builds a Sender, applying protocol defaults for any zero-valued sizing option.
+// NewSender builds a Sender and applies protocol defaults.
 func NewSender(opts SenderOptions) *Sender {
 	if opts.BlockSize <= 0 {
 		opts.BlockSize = DefaultBlockBytes
@@ -76,108 +87,98 @@ func NewSender(opts SenderOptions) *Sender {
 	if opts.Window <= 0 {
 		opts.Window = DefaultInflightBlocks
 	}
+	if opts.AckTimeout == 0 {
+		opts.AckTimeout = DefaultAckTimeout
+	}
+	if opts.MaxRetries <= 0 {
+		opts.MaxRetries = DefaultMaxBlockRetries
+	}
 	if opts.CreateDigest == nil {
 		opts.CreateDigest = NewSHA256Digest
 	}
 	s := &Sender{
-		o:             opts,
-		blockSize:     opts.BlockSize,
-		frameSize:     opts.FrameSize,
-		window:        opts.Window,
-		sendCounter:   opts.SendCounterStart,
-		recvCounter:   opts.RecvCounterStart,
-		lastRecvBlock: -1,
+		o:           opts,
+		blockSize:   opts.BlockSize,
+		frameSize:   opts.FrameSize,
+		window:      opts.Window,
+		ackTimeout:  opts.AckTimeout,
+		maxRetries:  opts.MaxRetries,
+		sendCounter: opts.SendCounterStart,
+		recvCounter: opts.RecvCounterStart,
+		inflight:    make(map[int]*inflightBlock),
+		retryQueued: make(map[int]bool),
 	}
 	s.cond = sync.NewCond(&s.mu)
 	return s
 }
 
-// Run drives the whole send. It returns the canonical whole-file digest (hex) once the
-// receiver confirms done, or an error on fail or an IO failure. The digest is the same value
-// carried in the manifest and complete, so a host can report it without recomputing. Canceling
-// ctx aborts the transfer in bounded time.
+// Run sends the file and returns its canonical digest after every block is acknowledged and the
+// receiver confirms the whole-file digest.
 func (s *Sender) Run(ctx context.Context) (string, error) {
-	// Watch ctx so a canceled transfer (peer dropped, host aborted) settles in bounded time
-	// rather than parking forever on the window gate or waitDone. stop retires the watcher when
-	// Run returns so it never outlives the send.
 	stop := make(chan struct{})
 	defer close(stop)
 	go func() {
 		select {
 		case <-ctx.Done():
-			s.cancel(ctx.Err())
+			s.cancelLocal(ctx.Err())
 		case <-stop:
 		}
 	}()
 
 	meta := s.o.File.Meta()
-
-	// Pass 1: whole-file digest, streamed so the file is never held.
 	digest := s.o.CreateDigest()
 	if err := s.o.File.Stream(func(chunk []byte) error {
 		digest.Update(chunk)
 		return nil
 	}); err != nil {
+		s.fail(err)
 		return "", err
 	}
 	fileDigest := digest.HexDigest()
 
 	blocks := 0
 	if meta.Size > 0 {
-		blocks = int((meta.Size + int64(s.blockSize) - 1) / int64(s.blockSize)) // ceil
+		blocks = int((meta.Size + int64(s.blockSize) - 1) / int64(s.blockSize))
 	}
 	if err := s.sendControl(NewManifest([]FileEntry{{
 		Idx: 0, Name: meta.Name, Size: meta.Size, Mime: meta.Mime,
 		LastModified: meta.LastModified, BlockSize: s.blockSize, Blocks: blocks,
 		FileDigest: fileDigest,
 	}}, meta.Size)); err != nil {
+		s.fail(err)
 		return "", err
 	}
 
-	// Pass 2: block data + per-block hash, gated to the in-flight window.
-	var blockParts []byte
-	streamErr := ReChunk(StreamFunc(s.o.File.Stream), s.blockSize, s.frameSize, func(p FramePiece) error {
-		s.gate(p.BlockIdx)
-		if s.isSettled() {
-			return errSenderSettled // aborted by an inbound fail (or early done)
-		}
-		flags := uint8(0)
-		if p.LastInBlock {
-			flags = FrameFlagLastInBlock
-		}
-		if err := s.sendFrame(FrameHeaderInput{
-			Version:  FrameVersion,
-			Type:     FrameBlockData,
-			Flags:    flags,
-			FileIdx:  0,
-			BlockIdx: uint32(p.BlockIdx),
-			FrameOff: uint32(p.FrameOff),
-		}, p.Payload); err != nil {
+	streamErr := ReChunk(StreamFunc(s.o.File.Stream), s.blockSize, s.blockSize, func(p FramePiece) error {
+		if err := s.beforeNewBlock(); err != nil {
 			return err
 		}
-		s.sent += int64(len(p.Payload))
-		if s.o.OnProgress != nil {
-			s.o.OnProgress(s.sent)
+		block := append([]byte(nil), p.Payload...)
+		s.mu.Lock()
+		if s.settled {
+			s.mu.Unlock()
+			return errSenderSettled
 		}
-		blockParts = append(blockParts, p.Payload...)
-		if p.LastInBlock {
-			sum := sha256.Sum256(blockParts)
-			blockParts = blockParts[:0]
-			if err := s.sendControl(NewBlockHash(0, p.BlockIdx, hex.EncodeToString(sum[:]))); err != nil {
-				return err
-			}
+		s.inflight[p.BlockIdx] = &inflightBlock{bytes: block}
+		s.mu.Unlock()
+		if err := s.sendBlock(p.BlockIdx, block); err != nil {
+			return err
 		}
+		s.armTimeout(p.BlockIdx)
 		return nil
 	})
-	if streamErr != nil {
-		if errors.Is(streamErr, errSenderSettled) {
-			// Settled mid-stream: propagate the fail, or return the digest on an early done.
-			return fileDigest, s.waitDone()
-		}
+	if streamErr != nil && !errors.Is(streamErr, errSenderSettled) {
+		s.fail(streamErr)
 		return "", streamErr
 	}
-
+	if err := s.waitInflight(); err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	s.completeSent = true
+	s.mu.Unlock()
 	if err := s.sendControl(NewComplete(fileDigest)); err != nil {
+		s.fail(err)
 		return "", err
 	}
 	if err := s.waitDone(); err != nil {
@@ -186,62 +187,300 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 	return fileDigest, nil
 }
 
-// Handle feeds one inbound frame from the receiver (block_recv / done / fail). It must be
-// called serially — the ordered DataChannel read loop satisfies this — because each frame
-// consumes the next receive counter.
+// Handle consumes one encrypted receiver control frame. Calls must remain ordered.
 func (s *Sender) Handle(frame []byte) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.settled {
+		s.mu.Unlock()
 		return
 	}
 	ctr := s.recvCounter
 	s.recvCounter++
+	s.mu.Unlock()
+
 	opened, err := Open(s.o.RecvDir, ctr, frame)
 	if err != nil {
-		s.failLocked(err)
+		s.fail(NewTransferError(FailIntegrity, err.Error()))
 		return
 	}
 	msg, err := DecodeControl(opened.Plaintext)
 	if err != nil {
-		s.failLocked(err)
+		s.fail(NewTransferError(FailIntegrity, err.Error()))
 		return
 	}
+	if opened.Header.Type != msg.FrameType() {
+		s.fail(NewTransferError(FailIntegrity, "control frame header/payload type mismatch"))
+		return
+	}
+
 	switch m := msg.(type) {
-	case *BlockRecv:
-		if m.BlockIdx > s.lastRecvBlock {
-			s.lastRecvBlock = m.BlockIdx
+	case *Ack:
+		s.onAck(m)
+	case *Nack:
+		if m.FileIdx != 0 {
+			s.fail(NewTransferError(FailIntegrity, "nack for unknown file"))
+			return
 		}
-		s.cond.Broadcast()
+		s.queueRetry(m.BlockIdx)
+	case *Control:
+		s.applyRemoteControl(m.Op)
 	case *Done:
-		s.settleLocked()
+		s.mu.Lock()
+		premature := !s.completeSent || len(s.inflight) != 0
+		s.mu.Unlock()
+		if premature {
+			s.fail(NewTransferError(FailIntegrity, "done before every block was acknowledged"))
+			return
+		}
+		s.settle()
 	case *Fail:
-		s.failLocked(NewTransferError(m.Reason, "receiver failed: "+string(m.Reason)))
+		s.fail(NewTransferError(m.Reason, "receiver failed: "+string(m.Reason)))
 	default:
-		s.failLocked(NewTransferError(FailIntegrity,
+		s.fail(NewTransferError(FailIntegrity,
 			fmt.Sprintf("unexpected sender-inbound type %d", msg.FrameType())))
 	}
 }
 
-// --- internal ---------------------------------------------------------------
+// Pause stops new data frames locally and notifies the peer.
+func (s *Sender) Pause() error {
+	if !s.setPaused(true) {
+		return nil
+	}
+	return s.sendControl(NewControl(ControlPause))
+}
 
-// gate blocks until the block is within the in-flight window of the receiver's last ack, or
-// the transfer settles.
-func (s *Sender) gate(blockIdx int) {
+// Resume reopens the data path and notifies the peer.
+func (s *Sender) Resume() error {
+	if !s.setPaused(false) {
+		return nil
+	}
+	return s.sendControl(NewControl(ControlResume))
+}
+
+// Cancel notifies the peer and terminates the sender. It is idempotent.
+func (s *Sender) Cancel(reason string) error {
+	s.mu.Lock()
+	settled := s.settled
+	s.mu.Unlock()
+	if settled {
+		return nil
+	}
+	err := s.sendControl(NewControl(ControlCancel))
+	s.fail(NewTransferError(FailCanceled, reason))
+	return err
+}
+
+func (s *Sender) onAck(ack *Ack) {
+	if ack.FileIdx != 0 {
+		s.fail(NewTransferError(FailIntegrity, "ack for unknown file"))
+		return
+	}
+	s.mu.Lock()
+	state := s.inflight[ack.BlockIdx]
+	if state == nil {
+		s.mu.Unlock()
+		return
+	}
+	if state.timer != nil {
+		state.timer.Stop()
+	}
+	delete(s.inflight, ack.BlockIdx)
+	delete(s.retryQueued, ack.BlockIdx)
+	s.acknowledged += int64(len(state.bytes))
+	acknowledged := s.acknowledged
+	s.cond.Broadcast()
+	s.mu.Unlock()
+	if s.o.OnProgress != nil {
+		s.o.OnProgress(acknowledged)
+	}
+}
+
+func (s *Sender) applyRemoteControl(op ControlOp) {
+	switch op {
+	case ControlPause:
+		s.setPaused(true)
+	case ControlResume:
+		s.setPaused(false)
+	case ControlCancel:
+		if s.o.OnStateChange != nil {
+			s.o.OnStateChange(TransferCanceled)
+		}
+		s.fail(NewTransferError(FailCanceled, "peer canceled the transfer"))
+	}
+}
+
+func (s *Sender) setPaused(paused bool) bool {
+	s.mu.Lock()
+	if s.settled || s.paused == paused {
+		s.mu.Unlock()
+		return false
+	}
+	s.paused = paused
+	for idx, state := range s.inflight {
+		if state.timer != nil {
+			state.timer.Stop()
+			state.timer = nil
+		}
+		if !paused {
+			s.armTimeoutLocked(idx, state)
+		}
+	}
+	s.cond.Broadcast()
+	s.mu.Unlock()
+	if s.o.OnStateChange != nil {
+		if paused {
+			s.o.OnStateChange(TransferPaused)
+		} else {
+			s.o.OnStateChange(TransferRunning)
+		}
+	}
+	return true
+}
+
+func (s *Sender) beforeNewBlock() error {
+	for {
+		idx, state, err := s.nextRetryOrWait(true)
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+		if err := s.resend(idx, state); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *Sender) waitInflight() error {
+	for {
+		idx, state, err := s.nextRetryOrWait(false)
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+		if err := s.resend(idx, state); err != nil {
+			return err
+		}
+	}
+}
+
+// nextRetryOrWait returns one queued retry. With capacity=true it returns nil once a new block
+// may enter the window; otherwise it returns nil once the entire window is acknowledged.
+func (s *Sender) nextRetryOrWait(capacity bool) (int, *inflightBlock, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for !s.settled && blockIdx-s.lastRecvBlock > s.window {
+	for {
+		if s.settled {
+			if s.err != nil {
+				return 0, nil, s.err
+			}
+			return 0, nil, errSenderSettled
+		}
+		if s.paused {
+			s.cond.Wait()
+			continue
+		}
+		for len(s.retryQueue) > 0 {
+			idx := s.retryQueue[0]
+			s.retryQueue = s.retryQueue[1:]
+			delete(s.retryQueued, idx)
+			if state := s.inflight[idx]; state != nil {
+				return idx, state, nil
+			}
+		}
+		if capacity && len(s.inflight) < s.window {
+			return 0, nil, nil
+		}
+		if !capacity && len(s.inflight) == 0 {
+			return 0, nil, nil
+		}
 		s.cond.Wait()
 	}
 }
 
-func (s *Sender) isSettled() bool {
+func (s *Sender) resend(blockIdx int, state *inflightBlock) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.settled
+	current := s.inflight[blockIdx]
+	if current == nil || current != state {
+		s.mu.Unlock()
+		return nil
+	}
+	if state.retries >= s.maxRetries {
+		s.mu.Unlock()
+		err := NewTransferError(FailRetryExhausted,
+			fmt.Sprintf("block %d remained unacknowledged", blockIdx))
+		_ = s.sendControl(NewFail(FailRetryExhausted))
+		s.fail(err)
+		return err
+	}
+	state.retries++
+	s.mu.Unlock()
+	if err := s.sendBlock(blockIdx, state.bytes); err != nil {
+		s.fail(err)
+		return err
+	}
+	s.armTimeout(blockIdx)
+	return nil
 }
 
-// waitDone blocks until the transfer settles and returns the fail error, or nil on done.
+func (s *Sender) queueRetry(blockIdx int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.inflight[blockIdx]
+	if state == nil || s.retryQueued[blockIdx] || s.settled {
+		return
+	}
+	if state.timer != nil {
+		state.timer.Stop()
+		state.timer = nil
+	}
+	s.retryQueued[blockIdx] = true
+	s.retryQueue = append(s.retryQueue, blockIdx)
+	s.cond.Broadcast()
+}
+
+func (s *Sender) armTimeout(blockIdx int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if state := s.inflight[blockIdx]; state != nil {
+		s.armTimeoutLocked(blockIdx, state)
+	}
+}
+
+func (s *Sender) armTimeoutLocked(blockIdx int, state *inflightBlock) {
+	if s.paused || s.ackTimeout < 0 || s.settled {
+		return
+	}
+	if state.timer != nil {
+		state.timer.Stop()
+	}
+	state.timer = time.AfterFunc(s.ackTimeout, func() { s.queueRetry(blockIdx) })
+}
+
+func (s *Sender) sendBlock(blockIdx int, block []byte) error {
+	for off := 0; off < len(block); off += s.frameSize {
+		end := off + s.frameSize
+		if end > len(block) {
+			end = len(block)
+		}
+		flags := uint8(0)
+		if end == len(block) {
+			flags = FrameFlagLastInBlock
+		}
+		if err := s.sendFrame(FrameHeaderInput{
+			Version: FrameVersion, Type: FrameBlockData, Flags: flags,
+			FileIdx: 0, BlockIdx: uint32(blockIdx), FrameOff: uint32(off),
+		}, block[off:end]); err != nil {
+			return err
+		}
+	}
+	sum := sha256.Sum256(block)
+	return s.sendControl(NewBlockHash(0, blockIdx, hex.EncodeToString(sum[:])))
+}
+
 func (s *Sender) waitDone() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -251,50 +490,53 @@ func (s *Sender) waitDone() error {
 	return s.err
 }
 
-// settleLocked marks a successful finish; the caller holds the mutex.
-func (s *Sender) settleLocked() {
+func (s *Sender) settle() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.settled {
 		return
 	}
 	s.settled = true
+	s.clearTimersLocked()
 	s.cond.Broadcast()
 }
 
-// failLocked records the first failure and wakes every waiter; the caller holds the mutex.
-func (s *Sender) failLocked(err error) {
+func (s *Sender) fail(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.settled {
 		return
 	}
 	s.settled = true
 	s.err = err
+	s.clearTimersLocked()
 	s.cond.Broadcast()
 }
 
-// cancel settles the send as canceled unless it has already finished. It is the ctx-cancellation
-// path: it only touches local state and wakes the waiters (gate/waitDone), never the transport,
-// so it cannot block on a peer that has already gone away.
-func (s *Sender) cancel(cause error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.failLocked(NewTransferError(FailCanceled, cause.Error()))
+func (s *Sender) cancelLocal(cause error) {
+	s.fail(NewTransferError(FailCanceled, cause.Error()))
 }
 
-// sendControl seals and sends a control message; its frame-header type is the message's tag.
+func (s *Sender) clearTimersLocked() {
+	for _, state := range s.inflight {
+		if state.timer != nil {
+			state.timer.Stop()
+		}
+	}
+}
+
 func (s *Sender) sendControl(msg ControlMsg) error {
 	payload, err := EncodeControl(msg)
 	if err != nil {
 		return err
 	}
-	return s.sendFrame(FrameHeaderInput{
-		Version: FrameVersion,
-		Type:    msg.FrameType(),
-		Flags:   0,
-		FileIdx: 0, BlockIdx: 0, FrameOff: 0,
-	}, payload)
+	return s.sendFrame(FrameHeaderInput{Version: FrameVersion, Type: msg.FrameType()}, payload)
 }
 
-// sendFrame seals payload under the next send counter and hands the frame to the transport.
+// sendFrame serializes sealing and transport writes so controls cannot race data for a nonce.
 func (s *Sender) sendFrame(header FrameHeaderInput, payload []byte) error {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
 	frame, err := Seal(s.o.SendDir, s.sendCounter, header, payload)
 	if err != nil {
 		return err

--- a/packages/wire/transfer_sender_test.go
+++ b/packages/wire/transfer_sender_test.go
@@ -62,7 +62,7 @@ func waitStable(t *testing.T, o *outbox, want int) {
 	t.Fatalf("outbox never stabilized at %d frames (saw %d)", want, o.len())
 }
 
-func TestSenderEmitsGrammarGatedByBlockRecv(t *testing.T) {
+func TestSenderEmitsGrammarGatedByAck(t *testing.T) {
 	keys, err := DeriveTransferKeys(senderMaster())
 	if err != nil {
 		t.Fatal(err)
@@ -107,14 +107,14 @@ func TestSenderEmitsGrammarGatedByBlockRecv(t *testing.T) {
 		peek++
 	}
 
-	// Ack every block so the window drains, then send done.
+	// Ack every verified block so the window drains, then send done.
 	ackCtr := uint64(0)
 	ack := func(blockIdx int) {
-		payload, err := EncodeControl(NewBlockRecv(0, blockIdx))
+		payload, err := EncodeControl(NewAck(0, blockIdx))
 		if err != nil {
 			t.Fatal(err)
 		}
-		frame, err := Seal(keys.J2O, ackCtr, FrameHeaderInput{Version: FrameVersion, Type: FrameBlockRecv}, payload)
+		frame, err := Seal(keys.J2O, ackCtr, FrameHeaderInput{Version: FrameVersion, Type: FrameAck}, payload)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -122,15 +122,14 @@ func TestSenderEmitsGrammarGatedByBlockRecv(t *testing.T) {
 		s.Handle(frame)
 	}
 	ack(0)
+	waitStable(t, &out, 7)
 	ack(1)
+	waitStable(t, &out, 9)
 	ack(2)
 
-	// Let pass 2 drain all blocks and send complete before we confirm done — otherwise done
-	// would settle the sender mid-stream and complete would never be sent. The final 4-byte
-	// block lands on a frame boundary, so like the TS reference it carries no block_hash:
-	// manifest + (block0: 2 data + hash) + (block1: 2 data + hash) + (block2: 1 data) +
-	// complete = 9 frames.
-	waitStable(t, &out, 9)
+	// Every block, including the short final block, carries a hash. The sender emits complete
+	// only after all three verified acknowledgements arrive.
+	waitStable(t, &out, 10)
 
 	donePayload, err := EncodeControl(NewDone())
 	if err != nil {
@@ -222,5 +221,158 @@ func TestSenderRejectsOnReceiverFail(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not return after receiver fail")
+	}
+}
+
+func TestSenderRetransmitsNackWithFreshCounterAndAckedProgress(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := []byte{1, 2, 3, 4}
+	var out outbox
+	var progress []int64
+	s := NewSender(SenderOptions{
+		File:       BytesSource(data, FileMeta{Name: "f", Size: int64(len(data))}, 0),
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		Window:     1,
+		AckTimeout: time.Second,
+		OnProgress: func(n int64) { progress = append(progress, n) },
+	})
+
+	res := make(chan error, 1)
+	go func() { _, runErr := s.Run(context.Background()); res <- runErr }()
+	waitStable(t, &out, 3)
+	if len(progress) != 0 {
+		t.Fatalf("progress before ack = %v", progress)
+	}
+
+	peerCounter := uint64(0)
+	feed := func(msg ControlMsg) {
+		payload, encodeErr := EncodeControl(msg)
+		if encodeErr != nil {
+			t.Fatal(encodeErr)
+		}
+		frame, sealErr := Seal(keys.J2O, peerCounter,
+			FrameHeaderInput{Version: FrameVersion, Type: msg.FrameType()}, payload)
+		if sealErr != nil {
+			t.Fatal(sealErr)
+		}
+		peerCounter++
+		s.Handle(frame)
+	}
+	feed(NewNack(0, 0, NackMissing))
+	waitStable(t, &out, 5)
+	feed(NewAck(0, 0))
+	waitStable(t, &out, 6)
+	feed(NewDone())
+	if runErr := <-res; runErr != nil {
+		t.Fatalf("Run: %v", runErr)
+	}
+	if len(progress) != 1 || progress[0] != int64(len(data)) {
+		t.Fatalf("progress = %v, want [%d]", progress, len(data))
+	}
+
+	frames := out.snapshot()
+	wantTypes := []uint8{FrameManifest, FrameBlockData, FrameBlockHash,
+		FrameBlockData, FrameBlockHash, FrameComplete}
+	for i, frame := range frames {
+		opened, openErr := Open(keys.O2J, uint64(i), frame)
+		if openErr != nil {
+			t.Fatalf("open frame %d: %v", i, openErr)
+		}
+		if opened.Header.Type != wantTypes[i] {
+			t.Errorf("frame %d type = %d, want %d", i, opened.Header.Type, wantTypes[i])
+		}
+	}
+	if string(frames[1]) == string(frames[3]) {
+		t.Error("retransmitted ciphertext reused the original nonce")
+	}
+}
+
+func TestSenderPauseResumeStopsNewData(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	var states []TransferState
+	s := NewSender(SenderOptions{
+		File:          BytesSource([]byte{1, 2, 3, 4}, FileMeta{Name: "f", Size: 4}, 0),
+		Send:          out.push,
+		SendDir:       keys.O2J,
+		RecvDir:       keys.J2O,
+		BlockSize:     8,
+		FrameSize:     4,
+		OnStateChange: func(state TransferState) { states = append(states, state) },
+	})
+	if err := s.Pause(); err != nil {
+		t.Fatal(err)
+	}
+	res := make(chan error, 1)
+	go func() { _, runErr := s.Run(context.Background()); res <- runErr }()
+	waitStable(t, &out, 2) // pause control + manifest
+	if err := s.Resume(); err != nil {
+		t.Fatal(err)
+	}
+	waitStable(t, &out, 5) // resume control + data + hash
+
+	peerCounter := uint64(0)
+	for _, msg := range []ControlMsg{NewAck(0, 0), NewDone()} {
+		if _, ok := msg.(*Done); ok {
+			waitStable(t, &out, 6) // complete precedes done
+		}
+		payload, encodeErr := EncodeControl(msg)
+		if encodeErr != nil {
+			t.Fatal(encodeErr)
+		}
+		frame, sealErr := Seal(keys.J2O, peerCounter,
+			FrameHeaderInput{Version: FrameVersion, Type: msg.FrameType()}, payload)
+		if sealErr != nil {
+			t.Fatal(sealErr)
+		}
+		peerCounter++
+		s.Handle(frame)
+	}
+	if runErr := <-res; runErr != nil {
+		t.Fatalf("Run: %v", runErr)
+	}
+	if len(states) != 2 || states[0] != TransferPaused || states[1] != TransferRunning {
+		t.Fatalf("states = %v, want [paused running]", states)
+	}
+}
+
+func TestSenderBoundsTimeoutRetries(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		File:       BytesSource([]byte{1, 2, 3, 4}, FileMeta{Name: "f", Size: 4}, 0),
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		AckTimeout: 5 * time.Millisecond,
+		MaxRetries: 1,
+	})
+	res := make(chan error, 1)
+	go func() { _, runErr := s.Run(context.Background()); res <- runErr }()
+	select {
+	case runErr := <-res:
+		if runErr == nil || !strings.Contains(runErr.Error(), string(FailRetryExhausted)) {
+			t.Fatalf("Run error = %v, want retry_exhausted", runErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not stop after bounded retries")
+	}
+	if out.len() != 6 { // manifest + initial data/hash + one retry data/hash + fail
+		t.Fatalf("outbox has %d frames, want 6", out.len())
 	}
 }


### PR DESCRIPTION
## Summary

- advance sender flow control and progress only after verify-and-sink acknowledgements
- retain only the bounded unacknowledged block window for recovery
- reseal NACK and timeout retransmissions under fresh AEAD counters
- cap retries and fail explicitly when acknowledgement recovery is exhausted
- recover authenticated missing and out-of-order block sequences without buffering the file
- add symmetric pause, resume, and cancel APIs to the TypeScript and Go engines
- preserve fail-closed behavior for GCM and block-hash integrity errors

## Verification

- TypeScript missing/reordered, retransmission, pause/resume, progress, and corruption tests
- Go equivalent state-machine tests plus bounded timeout retry coverage
- go test -race ./... in packages/wire
- pnpm run format:check
- just lint
- just typecheck
- just test (110 protocol tests, 39 web tests, all Go modules)
- just build