### PR TITLE
feat(transfer): add live controls and ETA

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ WebRTC connection, and streams the file without loading it all into memory.
   instead of being uploaded to server-side storage.
 - **Streams large files with bounded memory.** Fixed-size blocks, transport backpressure,
   and a bounded in-flight window keep memory use independent of file size.
+- **Reliable and controllable.** Verified block acknowledgements drive progress and recovery;
+  missing blocks are retried, and either peer can pause, resume, or cancel a transfer.
 - **Verifiable completion.** Every block is authenticated and hashed; the final streaming
   SHA-256 digest is compatible with `sha256sum`.
 - **Browser and CLI interoperability.** Send or receive with either client using the same

--- a/apps/cli/cmd/sendarc/main.go
+++ b/apps/cli/cmd/sendarc/main.go
@@ -101,9 +101,11 @@ func runSend(args []string) int {
 			OnCode:    codePrinter(*server),
 			OnPhase:   phasePrinter(rendezvous.RoleOfferer),
 		},
-		Source:     src,
-		OnConnect:  connectPrinter(fmt.Sprintf("Sending %s (%s) …", meta.Name, humanBytes(meta.Size))),
-		OnProgress: progress.report,
+		Source:        src,
+		OnConnect:     connectPrinter(fmt.Sprintf("Sending %s (%s) …", meta.Name, humanBytes(meta.Size))),
+		OnProgress:    progress.report,
+		OnControls:    terminalControls(),
+		OnStateChange: progress.setState,
 	})
 	progress.finish()
 	if err != nil {
@@ -159,7 +161,9 @@ func runReceive(args []string) int {
 			progress.setTotal(file.Size)
 			connectPrinter(fmt.Sprintf("Receiving %s (%s) …", file.Name, humanBytes(file.Size)))()
 		},
-		OnProgress: progress.report,
+		OnProgress:    progress.report,
+		OnControls:    terminalControls(),
+		OnStateChange: progress.setState,
 	})
 	progress.finish()
 	if err != nil {
@@ -229,43 +233,6 @@ func phasePrinter(role rendezvous.Role) func(rendezvous.Phase) {
 // open, just before the bytes begin to move.
 func connectPrinter(line string) func() {
 	return func() { fmt.Fprintln(os.Stderr, line) }
-}
-
-// progress renders a single, rewriting transfer-progress line on stderr. The total may be
-// unknown at first (the receiver learns it from the manifest), in which case only the byte
-// count is shown until setTotal is called.
-type progress struct {
-	total    int64
-	lastPct  int
-	reported bool
-}
-
-func newProgress(total int64) *progress { return &progress{total: total, lastPct: -1} }
-
-func (p *progress) setTotal(total int64) { p.total = total }
-
-// report prints cumulative bytes. It is invoked from the engine goroutine while the main
-// goroutine blocks in transfer.Run, so it needs no locking; it throttles to whole-percent
-// changes to keep the terminal quiet.
-func (p *progress) report(n int64) {
-	p.reported = true
-	if p.total <= 0 {
-		fmt.Fprintf(os.Stderr, "\r  %s", humanBytes(n))
-		return
-	}
-	pct := int(n * 100 / p.total)
-	if pct == p.lastPct {
-		return
-	}
-	p.lastPct = pct
-	fmt.Fprintf(os.Stderr, "\r  %s / %s (%d%%)", humanBytes(n), humanBytes(p.total), pct)
-}
-
-// finish terminates the progress line with a newline if anything was printed on it.
-func (p *progress) finish() {
-	if p.reported {
-		fmt.Fprintln(os.Stderr)
-	}
 }
 
 // handshakeError renders a transfer failure as a human-readable line, translating the

--- a/apps/cli/cmd/sendarc/progress.go
+++ b/apps/cli/cmd/sendarc/progress.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	clitransfer "github.com/sendarc/cli/internal/transfer"
+	"github.com/sendarc/wire"
+)
+
+type progressSample struct {
+	at    time.Time
+	bytes int64
+}
+
+// progress renders acknowledged bytes, a five-second rolling rate, and ETA on stderr.
+type progress struct {
+	mu       sync.Mutex
+	total    int64
+	bytes    int64
+	lastPct  int
+	reported bool
+	paused   bool
+	samples  []progressSample
+	now      func() time.Time
+}
+
+func newProgress(total int64) *progress {
+	return newProgressWithClock(total, time.Now)
+}
+
+func newProgressWithClock(total int64, now func() time.Time) *progress {
+	return &progress{total: total, lastPct: -1, now: now}
+}
+
+func (p *progress) setTotal(total int64) {
+	p.mu.Lock()
+	p.total = total
+	p.mu.Unlock()
+}
+
+func (p *progress) setState(state wire.TransferState) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.paused = state == wire.TransferPaused
+	if state == wire.TransferRunning {
+		p.samples = nil
+	}
+	if state == wire.TransferPaused {
+		p.reported = true
+		fmt.Fprintln(os.Stderr, "\n  Paused — buffered network data may still drain.")
+	}
+}
+
+func (p *progress) report(n int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if n < p.bytes {
+		return
+	}
+	p.bytes = n
+	p.reported = true
+	p.recordSample()
+	if p.total <= 0 {
+		fmt.Fprintf(os.Stderr, "\r  %s", humanBytes(n))
+		return
+	}
+	pct := int(n * 100 / p.total)
+	if pct == p.lastPct {
+		return
+	}
+	p.lastPct = pct
+	rate, eta := p.rateAndETA()
+	detail := "calculating speed"
+	if rate > 0 {
+		detail = fmt.Sprintf("%s · %s", formatRate(rate), formatETA(eta))
+	}
+	fmt.Fprintf(os.Stderr, "\r  %s / %s (%d%%) · %s", humanBytes(n), humanBytes(p.total), pct, detail)
+}
+
+func (p *progress) recordSample() {
+	if p.paused {
+		return
+	}
+	now := p.now()
+	p.samples = append(p.samples, progressSample{at: now, bytes: p.bytes})
+	cutoff := now.Add(-5 * time.Second)
+	for len(p.samples) > 2 && !p.samples[1].at.After(cutoff) {
+		p.samples = p.samples[1:]
+	}
+}
+
+func (p *progress) rateAndETA() (float64, time.Duration) {
+	if len(p.samples) < 2 {
+		return 0, 0
+	}
+	first := p.samples[0]
+	last := p.samples[len(p.samples)-1]
+	elapsed := last.at.Sub(first.at).Seconds()
+	if elapsed <= 0 || last.bytes <= first.bytes {
+		return 0, 0
+	}
+	rate := float64(last.bytes-first.bytes) / elapsed
+	remaining := p.total - p.bytes
+	if remaining < 0 {
+		remaining = 0
+	}
+	return rate, time.Duration(float64(time.Second) * float64(remaining) / rate)
+}
+
+func (p *progress) finish() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.reported {
+		fmt.Fprintln(os.Stderr)
+	}
+}
+
+func formatRate(bytesPerSecond float64) string {
+	switch {
+	case bytesPerSecond >= 1<<20:
+		return fmt.Sprintf("%.1f MiB/s", bytesPerSecond/(1<<20))
+	case bytesPerSecond >= 1<<10:
+		return fmt.Sprintf("%.1f KiB/s", bytesPerSecond/(1<<10))
+	default:
+		return fmt.Sprintf("%.0f B/s", bytesPerSecond)
+	}
+}
+
+func formatETA(eta time.Duration) string {
+	seconds := int64(math.Ceil(eta.Seconds()))
+	if seconds < 60 {
+		return fmt.Sprintf("%ds remaining", seconds)
+	}
+	return fmt.Sprintf("%dm %ds remaining", seconds/60, seconds%60)
+}
+
+// terminalControls enables line-oriented controls only for an interactive stdin. Piped CLI use
+// stays quiet and non-blocking.
+func terminalControls() func(clitransfer.Controls) {
+	return func(controls clitransfer.Controls) {
+		info, err := os.Stdin.Stat()
+		if err != nil || info.Mode()&os.ModeCharDevice == 0 {
+			return
+		}
+		fmt.Fprintln(os.Stderr, "Controls: p + Enter pause · r + Enter resume · c + Enter cancel")
+		go func() {
+			scanner := bufio.NewScanner(os.Stdin)
+			for scanner.Scan() {
+				switch strings.ToLower(strings.TrimSpace(scanner.Text())) {
+				case "p", "pause":
+					if err := controls.Pause(); err != nil {
+						fmt.Fprintf(os.Stderr, "\nPause failed: %v\n", err)
+					}
+				case "r", "resume":
+					if err := controls.Resume(); err != nil {
+						fmt.Fprintf(os.Stderr, "\nResume failed: %v\n", err)
+					}
+				case "c", "cancel":
+					_ = controls.Cancel("canceled from terminal")
+					return
+				}
+			}
+		}()
+	}
+}

--- a/apps/cli/cmd/sendarc/progress_test.go
+++ b/apps/cli/cmd/sendarc/progress_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestProgressRateAndETAStabilizeWithinFiveSeconds(t *testing.T) {
+	now := time.Unix(0, 0)
+	p := newProgressWithClock(10_000, func() time.Time { return now })
+	p.report(0)
+	for second := 1; second <= 5; second++ {
+		now = now.Add(time.Second)
+		p.report(int64(second * 1000))
+	}
+	p.mu.Lock()
+	rate, eta := p.rateAndETA()
+	p.mu.Unlock()
+	if math.Abs(rate-1000) > 0.01 {
+		t.Fatalf("rate = %f, want 1000", rate)
+	}
+	if eta != 5*time.Second {
+		t.Fatalf("eta = %s, want 5s", eta)
+	}
+}
+
+func TestProgressNeverRegresses(t *testing.T) {
+	p := newProgressWithClock(100, time.Now)
+	p.report(50)
+	p.report(40)
+	p.mu.Lock()
+	got := p.bytes
+	p.mu.Unlock()
+	if got != 50 {
+		t.Fatalf("bytes = %d, want monotonic 50", got)
+	}
+}
+
+func TestFormatETARoundsUpWhileWorkRemains(t *testing.T) {
+	if got := formatETA(100 * time.Millisecond); got != "1s remaining" {
+		t.Fatalf("formatETA() = %q, want %q", got, "1s remaining")
+	}
+}

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -26,6 +26,13 @@ type Signal interface {
 	Close()
 }
 
+// Controls is the live transfer surface exposed to terminal frontends.
+type Controls interface {
+	Pause() error
+	Resume() error
+	Cancel(reason string) error
+}
+
 // Spec configures one side of a transfer. Session carries the handshake inputs (role, code,
 // caps, progress callbacks); the driver supplies its Transport. A sending (offerer) spec sets
 // Source; a receiving (joiner) spec sets DestDir.
@@ -42,8 +49,12 @@ type Spec struct {
 	OnConnect func()
 	// OnManifest fires on the receiver when the sender's manifest arrives (file named and sized).
 	OnManifest func(wire.FileEntry)
-	// OnProgress reports cumulative bytes transferred.
+	// OnProgress reports cumulative bytes acknowledged after verify-and-sink.
 	OnProgress func(int64)
+	// OnControls receives the live engine after the channel opens, before bytes begin moving.
+	OnControls func(Controls)
+	// OnStateChange reports pause, resume, and remote cancellation.
+	OnStateChange func(wire.TransferState)
 }
 
 // Outcome is the result of a completed transfer.
@@ -216,8 +227,12 @@ func (d *driver) send(ctx context.Context, conn *rtc.DataConn, res *rendezvous.R
 		BlockSize:        negotiate(res.LocalCaps.BlockSize, res.RemoteCaps.BlockSize, wire.DefaultBlockBytes),
 		FrameSize:        negotiate(res.LocalCaps.MaxFrame, res.RemoteCaps.MaxFrame, wire.DefaultFrameBytes),
 		OnProgress:       d.spec.OnProgress,
+		OnStateChange:    d.spec.OnStateChange,
 	})
 	conn.OnData(sender.Handle)
+	if d.spec.OnControls != nil {
+		d.spec.OnControls(sender)
+	}
 	digest, err := sender.Run(ctx)
 	if err != nil {
 		return nil, err
@@ -237,6 +252,7 @@ func (d *driver) receive(ctx context.Context, conn *rtc.DataConn, res *rendezvou
 		RecvCounterStart: res.RecvCounter,
 		Sink:             deferred,
 		OnProgress:       d.spec.OnProgress,
+		OnStateChange:    d.spec.OnStateChange,
 		OnManifest: func(file wire.FileEntry) error {
 			// Open the destination lazily, named after the (sanitized) manifest file, before the
 			// first block is written — the browser DeferredSink pattern.
@@ -253,6 +269,9 @@ func (d *driver) receive(ctx context.Context, conn *rtc.DataConn, res *rendezvou
 		},
 	})
 	conn.OnData(receiver.Handle)
+	if d.spec.OnControls != nil {
+		d.spec.OnControls(receiver)
+	}
 	result, err := receiver.Wait(ctx)
 	if err != nil {
 		return nil, err

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -18,6 +18,8 @@
     phaseLabel,
     progressLabel,
     progressPercent,
+    rateLabel,
+    etaLabel,
     sasFingerprint,
     type ErrorLike,
   } from './lib/session/present.js';
@@ -44,6 +46,9 @@
   let transfer = $state.raw<TransferController | null>(null);
   let sentBytes = $state(0);
   let totalBytes = $state(0);
+  let rateBps = $state(0);
+  let etaSeconds = $state<number | undefined>(undefined);
+  let transferState = $state<'running' | 'paused' | 'canceled'>('running');
   let outcome = $state<TransferOutcome | null>(null);
   let downloadUrl = $state<string | null>(null);
 
@@ -141,9 +146,16 @@
     transfer = ctrl;
     sentBytes = 0;
     totalBytes = ctrl.total() ?? 0;
+    rateBps = 0;
+    etaSeconds = undefined;
+    transferState = 'running';
     progressTimer = setInterval(() => {
-      sentBytes = ctrl.progress();
-      totalBytes = ctrl.total() ?? totalBytes;
+      const snapshot = ctrl.snapshot();
+      sentBytes = snapshot.bytes;
+      totalBytes = snapshot.total ?? totalBytes;
+      rateBps = snapshot.rateBps;
+      etaSeconds = snapshot.etaSeconds;
+      transferState = snapshot.state;
     }, 100);
     ctrl.done.then(
       (result) => {
@@ -190,6 +202,9 @@
     pickedFile = null;
     sentBytes = 0;
     totalBytes = 0;
+    rateBps = 0;
+    etaSeconds = undefined;
+    transferState = 'running';
     outcome = null;
     phase = 'idle';
     code = '';
@@ -280,6 +295,19 @@
           <div class="bar-fill" style={`width:${progressPercent(sentBytes, totalBytes)}%`}></div>
         </div>
         <p class="status" aria-live="polite">{progressLabel(sentBytes, totalBytes)}</p>
+        <p class="transfer-detail" aria-live="polite">
+          {transferState === 'paused'
+            ? 'Paused'
+            : `${rateLabel(rateBps)} · ${etaLabel(etaSeconds)}`}
+        </p>
+        <div class="transfer-controls">
+          {#if transferState === 'paused'}
+            <button class="ghost" onclick={() => transfer?.resume()}>Resume</button>
+          {:else}
+            <button class="ghost" onclick={() => transfer?.pause()}>Pause</button>
+          {/if}
+          <button class="cancel" onclick={() => transfer?.cancel()}>Cancel transfer</button>
+        </div>
       {:else if role === 'offerer'}
         <label class="filepick">
           <span>Choose a file to send</span>
@@ -423,6 +451,20 @@
   .status {
     color: #555;
     margin: 0;
+  }
+  .transfer-detail {
+    color: #666;
+    font-size: 0.9rem;
+    margin: -0.5rem 0 0;
+  }
+  .transfer-controls {
+    display: flex;
+    gap: 0.5rem;
+  }
+  .cancel {
+    background: #fff5f5;
+    border-color: #ffc9c9;
+    color: #c92a2a;
   }
 
   .result h2 {

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -81,7 +81,16 @@ describe('App transfer completion', () => {
     const transfer = {
       progress: vi.fn(() => 3),
       total: vi.fn(() => 3),
+      snapshot: vi.fn(() => ({
+        bytes: 3,
+        total: 3,
+        rateBps: 1024,
+        etaSeconds: 0,
+        state: 'running',
+      })),
       done: completed.promise,
+      pause: vi.fn(),
+      resume: vi.fn(),
       cancel: vi.fn(),
     };
     mocks.offer.mockReturnValue(rendezvous);
@@ -114,6 +123,13 @@ describe('App transfer completion', () => {
     input!.dispatchEvent(new Event('change', { bubbles: true }));
     await settle();
     expect(mocks.runSend).toHaveBeenCalledOnce();
+
+    const pauseButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Pause',
+    );
+    expect(pauseButton).toBeDefined();
+    pauseButton!.click();
+    expect(transfer.pause).toHaveBeenCalledOnce();
 
     completed.resolve({
       name: 'proof.bin',

--- a/apps/web/src/lib/session/present.test.ts
+++ b/apps/web/src/lib/session/present.test.ts
@@ -6,9 +6,11 @@ import {
   describeError,
   humanBytes,
   inviteLinkFor,
+  etaLabel,
   phaseLabel,
   progressLabel,
   progressPercent,
+  rateLabel,
   sasFingerprint,
 } from './present.js';
 
@@ -118,5 +120,13 @@ describe('progressLabel', () => {
   });
   it('shows 100% at completion', () => {
     expect(progressLabel(4_194_304, 4_194_304)).toBe('4 MiB / 4 MiB (100%)');
+  });
+});
+
+describe('transfer rate and ETA labels', () => {
+  it('formats acknowledged throughput and remaining time', () => {
+    expect(rateLabel(1024)).toBe('1.0 KiB/s');
+    expect(etaLabel(42)).toBe('42s remaining');
+    expect(etaLabel(125)).toBe('2m 5s remaining');
   });
 });

--- a/apps/web/src/lib/session/present.ts
+++ b/apps/web/src/lib/session/present.ts
@@ -86,6 +86,23 @@ export function progressLabel(done: number, total: number): string {
   return `${humanBytes(done)} / ${humanBytes(total)} (${progressPercent(done, total)}%)`;
 }
 
+/** Smoothed acknowledged throughput for the transfer detail line. */
+export function rateLabel(bytesPerSecond: number): string {
+  if (bytesPerSecond <= 0) return 'Calculating speed…';
+  if (bytesPerSecond >= 2 ** 20) return `${(bytesPerSecond / 2 ** 20).toFixed(1)} MiB/s`;
+  if (bytesPerSecond >= 2 ** 10) return `${(bytesPerSecond / 2 ** 10).toFixed(1)} KiB/s`;
+  return `${Math.round(bytesPerSecond)} B/s`;
+}
+
+/** Compact remaining-time label. */
+export function etaLabel(seconds: number | undefined): string {
+  if (seconds === undefined) return 'Estimating time remaining…';
+  if (seconds < 60) return `${seconds}s remaining`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  return `${minutes}m ${rest}s remaining`;
+}
+
 /** Turn a rendezvous failure into a plain-language line, translating the stable codes. */
 export function describeError(e: ErrorLike): string {
   switch (e.code) {
@@ -108,6 +125,7 @@ export function describeError(e: ErrorLike): string {
     case 'rate_limited':
       return 'Too many attempts. Wait a moment and try again.';
     case 'aborted':
+    case 'canceled':
       return 'Cancelled.';
     default:
       return e.message || 'The connection failed.';

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -15,6 +15,7 @@ import type { SignalChannel } from '../signaling/client.js';
 import { SignalAuthenticator } from '../transfer/authed-signaling.js';
 import { createPeer, type Peer } from '../transfer/peer.js';
 import { ChannelWriter } from '../transfer/channel-writer.js';
+import { ProgressTracker, type TransferSnapshot } from '../transfer/progress.js';
 import { readOpfsFile } from '../transfer/sink.js';
 import type { HostToWorker, SessionCrypto, WorkerToHost } from '../transfer/wire.js';
 
@@ -32,8 +33,14 @@ export interface TransferController {
   progress(): number;
   /** The declared total size in bytes, once known (immediately when sending, on manifest when receiving). */
   total(): number | undefined;
+  /** A coherent acknowledged-byte, smoothed-rate, ETA, and run-state snapshot. */
+  snapshot(): TransferSnapshot;
   /** Resolves when the transfer completes and verifies; rejects on any failure. */
   readonly done: Promise<TransferOutcome>;
+  /** Stop producing new data frames; already-buffered transport bytes may drain. */
+  pause(): void;
+  /** Continue a paused transfer. */
+  resume(): void;
   /** Abort the transfer and tear down the worker, peer, and socket. Idempotent. */
   cancel(reason?: string): void;
 }
@@ -78,11 +85,13 @@ function run(
   signaling: SignalChannel,
   spec: RunSpec,
 ): TransferController {
-  let done = 0;
   let total = spec.total;
+  const progress = new ProgressTracker(total);
   let settled = false;
   let peer: Peer | undefined;
   let worker: Worker | undefined;
+  let writer: ChannelWriter | undefined;
+  let cancelTimer: ReturnType<typeof setTimeout> | undefined;
 
   let resolveDone!: (o: TransferOutcome) => void;
   let rejectDone!: (err: Error) => void;
@@ -92,6 +101,7 @@ function run(
   });
 
   const cleanup = (): void => {
+    clearTimeout(cancelTimer);
     worker?.terminate();
     peer?.close();
     signaling.close();
@@ -131,7 +141,7 @@ function run(
       const ready = workerReady(w);
 
       const channel = await p.channel;
-      const writer = new ChannelWriter(channel);
+      writer = new ChannelWriter(channel);
       await ready;
 
       // Worker → host events.
@@ -139,19 +149,30 @@ function run(
         const msg = ev.data as WorkerToHost;
         switch (msg.kind) {
           case 'outbound-frame':
-            writer.write(msg.frame);
+            writer?.write(msg.frame);
             return;
           case 'progress':
-            done = msg.bytes;
+            progress.update(msg.bytes);
             return;
           case 'manifest':
             total = msg.size;
+            progress.setTotal(msg.size);
+            return;
+          case 'state':
+            progress.setState(msg.state);
             return;
           case 'done':
             void completeReceive(msg.name, msg.size, msg.digest);
             return;
           case 'error':
-            fail(new Error(msg.message));
+            if (msg.reason === 'canceled') {
+              void (async () => {
+                await writer?.drain();
+                fail(new Error(msg.message));
+              })();
+            } else {
+              fail(new Error(msg.message));
+            }
             return;
           case 'ready':
             return;
@@ -185,12 +206,29 @@ function run(
   }
 
   return {
-    progress: () => done,
+    progress: () => progress.snapshot().bytes,
     total: () => total,
+    snapshot: () => progress.snapshot(),
     done: donePromise,
+    pause: () => {
+      if (settled || progress.snapshot().state === 'paused') return;
+      progress.setState('paused');
+      worker?.postMessage({ kind: 'control', op: 'pause' } satisfies HostToWorker);
+    },
+    resume: () => {
+      if (settled || progress.snapshot().state !== 'paused') return;
+      progress.setState('running');
+      worker?.postMessage({ kind: 'control', op: 'resume' } satisfies HostToWorker);
+    },
     cancel: (reason = 'cancelled') => {
-      worker?.postMessage({ kind: 'cancel', reason } satisfies HostToWorker);
-      fail(new Error(reason));
+      if (settled) return;
+      progress.setState('canceled');
+      if (!worker) {
+        fail(new Error(reason));
+        return;
+      }
+      worker.postMessage({ kind: 'control', op: 'cancel' } satisfies HostToWorker);
+      cancelTimer = setTimeout(() => fail(new Error(reason)), 1000);
     },
   };
 }

--- a/apps/web/src/lib/transfer/channel-writer.test.ts
+++ b/apps/web/src/lib/transfer/channel-writer.test.ts
@@ -59,4 +59,14 @@ describe('ChannelWriter', () => {
     new ChannelWriter(ch);
     expect(ch.bufferedAmountLowThreshold).toBe(1 * 1024 * 1024);
   });
+
+  it('waits for buffered bytes to drain before graceful teardown', async () => {
+    const ch = new FakeChannel();
+    const writer = new ChannelWriter(ch);
+    writer.write(new ArrayBuffer(100));
+    setTimeout(() => ch.drainTo(0), 5);
+    await writer.drain(100);
+    expect(ch.bufferedAmount).toBe(0);
+    expect(writer.pending).toBe(0);
+  });
 });

--- a/apps/web/src/lib/transfer/channel-writer.ts
+++ b/apps/web/src/lib/transfer/channel-writer.ts
@@ -35,6 +35,15 @@ export class ChannelWriter {
     }
   }
 
+  /** Wait briefly for queued and SCTP-buffered bytes to drain before graceful teardown. */
+  async drain(timeoutMs = 500): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while ((this.queue.length > 0 || this.channel.bufferedAmount > 0) && Date.now() < deadline) {
+      this.flush();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
   private flush(): void {
     while (this.queue.length > 0 && this.channel.bufferedAmount < BUFFERED_AMOUNT_HIGH) {
       const next = this.queue.shift()!;

--- a/apps/web/src/lib/transfer/progress.test.ts
+++ b/apps/web/src/lib/transfer/progress.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { ProgressTracker } from './progress.js';
+
+describe('ProgressTracker', () => {
+  it('is monotonic and reports acknowledged throughput and ETA over five seconds', () => {
+    let now = 0;
+    const tracker = new ProgressTracker(10_000, () => now);
+    expect(tracker.update(0).rateBps).toBe(0);
+
+    let snapshot = tracker.snapshot();
+    for (let second = 1; second <= 5; second++) {
+      now = second * 1000;
+      snapshot = tracker.update(second * 1000);
+    }
+    expect(snapshot.bytes).toBe(5000);
+    expect(snapshot.rateBps).toBe(1000);
+    expect(snapshot.etaSeconds).toBe(5);
+
+    now = 6000;
+    expect(tracker.update(4000).bytes).toBe(5000); // stale callback cannot regress progress
+  });
+
+  it('excludes paused time and rebuilds the rate after resume', () => {
+    let now = 0;
+    const tracker = new ProgressTracker(4000, () => now);
+    tracker.update(0);
+    now = 1000;
+    expect(tracker.update(1000).rateBps).toBe(1000);
+
+    tracker.setState('paused');
+    now = 11_000;
+    tracker.setState('running');
+    expect(tracker.snapshot().rateBps).toBe(0);
+    tracker.update(1000);
+    now = 12_000;
+    const resumed = tracker.update(2000);
+    expect(resumed.rateBps).toBe(1000);
+    expect(resumed.etaSeconds).toBe(2);
+  });
+});

--- a/apps/web/src/lib/transfer/progress.ts
+++ b/apps/web/src/lib/transfer/progress.ts
@@ -1,0 +1,79 @@
+import type { TransferRunState } from '@sendarc/protocol';
+
+export interface TransferSnapshot {
+  bytes: number;
+  total: number | undefined;
+  rateBps: number;
+  etaSeconds: number | undefined;
+  state: TransferRunState;
+}
+
+interface Sample {
+  at: number;
+  bytes: number;
+}
+
+/**
+ * Rolling acknowledged-byte progress. A five-second sample window smooths bursty block ACKs,
+ * while pause/resume resets the clock so idle time never depresses throughput or inflates ETA.
+ */
+export class ProgressTracker {
+  private bytes = 0;
+  private totalBytes: number | undefined;
+  private rateBps = 0;
+  private state: TransferRunState = 'running';
+  private readonly samples: Sample[] = [];
+
+  constructor(
+    total?: number,
+    private readonly now: () => number = () => performance.now(),
+    private readonly windowMs = 5000,
+  ) {
+    this.totalBytes = total;
+  }
+
+  setTotal(total: number): void {
+    this.totalBytes = total;
+  }
+
+  update(acknowledgedBytes: number): TransferSnapshot {
+    this.bytes = Math.max(this.bytes, acknowledgedBytes);
+    if (this.state !== 'running') return this.snapshot();
+
+    const sample = { at: this.now(), bytes: this.bytes };
+    this.samples.push(sample);
+    const cutoff = sample.at - this.windowMs;
+    while (this.samples.length > 2 && this.samples[1]!.at <= cutoff) this.samples.shift();
+
+    const first = this.samples[0]!;
+    const elapsedMs = sample.at - first.at;
+    const advanced = sample.bytes - first.bytes;
+    this.rateBps = elapsedMs > 0 && advanced > 0 ? (advanced * 1000) / elapsedMs : 0;
+    return this.snapshot();
+  }
+
+  setState(state: TransferRunState): TransferSnapshot {
+    if (this.state === state) return this.snapshot();
+    this.state = state;
+    if (state === 'running') {
+      this.samples.length = 0;
+      this.rateBps = 0;
+    }
+    return this.snapshot();
+  }
+
+  snapshot(): TransferSnapshot {
+    const remaining = Math.max(0, (this.totalBytes ?? 0) - this.bytes);
+    const etaSeconds =
+      this.totalBytes !== undefined && this.rateBps > 0
+        ? Math.ceil(remaining / this.rateBps)
+        : undefined;
+    return {
+      bytes: this.bytes,
+      total: this.totalBytes,
+      rateBps: this.rateBps,
+      etaSeconds,
+      state: this.state,
+    };
+  }
+}

--- a/apps/web/src/lib/transfer/transfer-core.test.ts
+++ b/apps/web/src/lib/transfer/transfer-core.test.ts
@@ -24,6 +24,14 @@ class FakePort implements DuplexPort<HostToWorker, WorkerToHost> {
   }
 }
 
+async function waitFor(check: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error('timed out waiting for worker state');
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
 describe('transfer-core loopback', () => {
   it('completes a transfer through the worker message protocol', async () => {
     const keys = await deriveTransferKeys(new Uint8Array(32).fill(7));
@@ -37,10 +45,12 @@ describe('transfer-core loopback', () => {
     let senderDone: (WorkerToHost & { kind: 'done' }) | undefined;
     let receiverDone: (WorkerToHost & { kind: 'done' }) | undefined;
     let manifest: (WorkerToHost & { kind: 'manifest' }) | undefined;
+    const senderStates: string[] = [];
 
     sendPort.onWorkerOut = (m) => {
       if (m.kind === 'outbound-frame') recvPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
       else if (m.kind === 'done') senderDone = m;
+      else if (m.kind === 'state') senderStates.push(m.state);
     };
     recvPort.onWorkerOut = (m) => {
       if (m.kind === 'outbound-frame') sendPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
@@ -73,6 +83,9 @@ describe('transfer-core loopback', () => {
       sendCounter: 1,
       recvCounter: 1,
     });
+    // Controls may arrive while WebRTC is still negotiating, before the engine is bound. The
+    // worker retains this pause and applies it before the first data block.
+    sendPort.toWorker({ kind: 'control', op: 'pause' });
     sendPort.toWorker({
       kind: 'start-send',
       file,
@@ -83,6 +96,11 @@ describe('transfer-core loopback', () => {
       blockSize: 64 * 1024,
       frameSize: 16 * 1024,
     });
+
+    await waitFor(() => senderStates.includes('paused'));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(senderDone).toBeUndefined();
+    sendPort.toWorker({ kind: 'control', op: 'resume' });
 
     await Promise.all([recvP, sendP]);
 
@@ -95,6 +113,7 @@ describe('transfer-core loopback', () => {
     expect(receiverDone?.size).toBe(bytes.length);
     expect(manifest?.name).toBe('loop.bin');
     expect(manifest?.size).toBe(bytes.length);
+    expect(senderStates).toEqual(['running', 'paused', 'running']);
   });
 
   it('surfaces an integrity failure when a data frame is corrupted in flight', async () => {

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -33,19 +33,39 @@ type Port = DuplexPort<HostToWorker, WorkerToHost>;
 /** Drive one transfer to completion over `port`. Resolves on `done`, rejects on any failure. */
 export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    let engine: { handle(frame: Uint8Array): void } | undefined;
+    let engine:
+      | {
+          handle(frame: Uint8Array): void;
+          pause(): void;
+          resume(): void;
+          cancel(reason?: string): void;
+        }
+      | undefined;
     let started = false;
     const pending: Uint8Array[] = [];
+    const pendingControls: Array<'pause' | 'resume' | 'cancel'> = [];
 
     const post = (msg: WorkerToHost): void => port.postMessage(msg);
     const send = (frame: Uint8Array): void => {
       const buf = transferable(frame);
       port.postMessage({ kind: 'outbound-frame', frame: buf }, [buf]);
     };
-    const bind = (e: { handle(frame: Uint8Array): void }): void => {
+    const bind = (e: {
+      handle(frame: Uint8Array): void;
+      pause(): void;
+      resume(): void;
+      cancel(reason?: string): void;
+    }): void => {
       engine = e;
+      post({ kind: 'state', state: 'running' });
       for (const f of pending) e.handle(f);
       pending.length = 0;
+      for (const op of pendingControls) {
+        if (op === 'pause') e.pause();
+        else if (op === 'resume') e.resume();
+        else e.cancel();
+      }
+      pendingControls.length = 0;
     };
     const fail = (e: unknown): void => {
       const reason = e instanceof TransferError ? e.reason : 'integrity';
@@ -76,7 +96,15 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           return;
         }
         case 'cancel':
-          fail(new TransferError('canceled', msg.reason ?? 'canceled'));
+          if (engine) engine.cancel(msg.reason);
+          else pendingControls.push('cancel');
+          return;
+        case 'control':
+          if (!engine) {
+            pendingControls.push(msg.op);
+          } else if (msg.op === 'pause') engine.pause();
+          else if (msg.op === 'resume') engine.resume();
+          else engine.cancel();
           return;
       }
     });
@@ -93,6 +121,7 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           recvCounterStart: msg.recvCounter,
           createDigest: deps.createDigest,
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
+          onStateChange: (state) => post({ kind: 'state', state }),
           ...(msg.blockSize !== undefined ? { blockSize: msg.blockSize } : {}),
           ...(msg.frameSize !== undefined ? { frameSize: msg.frameSize } : {}),
           ...(msg.window !== undefined ? { window: msg.window } : {}),
@@ -118,6 +147,7 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           createDigest: deps.createDigest,
           sink: deferred,
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
+          onStateChange: (state) => post({ kind: 'state', state }),
           onManifest: async (file) => {
             deferred.attach(await deps.createSink(file));
             post({ kind: 'manifest', name: file.name, size: file.size, mime: file.mime });

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -5,7 +5,7 @@
  * this protocol are exercised end-to-end by the Node loopback test, so the shapes are the contract.
  */
 
-import type { DirectionalKey } from '@sendarc/protocol';
+import type { ControlOp, DirectionalKey, TransferRunState } from '@sendarc/protocol';
 
 /** Session crypto state handed to the worker at start — counters continue, never reset. */
 export interface SessionCrypto {
@@ -33,7 +33,12 @@ export interface CancelMsg {
   kind: 'cancel';
   reason?: string;
 }
-export type HostToWorker = StartSendMsg | StartRecvMsg | InboundFrameMsg | CancelMsg;
+export interface TransferControlMsg {
+  kind: 'control';
+  op: ControlOp;
+}
+export type HostToWorker =
+  StartSendMsg | StartRecvMsg | InboundFrameMsg | TransferControlMsg | CancelMsg;
 
 export interface OutboundFrameMsg {
   kind: 'outbound-frame';
@@ -53,6 +58,10 @@ export interface ProgressMsg {
   kind: 'progress';
   bytes: number;
 }
+export interface StateMsg {
+  kind: 'state';
+  state: TransferRunState;
+}
 export interface DoneMsg {
   kind: 'done';
   name: string;
@@ -65,7 +74,7 @@ export interface ErrorMsg {
   message: string;
 }
 export type WorkerToHost =
-  ReadyMsg | OutboundFrameMsg | ManifestMsg | ProgressMsg | DoneMsg | ErrorMsg;
+  ReadyMsg | OutboundFrameMsg | ManifestMsg | ProgressMsg | StateMsg | DoneMsg | ErrorMsg;
 
 /** The slice of Worker / DedicatedWorkerGlobalScope the core needs, so a test can inject a fake. */
 export interface DuplexPort<In, Out> {

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 )
 
 // Receiver verifies and commits blocks before acknowledging them. A valid block that arrives
@@ -82,7 +83,7 @@ func (r *Receiver) Wait(ctx context.Context) (ReceiveResult, error) {
 	select {
 	case <-r.done:
 	case <-ctx.Done():
-		r.abortWith(NewTransferError(FailCanceled, ctx.Err().Error()), true)
+		r.cancelFromContext(ctx.Err())
 		<-r.done
 	}
 	r.mu.Lock()
@@ -390,6 +391,19 @@ func (r *Receiver) abortWith(err *TransferError, notifyPeer bool) {
 	}
 	_ = r.o.Sink.Abort(string(err.Reason))
 	close(r.done)
+}
+
+func (r *Receiver) cancelFromContext(cause error) {
+	sent := make(chan struct{})
+	go func() {
+		_ = r.sendControl(NewControl(ControlCancel))
+		close(sent)
+	}()
+	select {
+	case <-sent:
+	case <-time.After(250 * time.Millisecond):
+	}
+	r.abortWith(NewTransferError(FailCanceled, cause.Error()), false)
 }
 
 func (r *Receiver) settle(result ReceiveResult) {

--- a/packages/wire/transfer_receiver_test.go
+++ b/packages/wire/transfer_receiver_test.go
@@ -335,6 +335,37 @@ func TestReceiverRequestsMissingAndRecoversReorderedBlocks(t *testing.T) {
 	}
 }
 
+func TestReceiverContextCancellationNotifiesPeer(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back outbox
+	sink := &MemorySink{}
+	r := NewReceiver(ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = r.Wait(ctx)
+	if err == nil || !strings.Contains(err.Error(), string(FailCanceled)) {
+		t.Fatalf("Wait error = %v, want canceled", err)
+	}
+	frames := back.snapshot()
+	if len(frames) != 1 {
+		t.Fatalf("back-channel has %d frames, want cancel control", len(frames))
+	}
+	opened, openErr := Open(keys.J2O, 0, frames[0])
+	if openErr != nil {
+		t.Fatal(openErr)
+	}
+	msg, decodeErr := DecodeControl(opened.Plaintext)
+	control, ok := msg.(*Control)
+	if decodeErr != nil || !ok || control.Op != ControlCancel {
+		t.Fatalf("cancellation frame = %#v, err=%v", msg, decodeErr)
+	}
+}
+
 func idxOf(xs []string, want string) int {
 	for i, x := range xs {
 		if x == want {

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -120,7 +120,7 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 	go func() {
 		select {
 		case <-ctx.Done():
-			s.cancelLocal(ctx.Err())
+			s.cancelFromContext(ctx.Err())
 		case <-stop:
 		}
 	}()
@@ -515,6 +515,19 @@ func (s *Sender) fail(err error) {
 
 func (s *Sender) cancelLocal(cause error) {
 	s.fail(NewTransferError(FailCanceled, cause.Error()))
+}
+
+func (s *Sender) cancelFromContext(cause error) {
+	sent := make(chan struct{})
+	go func() {
+		_ = s.sendControl(NewControl(ControlCancel))
+		close(sent)
+	}()
+	select {
+	case <-sent:
+	case <-time.After(250 * time.Millisecond):
+	}
+	s.cancelLocal(cause)
 }
 
 func (s *Sender) clearTimersLocked() {

--- a/packages/wire/transfer_sender_test.go
+++ b/packages/wire/transfer_sender_test.go
@@ -376,3 +376,39 @@ func TestSenderBoundsTimeoutRetries(t *testing.T) {
 		t.Fatalf("outbox has %d frames, want 6", out.len())
 	}
 }
+
+func TestSenderContextCancellationNotifiesPeer(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		File: BytesSource([]byte{1, 2, 3, 4}, FileMeta{Name: "f", Size: 4}, 0),
+		Send: out.push, SendDir: keys.O2J, RecvDir: keys.J2O,
+		BlockSize: 8, FrameSize: 4, AckTimeout: time.Second,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	res := make(chan error, 1)
+	go func() { _, runErr := s.Run(ctx); res <- runErr }()
+	waitStable(t, &out, 3)
+	cancel()
+	select {
+	case runErr := <-res:
+		if runErr == nil || !strings.Contains(runErr.Error(), string(FailCanceled)) {
+			t.Fatalf("Run error = %v, want canceled", runErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not stop after context cancellation")
+	}
+	frames := out.snapshot()
+	opened, openErr := Open(keys.O2J, uint64(len(frames)-1), frames[len(frames)-1])
+	if openErr != nil {
+		t.Fatal(openErr)
+	}
+	msg, decodeErr := DecodeControl(opened.Plaintext)
+	control, ok := msg.(*Control)
+	if decodeErr != nil || !ok || control.Op != ControlCancel {
+		t.Fatalf("last cancellation frame = %#v, err=%v", msg, decodeErr)
+	}
+}


### PR DESCRIPTION
## Summary

- expose pause, resume, and cancel controls in the browser and terminal clients
- report monotonic verify-and-sink progress with a rolling transfer rate and ETA
- propagate cancellation to the remote peer before bounded local teardown
- document reliable, controllable transfers as a current product capability

## Verification

- `pnpm run format:check`
- `just lint`
- `just typecheck`
- `just test`
- `just build`
- `go test -race ./packages/wire ./apps/cli/...`
- real 12 MiB CLI-to-CLI transfer with matching SHA-256 and byte comparison
- real 128 MiB CLI-to-CLI pause/resume transfer with matching SHA-256 and byte comparison