### PR TITLE
feat(protocol): validate safe transfer paths

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -21,3 +21,4 @@ export * from './transfer-chunker.js';
 export * from './transfer-messages.js';
 export * from './transfer-sender.js';
 export * from './transfer-receiver.js';
+export * from './safe-path.js';

--- a/packages/protocol/src/safe-path.test.ts
+++ b/packages/protocol/src/safe-path.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { FrameType, type Manifest } from './transfer.js';
+import { normalizeTransferPath, validateManifest } from './safe-path.js';
+
+describe('normalizeTransferPath', () => {
+  it('normalizes portable nested paths', () => {
+    expect(normalizeTransferPath('photos\\2026\\arc.jpg')).toBe('photos/2026/arc.jpg');
+    expect(normalizeTransferPath('résumé/猫.txt')).toBe('résumé/猫.txt');
+  });
+
+  it.each([
+    '',
+    '/etc/passwd',
+    '\\server\\share',
+    'C:\\secret.txt',
+    '../secret',
+    'safe/../../secret',
+    './file',
+    'folder//file',
+    'folder/',
+    'nul',
+    'COM1.txt',
+    'folder/aux.json',
+    'trailing. ',
+    'bad\0name',
+    'bad:name',
+  ])('rejects unsafe path %j', (path) => {
+    expect(() => normalizeTransferPath(path)).toThrow();
+  });
+
+  it('caps depth and encoded component length', () => {
+    expect(() => normalizeTransferPath(Array.from({ length: 33 }, () => 'a').join('/'))).toThrow();
+    expect(() => normalizeTransferPath('é'.repeat(128))).toThrow();
+  });
+});
+
+describe('validateManifest', () => {
+  const entry = (idx: number, name: string, size = 9) => ({
+    idx,
+    name,
+    size,
+    mime: 'application/octet-stream',
+    lastModified: 0,
+    blockSize: 8,
+    blocks: Math.ceil(size / 8),
+    fileDigest: '00',
+  });
+  const manifest = (files: ReturnType<typeof entry>[], totalSize: number): Manifest => ({
+    type: FrameType.Manifest,
+    files,
+    totalSize,
+  });
+
+  it('canonicalizes paths and accepts exact aggregate geometry', () => {
+    expect(validateManifest(manifest([entry(0, 'a\\b.bin', 9), entry(1, 'empty', 0)], 9))).toEqual(
+      manifest([entry(0, 'a/b.bin', 9), entry(1, 'empty', 0)], 9),
+    );
+  });
+
+  it.each([
+    manifest([], 0),
+    manifest([entry(1, 'a')], 9),
+    manifest([entry(0, 'a'), entry(1, 'A')], 18),
+    manifest([entry(0, '../a')], 9),
+    manifest([{ ...entry(0, 'a'), blocks: 99 }], 9),
+    manifest([entry(0, 'a')], 8),
+  ])('rejects an unsafe manifest', (value) => {
+    expect(() => validateManifest(value)).toThrow();
+  });
+});

--- a/packages/protocol/src/safe-path.ts
+++ b/packages/protocol/src/safe-path.ts
@@ -1,0 +1,79 @@
+import { FrameType, type FileEntry, type Manifest } from './transfer.js';
+
+export const MAX_TRANSFER_FILES = 4096;
+export const MAX_TRANSFER_PATH_BYTES = 1024;
+export const MAX_TRANSFER_PATH_DEPTH = 32;
+export const MAX_TRANSFER_SEGMENT_BYTES = 255;
+
+const utf8 = new TextEncoder();
+const windowsReserved = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
+const unsafeWindowsChars = /[<>:"|?*]/;
+
+/** Canonicalize an untrusted manifest path or throw before any destination is opened. */
+export function normalizeTransferPath(input: string): string {
+  if (input.length === 0) throw new Error('manifest path is empty');
+  if (input.startsWith('/') || input.startsWith('\\') || /^[A-Za-z]:/.test(input)) {
+    throw new Error('manifest path must be relative');
+  }
+  const canonical = input.replaceAll('\\', '/');
+  const segments = canonical.split('/');
+  if (segments.length > MAX_TRANSFER_PATH_DEPTH) throw new Error('manifest path is too deep');
+  for (const segment of segments) {
+    if (segment.length === 0 || segment === '.' || segment === '..') {
+      throw new Error('manifest path contains an unsafe segment');
+    }
+    for (const character of segment) {
+      if ((character.codePointAt(0) ?? 0) <= 0x1f || unsafeWindowsChars.test(character)) {
+        throw new Error('manifest path contains unsafe characters');
+      }
+    }
+    if (segment.endsWith('.') || segment.endsWith(' ')) {
+      throw new Error('manifest path has an unsafe suffix');
+    }
+    if (windowsReserved.test(segment)) throw new Error('manifest path uses a reserved name');
+    if (utf8.encode(segment).length > MAX_TRANSFER_SEGMENT_BYTES) {
+      throw new Error('manifest path segment is too long');
+    }
+  }
+  if (utf8.encode(canonical).length > MAX_TRANSFER_PATH_BYTES) {
+    throw new Error('manifest path is too long');
+  }
+  return canonical;
+}
+
+/** Validate manifest-wide geometry and return a copy with canonical relative paths. */
+export function validateManifest(manifest: Manifest): Manifest {
+  if (manifest.files.length === 0 || manifest.files.length > MAX_TRANSFER_FILES) {
+    throw new Error('manifest has an invalid file count');
+  }
+  const paths = new Set<string>();
+  let totalSize = 0;
+  const files: FileEntry[] = manifest.files.map((file, idx) => {
+    if (file.idx !== idx) throw new Error('manifest file indexes must be contiguous');
+    for (const [label, value] of [
+      ['size', file.size],
+      ['lastModified', file.lastModified],
+      ['blockSize', file.blockSize],
+      ['blocks', file.blocks],
+    ] as const) {
+      if (!Number.isSafeInteger(value)) throw new Error(`manifest ${label} is not a safe integer`);
+    }
+    if (file.size < 0 || file.lastModified < 0 || file.blockSize <= 0) {
+      throw new Error('manifest has invalid file geometry');
+    }
+    if (file.blocks !== Math.ceil(file.size / file.blockSize)) {
+      throw new Error('manifest has invalid block geometry');
+    }
+    const name = normalizeTransferPath(file.name);
+    const key = name.toLowerCase();
+    if (paths.has(key)) throw new Error('manifest contains duplicate paths');
+    paths.add(key);
+    totalSize += file.size;
+    if (!Number.isSafeInteger(totalSize)) throw new Error('manifest total size is too large');
+    return { ...file, name };
+  });
+  if (!Number.isSafeInteger(manifest.totalSize) || manifest.totalSize !== totalSize) {
+    throw new Error('manifest total size mismatch');
+  }
+  return { type: FrameType.Manifest, files, totalSize };
+}

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -16,6 +16,7 @@ import { bytesToHex } from './bytes.js';
 import { TransferError, type Digest, type Sink } from './transfer-ports.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
 import type { TransferRunState } from './transfer-sender.js';
+import { validateManifest } from './safe-path.js';
 
 export interface ReceiveResult {
   file: FileEntry;
@@ -154,17 +155,15 @@ export class TransferReceiver {
     if (this.file) throw new TransferError('integrity', 'duplicate manifest');
     const msg = decodeControl(payload);
     if (msg.type !== FrameType.Manifest) throw new TransferError('integrity', 'expected manifest');
-    const file = msg.files[0];
-    if (!file || msg.files.length !== 1) {
-      throw new TransferError('integrity', 'single-file manifest required');
+    let manifest;
+    try {
+      manifest = validateManifest(msg);
+    } catch (e) {
+      throw new TransferError('integrity', e instanceof Error ? e.message : String(e));
     }
-    if (
-      file.idx !== 0 ||
-      file.size < 0 ||
-      file.blockSize <= 0 ||
-      file.blocks !== Math.ceil(file.size / file.blockSize)
-    ) {
-      throw new TransferError('integrity', 'invalid manifest geometry');
+    const file = manifest.files[0];
+    if (!file || manifest.files.length !== 1) {
+      throw new TransferError('integrity', 'single-file manifest required');
     }
     this.file = file;
     try {

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -21,6 +21,7 @@ import { bytesToHex } from './bytes.js';
 import { TransferError, type Digest, type FileSource } from './transfer-ports.js';
 import { reChunk } from './transfer-chunker.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
+import { validateManifest } from './safe-path.js';
 
 /** Header flag: this frame is the last of its block. */
 export const FRAME_FLAG_LAST_IN_BLOCK = 0x01;
@@ -156,7 +157,7 @@ export class TransferSender {
     const fileDigest = await digest.hexDigest();
 
     const blocks = Math.ceil(meta.size / this.blockSize);
-    await this.sendControl(FrameType.Manifest, {
+    const manifest = validateManifest({
       type: FrameType.Manifest,
       files: [
         {
@@ -172,6 +173,7 @@ export class TransferSender {
       ],
       totalSize: meta.size,
     });
+    await this.sendControl(FrameType.Manifest, manifest);
 
     // Asking reChunk for block-sized pieces yields one retained buffer per logical block. The
     // block is then split into transport-sized frames by sendBlock.

--- a/packages/wire/safe_path.go
+++ b/packages/wire/safe_path.go
@@ -1,0 +1,113 @@
+package wire
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// MaxTransferFiles caps manifest allocation and stays well below the u16 file index limit.
+	MaxTransferFiles = 4096
+	// MaxTransferPathBytes is the maximum UTF-8 encoded canonical relative path.
+	MaxTransferPathBytes = 1024
+	// MaxTransferPathDepth caps nested folder components.
+	MaxTransferPathDepth = 32
+	// MaxTransferSegmentBytes matches the common filesystem component limit.
+	MaxTransferSegmentBytes = 255
+)
+
+var (
+	drivePath       = regexp.MustCompile(`^[A-Za-z]:`)
+	windowsReserved = regexp.MustCompile(`(?i)^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)`)
+)
+
+// NormalizeTransferPath canonicalizes an untrusted manifest path without touching disk.
+func NormalizeTransferPath(input string) (string, error) {
+	if input == "" {
+		return "", errors.New("manifest path is empty")
+	}
+	if strings.HasPrefix(input, "/") || strings.HasPrefix(input, `\`) || drivePath.MatchString(input) {
+		return "", errors.New("manifest path must be relative")
+	}
+	canonical := strings.ReplaceAll(input, `\`, "/")
+	segments := strings.Split(canonical, "/")
+	if len(segments) > MaxTransferPathDepth {
+		return "", errors.New("manifest path is too deep")
+	}
+	for _, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			return "", errors.New("manifest path contains an unsafe segment")
+		}
+		for _, r := range segment {
+			if r <= 0x1f || strings.ContainsRune(`<>:"|?*`, r) {
+				return "", errors.New("manifest path contains unsafe characters")
+			}
+		}
+		if strings.HasSuffix(segment, ".") || strings.HasSuffix(segment, " ") {
+			return "", errors.New("manifest path has an unsafe suffix")
+		}
+		if windowsReserved.MatchString(segment) {
+			return "", errors.New("manifest path uses a reserved name")
+		}
+		if len(segment) > MaxTransferSegmentBytes {
+			return "", errors.New("manifest path segment is too long")
+		}
+	}
+	if len(canonical) > MaxTransferPathBytes {
+		return "", errors.New("manifest path is too long")
+	}
+	if !utf8.ValidString(canonical) {
+		return "", errors.New("manifest path is not valid UTF-8")
+	}
+	return canonical, nil
+}
+
+// ValidateManifest checks aggregate geometry and returns a copy with canonical relative paths.
+func ValidateManifest(manifest Manifest) (Manifest, error) {
+	if len(manifest.Files) == 0 || len(manifest.Files) > MaxTransferFiles {
+		return Manifest{}, errors.New("manifest has an invalid file count")
+	}
+	files := make([]FileEntry, len(manifest.Files))
+	paths := make(map[string]struct{}, len(manifest.Files))
+	var total int64
+	for idx, file := range manifest.Files {
+		if file.Idx != idx {
+			return Manifest{}, errors.New("manifest file indexes must be contiguous")
+		}
+		if file.Size < 0 || file.LastModified < 0 || file.BlockSize <= 0 || file.Blocks < 0 {
+			return Manifest{}, errors.New("manifest has invalid file geometry")
+		}
+		wantBlocks := 0
+		if file.Size > 0 {
+			wantBlocks = int((file.Size-1)/int64(file.BlockSize) + 1)
+		}
+		if file.Blocks != wantBlocks {
+			return Manifest{}, errors.New("manifest has invalid block geometry")
+		}
+		name, err := NormalizeTransferPath(file.Name)
+		if err != nil {
+			return Manifest{}, err
+		}
+		key := strings.ToLower(name)
+		if _, exists := paths[key]; exists {
+			return Manifest{}, errors.New("manifest contains duplicate paths")
+		}
+		paths[key] = struct{}{}
+		if file.Size > math.MaxInt64-total {
+			return Manifest{}, errors.New("manifest total size is too large")
+		}
+		total += file.Size
+		file.Name = name
+		files[idx] = file
+	}
+	if manifest.TotalSize != total {
+		return Manifest{}, fmt.Errorf("manifest total size mismatch: got %d, want %d", manifest.TotalSize, total)
+	}
+	manifest.Files = files
+	manifest.Type = FrameManifest
+	return manifest, nil
+}

--- a/packages/wire/safe_path_test.go
+++ b/packages/wire/safe_path_test.go
@@ -1,0 +1,70 @@
+package wire
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeTransferPath(t *testing.T) {
+	got, err := NormalizeTransferPath(`photos\2026\arc.jpg`)
+	if err != nil || got != "photos/2026/arc.jpg" {
+		t.Fatalf("NormalizeTransferPath = %q, %v", got, err)
+	}
+	bad := []string{
+		"", "/etc/passwd", `\server\share`, `C:\secret.txt`, "../secret", "safe/../../secret",
+		"./file", "folder//file", "folder/", "nul", "COM1.txt", "folder/aux.json",
+		"trailing. ", "bad\x00name", "bad:name", strings.Repeat("é", 128),
+		strings.Repeat("a/", MaxTransferPathDepth) + "a",
+	}
+	for _, path := range bad {
+		if normalized, err := NormalizeTransferPath(path); err == nil {
+			t.Errorf("NormalizeTransferPath(%q) = %q, want error", path, normalized)
+		}
+	}
+}
+
+func TestValidateManifest(t *testing.T) {
+	entry := func(idx int, name string, size int64) FileEntry {
+		blocks := int((size + 7) / 8)
+		return FileEntry{Idx: idx, Name: name, Size: size, BlockSize: 8, Blocks: blocks}
+	}
+	valid, err := ValidateManifest(*NewManifest([]FileEntry{
+		entry(0, `a\b.bin`, 9), entry(1, "empty", 0),
+	}, 9))
+	if err != nil || valid.Files[0].Name != "a/b.bin" {
+		t.Fatalf("ValidateManifest = %#v, %v", valid, err)
+	}
+	bad := []Manifest{
+		*NewManifest(nil, 0),
+		*NewManifest([]FileEntry{entry(1, "a", 9)}, 9),
+		*NewManifest([]FileEntry{entry(0, "a", 9), entry(1, "A", 9)}, 18),
+		*NewManifest([]FileEntry{entry(0, "../a", 9)}, 9),
+		*NewManifest([]FileEntry{func() FileEntry { f := entry(0, "a", 9); f.Blocks = 99; return f }()}, 9),
+		*NewManifest([]FileEntry{entry(0, "a", 9)}, 8),
+	}
+	for i, manifest := range bad {
+		if _, err := ValidateManifest(manifest); err == nil {
+			t.Errorf("bad manifest %d accepted", i)
+		}
+	}
+}
+
+func FuzzNormalizeTransferPath(f *testing.F) {
+	for _, seed := range []string{"safe/file.txt", "../escape", `C:\escape`, "nul", "猫/写真.jpg"} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		path, err := NormalizeTransferPath(input)
+		if err != nil {
+			return
+		}
+		if path == "" || strings.Contains(path, `\`) || strings.HasPrefix(path, "/") {
+			t.Fatalf("unsafe normalized path %q from %q", path, input)
+		}
+		for _, part := range strings.Split(path, "/") {
+			if part == "" || part == "." || part == ".." {
+				t.Fatalf("unsafe segment in %q from %q", path, input)
+			}
+		}
+	})
+}

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -176,17 +176,14 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	if !ok {
 		return NewTransferError(FailIntegrity, "expected manifest")
 	}
-	if len(m.Files) != 1 {
+	validated, err := ValidateManifest(*m)
+	if err != nil {
+		return NewTransferError(FailIntegrity, err.Error())
+	}
+	if len(validated.Files) != 1 {
 		return NewTransferError(FailIntegrity, "single-file manifest required")
 	}
-	f := m.Files[0]
-	wantBlocks := 0
-	if f.Size > 0 && f.BlockSize > 0 {
-		wantBlocks = int((f.Size + int64(f.BlockSize) - 1) / int64(f.BlockSize))
-	}
-	if f.Idx != 0 || f.Size < 0 || f.BlockSize <= 0 || f.Blocks != wantBlocks {
-		return NewTransferError(FailIntegrity, "invalid manifest geometry")
-	}
+	f := validated.Files[0]
 	r.file = &f
 	if r.o.OnManifest != nil {
 		if err := r.o.OnManifest(f); err != nil {

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -138,13 +138,18 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 
 	blocks := 0
 	if meta.Size > 0 {
-		blocks = int((meta.Size + int64(s.blockSize) - 1) / int64(s.blockSize))
+		blocks = int((meta.Size-1)/int64(s.blockSize) + 1)
 	}
-	if err := s.sendControl(NewManifest([]FileEntry{{
+	manifest, err := ValidateManifest(*NewManifest([]FileEntry{{
 		Idx: 0, Name: meta.Name, Size: meta.Size, Mime: meta.Mime,
 		LastModified: meta.LastModified, BlockSize: s.blockSize, Blocks: blocks,
 		FileDigest: fileDigest,
-	}}, meta.Size)); err != nil {
+	}}, meta.Size))
+	if err != nil {
+		s.fail(err)
+		return "", err
+	}
+	if err := s.sendControl(&manifest); err != nil {
 		s.fail(err)
 		return "", err
 	}


### PR DESCRIPTION
## Summary

- canonicalize portable relative manifest paths in TypeScript and Go
- reject traversal, absolute and drive paths, reserved names, unsafe suffixes and characters
- validate manifest indexes, block geometry, aggregate size, path uniqueness, depth and length before opening a sink
- apply identical validation on both send and receive paths with table and fuzz coverage

## Verification

- `pnpm run format:check`
- `just lint`
- `just typecheck`
- `just test`
- `just build`
- `go test -race ./packages/wire`