### PR TITLE
feat(transfer): support files and folders

### DIFF
--- a/apps/cli/cmd/sendarc/main.go
+++ b/apps/cli/cmd/sendarc/main.go
@@ -54,7 +54,7 @@ func usage(w *os.File) {
 	_, _ = fmt.Fprint(w, `sendarc — secure peer-to-peer file transfer
 
 Usage:
-  sendarc send <file> [flags]
+  sendarc send <file-or-folder>... [flags]
   sendarc receive <code|link> [flags]
 
 Flags:
@@ -76,12 +76,20 @@ func runSend(args []string) int {
 		fmt.Fprintln(os.Stderr, "sendarc send: a file to send is required")
 		return 2
 	}
-	src, err := transfer.NewOSFileSource(positionals[0])
+	sources, totalSize, err := transfer.NewOSFileSources(positionals)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "sendarc send: %s\n", err)
 		return 1
 	}
-	meta := src.Meta()
+	progressFiles := make([]progressFile, len(sources))
+	for i, source := range sources {
+		meta := source.Meta()
+		progressFiles[i] = progressFile{name: meta.Name, size: meta.Size}
+	}
+	label := progressFiles[0].name
+	if len(progressFiles) > 1 {
+		label = fmt.Sprintf("%d files", len(progressFiles))
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -93,7 +101,8 @@ func runSend(args []string) int {
 	}
 	defer client.Close()
 
-	progress := newProgress(meta.Size)
+	progress := newProgress(totalSize)
+	progress.setFiles(progressFiles)
 	out, err := transfer.Run(ctx, client, transfer.Spec{
 		Session: rendezvous.Options{
 			Role:      rendezvous.RoleOfferer,
@@ -101,20 +110,28 @@ func runSend(args []string) int {
 			OnCode:    codePrinter(*server),
 			OnPhase:   phasePrinter(rendezvous.RoleOfferer),
 		},
-		Source:        src,
-		OnConnect:     connectPrinter(fmt.Sprintf("Sending %s (%s) …", meta.Name, humanBytes(meta.Size))),
-		OnProgress:    progress.report,
-		OnControls:    terminalControls(),
-		OnStateChange: progress.setState,
+		Sources:        sources,
+		OnConnect:      connectPrinter(fmt.Sprintf("Sending %s (%s) …", label, humanBytes(totalSize))),
+		OnFileProgress: progress.reportFile,
+		OnControls:     terminalControls(),
+		OnStateChange:  progress.setState,
 	})
 	progress.finish()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nFailed: %s\n", handshakeError(err))
 		return 1
 	}
-	fmt.Printf("\n✓ Sent %s (%s).\n", out.Name, humanBytes(out.Size))
+	if len(out.Files) == 1 {
+		fmt.Printf("\n✓ Sent %s (%s).\n", out.Name, humanBytes(out.Size))
+	} else {
+		fmt.Printf("\n✓ Sent %d files (%s).\n", len(out.Files), humanBytes(out.Size))
+	}
 	fmt.Printf("  Fingerprint:  %s\n", fingerprint(out.Handshake.Master))
-	fmt.Printf("  SHA-256:      %s\n", out.Digest)
+	if len(out.Files) == 1 {
+		fmt.Printf("  SHA-256:      %s\n", out.Digest)
+	} else {
+		fmt.Printf("  File-set SHA-256: %s\n", out.Digest)
+	}
 	return 0
 }
 
@@ -157,22 +174,39 @@ func runReceive(args []string) int {
 			OnPhase: phasePrinter(rendezvous.RoleJoiner),
 		},
 		DestDir: *outDir,
-		OnManifest: func(file wire.FileEntry) {
-			progress.setTotal(file.Size)
-			connectPrinter(fmt.Sprintf("Receiving %s (%s) …", file.Name, humanBytes(file.Size)))()
+		OnManifestSet: func(manifest wire.Manifest) {
+			progress.setTotal(manifest.TotalSize)
+			files := make([]progressFile, len(manifest.Files))
+			for i, file := range manifest.Files {
+				files[i] = progressFile{name: file.Name, size: file.Size}
+			}
+			progress.setFiles(files)
+			label := files[0].name
+			if len(files) > 1 {
+				label = fmt.Sprintf("%d files", len(files))
+			}
+			connectPrinter(fmt.Sprintf("Receiving %s (%s) …", label, humanBytes(manifest.TotalSize)))()
 		},
-		OnProgress:    progress.report,
-		OnControls:    terminalControls(),
-		OnStateChange: progress.setState,
+		OnFileProgress: progress.reportFile,
+		OnControls:     terminalControls(),
+		OnStateChange:  progress.setState,
 	})
 	progress.finish()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nFailed: %s\n", handshakeError(err))
 		return 1
 	}
-	fmt.Printf("\n✓ Received %s (%s) → %s\n", out.Name, humanBytes(out.Size), out.Path)
+	if len(out.Files) == 1 {
+		fmt.Printf("\n✓ Received %s (%s) → %s\n", out.Name, humanBytes(out.Size), out.Path)
+	} else {
+		fmt.Printf("\n✓ Received %d files (%s) → %s\n", len(out.Files), humanBytes(out.Size), *outDir)
+	}
 	fmt.Printf("  Fingerprint:  %s\n", fingerprint(out.Handshake.Master))
-	fmt.Printf("  SHA-256:      %s\n", out.Digest)
+	if len(out.Files) == 1 {
+		fmt.Printf("  SHA-256:      %s\n", out.Digest)
+	} else {
+		fmt.Printf("  File-set SHA-256: %s\n", out.Digest)
+	}
 	return 0
 }
 

--- a/apps/cli/cmd/sendarc/progress.go
+++ b/apps/cli/cmd/sendarc/progress.go
@@ -18,16 +18,24 @@ type progressSample struct {
 	bytes int64
 }
 
+type progressFile struct {
+	name string
+	size int64
+}
+
 // progress renders acknowledged bytes, a five-second rolling rate, and ETA on stderr.
 type progress struct {
-	mu       sync.Mutex
-	total    int64
-	bytes    int64
-	lastPct  int
-	reported bool
-	paused   bool
-	samples  []progressSample
-	now      func() time.Time
+	mu        sync.Mutex
+	total     int64
+	bytes     int64
+	lastPct   int
+	reported  bool
+	paused    bool
+	samples   []progressSample
+	now       func() time.Time
+	files     []progressFile
+	fileIdx   int
+	fileBytes int64
 }
 
 func newProgress(total int64) *progress {
@@ -35,12 +43,26 @@ func newProgress(total int64) *progress {
 }
 
 func newProgressWithClock(total int64, now func() time.Time) *progress {
-	return &progress{total: total, lastPct: -1, now: now}
+	return &progress{total: total, lastPct: -1, fileIdx: -1, now: now}
 }
 
 func (p *progress) setTotal(total int64) {
 	p.mu.Lock()
 	p.total = total
+	p.mu.Unlock()
+}
+
+func (p *progress) setFiles(files []progressFile) {
+	p.mu.Lock()
+	p.files = append([]progressFile(nil), files...)
+	p.mu.Unlock()
+}
+
+func (p *progress) reportFile(fileIdx int, fileBytes, acknowledgedBytes int64) {
+	p.mu.Lock()
+	p.fileIdx = fileIdx
+	p.fileBytes = fileBytes
+	p.reportLocked(acknowledgedBytes)
 	p.mu.Unlock()
 }
 
@@ -60,6 +82,10 @@ func (p *progress) setState(state wire.TransferState) {
 func (p *progress) report(n int64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.reportLocked(n)
+}
+
+func (p *progress) reportLocked(n int64) {
 	if n < p.bytes {
 		return
 	}
@@ -79,6 +105,10 @@ func (p *progress) report(n int64) {
 	detail := "calculating speed"
 	if rate > 0 {
 		detail = fmt.Sprintf("%s · %s", formatRate(rate), formatETA(eta))
+	}
+	if p.fileIdx >= 0 && p.fileIdx < len(p.files) {
+		file := p.files[p.fileIdx]
+		detail = fmt.Sprintf("%s: %s / %s · %s", file.name, humanBytes(p.fileBytes), humanBytes(file.size), detail)
 	}
 	fmt.Fprintf(os.Stderr, "\r  %s / %s (%d%%) · %s", humanBytes(n), humanBytes(p.total), pct, detail)
 }

--- a/apps/cli/internal/rendezvous/caps.go
+++ b/apps/cli/internal/rendezvous/caps.go
@@ -30,8 +30,8 @@ func DefaultCaps() Caps {
 		Version:   wire.ProtocolVersion,
 		MaxFrame:  defaultFrameBytes,
 		BlockSize: defaultBlockBytes,
-		Features:  []string{},
-		SinkHints: []string{},
+		Features:  []string{"folders"},
+		SinkHints: []string{"direct-file"},
 	}
 }
 

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/pion/webrtc/v4"
@@ -40,6 +41,8 @@ type Spec struct {
 	Session rendezvous.Options
 	// Source is the file to send; required for an offerer, ignored for a joiner.
 	Source wire.FileSource
+	// Sources is an ordered multi-file/folder set. Set either Source or Sources.
+	Sources []wire.FileSource
 	// DestDir is the directory the received file is written into; used by a joiner.
 	DestDir string
 	// ICEServers overrides rtc.DefaultICEServers. An explicit empty slice uses host candidates
@@ -49,8 +52,11 @@ type Spec struct {
 	OnConnect func()
 	// OnManifest fires on the receiver when the sender's manifest arrives (file named and sized).
 	OnManifest func(wire.FileEntry)
+	// OnManifestSet fires once with the complete validated file set.
+	OnManifestSet func(wire.Manifest)
 	// OnProgress reports cumulative bytes acknowledged after verify-and-sink.
-	OnProgress func(int64)
+	OnProgress     func(int64)
+	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
 	// OnControls receives the live engine after the channel opens, before bytes begin moving.
 	OnControls func(Controls)
 	// OnStateChange reports pause, resume, and remote cancellation.
@@ -64,6 +70,15 @@ type Outcome struct {
 	Size      int64
 	Digest    string // whole-file SHA-256 (hex); identical on both peers
 	Path      string // receiver: the written file; empty for a sender
+	Files     []FileOutcome
+}
+
+// FileOutcome is one source or received destination within an Outcome.
+type FileOutcome struct {
+	Name   string
+	Size   int64
+	Digest string
+	Path   string
 }
 
 // Run performs the handshake over sig and then the file transfer, returning when the transfer
@@ -214,11 +229,24 @@ func (d *driver) transfer(ctx context.Context, conn *rtc.DataConn, res *rendezvo
 }
 
 func (d *driver) send(ctx context.Context, conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
-	if d.spec.Source == nil {
-		return nil, errors.New("transfer: a file source is required to send")
+	if (d.spec.Source == nil) == (len(d.spec.Sources) == 0) {
+		return nil, errors.New("transfer: exactly one of Source or Sources is required to send")
+	}
+	sources := d.spec.Sources
+	if len(sources) == 0 {
+		sources = []wire.FileSource{d.spec.Source}
+	}
+	needsFolders := len(sources) > 1
+	for _, source := range sources {
+		if strings.Contains(source.Meta().Name, "/") {
+			needsFolders = true
+		}
+	}
+	if needsFolders && !containsString(res.RemoteCaps.Features, "folders") {
+		return nil, errors.New("transfer: receiver does not support files or folders as a set")
 	}
 	sender := wire.NewSender(wire.SenderOptions{
-		File:             d.spec.Source,
+		Files:            sources,
 		Send:             conn.Send,
 		SendDir:          sendDir,
 		RecvDir:          recvDir,
@@ -227,6 +255,7 @@ func (d *driver) send(ctx context.Context, conn *rtc.DataConn, res *rendezvous.R
 		BlockSize:        negotiate(res.LocalCaps.BlockSize, res.RemoteCaps.BlockSize, wire.DefaultBlockBytes),
 		FrameSize:        negotiate(res.LocalCaps.MaxFrame, res.RemoteCaps.MaxFrame, wire.DefaultFrameBytes),
 		OnProgress:       d.spec.OnProgress,
+		OnFileProgress:   d.spec.OnFileProgress,
 		OnStateChange:    d.spec.OnStateChange,
 	})
 	conn.OnData(sender.Handle)
@@ -237,31 +266,47 @@ func (d *driver) send(ctx context.Context, conn *rtc.DataConn, res *rendezvous.R
 	if err != nil {
 		return nil, err
 	}
-	meta := d.spec.Source.Meta()
-	return &Outcome{Name: meta.Name, Size: meta.Size, Digest: digest}, nil
+	files := make([]FileOutcome, len(sources))
+	var total int64
+	for i, source := range sources {
+		meta := source.Meta()
+		files[i] = FileOutcome{Name: meta.Name, Size: meta.Size}
+		total += meta.Size
+	}
+	return &Outcome{Name: files[0].Name, Size: total, Digest: digest, Files: files}, nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *driver) receive(ctx context.Context, conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
-	deferred := &deferredSink{}
-	var sinkPath string
+	destination, err := NewOSDestination(d.spec.DestDir)
+	if err != nil {
+		return nil, wire.NewTransferError(wire.FailSinkError, err.Error())
+	}
 	receiver := wire.NewReceiver(wire.ReceiverOptions{
 		Send:             conn.Send,
 		SendDir:          sendDir,
 		RecvDir:          recvDir,
 		SendCounterStart: res.SendCounter,
 		RecvCounterStart: res.RecvCounter,
-		Sink:             deferred,
+		Destination:      destination,
 		OnProgress:       d.spec.OnProgress,
+		OnFileProgress:   d.spec.OnFileProgress,
 		OnStateChange:    d.spec.OnStateChange,
-		OnManifest: func(file wire.FileEntry) error {
-			// Open the destination lazily, named after the (sanitized) manifest file, before the
-			// first block is written — the browser DeferredSink pattern.
-			sink, err := NewOSFileSink(d.spec.DestDir, file.Name)
-			if err != nil {
-				return wire.NewTransferError(wire.FailSinkError, err.Error())
+		OnManifestSet: func(manifest wire.Manifest) error {
+			if d.spec.OnManifestSet != nil {
+				d.spec.OnManifestSet(manifest)
 			}
-			deferred.attach(sink)
-			sinkPath = sink.Path()
+			return nil
+		},
+		OnManifest: func(file wire.FileEntry) error {
 			if d.spec.OnManifest != nil {
 				d.spec.OnManifest(file)
 			}
@@ -276,7 +321,14 @@ func (d *driver) receive(ctx context.Context, conn *rtc.DataConn, res *rendezvou
 	if err != nil {
 		return nil, err
 	}
-	return &Outcome{Name: result.File.Name, Size: result.File.Size, Digest: result.Digest, Path: sinkPath}, nil
+	files := make([]FileOutcome, len(result.Files))
+	for i, file := range result.Files {
+		files[i] = FileOutcome{Name: file.Name, Size: file.Size, Digest: result.Digests[i], Path: destination.Path(file.Idx)}
+	}
+	return &Outcome{
+		Name: result.File.Name, Size: result.TotalSize, Digest: result.Digest,
+		Path: destination.Path(result.File.Idx), Files: files,
+	}, nil
 }
 
 // directionalKeys selects the seal/open keys for this peer's role, mirroring the session's

--- a/apps/cli/internal/transfer/ports_test.go
+++ b/apps/cli/internal/transfer/ports_test.go
@@ -214,3 +214,137 @@ func TestDeferredSinkDelegatesAfterAttach(t *testing.T) {
 		t.Errorf("delegated file = %q, want data", got)
 	}
 }
+
+func TestNewOSFileSourcesExpandsFolderDeterministically(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "album")
+	if err := os.MkdirAll(filepath.Join(root, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{"z.txt": "z", "nested/a.txt": "alpha", "empty": ""} {
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(name)), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sources, total, err := NewOSFileSources([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNames := []string{"album/empty", "album/nested/a.txt", "album/z.txt"}
+	if len(sources) != len(wantNames) || total != 6 {
+		t.Fatalf("sources=%d total=%d", len(sources), total)
+	}
+	for i, source := range sources {
+		if source.Meta().Name != wantNames[i] {
+			t.Errorf("source %d name=%q want=%q", i, source.Meta().Name, wantNames[i])
+		}
+	}
+}
+
+func TestNewOSFileSourcesRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, _, err := NewOSFileSources([]string{link}); err == nil {
+		t.Fatal("symlink source accepted")
+	}
+}
+
+func destinationManifest(names ...string) wire.Manifest {
+	files := make([]wire.FileEntry, len(names))
+	for i, name := range names {
+		files[i] = wire.FileEntry{Idx: i, Name: name, Size: 1, BlockSize: 1, Blocks: 1}
+	}
+	return *wire.NewManifest(files, int64(len(files)))
+}
+
+func TestOSDestinationWritesNestedTreeWithoutOverwrite(t *testing.T) {
+	root := t.TempDir()
+	destination, err := NewOSDestination(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := destinationManifest("folder/a.txt", "b.txt")
+	if err := destination.Prepare(manifest); err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range manifest.Files {
+		sink, openErr := destination.Open(file)
+		if openErr != nil {
+			t.Fatal(openErr)
+		}
+		if err := sink.Write(0, []byte{byte('a' + file.Idx)}); err != nil {
+			t.Fatal(err)
+		}
+		if err := sink.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := destination.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "folder", "a.txt")); err != nil || string(got) != "a" {
+		t.Fatalf("nested file=%q err=%v", got, err)
+	}
+
+	existing := filepath.Join(root, "existing.txt")
+	if err := os.WriteFile(existing, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewOSDestination(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := destinationManifest("existing.txt").Files[0]
+	if _, err := second.Open(file); err == nil {
+		t.Fatal("existing destination was overwritten")
+	}
+	got, _ := os.ReadFile(existing)
+	if string(got) != "keep" {
+		t.Fatalf("existing content changed to %q", got)
+	}
+}
+
+func TestOSDestinationAbortRemovesCompletedTreeAndRejectsSymlinkComponent(t *testing.T) {
+	root := t.TempDir()
+	destination, err := NewOSDestination(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := destinationManifest("folder/a.txt").Files[0]
+	sink, err := destination.Open(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Write(0, []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.Abort("later file failed"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "folder", "a.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("completed partial output survived abort: %v", err)
+	}
+
+	outside := t.TempDir()
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	third, err := NewOSDestination(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := third.Open(destinationManifest("linked/escape.txt").Files[0]); err == nil {
+		t.Fatal("symlink destination component accepted")
+	}
+}

--- a/apps/cli/internal/transfer/sink.go
+++ b/apps/cli/internal/transfer/sink.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,125 @@ func NewOSFileSink(dir, name string) (*OSFileSink, error) {
 		return nil, err
 	}
 	return &OSFileSink{path: path, f: f}, nil
+}
+
+// OSDestination owns a safe relative file tree for one transfer and removes the complete tree of
+// files it created if any later file fails. Existing files are never overwritten.
+type OSDestination struct {
+	mu     sync.Mutex
+	root   string
+	sinks  []*OSFileSink
+	files  []string
+	dirs   []string
+	paths  map[int]string
+	closed bool
+}
+
+// NewOSDestination prepares a filesystem-rooted multi-file destination.
+func NewOSDestination(root string) (*OSDestination, error) {
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, err
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, err
+	}
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		return nil, err
+	}
+	return &OSDestination{root: abs, paths: make(map[int]string)}, nil
+}
+
+// Prepare validates the already-canonical manifest before any output is created.
+func (d *OSDestination) Prepare(manifest wire.Manifest) error {
+	_, err := wire.ValidateManifest(manifest)
+	return err
+}
+
+// Open creates one manifest path without following symlinked child directories.
+func (d *OSDestination) Open(file wire.FileEntry) (wire.Sink, error) {
+	name, err := wire.NormalizeTransferPath(file.Name)
+	if err != nil {
+		return nil, err
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil, errSinkClosed
+	}
+	parts := strings.Split(name, "/")
+	parent := d.root
+	for _, part := range parts[:len(parts)-1] {
+		parent = filepath.Join(parent, part)
+		info, statErr := os.Lstat(parent)
+		if errors.Is(statErr, os.ErrNotExist) {
+			if err := os.Mkdir(parent, 0o755); err != nil {
+				return nil, err
+			}
+			d.dirs = append(d.dirs, parent)
+			continue
+		}
+		if statErr != nil {
+			return nil, statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return nil, fmt.Errorf("transfer: destination component is not a safe directory: %s", parent)
+		}
+	}
+	path := filepath.Join(parent, parts[len(parts)-1])
+	rel, err := filepath.Rel(d.root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, errors.New("transfer: destination path escaped its root")
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	sink := &OSFileSink{path: path, f: f}
+	d.sinks = append(d.sinks, sink)
+	d.files = append(d.files, path)
+	d.paths[file.Idx] = path
+	return sink, nil
+}
+
+// Close commits the destination. Individual files have already been flushed and closed.
+func (d *OSDestination) Close() error {
+	d.mu.Lock()
+	d.closed = true
+	d.mu.Unlock()
+	return nil
+}
+
+// Abort closes active files and removes every file and empty directory created by this transfer.
+func (d *OSDestination) Abort(reason string) error {
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil
+	}
+	d.closed = true
+	sinks := append([]*OSFileSink(nil), d.sinks...)
+	files := append([]string(nil), d.files...)
+	dirs := append([]string(nil), d.dirs...)
+	d.mu.Unlock()
+	for _, sink := range sinks {
+		_ = sink.Abort(reason)
+	}
+	for _, path := range files {
+		_ = os.Remove(path)
+	}
+	for i := len(dirs) - 1; i >= 0; i-- {
+		_ = os.Remove(dirs[i])
+	}
+	return nil
+}
+
+// Path returns the output path assigned to one manifest index.
+func (d *OSDestination) Path(fileIdx int) string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.paths[fileIdx]
 }
 
 // Path is the destination path the sink writes to.

--- a/apps/cli/internal/transfer/source.go
+++ b/apps/cli/internal/transfer/source.go
@@ -1,11 +1,14 @@
 package transfer
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/sendarc/wire"
 )
@@ -27,6 +30,10 @@ type OSFileSource struct {
 // NewOSFileSource stats path and prepares a repeatable streaming source. It errors if the path
 // is missing or is a directory.
 func NewOSFileSource(path string) (*OSFileSource, error) {
+	return newOSFileSource(path, filepath.Base(path))
+}
+
+func newOSFileSource(path, transferName string) (*OSFileSource, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -41,12 +48,87 @@ func NewOSFileSource(path string) (*OSFileSource, error) {
 	return &OSFileSource{
 		path: path,
 		meta: wire.FileMeta{
-			Name:         filepath.Base(path),
+			Name:         filepath.ToSlash(transferName),
 			Size:         info.Size(),
 			Mime:         mimeType,
 			LastModified: info.ModTime().UnixMilli(),
 		},
 	}, nil
+}
+
+// NewOSFileSources expands regular files and folders into a deterministic ordered transfer set.
+// Folder entries retain the selected folder's base name as their safe relative-path prefix.
+func NewOSFileSources(paths []string) ([]wire.FileSource, int64, error) {
+	if len(paths) == 0 {
+		return nil, 0, errors.New("transfer: at least one file or folder is required")
+	}
+	type candidate struct{ path, name string }
+	var candidates []candidate
+	for _, input := range paths {
+		info, err := os.Lstat(input)
+		if err != nil {
+			return nil, 0, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, 0, fmt.Errorf("transfer: symbolic links are not supported: %s", input)
+		}
+		if !info.IsDir() {
+			if !info.Mode().IsRegular() {
+				return nil, 0, fmt.Errorf("transfer: %s is not a regular file", input)
+			}
+			candidates = append(candidates, candidate{input, filepath.Base(input)})
+			continue
+		}
+		root := filepath.Clean(input)
+		prefix := filepath.Base(root)
+		err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if path == root {
+				return nil
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				return fmt.Errorf("transfer: symbolic links are not supported: %s", path)
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			if !entry.Type().IsRegular() {
+				return fmt.Errorf("transfer: %s is not a regular file", path)
+			}
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				return relErr
+			}
+			candidates = append(candidates, candidate{path, filepath.Join(prefix, rel)})
+			return nil
+		})
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, 0, errors.New("transfer: selected folders contain no regular files")
+	}
+	sort.SliceStable(candidates, func(i, j int) bool { return candidates[i].name < candidates[j].name })
+	sources := make([]wire.FileSource, len(candidates))
+	var total int64
+	for i, candidate := range candidates {
+		source, err := newOSFileSource(candidate.path, candidate.name)
+		if err != nil {
+			return nil, 0, err
+		}
+		if _, err := wire.NormalizeTransferPath(source.meta.Name); err != nil {
+			return nil, 0, fmt.Errorf("transfer: unsafe source path %q: %w", source.meta.Name, err)
+		}
+		if source.meta.Size > math.MaxInt64-total {
+			return nil, 0, errors.New("transfer: total size overflow")
+		}
+		total += source.meta.Size
+		sources[i] = source
+	}
+	return sources, total, nil
 }
 
 // Meta returns the file's manifest metadata, captured at construction.

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -22,3 +22,4 @@ export * from './transfer-messages.js';
 export * from './transfer-sender.js';
 export * from './transfer-receiver.js';
 export * from './safe-path.js';
+export * from './transfer-set.js';

--- a/packages/protocol/src/transfer-loopback.test.ts
+++ b/packages/protocol/src/transfer-loopback.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { createHash } from 'node:crypto';
 import { deriveTransferKeys } from './keyschedule.js';
-import { bytesSource, MemorySink, type Digest } from './transfer-ports.js';
+import { bytesSource, MemorySink, type Destination, type Digest } from './transfer-ports.js';
+import type { FileEntry, Manifest } from './transfer.js';
 import { TransferSender } from './transfer-sender.js';
 import { TransferReceiver } from './transfer-receiver.js';
 
@@ -97,5 +98,73 @@ describe('transfer loopback (no browser)', () => {
     });
     expect(result.some((r) => r.status === 'rejected')).toBe(true);
     expect(sink.isClosed).toBe(false);
+  });
+
+  it('streams a nested multi-file set with empty files and aggregate progress', async () => {
+    const keys = await deriveTransferKeys(master);
+    const contents = [
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array(),
+      new Uint8Array(3000).map((_, i) => i & 0xff),
+    ];
+    const names = ['folder/a.bin', 'folder/empty.txt', 'b.bin'];
+    const sinks = new Map<string, MemorySink>();
+    let prepared: Manifest | undefined;
+    let committed = false;
+    const destination: Destination = {
+      prepare(manifest) {
+        prepared = manifest;
+      },
+      open(file: FileEntry) {
+        const sink = new MemorySink();
+        sinks.set(file.name, sink);
+        return sink;
+      },
+      close() {
+        committed = true;
+      },
+      abort(reason) {
+        for (const sink of sinks.values()) sink.abort(reason);
+      },
+    };
+    const box: { receiver?: TransferReceiver } = {};
+    const progress: number[] = [];
+    const sender = new TransferSender({
+      files: contents.map((bytes, idx) =>
+        bytesSource(bytes, { name: names[idx]!, size: bytes.length, mime: '', lastModified: 1 }),
+      ),
+      send: (frame) => queueMicrotask(() => box.receiver!.handle(frame)),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 1024,
+      frameSize: 256,
+      window: 2,
+      onProgress: (bytes) => progress.push(bytes),
+    });
+    const receiver = new TransferReceiver({
+      send: (frame) => queueMicrotask(() => sender.handle(frame)),
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      destination,
+    });
+    box.receiver = receiver;
+
+    const [sendDigest, received] = await Promise.all([sender.run(), receiver.done]);
+    expect(prepared?.files.map((file) => file.name)).toEqual(names);
+    expect(received.files.map((file) => file.name)).toEqual(names);
+    expect(received.digest).toBe(sendDigest);
+    expect(received.digests).toEqual(
+      contents.map((bytes) => createHash('sha256').update(bytes).digest('hex')),
+    );
+    for (const [idx, name] of names.entries())
+      expect(sinks.get(name)?.bytes()).toEqual(contents[idx]);
+    expect(progress.at(-1)).toBe(contents.reduce((total, bytes) => total + bytes.length, 0));
+    expect(committed).toBe(true);
   });
 });

--- a/packages/protocol/src/transfer-ports.ts
+++ b/packages/protocol/src/transfer-ports.ts
@@ -5,7 +5,7 @@
  * in the host; this module defines the contracts plus in-memory helpers for tests.
  */
 
-import type { Fail } from './transfer.js';
+import type { Fail, FileEntry, Manifest } from './transfer.js';
 
 /** Minimal file metadata carried in the manifest. */
 export interface FileMeta {
@@ -29,6 +29,37 @@ export interface Sink {
   write(offset: number, bytes: Uint8Array): void | Promise<void>;
   close(): void | Promise<void>;
   abort(reason?: string): void | Promise<void>;
+}
+
+/** A complete transfer destination that owns one streaming sink per manifest file. */
+export interface Destination {
+  /** Validate capacity and prepare the destination before the first file is opened. */
+  prepare(manifest: Manifest): void | Promise<void>;
+  /** Open one canonical manifest path. Files are opened in ascending index order. */
+  open(file: FileEntry): Sink | Promise<Sink>;
+  /** Commit destination-wide metadata after every file has independently verified. */
+  close(): void | Promise<void>;
+  /** Discard all partial output, including files already completed in this transfer. */
+  abort(reason?: string): void | Promise<void>;
+}
+
+/** Adapt the original one-file sink contract to the destination API. */
+export function singleSinkDestination(sink: Sink): Destination {
+  let opened = false;
+  return {
+    prepare(manifest): void {
+      if (manifest.files.length !== 1) throw new Error('single sink cannot receive multiple files');
+    },
+    open(): Sink {
+      if (opened) throw new Error('single sink opened more than once');
+      opened = true;
+      return sink;
+    },
+    close(): void {},
+    abort(reason?: string): void | Promise<void> {
+      return sink.abort(reason);
+    },
+  };
 }
 
 /** A streaming whole-file hasher producing a `sha256sum`-identical hex string. */

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -9,16 +9,27 @@
 
 import { open, seal, type FrameHeaderInput } from './aead.js';
 import type { DirectionalKey } from './keyschedule.js';
-import { FrameType, type ControlOp, type FileEntry } from './transfer.js';
+import { FrameType, type ControlOp, type FileEntry, type Manifest } from './transfer.js';
 import { DEFAULT_INFLIGHT_BLOCKS, FRAME_VERSION } from './constants.js';
 import { sha256 } from './webcrypto.js';
 import { bytesToHex } from './bytes.js';
-import { TransferError, type Digest, type Sink } from './transfer-ports.js';
+import {
+  TransferError,
+  singleSinkDestination,
+  type Destination,
+  type Digest,
+  type Sink,
+} from './transfer-ports.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
 import type { TransferRunState } from './transfer-sender.js';
 import { validateManifest } from './safe-path.js';
+import { completionDigest } from './transfer-set.js';
 
 export interface ReceiveResult {
+  files: FileEntry[];
+  digests: string[];
+  totalSize: number;
+  /** Compatibility aliases for the first file and transfer completion digest. */
   file: FileEntry;
   digest: string;
 }
@@ -30,23 +41,35 @@ export interface TransferReceiverOptions {
   sendCounterStart: number;
   recvCounterStart: number;
   createDigest(): Digest;
-  sink: Sink;
+  /** One-file compatibility destination. Exactly one of sink/destination is required. */
+  sink?: Sink;
+  destination?: Destination;
   /** Reports bytes only after verify-and-sink. */
   onProgress?(acknowledgedBytes: number): void;
+  onFileProgress?(fileIdx: number, fileBytes: number, acknowledgedBytes: number): void;
   onStateChange?(state: TransferRunState): void;
-  /** Called once after the manifest is validated and before the first sink write. */
+  /** Called once with the validated complete file set before any destination opens. */
+  onManifestSet?(manifest: Manifest): void | Promise<void>;
+  /** Called for each file immediately before its sink opens. */
   onManifest?(file: FileEntry): void | Promise<void>;
 }
 
 export class TransferReceiver {
   private readonly o: TransferReceiverOptions;
-  private readonly digest: Digest;
+  private readonly destination: Destination;
 
   private sendCounter: number;
   private recvCounter: number;
+  private manifest: Manifest | undefined;
+  private fileIdx = 0;
   private file: FileEntry | undefined;
+  private sink: Sink | undefined;
+  private digest: Digest | undefined;
+  private readonly digests: string[] = [];
+  private acknowledged = 0;
   private nextBlock = 0;
   private assemblingBlock = -1;
+  private assemblingFileIdx = -1;
   private blockBuf: Uint8Array | undefined;
   private blockReceived = 0;
   private readonly seenAhead = new Set<number>();
@@ -62,7 +85,10 @@ export class TransferReceiver {
 
   constructor(opts: TransferReceiverOptions) {
     this.o = opts;
-    this.digest = opts.createDigest();
+    if ((opts.sink === undefined) === (opts.destination === undefined)) {
+      throw new Error('exactly one of sink or destination is required');
+    }
+    this.destination = opts.destination ?? singleSinkDestination(opts.sink!);
     this.sendCounter = opts.sendCounterStart;
     this.recvCounter = opts.recvCounterStart;
     this.done = new Promise<ReceiveResult>((res, rej) => {
@@ -152,7 +178,7 @@ export class TransferReceiver {
   }
 
   private async applyManifest(payload: Uint8Array): Promise<void> {
-    if (this.file) throw new TransferError('integrity', 'duplicate manifest');
+    if (this.manifest) throw new TransferError('integrity', 'duplicate manifest');
     const msg = decodeControl(payload);
     if (msg.type !== FrameType.Manifest) throw new TransferError('integrity', 'expected manifest');
     let manifest;
@@ -161,18 +187,67 @@ export class TransferReceiver {
     } catch (e) {
       throw new TransferError('integrity', e instanceof Error ? e.message : String(e));
     }
-    const file = manifest.files[0];
-    if (!file || manifest.files.length !== 1) {
-      throw new TransferError('integrity', 'single-file manifest required');
-    }
-    this.file = file;
     try {
-      await this.o.onManifest?.(file);
+      await this.destination.prepare(manifest);
+      await this.o.onManifestSet?.(manifest);
     } catch (e) {
       throw e instanceof TransferError
         ? e
         : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
     }
+    this.manifest = manifest;
+    await this.openNextFile();
+  }
+
+  /** Open the next file and immediately verify/close consecutive empty files. */
+  private async openNextFile(): Promise<void> {
+    const manifest = this.manifest;
+    if (!manifest) throw new TransferError('integrity', 'file opened before manifest');
+    while (this.fileIdx < manifest.files.length) {
+      const file = manifest.files[this.fileIdx]!;
+      this.file = file;
+      this.nextBlock = 0;
+      this.seenAhead.clear();
+      this.nackOutstanding = undefined;
+      this.digest = this.o.createDigest();
+      try {
+        await this.o.onManifest?.(file);
+        this.sink = await this.destination.open(file);
+      } catch (e) {
+        throw e instanceof TransferError
+          ? e
+          : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
+      }
+      if (file.blocks > 0) return;
+      await this.finishCurrentFile();
+    }
+    this.file = undefined;
+    this.sink = undefined;
+    this.digest = undefined;
+  }
+
+  private async finishCurrentFile(): Promise<void> {
+    const file = this.file;
+    const digest = this.digest;
+    const sink = this.sink;
+    if (!file || !digest || !sink) throw new TransferError('integrity', 'no active file');
+    const got = await digest.hexDigest();
+    if (got !== file.fileDigest) {
+      throw new TransferError('digest_mismatch', `file ${file.idx} digest mismatch`);
+    }
+    try {
+      await sink.close();
+    } catch (e) {
+      throw e instanceof TransferError
+        ? e
+        : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
+    }
+    this.digests[file.idx] = got;
+    this.o.onFileProgress?.(file.idx, file.size, this.acknowledged);
+    this.fileIdx++;
+    this.file = undefined;
+    this.sink = undefined;
+    this.digest = undefined;
   }
 
   private onBlockData(
@@ -181,19 +256,21 @@ export class TransferReceiver {
     frameOff: number,
     payload: Uint8Array,
   ): void {
-    const file = this.file;
-    if (!file) throw new TransferError('integrity', 'block_data before manifest');
-    if (fileIdx !== 0 || blockIdx < 0 || blockIdx >= file.blocks) {
+    const manifest = this.manifest;
+    if (!manifest) throw new TransferError('integrity', 'block_data before manifest');
+    const entry = manifest.files[fileIdx];
+    if (!entry || fileIdx > this.fileIdx || blockIdx < 0 || blockIdx >= entry.blocks) {
       throw new TransferError('integrity', `block_data outside manifest: ${blockIdx}`);
     }
     if (frameOff === 0) {
       if (this.blockBuf) throw new TransferError('integrity', 'new block before block_hash');
-      const blockLen = Math.min(file.blockSize, file.size - blockIdx * file.blockSize);
+      const blockLen = Math.min(entry.blockSize, entry.size - blockIdx * entry.blockSize);
+      this.assemblingFileIdx = fileIdx;
       this.assemblingBlock = blockIdx;
       this.blockBuf = new Uint8Array(blockLen);
       this.blockReceived = 0;
     }
-    if (!this.blockBuf || this.assemblingBlock !== blockIdx) {
+    if (!this.blockBuf || this.assemblingFileIdx !== fileIdx || this.assemblingBlock !== blockIdx) {
       throw new TransferError('integrity', `unexpected block fragment ${blockIdx}`);
     }
     if (frameOff !== this.blockReceived || frameOff + payload.length > this.blockBuf.length) {
@@ -204,14 +281,15 @@ export class TransferReceiver {
   }
 
   private async onBlockHash(payload: Uint8Array): Promise<void> {
-    const file = this.file;
     const block = this.blockBuf;
-    if (!file || !block) throw new TransferError('integrity', 'block_hash without a block');
+    if (!this.manifest || !block) {
+      throw new TransferError('integrity', 'block_hash without a block');
+    }
     const msg = decodeControl(payload);
     if (msg.type !== FrameType.BlockHash) {
       throw new TransferError('integrity', 'expected block_hash');
     }
-    if (msg.fileIdx !== 0 || msg.blockIdx !== this.assemblingBlock) {
+    if (msg.fileIdx !== this.assemblingFileIdx || msg.blockIdx !== this.assemblingBlock) {
       throw new TransferError('integrity', 'block_hash does not match assembled block');
     }
     if (this.blockReceived !== block.length) throw new TransferError('integrity', 'short block');
@@ -223,9 +301,21 @@ export class TransferReceiver {
     this.blockBuf = undefined;
     this.blockReceived = 0;
     this.assemblingBlock = -1;
+    this.assemblingFileIdx = -1;
+
+    if (msg.fileIdx < this.fileIdx) {
+      await this.sendAck(msg.fileIdx, msg.blockIdx);
+      return;
+    }
+    const file = this.file;
+    const sink = this.sink;
+    const digest = this.digest;
+    if (!file || !sink || !digest || msg.fileIdx !== this.fileIdx) {
+      throw new TransferError('integrity', 'block_hash for inactive file');
+    }
 
     if (msg.blockIdx < this.nextBlock) {
-      await this.sendAck(msg.blockIdx); // verified duplicate; acknowledgement was likely lost
+      await this.sendAck(msg.fileIdx, msg.blockIdx);
       return;
     }
     if (msg.blockIdx > this.nextBlock) {
@@ -236,25 +326,32 @@ export class TransferReceiver {
 
     const offset = this.nextBlock * file.blockSize;
     try {
-      await this.o.sink.write(offset, block);
+      await sink.write(offset, block);
     } catch (e) {
       throw e instanceof TransferError
         ? e
         : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
     }
-    this.digest.update(block);
+    digest.update(block);
     this.nextBlock++;
     this.nackOutstanding = undefined;
-    this.o.onProgress?.(offset + block.length);
-    await this.sendAck(msg.blockIdx);
+    this.acknowledged += block.length;
+    this.o.onProgress?.(this.acknowledged);
+    this.o.onFileProgress?.(file.idx, offset + block.length, this.acknowledged);
+    await this.sendAck(msg.fileIdx, msg.blockIdx);
 
-    if (this.seenAhead.delete(this.nextBlock)) await this.requestMissing();
+    if (this.nextBlock === file.blocks) {
+      await this.finishCurrentFile();
+      await this.openNextFile();
+    } else if (this.seenAhead.delete(this.nextBlock)) {
+      await this.requestMissing();
+    }
   }
 
-  private async sendAck(blockIdx: number): Promise<void> {
+  private async sendAck(fileIdx: number, blockIdx: number): Promise<void> {
     await this.sendControl(FrameType.Ack, {
       type: FrameType.Ack,
-      fileIdx: 0,
+      fileIdx,
       blockIdx,
     });
   }
@@ -264,7 +361,7 @@ export class TransferReceiver {
     this.nackOutstanding = this.nextBlock;
     await this.sendControl(FrameType.Nack, {
       type: FrameType.Nack,
-      fileIdx: 0,
+      fileIdx: this.fileIdx,
       blockIdx: this.nextBlock,
       reason: 'missing',
     });
@@ -307,20 +404,21 @@ export class TransferReceiver {
   }
 
   private async onComplete(payload: Uint8Array): Promise<void> {
-    const file = this.file;
-    if (!file) throw new TransferError('integrity', 'complete before manifest');
+    const manifest = this.manifest;
+    if (!manifest) throw new TransferError('integrity', 'complete before manifest');
     const msg = decodeControl(payload);
     if (msg.type !== FrameType.Complete) throw new TransferError('integrity', 'expected complete');
-    if (this.nextBlock !== file.blocks) {
+    if (this.file && this.nextBlock !== this.file.blocks) {
       await this.requestMissing();
       return;
     }
-    const got = await this.digest.hexDigest();
-    if (msg.fileDigest !== file.fileDigest || got !== msg.fileDigest) {
-      throw new TransferError('digest_mismatch', 'whole-file digest mismatch');
+    if (this.fileIdx !== manifest.files.length) {
+      throw new TransferError('integrity', 'complete before every file was received');
     }
+    const got = await completionDigest(manifest.files);
+    if (got !== msg.fileDigest) throw new TransferError('digest_mismatch', 'file-set mismatch');
     try {
-      await this.o.sink.close();
+      await this.destination.close();
     } catch (e) {
       throw e instanceof TransferError
         ? e
@@ -328,7 +426,13 @@ export class TransferReceiver {
     }
     await this.sendControl(FrameType.Done, { type: FrameType.Done });
     this.settled = true;
-    this.resolveDone({ file, digest: got });
+    this.resolveDone({
+      files: manifest.files,
+      digests: [...this.digests],
+      totalSize: manifest.totalSize,
+      file: manifest.files[0]!,
+      digest: got,
+    });
   }
 
   private async abortWith(
@@ -345,7 +449,7 @@ export class TransferReceiver {
       }
     }
     try {
-      await this.o.sink.abort(err.reason);
+      await this.destination.abort(err.reason);
     } catch {
       // Sink abort is best-effort after the first terminal failure.
     }

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -22,6 +22,7 @@ import { TransferError, type Digest, type FileSource } from './transfer-ports.js
 import { reChunk } from './transfer-chunker.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
 import { validateManifest } from './safe-path.js';
+import { completionDigest } from './transfer-set.js';
 
 /** Header flag: this frame is the last of its block. */
 export const FRAME_FLAG_LAST_IN_BLOCK = 0x01;
@@ -29,7 +30,10 @@ export const FRAME_FLAG_LAST_IN_BLOCK = 0x01;
 export type TransferRunState = 'running' | 'paused' | 'canceled';
 
 export interface TransferSenderOptions {
-  file: FileSource;
+  /** One file (compatibility shorthand). Exactly one of file/files must be supplied. */
+  file?: FileSource;
+  /** Ordered file set with canonical relative paths in each source's meta.name. */
+  files?: readonly FileSource[];
   send(frame: Uint8Array): void | Promise<void>;
   sendDir: DirectionalKey;
   recvDir: DirectionalKey;
@@ -45,6 +49,8 @@ export interface TransferSenderOptions {
   maxRetries?: number;
   /** Reports bytes acknowledged after verify-and-sink. */
   onProgress?(acknowledgedBytes: number): void;
+  /** Reports verified progress for the active file plus aggregate acknowledged bytes. */
+  onFileProgress?(fileIdx: number, fileBytes: number, acknowledgedBytes: number): void;
   onStateChange?(state: TransferRunState): void;
 }
 
@@ -64,12 +70,15 @@ export class TransferSender {
   private readonly window: number;
   private readonly ackTimeoutMs: number;
   private readonly maxRetries: number;
+  private readonly files: readonly FileSource[];
 
   private sendCounter: number;
   private recvCounter: number;
   private acknowledged = 0;
   private paused = false;
   private completeSent = false;
+  private activeFileIdx = -1;
+  private activeFileAcknowledged = 0;
 
   private readonly inflight = new Map<number, InflightBlock>();
   private readonly retryQueue: number[] = [];
@@ -85,6 +94,11 @@ export class TransferSender {
 
   constructor(opts: TransferSenderOptions) {
     this.o = opts;
+    if ((opts.file === undefined) === (opts.files === undefined)) {
+      throw new Error('exactly one of file or files is required');
+    }
+    this.files = opts.files ?? [opts.file!];
+    if (this.files.length === 0) throw new Error('at least one file is required');
     this.blockSize = opts.blockSize ?? DEFAULT_BLOCK_BYTES;
     this.frameSize = opts.frameSize ?? DEFAULT_FRAME_BYTES;
     this.window = opts.window ?? DEFAULT_INFLIGHT_BLOCKS;
@@ -150,51 +164,59 @@ export class TransferSender {
   }
 
   private async drive(): Promise<string> {
-    const { meta } = this.o.file;
-
-    const digest = this.o.createDigest();
-    for await (const chunk of this.o.file.stream()) digest.update(chunk);
-    const fileDigest = await digest.hexDigest();
-
-    const blocks = Math.ceil(meta.size / this.blockSize);
+    const entries = [];
+    let totalSize = 0;
+    for (const [idx, source] of this.files.entries()) {
+      const digest = this.o.createDigest();
+      for await (const chunk of source.stream()) digest.update(chunk);
+      const { meta } = source;
+      totalSize += meta.size;
+      entries.push({
+        idx,
+        name: meta.name,
+        size: meta.size,
+        mime: meta.mime,
+        lastModified: meta.lastModified,
+        blockSize: this.blockSize,
+        blocks: Math.ceil(meta.size / this.blockSize),
+        fileDigest: await digest.hexDigest(),
+      });
+    }
     const manifest = validateManifest({
       type: FrameType.Manifest,
-      files: [
-        {
-          idx: 0,
-          name: meta.name,
-          size: meta.size,
-          mime: meta.mime,
-          lastModified: meta.lastModified,
-          blockSize: this.blockSize,
-          blocks,
-          fileDigest,
-        },
-      ],
-      totalSize: meta.size,
+      files: entries,
+      totalSize,
     });
+    const transferDigest = await completionDigest(manifest.files);
     await this.sendControl(FrameType.Manifest, manifest);
 
-    // Asking reChunk for block-sized pieces yields one retained buffer per logical block. The
-    // block is then split into transport-sized frames by sendBlock.
-    for await (const piece of reChunk(this.o.file.stream(), this.blockSize, this.blockSize)) {
-      await this.beforeNewBlock();
-      await this.propagateSettlement();
-      const bytes = piece.payload.slice();
-      this.inflight.set(piece.blockIdx, { bytes, retries: 0, timer: undefined });
-      await this.sendBlock(piece.blockIdx, bytes);
-      this.armTimeout(piece.blockIdx);
-    }
-
-    while (this.inflight.size > 0) {
-      await this.propagateSettlement();
-      await this.serviceRetriesOrWait();
+    for (const [fileIdx, source] of this.files.entries()) {
+      this.activeFileIdx = fileIdx;
+      this.activeFileAcknowledged = 0;
+      // Asking reChunk for block-sized pieces yields one retained buffer per logical block. The
+      // block is then split into transport-sized frames by sendBlock.
+      for await (const piece of reChunk(source.stream(), this.blockSize, this.blockSize)) {
+        await this.beforeNewBlock();
+        await this.propagateSettlement();
+        const bytes = piece.payload.slice();
+        this.inflight.set(piece.blockIdx, { bytes, retries: 0, timer: undefined });
+        await this.sendBlock(piece.blockIdx, bytes);
+        this.armTimeout(piece.blockIdx);
+      }
+      while (this.inflight.size > 0) {
+        await this.propagateSettlement();
+        await this.serviceRetriesOrWait();
+      }
+      this.o.onFileProgress?.(fileIdx, this.activeFileAcknowledged, this.acknowledged);
     }
 
     this.completeSent = true;
-    await this.sendControl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
+    await this.sendControl(FrameType.Complete, {
+      type: FrameType.Complete,
+      fileDigest: transferDigest,
+    });
     await this.done;
-    return fileDigest;
+    return transferDigest;
   }
 
   private async processInbound(frame: Uint8Array): Promise<void> {
@@ -214,19 +236,27 @@ export class TransferSender {
     }
     switch (msg.type) {
       case FrameType.Ack: {
-        if (msg.fileIdx !== 0) throw new TransferError('integrity', 'ack for unknown file');
+        if (msg.fileIdx < this.activeFileIdx) return;
+        if (msg.fileIdx !== this.activeFileIdx) {
+          throw new TransferError('integrity', 'ack for unknown file');
+        }
         const state = this.inflight.get(msg.blockIdx);
         if (!state) return; // duplicate acknowledgement
         if (state.timer) clearTimeout(state.timer);
         this.inflight.delete(msg.blockIdx);
         this.retryQueued.delete(msg.blockIdx);
         this.acknowledged += state.bytes.length;
+        this.activeFileAcknowledged += state.bytes.length;
         this.o.onProgress?.(this.acknowledged);
+        this.o.onFileProgress?.(this.activeFileIdx, this.activeFileAcknowledged, this.acknowledged);
         this.wake();
         return;
       }
       case FrameType.Nack:
-        if (msg.fileIdx !== 0) throw new TransferError('integrity', 'nack for unknown file');
+        if (msg.fileIdx < this.activeFileIdx) return;
+        if (msg.fileIdx !== this.activeFileIdx) {
+          throw new TransferError('integrity', 'nack for unknown file');
+        }
         this.queueRetry(msg.blockIdx);
         return;
       case FrameType.Control:
@@ -337,7 +367,7 @@ export class TransferSender {
           version: FRAME_VERSION,
           type: FrameType.BlockData,
           flags: end === bytes.length ? FRAME_FLAG_LAST_IN_BLOCK : 0,
-          fileIdx: 0,
+          fileIdx: this.activeFileIdx,
           blockIdx,
           frameOff: off,
         },
@@ -346,7 +376,7 @@ export class TransferSender {
     }
     await this.sendControl(FrameType.BlockHash, {
       type: FrameType.BlockHash,
-      fileIdx: 0,
+      fileIdx: this.activeFileIdx,
       blockIdx,
       sha256: bytesToHex(await sha256(bytes)),
     });

--- a/packages/protocol/src/transfer-set.test.ts
+++ b/packages/protocol/src/transfer-set.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import type { FileEntry } from './transfer.js';
+import { completionDigest } from './transfer-set.js';
+
+const file = (idx: number, digest: string): FileEntry => ({
+  idx,
+  name: `${idx}.bin`,
+  size: 0,
+  mime: '',
+  lastModified: 0,
+  blockSize: 1,
+  blocks: 0,
+  fileDigest: digest,
+});
+
+describe('completionDigest', () => {
+  it('preserves the single-file digest and matches the Go multi-file vector', async () => {
+    const a = 'a'.repeat(64);
+    const b = 'b'.repeat(64);
+    expect(await completionDigest([file(0, a)])).toBe(a);
+    expect(await completionDigest([file(0, a), file(1, b)])).toBe(
+      '5e9ae866add9a85d69c3481d059bb9f158a39e5670ba11f95112fc409630894e',
+    );
+  });
+});

--- a/packages/protocol/src/transfer-set.ts
+++ b/packages/protocol/src/transfer-set.ts
@@ -1,0 +1,12 @@
+import { bytesToHex, utf8 } from './bytes.js';
+import type { FileEntry } from './transfer.js';
+import { sha256 } from './webcrypto.js';
+
+/**
+ * Completion token for an ordered file set. A single file retains the original wire value;
+ * multiple files hash the newline-delimited canonical per-file digests.
+ */
+export async function completionDigest(files: readonly FileEntry[]): Promise<string> {
+  if (files.length === 1) return files[0]!.fileDigest;
+  return bytesToHex(await sha256(utf8(files.map((file) => file.fileDigest).join('\n'))));
+}

--- a/packages/wire/transfer_loopback_test.go
+++ b/packages/wire/transfer_loopback_test.go
@@ -136,3 +136,106 @@ func TestLoopbackAbortsOnCorruptedFrame(t *testing.T) {
 		t.Error("sink was closed despite a corrupted frame; it must not commit")
 	}
 }
+
+type multiMemoryDestination struct {
+	manifest Manifest
+	sinks    map[string]*MemorySink
+	closed   bool
+}
+
+func (d *multiMemoryDestination) Prepare(manifest Manifest) error {
+	d.manifest = manifest
+	d.sinks = make(map[string]*MemorySink, len(manifest.Files))
+	return nil
+}
+
+func (d *multiMemoryDestination) Open(file FileEntry) (Sink, error) {
+	sink := &MemorySink{}
+	d.sinks[file.Name] = sink
+	return sink, nil
+}
+
+func (d *multiMemoryDestination) Close() error { d.closed = true; return nil }
+
+func (d *multiMemoryDestination) Abort(reason string) error {
+	for _, sink := range d.sinks {
+		_ = sink.Abort(reason)
+	}
+	return nil
+}
+
+func TestLoopbackStreamsNestedMultiFileSet(t *testing.T) {
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := [][]byte{{1, 2, 3}, {}, make([]byte, 3000)}
+	for i := range contents[2] {
+		contents[2][i] = byte(i & 0xff)
+	}
+	names := []string{"folder/a.bin", "folder/empty.txt", "b.bin"}
+	sources := make([]FileSource, len(contents))
+	var total int64
+	for i, content := range contents {
+		sources[i] = BytesSource(content, FileMeta{Name: names[i], Size: int64(len(content)), LastModified: 1}, 0)
+		total += int64(len(content))
+	}
+	s2r := make(chan []byte, 4096)
+	r2s := make(chan []byte, 4096)
+	copyFrame := func(frame []byte) []byte { return append([]byte(nil), frame...) }
+	destination := &multiMemoryDestination{}
+	var progress int64
+	sender := NewSender(SenderOptions{
+		Files: sources, Send: func(frame []byte) error { s2r <- copyFrame(frame); return nil },
+		SendDir: keys.O2J, RecvDir: keys.J2O, BlockSize: 1024, FrameSize: 256, Window: 2,
+		OnProgress: func(bytes int64) { progress = bytes },
+	})
+	receiver := NewReceiver(ReceiverOptions{
+		Send:    func(frame []byte) error { r2s <- copyFrame(frame); return nil },
+		SendDir: keys.J2O, RecvDir: keys.O2J, Destination: destination,
+	})
+	go func() {
+		for frame := range s2r {
+			receiver.Handle(frame)
+		}
+	}()
+	go func() {
+		for frame := range r2s {
+			sender.Handle(frame)
+		}
+	}()
+	sendDone := make(chan struct {
+		digest string
+		err    error
+	}, 1)
+	go func() {
+		digest, runErr := sender.Run(context.Background())
+		sendDone <- struct {
+			digest string
+			err    error
+		}{digest, runErr}
+	}()
+	received, recvErr := receiver.Wait(context.Background())
+	sent := <-sendDone
+	close(s2r)
+	close(r2s)
+	if sent.err != nil || recvErr != nil {
+		t.Fatalf("send=%v receive=%v", sent.err, recvErr)
+	}
+	if sent.digest != received.Digest || progress != total || !destination.closed {
+		t.Fatalf("digest/progress/commit mismatch: sent=%s received=%s progress=%d closed=%v",
+			sent.digest, received.Digest, progress, destination.closed)
+	}
+	if len(received.Files) != len(contents) || len(received.Digests) != len(contents) {
+		t.Fatalf("received %d files and %d digests", len(received.Files), len(received.Digests))
+	}
+	for i, name := range names {
+		if got := destination.sinks[name].Bytes(); string(got) != string(contents[i]) {
+			t.Errorf("%s differs", name)
+		}
+		want := sha256.Sum256(contents[i])
+		if received.Digests[i] != hex.EncodeToString(want[:]) {
+			t.Errorf("%s digest = %s", name, received.Digests[i])
+		}
+	}
+}

--- a/packages/wire/transfer_ports.go
+++ b/packages/wire/transfer_ports.go
@@ -37,6 +37,42 @@ type Sink interface {
 	Abort(reason string) error
 }
 
+// Destination owns every per-file Sink in one transfer so a terminal failure can discard the
+// complete partial output rather than leaving already-verified files behind.
+type Destination interface {
+	Prepare(manifest Manifest) error
+	Open(file FileEntry) (Sink, error)
+	Close() error
+	Abort(reason string) error
+}
+
+type singleSinkDestination struct {
+	sink   Sink
+	opened bool
+}
+
+// SingleSinkDestination adapts the original one-file Sink contract for compatibility.
+func SingleSinkDestination(sink Sink) Destination { return &singleSinkDestination{sink: sink} }
+
+func (d *singleSinkDestination) Prepare(manifest Manifest) error {
+	if len(manifest.Files) != 1 {
+		return errors.New("single sink cannot receive multiple files")
+	}
+	return nil
+}
+
+func (d *singleSinkDestination) Open(FileEntry) (Sink, error) {
+	if d.opened {
+		return nil, errors.New("single sink opened more than once")
+	}
+	d.opened = true
+	return d.sink, nil
+}
+
+func (d *singleSinkDestination) Close() error { return nil }
+
+func (d *singleSinkDestination) Abort(reason string) error { return d.sink.Abort(reason) }
+
 // Digest is a streaming whole-file hasher producing a sha256sum-identical hex string. The
 // sender computes it in a first pass so the file is never buffered whole; a fresh Digest is
 // requested per transfer so implementations may be stateful. It is the Go twin of the TS

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -16,8 +16,11 @@ import (
 
 // ReceiveResult is the successful manifest entry and canonical whole-file digest.
 type ReceiveResult struct {
-	File   FileEntry
-	Digest string
+	Files     []FileEntry
+	Digests   []string
+	TotalSize int64
+	File      FileEntry
+	Digest    string
 }
 
 // ReceiverOptions configures a Receiver.
@@ -29,24 +32,34 @@ type ReceiverOptions struct {
 	RecvCounterStart uint64
 	CreateDigest     func() Digest
 	Sink             Sink
+	Destination      Destination
 	// OnProgress reports bytes only after verify-and-sink.
-	OnProgress    func(acknowledgedBytes int64)
-	OnStateChange func(TransferState)
-	OnManifest    func(file FileEntry) error
+	OnProgress     func(acknowledgedBytes int64)
+	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
+	OnStateChange  func(TransferState)
+	OnManifestSet  func(manifest Manifest) error
+	OnManifest     func(file FileEntry) error
 }
 
 // Receiver drives one file receive. Handle calls must remain ordered.
 type Receiver struct {
-	o      ReceiverOptions
-	digest Digest
+	o           ReceiverOptions
+	destination Destination
 
 	sendMu      sync.Mutex
 	sendCounter uint64
 
 	// Assembly state belongs to the serial Handle path.
 	recvCounter     uint64
+	manifest        *Manifest
+	fileIdx         int
 	file            *FileEntry
+	sink            Sink
+	digest          Digest
+	digests         []string
+	acknowledged    int64
 	nextBlock       int
+	assemblingFile  int
 	assembling      int
 	blockBuf        []byte
 	blockReceived   int
@@ -66,12 +79,17 @@ func NewReceiver(opts ReceiverOptions) *Receiver {
 	if opts.CreateDigest == nil {
 		opts.CreateDigest = NewSHA256Digest
 	}
+	destination := opts.Destination
+	if destination == nil && opts.Sink != nil {
+		destination = SingleSinkDestination(opts.Sink)
+	}
 	return &Receiver{
 		o:               opts,
-		digest:          opts.CreateDigest(),
+		destination:     destination,
 		sendCounter:     opts.SendCounterStart,
 		recvCounter:     opts.RecvCounterStart,
 		assembling:      -1,
+		assemblingFile:  -1,
 		seenAhead:       make(map[int]bool),
 		nackOutstanding: -1,
 		done:            make(chan struct{}),
@@ -165,7 +183,7 @@ func (r *Receiver) process(frame []byte) error {
 }
 
 func (r *Receiver) applyManifest(payload []byte) error {
-	if r.file != nil {
+	if r.manifest != nil {
 		return NewTransferError(FailIntegrity, "duplicate manifest")
 	}
 	msg, err := DecodeControl(payload)
@@ -180,40 +198,105 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	if err != nil {
 		return NewTransferError(FailIntegrity, err.Error())
 	}
-	if len(validated.Files) != 1 {
-		return NewTransferError(FailIntegrity, "single-file manifest required")
+	if r.destination == nil {
+		return NewTransferError(FailSinkError, "transfer destination is required")
 	}
-	f := validated.Files[0]
-	r.file = &f
-	if r.o.OnManifest != nil {
-		if err := r.o.OnManifest(f); err != nil {
+	if err := r.destination.Prepare(validated); err != nil {
+		return asTransferError(err, FailSinkError)
+	}
+	if r.o.OnManifestSet != nil {
+		if err := r.o.OnManifestSet(validated); err != nil {
 			return asTransferError(err, FailSinkError)
 		}
 	}
+	r.manifest = &validated
+	r.digests = make([]string, len(validated.Files))
+	return r.openNextFile()
+}
+
+func (r *Receiver) openNextFile() error {
+	if r.manifest == nil {
+		return NewTransferError(FailIntegrity, "file opened before manifest")
+	}
+	for r.fileIdx < len(r.manifest.Files) {
+		file := r.manifest.Files[r.fileIdx]
+		r.file = &file
+		r.nextBlock = 0
+		r.seenAhead = make(map[int]bool)
+		r.nackOutstanding = -1
+		r.digest = r.o.CreateDigest()
+		if r.o.OnManifest != nil {
+			if err := r.o.OnManifest(file); err != nil {
+				return asTransferError(err, FailSinkError)
+			}
+		}
+		sink, err := r.destination.Open(file)
+		if err != nil {
+			return asTransferError(err, FailSinkError)
+		}
+		r.sink = sink
+		if file.Blocks > 0 {
+			return nil
+		}
+		if err := r.finishCurrentFile(); err != nil {
+			return err
+		}
+	}
+	r.file = nil
+	r.sink = nil
+	r.digest = nil
+	return nil
+}
+
+func (r *Receiver) finishCurrentFile() error {
+	if r.file == nil || r.sink == nil || r.digest == nil {
+		return NewTransferError(FailIntegrity, "no active file")
+	}
+	got := r.digest.HexDigest()
+	if got != r.file.FileDigest {
+		return NewTransferError(FailDigestMismatch, fmt.Sprintf("file %d digest mismatch", r.file.Idx))
+	}
+	if err := r.sink.Close(); err != nil {
+		return asTransferError(err, FailSinkError)
+	}
+	r.digests[r.file.Idx] = got
+	if r.o.OnFileProgress != nil {
+		r.o.OnFileProgress(r.file.Idx, r.file.Size, r.acknowledged)
+	}
+	r.fileIdx++
+	r.file = nil
+	r.sink = nil
+	r.digest = nil
 	return nil
 }
 
 func (r *Receiver) onBlockData(fileIdx uint16, blockIdx uint32, frameOff uint32, payload []byte) error {
-	if r.file == nil {
+	if r.manifest == nil {
 		return NewTransferError(FailIntegrity, "block_data before manifest")
 	}
+	fileNumber := int(fileIdx)
+	if fileNumber < 0 || fileNumber >= len(r.manifest.Files) || fileNumber > r.fileIdx {
+		return NewTransferError(FailIntegrity, fmt.Sprintf("block_data outside manifest: %d", blockIdx))
+	}
+	entry := r.manifest.Files[fileNumber]
 	idx := int(blockIdx)
-	if fileIdx != 0 || idx < 0 || idx >= r.file.Blocks {
+	if idx < 0 || idx >= entry.Blocks {
 		return NewTransferError(FailIntegrity, fmt.Sprintf("block_data outside manifest: %d", idx))
 	}
 	if frameOff == 0 {
 		if r.blockBuf != nil {
 			return NewTransferError(FailIntegrity, "new block before block_hash")
 		}
-		blockLen := r.file.BlockSize
-		if rem := r.file.Size - int64(idx)*int64(r.file.BlockSize); int64(blockLen) > rem {
+		blockLen := entry.BlockSize
+		if rem := entry.Size - int64(idx)*int64(entry.BlockSize); int64(blockLen) > rem {
 			blockLen = int(rem)
 		}
+		r.assemblingFile = fileNumber
 		r.assembling = idx
 		r.blockBuf = make([]byte, blockLen)
 		r.blockReceived = 0
 	}
-	if r.blockBuf == nil || r.assembling != idx {
+	if r.blockBuf == nil || r.assemblingFile != fileNumber || r.assembling != idx {
 		return NewTransferError(FailIntegrity, fmt.Sprintf("unexpected block fragment %d", idx))
 	}
 	off := int(frameOff)
@@ -226,7 +309,7 @@ func (r *Receiver) onBlockData(fileIdx uint16, blockIdx uint32, frameOff uint32,
 }
 
 func (r *Receiver) onBlockHash(payload []byte) error {
-	if r.file == nil || r.blockBuf == nil {
+	if r.manifest == nil || r.blockBuf == nil {
 		return NewTransferError(FailIntegrity, "block_hash without a block")
 	}
 	msg, err := DecodeControl(payload)
@@ -237,7 +320,7 @@ func (r *Receiver) onBlockHash(payload []byte) error {
 	if !ok {
 		return NewTransferError(FailIntegrity, "expected block_hash")
 	}
-	if bh.FileIdx != 0 || bh.BlockIdx != r.assembling {
+	if bh.FileIdx != r.assemblingFile || bh.BlockIdx != r.assembling {
 		return NewTransferError(FailIntegrity, "block_hash does not match assembled block")
 	}
 	if r.blockReceived != len(r.blockBuf) {
@@ -252,9 +335,17 @@ func (r *Receiver) onBlockHash(payload []byte) error {
 	r.blockBuf = nil
 	r.blockReceived = 0
 	r.assembling = -1
+	r.assemblingFile = -1
+
+	if bh.FileIdx < r.fileIdx {
+		return r.sendControl(NewAck(bh.FileIdx, bh.BlockIdx))
+	}
+	if r.file == nil || r.sink == nil || r.digest == nil || bh.FileIdx != r.fileIdx {
+		return NewTransferError(FailIntegrity, "block_hash for inactive file")
+	}
 
 	if bh.BlockIdx < r.nextBlock {
-		return r.sendControl(NewAck(0, bh.BlockIdx))
+		return r.sendControl(NewAck(bh.FileIdx, bh.BlockIdx))
 	}
 	if bh.BlockIdx > r.nextBlock {
 		if len(r.seenAhead) < DefaultInflightBlocks {
@@ -264,17 +355,27 @@ func (r *Receiver) onBlockHash(payload []byte) error {
 	}
 
 	offset := int64(r.nextBlock) * int64(r.file.BlockSize)
-	if err := r.o.Sink.Write(offset, block); err != nil {
+	if err := r.sink.Write(offset, block); err != nil {
 		return asTransferError(err, FailSinkError)
 	}
 	r.digest.Update(block)
 	r.nextBlock++
 	r.nackOutstanding = -1
+	r.acknowledged += int64(len(block))
 	if r.o.OnProgress != nil {
-		r.o.OnProgress(offset + int64(len(block)))
+		r.o.OnProgress(r.acknowledged)
 	}
-	if err := r.sendControl(NewAck(0, bh.BlockIdx)); err != nil {
+	if r.o.OnFileProgress != nil {
+		r.o.OnFileProgress(r.file.Idx, offset+int64(len(block)), r.acknowledged)
+	}
+	if err := r.sendControl(NewAck(bh.FileIdx, bh.BlockIdx)); err != nil {
 		return err
+	}
+	if r.nextBlock == r.file.Blocks {
+		if err := r.finishCurrentFile(); err != nil {
+			return err
+		}
+		return r.openNextFile()
 	}
 	if r.seenAhead[r.nextBlock] {
 		delete(r.seenAhead, r.nextBlock)
@@ -288,7 +389,7 @@ func (r *Receiver) requestMissing() error {
 		return nil
 	}
 	r.nackOutstanding = r.nextBlock
-	return r.sendControl(NewNack(0, r.nextBlock, NackMissing))
+	return r.sendControl(NewNack(r.fileIdx, r.nextBlock, NackMissing))
 }
 
 func (r *Receiver) onControl(payload []byte) error {
@@ -328,7 +429,7 @@ func (r *Receiver) onPeerFail(payload []byte) error {
 }
 
 func (r *Receiver) onComplete(payload []byte) error {
-	if r.file == nil {
+	if r.manifest == nil {
 		return NewTransferError(FailIntegrity, "complete before manifest")
 	}
 	msg, err := DecodeControl(payload)
@@ -339,20 +440,26 @@ func (r *Receiver) onComplete(payload []byte) error {
 	if !ok {
 		return NewTransferError(FailIntegrity, "expected complete")
 	}
-	if r.nextBlock != r.file.Blocks {
+	if r.file != nil && r.nextBlock != r.file.Blocks {
 		return r.requestMissing()
 	}
-	got := r.digest.HexDigest()
-	if complete.FileDigest != r.file.FileDigest || got != complete.FileDigest {
-		return NewTransferError(FailDigestMismatch, "whole-file digest mismatch")
+	if r.fileIdx != len(r.manifest.Files) {
+		return NewTransferError(FailIntegrity, "complete before every file was received")
 	}
-	if err := r.o.Sink.Close(); err != nil {
+	got := CompletionDigest(r.manifest.Files)
+	if complete.FileDigest != got {
+		return NewTransferError(FailDigestMismatch, "file-set mismatch")
+	}
+	if err := r.destination.Close(); err != nil {
 		return asTransferError(err, FailSinkError)
 	}
 	if err := r.sendControl(NewDone()); err != nil {
 		return err
 	}
-	r.settle(ReceiveResult{File: *r.file, Digest: got})
+	r.settle(ReceiveResult{
+		Files: append([]FileEntry(nil), r.manifest.Files...), Digests: append([]string(nil), r.digests...),
+		TotalSize: r.manifest.TotalSize, File: r.manifest.Files[0], Digest: got,
+	})
 	return nil
 }
 
@@ -386,7 +493,9 @@ func (r *Receiver) abortWith(err *TransferError, notifyPeer bool) {
 	if notifyPeer {
 		_ = r.sendControl(NewFail(err.Reason))
 	}
-	_ = r.o.Sink.Abort(string(err.Reason))
+	if r.destination != nil {
+		_ = r.destination.Abort(string(err.Reason))
+	}
 	close(r.done)
 }
 

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 )
@@ -26,7 +27,9 @@ const (
 
 // SenderOptions configures a Sender. Zero-valued sizing and retry fields select defaults.
 type SenderOptions struct {
+	// File is the one-file compatibility shorthand. Set either File or Files, not both.
 	File             FileSource
+	Files            []FileSource
 	Send             func(frame []byte) error
 	SendDir          DirectionalKey
 	RecvDir          DirectionalKey
@@ -39,8 +42,9 @@ type SenderOptions struct {
 	AckTimeout       time.Duration
 	MaxRetries       int
 	// OnProgress reports bytes acknowledged after verify-and-sink.
-	OnProgress    func(acknowledgedBytes int64)
-	OnStateChange func(TransferState)
+	OnProgress     func(acknowledgedBytes int64)
+	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
+	OnStateChange  func(TransferState)
 }
 
 type inflightBlock struct {
@@ -57,21 +61,24 @@ type Sender struct {
 	window     int
 	ackTimeout time.Duration
 	maxRetries int
+	files      []FileSource
 
 	sendMu      sync.Mutex
 	sendCounter uint64
 
-	mu           sync.Mutex
-	cond         *sync.Cond
-	recvCounter  uint64
-	inflight     map[int]*inflightBlock
-	retryQueue   []int
-	retryQueued  map[int]bool
-	acknowledged int64
-	paused       bool
-	completeSent bool
-	settled      bool
-	err          error
+	mu                     sync.Mutex
+	cond                   *sync.Cond
+	recvCounter            uint64
+	inflight               map[int]*inflightBlock
+	retryQueue             []int
+	retryQueued            map[int]bool
+	acknowledged           int64
+	activeFileIdx          int
+	activeFileAcknowledged int64
+	paused                 bool
+	completeSent           bool
+	settled                bool
+	err                    error
 }
 
 var errSenderSettled = errors.New("sender settled")
@@ -96,17 +103,23 @@ func NewSender(opts SenderOptions) *Sender {
 	if opts.CreateDigest == nil {
 		opts.CreateDigest = NewSHA256Digest
 	}
+	files := opts.Files
+	if len(files) == 0 && opts.File != nil {
+		files = []FileSource{opts.File}
+	}
 	s := &Sender{
-		o:           opts,
-		blockSize:   opts.BlockSize,
-		frameSize:   opts.FrameSize,
-		window:      opts.Window,
-		ackTimeout:  opts.AckTimeout,
-		maxRetries:  opts.MaxRetries,
-		sendCounter: opts.SendCounterStart,
-		recvCounter: opts.RecvCounterStart,
-		inflight:    make(map[int]*inflightBlock),
-		retryQueued: make(map[int]bool),
+		o:             opts,
+		blockSize:     opts.BlockSize,
+		frameSize:     opts.FrameSize,
+		window:        opts.Window,
+		ackTimeout:    opts.AckTimeout,
+		maxRetries:    opts.MaxRetries,
+		files:         files,
+		sendCounter:   opts.SendCounterStart,
+		recvCounter:   opts.RecvCounterStart,
+		inflight:      make(map[int]*inflightBlock),
+		retryQueued:   make(map[int]bool),
+		activeFileIdx: -1,
 	}
 	s.cond = sync.NewCond(&s.mu)
 	return s
@@ -125,71 +138,95 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 		}
 	}()
 
-	meta := s.o.File.Meta()
-	digest := s.o.CreateDigest()
-	if err := s.o.File.Stream(func(chunk []byte) error {
-		digest.Update(chunk)
-		return nil
-	}); err != nil {
+	if len(s.files) == 0 || (s.o.File != nil && len(s.o.Files) > 0) {
+		err := errors.New("transfer: exactly one of File or Files is required")
 		s.fail(err)
 		return "", err
 	}
-	fileDigest := digest.HexDigest()
-
-	blocks := 0
-	if meta.Size > 0 {
-		blocks = int((meta.Size-1)/int64(s.blockSize) + 1)
+	entries := make([]FileEntry, len(s.files))
+	var totalSize int64
+	for idx, source := range s.files {
+		meta := source.Meta()
+		digest := s.o.CreateDigest()
+		if err := source.Stream(func(chunk []byte) error {
+			digest.Update(chunk)
+			return nil
+		}); err != nil {
+			s.fail(err)
+			return "", err
+		}
+		blocks := 0
+		if meta.Size > 0 {
+			blocks = int((meta.Size-1)/int64(s.blockSize) + 1)
+		}
+		entries[idx] = FileEntry{
+			Idx: idx, Name: meta.Name, Size: meta.Size, Mime: meta.Mime,
+			LastModified: meta.LastModified, BlockSize: s.blockSize, Blocks: blocks,
+			FileDigest: digest.HexDigest(),
+		}
+		if meta.Size > math.MaxInt64-totalSize {
+			err := errors.New("transfer: total size overflow")
+			s.fail(err)
+			return "", err
+		}
+		totalSize += meta.Size
 	}
-	manifest, err := ValidateManifest(*NewManifest([]FileEntry{{
-		Idx: 0, Name: meta.Name, Size: meta.Size, Mime: meta.Mime,
-		LastModified: meta.LastModified, BlockSize: s.blockSize, Blocks: blocks,
-		FileDigest: fileDigest,
-	}}, meta.Size))
+	manifest, err := ValidateManifest(*NewManifest(entries, totalSize))
 	if err != nil {
 		s.fail(err)
 		return "", err
 	}
+	transferDigest := CompletionDigest(manifest.Files)
 	if err := s.sendControl(&manifest); err != nil {
 		s.fail(err)
 		return "", err
 	}
 
-	streamErr := ReChunk(StreamFunc(s.o.File.Stream), s.blockSize, s.blockSize, func(p FramePiece) error {
-		if err := s.beforeNewBlock(); err != nil {
-			return err
-		}
-		block := append([]byte(nil), p.Payload...)
+	for fileIdx, source := range s.files {
 		s.mu.Lock()
-		if s.settled {
-			s.mu.Unlock()
-			return errSenderSettled
-		}
-		s.inflight[p.BlockIdx] = &inflightBlock{bytes: block}
+		s.activeFileIdx = fileIdx
+		s.activeFileAcknowledged = 0
 		s.mu.Unlock()
-		if err := s.sendBlock(p.BlockIdx, block); err != nil {
-			return err
+		streamErr := ReChunk(StreamFunc(source.Stream), s.blockSize, s.blockSize, func(p FramePiece) error {
+			if err := s.beforeNewBlock(); err != nil {
+				return err
+			}
+			block := append([]byte(nil), p.Payload...)
+			s.mu.Lock()
+			if s.settled {
+				s.mu.Unlock()
+				return errSenderSettled
+			}
+			s.inflight[p.BlockIdx] = &inflightBlock{bytes: block}
+			s.mu.Unlock()
+			if err := s.sendBlock(p.BlockIdx, block); err != nil {
+				return err
+			}
+			s.armTimeout(p.BlockIdx)
+			return nil
+		})
+		if streamErr != nil && !errors.Is(streamErr, errSenderSettled) {
+			s.fail(streamErr)
+			return "", streamErr
 		}
-		s.armTimeout(p.BlockIdx)
-		return nil
-	})
-	if streamErr != nil && !errors.Is(streamErr, errSenderSettled) {
-		s.fail(streamErr)
-		return "", streamErr
-	}
-	if err := s.waitInflight(); err != nil {
-		return "", err
+		if err := s.waitInflight(); err != nil {
+			return "", err
+		}
+		if s.o.OnFileProgress != nil {
+			s.o.OnFileProgress(fileIdx, entries[fileIdx].Size, s.acknowledged)
+		}
 	}
 	s.mu.Lock()
 	s.completeSent = true
 	s.mu.Unlock()
-	if err := s.sendControl(NewComplete(fileDigest)); err != nil {
+	if err := s.sendControl(NewComplete(transferDigest)); err != nil {
 		s.fail(err)
 		return "", err
 	}
 	if err := s.waitDone(); err != nil {
 		return "", err
 	}
-	return fileDigest, nil
+	return transferDigest, nil
 }
 
 // Handle consumes one encrypted receiver control frame. Calls must remain ordered.
@@ -222,7 +259,13 @@ func (s *Sender) Handle(frame []byte) {
 	case *Ack:
 		s.onAck(m)
 	case *Nack:
-		if m.FileIdx != 0 {
+		s.mu.Lock()
+		active := s.activeFileIdx
+		s.mu.Unlock()
+		if m.FileIdx < active {
+			return
+		}
+		if m.FileIdx != active {
 			s.fail(NewTransferError(FailIntegrity, "nack for unknown file"))
 			return
 		}
@@ -276,11 +319,16 @@ func (s *Sender) Cancel(reason string) error {
 }
 
 func (s *Sender) onAck(ack *Ack) {
-	if ack.FileIdx != 0 {
+	s.mu.Lock()
+	if ack.FileIdx < s.activeFileIdx {
+		s.mu.Unlock()
+		return
+	}
+	if ack.FileIdx != s.activeFileIdx {
+		s.mu.Unlock()
 		s.fail(NewTransferError(FailIntegrity, "ack for unknown file"))
 		return
 	}
-	s.mu.Lock()
 	state := s.inflight[ack.BlockIdx]
 	if state == nil {
 		s.mu.Unlock()
@@ -292,11 +340,17 @@ func (s *Sender) onAck(ack *Ack) {
 	delete(s.inflight, ack.BlockIdx)
 	delete(s.retryQueued, ack.BlockIdx)
 	s.acknowledged += int64(len(state.bytes))
+	s.activeFileAcknowledged += int64(len(state.bytes))
 	acknowledged := s.acknowledged
+	fileAcknowledged := s.activeFileAcknowledged
+	fileIdx := s.activeFileIdx
 	s.cond.Broadcast()
 	s.mu.Unlock()
 	if s.o.OnProgress != nil {
 		s.o.OnProgress(acknowledged)
+	}
+	if s.o.OnFileProgress != nil {
+		s.o.OnFileProgress(fileIdx, fileAcknowledged, acknowledged)
 	}
 }
 
@@ -466,6 +520,9 @@ func (s *Sender) armTimeoutLocked(blockIdx int, state *inflightBlock) {
 }
 
 func (s *Sender) sendBlock(blockIdx int, block []byte) error {
+	s.mu.Lock()
+	fileIdx := s.activeFileIdx
+	s.mu.Unlock()
 	for off := 0; off < len(block); off += s.frameSize {
 		end := off + s.frameSize
 		if end > len(block) {
@@ -477,13 +534,13 @@ func (s *Sender) sendBlock(blockIdx int, block []byte) error {
 		}
 		if err := s.sendFrame(FrameHeaderInput{
 			Version: FrameVersion, Type: FrameBlockData, Flags: flags,
-			FileIdx: 0, BlockIdx: uint32(blockIdx), FrameOff: uint32(off),
+			FileIdx: uint16(fileIdx), BlockIdx: uint32(blockIdx), FrameOff: uint32(off),
 		}, block[off:end]); err != nil {
 			return err
 		}
 	}
 	sum := sha256.Sum256(block)
-	return s.sendControl(NewBlockHash(0, blockIdx, hex.EncodeToString(sum[:])))
+	return s.sendControl(NewBlockHash(fileIdx, blockIdx, hex.EncodeToString(sum[:])))
 }
 
 func (s *Sender) waitDone() error {

--- a/packages/wire/transfer_set.go
+++ b/packages/wire/transfer_set.go
@@ -1,0 +1,21 @@
+package wire
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// CompletionDigest preserves the original single-file token and commits an ordered multi-file
+// set by hashing its newline-delimited canonical per-file digests.
+func CompletionDigest(files []FileEntry) string {
+	if len(files) == 1 {
+		return files[0].FileDigest
+	}
+	digests := make([]string, len(files))
+	for i, file := range files {
+		digests[i] = file.FileDigest
+	}
+	sum := sha256.Sum256([]byte(strings.Join(digests, "\n")))
+	return hex.EncodeToString(sum[:])
+}

--- a/packages/wire/transfer_set_test.go
+++ b/packages/wire/transfer_set_test.go
@@ -1,0 +1,18 @@
+package wire
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompletionDigestInteropVector(t *testing.T) {
+	a := strings.Repeat("a", 64)
+	b := strings.Repeat("b", 64)
+	if got := CompletionDigest([]FileEntry{{FileDigest: a}}); got != a {
+		t.Fatalf("single completion digest = %s", got)
+	}
+	want := "5e9ae866add9a85d69c3481d059bb9f158a39e5670ba11f95112fc409630894e"
+	if got := CompletionDigest([]FileEntry{{FileDigest: a}, {FileDigest: b}}); got != want {
+		t.Fatalf("multi completion digest = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- generalize TypeScript and Go transfer engines to ordered file sets with independent SHA-256 verification
- preserve bounded ACK/NACK recovery while reporting per-file and aggregate acknowledged progress
- add a cross-language file-set completion digest and empty-file coverage
- recursively discover CLI folders while rejecting symlink sources
- write nested destinations without traversal, symlink following, or overwriting existing files
- remove every output created by a failed multi-file transfer

## Verification

- `pnpm run format:check`
- `just lint`
- `just typecheck`
- `just test`
- `just build`
- `go test -race ./packages/wire ./apps/cli/...`
- real nested three-file CLI-to-CLI folder transfer, including an empty file
- matching per-file SHA-256 values, matching file-set digest, and clean `diff -qr`