### PR TITLE
feat(web): add streaming folder destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and terminal. It authenticates two peers with a short invite code, establishes a
 WebRTC connection, and streams the file without loading it all into memory.
 
 > [!NOTE]
-> SendArc is pre-release software. Direct single-file transfers are working, but there is
+> SendArc is pre-release software. Direct file and folder transfers are working, but there is
 > no stable release or compatibility guarantee yet.
 
 ## Why SendArc
@@ -22,6 +22,8 @@ WebRTC connection, and streams the file without loading it all into memory.
   instead of being uploaded to server-side storage.
 - **Streams large files with bounded memory.** Fixed-size blocks, transport backpressure,
   and a bounded in-flight window keep memory use independent of file size.
+- **Files and folders.** Each file is independently verified; browsers can write directly to a
+  chosen destination or stream a portable ZIP fallback without buffering the file set in memory.
 - **Reliable and controllable.** Verified block acknowledgements drive progress and recovery;
   missing blocks are retried, and either peer can pause, resume, or cancel a transfer.
 - **Verifiable completion.** Every block is authenticated and hashed; the final streaming
@@ -91,10 +93,10 @@ With the local server running, build the CLI:
 (cd apps/cli && go build -o ../../bin/sendarc ./cmd/sendarc)
 ```
 
-Send a file:
+Send one or more files or folders:
 
 ```bash
-bin/sendarc send ./example.zip --insecure-skip-verify
+bin/sendarc send ./photos ./notes.txt --insecure-skip-verify
 ```
 
 Receive it from another terminal:

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -4,6 +4,7 @@
 
   import { offer, join, type RendezvousController } from './lib/session/rendezvous.js';
   import type { SignalChannel } from './lib/signaling/client.js';
+  import type { ReceiveDestinationSpec } from './lib/transfer/wire.js';
   import {
     runSend,
     runReceive,
@@ -38,7 +39,9 @@
 
   // Transfer state, live once the handshake settles and the socket is adopted.
   let role = $state<Role | undefined>(undefined);
-  let pickedFile = $state<File | null>(null);
+  let pickedFiles = $state.raw<File[]>([]);
+  let receiveTarget = $state<'auto' | 'direct-file' | 'direct-directory'>('auto');
+  let receiveDestination = $state.raw<ReceiveDestinationSpec>({ kind: 'auto' });
   // TransferController is an imperative identity-bearing object (methods + a terminal Promise),
   // not a reactive data model. Deep-proxying it makes `transfer !== ctrl` even immediately after
   // assignment, so the stale-controller guard below discards the real completion callback and
@@ -58,8 +61,28 @@
   let copyTimer: ReturnType<typeof setTimeout> | undefined;
   let progressTimer: ReturnType<typeof setInterval> | undefined;
 
+  interface PickerWindow extends Window {
+    showSaveFilePicker?: () => Promise<FileSystemFileHandle>;
+    showDirectoryPicker?: () => Promise<FileSystemDirectoryHandle>;
+  }
+
   function readHashCode(): string {
     return typeof window === 'undefined' ? '' : codeFromHash(window.location.hash);
+  }
+
+  function browserCaps(): Partial<CapsPayload> {
+    const pickerWindow = window as PickerWindow;
+    const storage = navigator.storage as StorageManager | undefined;
+    const hasOpfs = typeof storage?.getDirectory === 'function';
+    const features: CapsPayload['features'] = [];
+    const sinkHints: CapsPayload['sinkHints'] = [];
+    if (hasOpfs || pickerWindow.showDirectoryPicker) features.push('folders');
+    if (hasOpfs) {
+      features.push('archive');
+      sinkHints.push('opfs', 'archive');
+    }
+    if (pickerWindow.showSaveFilePicker) sinkHints.push('direct-file');
+    return { features, sinkHints };
   }
 
   function startSend() {
@@ -67,6 +90,7 @@
     screen = 'sending';
     track(
       offer({
+        localCaps: browserCaps(),
         onPhase: (p) => (phase = p),
         onCode: (c) => {
           code = c;
@@ -76,14 +100,36 @@
     );
   }
 
-  function startReceive() {
+  async function startReceive() {
     const trimmed = codeInput.trim();
     if (trimmed === '') return;
+    let destination: ReceiveDestinationSpec = { kind: 'auto' };
+    try {
+      const pickerWindow = window as PickerWindow;
+      if (receiveTarget === 'direct-file') {
+        if (!pickerWindow.showSaveFilePicker) throw new Error('Direct file saving is unavailable.');
+        destination = { kind: 'direct-file', handle: await pickerWindow.showSaveFilePicker() };
+      } else if (receiveTarget === 'direct-directory') {
+        if (!pickerWindow.showDirectoryPicker)
+          throw new Error('Direct folder saving is unavailable.');
+        destination = {
+          kind: 'direct-directory',
+          handle: await pickerWindow.showDirectoryPicker(),
+        };
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      errorText = err instanceof Error ? err.message : String(err);
+      screen = 'failed';
+      return;
+    }
     reset();
+    receiveDestination = destination;
     screen = 'receiving';
     track(
       join({
         code: trimmed,
+        localCaps: browserCaps(),
         onPhase: (p) => (phase = p),
       }),
     );
@@ -123,7 +169,7 @@
 
   function onPick(ev: Event) {
     const input = ev.currentTarget as HTMLInputElement;
-    pickedFile = input.files?.[0] ?? null;
+    pickedFiles = Array.from(input.files ?? []);
     startTransferIfReady();
   }
 
@@ -134,10 +180,10 @@
   function startTransferIfReady() {
     if (transfer || handshake === undefined || signaling === undefined) return;
     if (role === 'offerer') {
-      if (pickedFile === null) return; // still waiting for the sender to choose a file
-      beginTransfer(runSend(handshake, signaling, { file: pickedFile }));
+      if (pickedFiles.length === 0) return;
+      beginTransfer(runSend(handshake, signaling, { files: pickedFiles }));
     } else {
-      beginTransfer(runReceive(handshake, signaling));
+      beginTransfer(runReceive(handshake, signaling, receiveDestination));
     }
   }
 
@@ -196,10 +242,12 @@
     progressTimer = undefined;
     if (downloadUrl) URL.revokeObjectURL(downloadUrl);
     downloadUrl = null;
+    void outcome?.cleanup?.();
     handshake = undefined;
     signaling = undefined;
     role = undefined;
-    pickedFile = null;
+    pickedFiles = [];
+    receiveDestination = { kind: 'auto' };
     sentBytes = 0;
     totalBytes = 0;
     rateBps = 0;
@@ -235,7 +283,7 @@
         class="receive"
         onsubmit={(e) => {
           e.preventDefault();
-          startReceive();
+          void startReceive();
         }}
       >
         <label for="code">Have an invite code?</label>
@@ -250,6 +298,12 @@
           />
           <button type="submit" disabled={codeInput.trim() === ''}>Receive</button>
         </div>
+        <label for="destination">Destination</label>
+        <select id="destination" bind:value={receiveTarget}>
+          <option value="auto">Download when verified</option>
+          <option value="direct-file">Save directly to one file</option>
+          <option value="direct-directory">Save directly to a folder</option>
+        </select>
       </form>
     </section>
   {:else if screen === 'sending'}
@@ -283,10 +337,22 @@
 
       {#if outcome}
         {#if downloadUrl}
-          <p class="status">Received <strong>{outcome.name}</strong> — verified.</p>
+          <p class="status">
+            Received <strong
+              >{outcome.files.length === 1 ? outcome.name : `${outcome.files.length} files`}</strong
+            >
+            — verified.
+          </p>
           <a class="primary download" href={downloadUrl} download={outcome.name}>
             Save {outcome.name}
           </a>
+        {:else if outcome.savedDirectly}
+          <p class="status">
+            Received <strong
+              >{outcome.files.length === 1 ? outcome.name : `${outcome.files.length} files`}</strong
+            >
+            — verified and saved.
+          </p>
         {:else}
           <p class="status">Sent <strong>{outcome.name}</strong> — verified by the receiver.</p>
         {/if}
@@ -310,8 +376,12 @@
         </div>
       {:else if role === 'offerer'}
         <label class="filepick">
-          <span>Choose a file to send</span>
-          <input type="file" onchange={onPick} />
+          <span>Choose files to send</span>
+          <input type="file" multiple onchange={onPick} />
+        </label>
+        <label class="filepick">
+          <span>Choose a folder to send</span>
+          <input type="file" multiple webkitdirectory onchange={onPick} />
         </label>
       {:else}
         <p class="status" aria-live="polite">Waiting for the sender to choose a file…</p>

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -16,15 +16,24 @@ import { SignalAuthenticator } from '../transfer/authed-signaling.js';
 import { createPeer, type Peer } from '../transfer/peer.js';
 import { ChannelWriter } from '../transfer/channel-writer.js';
 import { ProgressTracker, type TransferSnapshot } from '../transfer/progress.js';
-import { readOpfsFile } from '../transfer/sink.js';
-import type { HostToWorker, SessionCrypto, WorkerToHost } from '../transfer/wire.js';
+import { readOpfsOutput, removeOpfsOutput } from '../transfer/sink.js';
+import type {
+  HostToWorker,
+  ReceiveDestinationSpec,
+  SessionCrypto,
+  WorkerToHost,
+} from '../transfer/wire.js';
 
 /** Terminal outcome of a transfer. `file` is present on the receive side (the downloadable result). */
 export interface TransferOutcome {
   name: string;
   size: number;
   digest: string;
+  files: Array<{ name: string; size: number; digest: string }>;
   file?: File;
+  savedDirectly?: boolean;
+  /** Release a temporary browser-staged output after its download link is gone. */
+  cleanup?: () => Promise<void>;
 }
 
 /** A transfer in progress. `done` settles once; `progress` is polled by the UI for a live bar. */
@@ -46,10 +55,10 @@ export interface TransferController {
 }
 
 export interface SendOptions {
-  file: File;
+  files: File[];
 }
 
-/** Start sending `opts.file` to the peer over the adopted rendezvous socket. */
+/** Start sending an ordered file/folder selection over the adopted rendezvous socket. */
 export function runSend(
   rendezvous: RendezvousResult,
   signaling: SignalChannel,
@@ -57,8 +66,8 @@ export function runSend(
 ): TransferController {
   return run(rendezvous, signaling, {
     role: 'send',
-    total: opts.file.size,
-    start: () => ({ kind: 'start-send', file: opts.file, ...crypto(rendezvous) }),
+    total: opts.files.reduce((total, file) => total + file.size, 0),
+    start: () => ({ kind: 'start-send', files: opts.files, ...crypto(rendezvous) }),
   });
 }
 
@@ -66,10 +75,11 @@ export function runSend(
 export function runReceive(
   rendezvous: RendezvousResult,
   signaling: SignalChannel,
+  destination: ReceiveDestinationSpec = { kind: 'auto' },
 ): TransferController {
   return run(rendezvous, signaling, {
     role: 'receive',
-    start: () => ({ kind: 'start-recv', ...crypto(rendezvous) }),
+    start: () => ({ kind: 'start-recv', destination, ...crypto(rendezvous) }),
   });
 }
 
@@ -155,14 +165,14 @@ function run(
             progress.update(msg.bytes);
             return;
           case 'manifest':
-            total = msg.size;
-            progress.setTotal(msg.size);
+            total = msg.totalSize;
+            progress.setTotal(msg.totalSize);
             return;
           case 'state':
             progress.setState(msg.state);
             return;
           case 'done':
-            void completeReceive(msg.name, msg.size, msg.digest);
+            void completeTransfer(msg);
             return;
           case 'error':
             if (msg.reason === 'canceled') {
@@ -192,16 +202,40 @@ function run(
     }
   })();
 
-  async function completeReceive(name: string, size: number, digest: string): Promise<void> {
+  async function completeTransfer(msg: Extract<WorkerToHost, { kind: 'done' }>): Promise<void> {
+    const first = msg.files[0]!;
     if (spec.role === 'receive') {
       try {
-        const file = await readOpfsFile(name);
-        finish({ name, size, digest, file });
+        const output = msg.output;
+        if (output?.kind === 'opfs') {
+          const file = await readOpfsOutput(output.key, output.name, output.mime);
+          finish({
+            name: output.name,
+            size: msg.totalSize,
+            digest: msg.digest,
+            files: msg.files,
+            file,
+            cleanup: () => removeOpfsOutput(output.key),
+          });
+        } else {
+          finish({
+            name: first.name,
+            size: msg.totalSize,
+            digest: msg.digest,
+            files: msg.files,
+            savedDirectly: true,
+          });
+        }
       } catch (err) {
         fail(err instanceof Error ? err : new Error(String(err)));
       }
     } else {
-      finish({ name, size, digest });
+      finish({
+        name: msg.files.length === 1 ? first.name : `${msg.files.length} files`,
+        size: msg.totalSize,
+        digest: msg.digest,
+        files: msg.files,
+      });
     }
   }
 

--- a/apps/web/src/lib/transfer/file-source.ts
+++ b/apps/web/src/lib/transfer/file-source.ts
@@ -11,7 +11,7 @@ const DEFAULT_CHUNK = 64 * 1024;
 
 export function blobFileSource(file: File, chunk: number = DEFAULT_CHUNK): FileSource {
   const meta: FileMeta = {
-    name: file.name,
+    name: file.webkitRelativePath || file.name,
     size: file.size,
     mime: file.type,
     lastModified: file.lastModified,

--- a/apps/web/src/lib/transfer/sink.test.ts
+++ b/apps/web/src/lib/transfer/sink.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FrameType, type Manifest } from '@sendarc/protocol';
+import {
+  ArchiveDestination,
+  createBrowserDestination,
+  readOpfsOutput,
+  removeOpfsOutput,
+} from './sink.js';
+import type { WritableFileLike } from './stream-sink.js';
+
+class FakeWritable implements WritableFileLike {
+  bytes = new Uint8Array();
+  writes: number[] = [];
+  closed = false;
+  aborted = false;
+  async write(request: { type: 'write'; position: number; data: Uint8Array }): Promise<void> {
+    const end = request.position + request.data.length;
+    if (end > this.bytes.length) {
+      const grown = new Uint8Array(end);
+      grown.set(this.bytes);
+      this.bytes = grown;
+    }
+    this.bytes.set(request.data, request.position);
+    this.writes.push(request.data.length);
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+  async abort(): Promise<void> {
+    this.aborted = true;
+  }
+}
+
+function manifest(names: Array<[string, number]>): Manifest {
+  return {
+    type: FrameType.Manifest,
+    files: names.map(([name, size], idx) => ({
+      idx,
+      name,
+      size,
+      mime: '',
+      lastModified: 0,
+      blockSize: 8,
+      blocks: Math.ceil(size / 8),
+      fileDigest: '00',
+    })),
+    totalSize: names.reduce((total, [, size]) => total + size, 0),
+  };
+}
+
+function fakeStorage(writable: FakeWritable, available = 1 << 30) {
+  const root = {
+    getFileHandle: vi.fn(async () => ({ createWritable: vi.fn(async () => writable) })),
+    removeEntry: vi.fn(async () => {}),
+  };
+  vi.stubGlobal('navigator', {
+    storage: {
+      estimate: vi.fn(async () => ({ quota: available, usage: 0 })),
+      getDirectory: vi.fn(async () => root),
+    },
+  });
+  return root;
+}
+
+function hasSignature(bytes: Uint8Array, signature: number): boolean {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  for (let idx = 0; idx <= bytes.length - 4; idx++) {
+    if (view.getUint32(idx, true) === signature) return true;
+  }
+  return false;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('browser destinations', () => {
+  it('streams a store-only ZIP with descriptors and a central directory', async () => {
+    const writable = new FakeWritable();
+    fakeStorage(writable);
+    const destination = new ArchiveDestination();
+    await destination.prepare(
+      manifest([
+        ['folder/a.bin', 3],
+        ['folder/empty.txt', 0],
+      ]),
+    );
+
+    const first = await destination.open(manifest([['folder/a.bin', 3]]).files[0]!);
+    await first.write(0, new Uint8Array([1, 2]));
+    await first.write(2, new Uint8Array([3]));
+    await first.close();
+    const second = await destination.open(manifest([['folder/empty.txt', 0]]).files[0]!);
+    await second.close();
+    await destination.close();
+
+    const view = new DataView(writable.bytes.buffer);
+    expect(view.getUint32(0, true)).toBe(0x04034b50);
+    expect(view.getUint32(writable.bytes.length - 22, true)).toBe(0x06054b50);
+    expect(hasSignature(writable.bytes, 0x02014b50)).toBe(true);
+    expect(writable.closed).toBe(true);
+    expect(Math.max(...writable.writes)).toBeLessThan(writable.bytes.length);
+    expect(destination.result()).toMatchObject({ kind: 'opfs', name: 'folder.zip' });
+
+    const dir = mkdtempSync(join(tmpdir(), 'sendarc-zip-test-'));
+    try {
+      const path = join(dir, 'folder.zip');
+      writeFileSync(path, writable.bytes);
+      expect(execFileSync('unzip', ['-t', path], { encoding: 'utf8' })).toContain('No errors');
+      expect(execFileSync('unzip', ['-p', path, 'folder/a.bin'])).toEqual(Buffer.from([1, 2, 3]));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses insufficient quota before opening OPFS', async () => {
+    const writable = new FakeWritable();
+    const root = fakeStorage(writable, 10);
+    const destination = new ArchiveDestination();
+    await expect(destination.prepare(manifest([['a.bin', 20]]))).rejects.toMatchObject({
+      reason: 'quota',
+    });
+    expect(root.getFileHandle).not.toHaveBeenCalled();
+  });
+
+  it('writes a direct single-file destination without staging in memory', async () => {
+    const writable = new FakeWritable();
+    const handle = {
+      createWritable: vi.fn(async () => writable),
+    } as unknown as FileSystemFileHandle;
+    const destination = createBrowserDestination({ kind: 'direct-file', handle });
+    const one = manifest([['out.bin', 3]]);
+    await destination.prepare(one);
+    const sink = await destination.open(one.files[0]!);
+    await sink.write(0, new Uint8Array([4, 5, 6]));
+    await sink.close();
+    await destination.close();
+    expect(writable.bytes).toEqual(new Uint8Array([4, 5, 6]));
+    expect(destination.result()).toEqual({ kind: 'direct' });
+  });
+
+  it('keeps an OPFS result alive until the UI explicitly cleans it up', async () => {
+    const source = new File([new Uint8Array([7, 8, 9])], 'staged.bin');
+    const removeEntry = vi.fn(async () => {});
+    vi.stubGlobal('navigator', {
+      storage: {
+        getDirectory: vi.fn(async () => ({
+          getFileHandle: vi.fn(async () => ({ getFile: vi.fn(async () => source) })),
+          removeEntry,
+        })),
+      },
+    });
+
+    const result = await readOpfsOutput('staged-key', 'result.bin', 'application/octet-stream');
+    expect(new Uint8Array(await result.arrayBuffer())).toEqual(new Uint8Array([7, 8, 9]));
+    expect(removeEntry).not.toHaveBeenCalled();
+
+    await removeOpfsOutput('staged-key');
+    expect(removeEntry).toHaveBeenCalledWith('staged-key');
+  });
+});

--- a/apps/web/src/lib/transfer/sink.ts
+++ b/apps/web/src/lib/transfer/sink.ts
@@ -1,47 +1,366 @@
-/**
- * Opens an OPFS destination for a received file. OPFS needs no user gesture, so it works when the
- * manifest arrives mid-connection. The worker writes verified blocks here; on completion the host
- * reads the file back out for a download. Not unit-tested — exercised by the e2e transfer.
- */
-
-import type { Sink } from '@sendarc/protocol';
+import {
+  TransferError,
+  normalizeTransferPath,
+  type Destination,
+  type FileEntry,
+  type Manifest,
+  type Sink,
+} from '@sendarc/protocol';
 import { streamSink, type WritableFileLike } from './stream-sink.js';
+import type { ReceiveDestinationSpec } from './wire.js';
 
-export interface OpenedSink {
-  sink: Sink;
-  /** Read the finished file back (after `sink.close()`), e.g. to trigger a download. */
-  file(): Promise<File>;
+export type DestinationOutput =
+  { kind: 'opfs'; key: string; name: string; mime: string } | { kind: 'direct' };
+
+export interface BrowserDestination extends Destination {
+  result(): DestinationOutput | undefined;
 }
 
-export async function openOpfsSink(name: string): Promise<OpenedSink> {
-  const root = await navigator.storage.getDirectory();
-  const handle = await root.getFileHandle(sanitize(name), { create: true });
-  const writable = (await handle.createWritable({
-    keepExistingData: false,
-  })) as unknown as WritableFileLike;
+/** Select a concrete destination only after the authenticated manifest is available. */
+export function createBrowserDestination(spec: ReceiveDestinationSpec): BrowserDestination {
+  let inner: BrowserDestination | undefined;
+  const get = (): BrowserDestination => {
+    if (!inner) throw new TransferError('sink_error', 'destination used before manifest');
+    return inner;
+  };
   return {
-    sink: streamSink(writable),
-    async file() {
-      const f = await handle.getFile();
-      return new File([f], name, { type: f.type, lastModified: f.lastModified });
+    async prepare(manifest) {
+      if (spec.kind === 'direct-file') inner = new DirectFileDestination(spec.handle);
+      else if (spec.kind === 'direct-directory')
+        inner = new DirectDirectoryDestination(spec.handle);
+      else if (manifest.files.length === 1 && !manifest.files[0]!.name.includes('/')) {
+        inner = new OpfsFileDestination();
+      } else {
+        inner = new ArchiveDestination();
+      }
+      await inner.prepare(manifest);
     },
+    open: (file) => get().open(file),
+    close: () => get().close(),
+    abort: (reason) => get().abort(reason),
+    result: () => inner?.result(),
   };
 }
 
-/** OPFS keys are path-like; strip separators so the manifest name can't escape the directory. */
-function sanitize(name: string): string {
-  const base = name.replace(/^.*[\\/]/, '').trim();
-  return base.length > 0 ? base : 'download';
+class DirectFileDestination implements BrowserDestination {
+  private sink: Sink | undefined;
+  constructor(private readonly handle: FileSystemFileHandle) {}
+  prepare(manifest: Manifest): void {
+    if (manifest.files.length !== 1 || manifest.files[0]!.name.includes('/')) {
+      throw new TransferError('sink_error', 'the selected file destination accepts one file only');
+    }
+  }
+  async open(): Promise<Sink> {
+    if (this.sink) throw new TransferError('sink_error', 'destination file opened twice');
+    const writable = (await this.handle.createWritable({
+      keepExistingData: false,
+    })) as WritableFileLike;
+    return (this.sink = streamSink(writable));
+  }
+  close(): void {}
+  async abort(reason?: string): Promise<void> {
+    await this.sink?.abort(reason);
+  }
+  result(): DestinationOutput {
+    return { kind: 'direct' };
+  }
+}
+
+class DirectDirectoryDestination implements BrowserDestination {
+  private readonly opened: Sink[] = [];
+  private readonly created: string[][] = [];
+  constructor(private readonly root: FileSystemDirectoryHandle) {}
+  prepare(): void {}
+  async open(file: FileEntry): Promise<Sink> {
+    const parts = normalizeTransferPath(file.name).split('/');
+    let directory = this.root;
+    for (const part of parts.slice(0, -1)) {
+      directory = await directory.getDirectoryHandle(part, { create: true });
+    }
+    const leaf = parts.at(-1)!;
+    try {
+      await directory.getFileHandle(leaf);
+      throw new TransferError('sink_error', `destination already contains ${file.name}`);
+    } catch (err) {
+      if (err instanceof TransferError) throw err;
+      if (!(err instanceof DOMException) || err.name !== 'NotFoundError') throw err;
+    }
+    const handle = await directory.getFileHandle(leaf, { create: true });
+    const writable = (await handle.createWritable({ keepExistingData: false })) as WritableFileLike;
+    const sink = streamSink(writable);
+    this.opened.push(sink);
+    this.created.push(parts);
+    return sink;
+  }
+  close(): void {}
+  async abort(reason?: string): Promise<void> {
+    await Promise.allSettled(this.opened.map((sink) => sink.abort(reason)));
+    for (const parts of [...this.created].reverse()) {
+      let directory = this.root;
+      try {
+        for (const part of parts.slice(0, -1)) {
+          directory = await directory.getDirectoryHandle(part);
+        }
+        await directory.removeEntry(parts.at(-1)!);
+      } catch {
+        // Best effort after the first transfer failure.
+      }
+    }
+  }
+  result(): DestinationOutput {
+    return { kind: 'direct' };
+  }
+}
+
+class OpfsFileDestination implements BrowserDestination {
+  private root: FileSystemDirectoryHandle | undefined;
+  private key = '';
+  private outputName = '';
+  private mime = '';
+  private sink: Sink | undefined;
+  async prepare(manifest: Manifest): Promise<void> {
+    await ensureQuota(manifest.totalSize);
+    const file = manifest.files[0]!;
+    this.root = await opfsRoot();
+    this.outputName = file.name;
+    this.mime = file.mime;
+    this.key = uniqueKey(file.name);
+  }
+  async open(): Promise<Sink> {
+    if (!this.root || this.sink) throw new TransferError('sink_error', 'OPFS destination state');
+    const handle = await this.root.getFileHandle(this.key, { create: true });
+    const writable = (await handle.createWritable({ keepExistingData: false })) as WritableFileLike;
+    return (this.sink = streamSink(writable));
+  }
+  close(): void {}
+  async abort(reason?: string): Promise<void> {
+    await this.sink?.abort(reason);
+    if (this.root && this.key) await this.root.removeEntry(this.key).catch(() => {});
+  }
+  result(): DestinationOutput {
+    return { kind: 'opfs', key: this.key, name: this.outputName, mime: this.mime };
+  }
+}
+
+interface ZipEntry {
+  name: Uint8Array;
+  crc: number;
+  size: number;
+  offset: number;
+}
+
+/** Streaming, store-only ZIP destination used when direct directory access is unavailable. */
+export class ArchiveDestination implements BrowserDestination {
+  private root: FileSystemDirectoryHandle | undefined;
+  private writable: WritableFileLike | undefined;
+  private key = '';
+  private name = 'sendarc-files.zip';
+  private position = 0;
+  private readonly entries: ZipEntry[] = [];
+  private active: ArchiveEntrySink | undefined;
+
+  async prepare(manifest: Manifest): Promise<void> {
+    const namesSize = manifest.files.reduce(
+      (total, file) => total + new TextEncoder().encode(file.name).length * 2 + 92,
+      22,
+    );
+    const archiveSize = manifest.totalSize + namesSize;
+    if (archiveSize > 0xffffffff || manifest.files.some((file) => file.size > 0xffffffff)) {
+      throw new TransferError('sink_error', 'ZIP fallback is limited to 4 GiB; choose a folder');
+    }
+    await ensureQuota(archiveSize);
+    const top = manifest.files[0]!.name.split('/')[0]!;
+    if (manifest.files.every((file) => file.name.startsWith(`${top}/`))) this.name = `${top}.zip`;
+    this.key = uniqueKey(this.name);
+    this.root = await opfsRoot();
+    const handle = await this.root.getFileHandle(this.key, { create: true });
+    this.writable = (await handle.createWritable({ keepExistingData: false })) as WritableFileLike;
+  }
+
+  async open(file: FileEntry): Promise<Sink> {
+    if (!this.writable || this.active) throw new TransferError('sink_error', 'ZIP entry state');
+    const name = new TextEncoder().encode(normalizeTransferPath(file.name));
+    const offset = this.position;
+    await this.append(localHeader(name));
+    const entry = new ArchiveEntrySink(this, name, offset, file.size);
+    this.active = entry;
+    return entry;
+  }
+
+  async close(): Promise<void> {
+    if (!this.writable || this.active)
+      throw new TransferError('sink_error', 'ZIP not ready to close');
+    const centralOffset = this.position;
+    for (const entry of this.entries) await this.append(centralHeader(entry));
+    const centralSize = this.position - centralOffset;
+    await this.append(endOfCentralDirectory(this.entries.length, centralSize, centralOffset));
+    await this.writable.close();
+  }
+
+  async abort(reason?: string): Promise<void> {
+    await this.writable?.abort?.(reason);
+    if (this.root && this.key) await this.root.removeEntry(this.key).catch(() => {});
+  }
+
+  result(): DestinationOutput {
+    return { kind: 'opfs', key: this.key, name: this.name, mime: 'application/zip' };
+  }
+
+  async append(bytes: Uint8Array): Promise<void> {
+    if (!this.writable) throw new TransferError('sink_error', 'ZIP writer unavailable');
+    await this.writable.write({ type: 'write', position: this.position, data: bytes });
+    this.position += bytes.length;
+  }
+
+  finishEntry(entry: ZipEntry): void {
+    this.entries.push(entry);
+    this.active = undefined;
+  }
+}
+
+class ArchiveEntrySink implements Sink {
+  private offset = 0;
+  private crc = 0xffffffff;
+  private closed = false;
+  constructor(
+    private readonly archive: ArchiveDestination,
+    private readonly name: Uint8Array,
+    private readonly localOffset: number,
+    private readonly expectedSize: number,
+  ) {}
+  async write(offset: number, bytes: Uint8Array): Promise<void> {
+    if (this.closed || offset !== this.offset)
+      throw new TransferError('sink_error', 'ZIP write order');
+    await this.archive.append(bytes);
+    this.crc = crc32Update(this.crc, bytes);
+    this.offset += bytes.length;
+  }
+  async close(): Promise<void> {
+    if (this.closed || this.offset !== this.expectedSize) {
+      throw new TransferError('sink_error', 'ZIP entry size mismatch');
+    }
+    this.closed = true;
+    const crc = (this.crc ^ 0xffffffff) >>> 0;
+    await this.archive.append(dataDescriptor(crc, this.offset));
+    this.archive.finishEntry({ name: this.name, crc, size: this.offset, offset: this.localOffset });
+  }
+  abort(): void {
+    this.closed = true;
+  }
+}
+
+async function ensureQuota(required: number): Promise<void> {
+  const storage = navigator.storage as StorageManager | undefined;
+  if (!storage) throw new TransferError('sink_error', 'browser storage is unavailable');
+  const estimate = await storage.estimate();
+  if (estimate.quota === undefined) return;
+  const available = Math.max(0, estimate.quota - (estimate.usage ?? 0));
+  if (available < required) {
+    throw new TransferError('quota', `need ${required} bytes but only ${available} are available`);
+  }
+}
+
+function uniqueKey(name: string): string {
+  const base = name.replace(/^.*\//, '').replace(/[^\p{L}\p{N}._-]+/gu, '_') || 'download';
+  return `sendarc-${crypto.randomUUID()}-${base}`;
 }
 
 /**
- * Read a finished OPFS file back by name, without opening a writable (which would truncate it).
- * The orchestrator calls this after the worker reports `done` to hand a downloadable File to the
- * UI. OPFS is origin-global, so the file the worker wrote is visible here on the main thread.
+ * Open a completed OPFS output without truncating or removing its backing entry.
+ * Chromium-backed File snapshots become unreadable when that entry is removed, so the UI owns
+ * cleanup and keeps it alive for as long as the download link is visible.
  */
-export async function readOpfsFile(name: string): Promise<File> {
-  const root = await navigator.storage.getDirectory();
-  const handle = await root.getFileHandle(sanitize(name), { create: false });
-  const f = await handle.getFile();
-  return new File([f], name, { type: f.type, lastModified: f.lastModified });
+export async function readOpfsOutput(key: string, name: string, mime: string): Promise<File> {
+  const root = await opfsRoot();
+  const handle = await root.getFileHandle(key, { create: false });
+  const file = await handle.getFile();
+  return new File([file], name, {
+    type: mime || file.type,
+    lastModified: file.lastModified,
+  });
+}
+
+/** Remove an OPFS result once its download link is no longer exposed. */
+export async function removeOpfsOutput(key: string): Promise<void> {
+  const root = await opfsRoot();
+  await root.removeEntry(key).catch(() => {});
+}
+
+async function opfsRoot(): Promise<FileSystemDirectoryHandle> {
+  const storage = navigator.storage as StorageManager | undefined;
+  if (!storage || typeof storage.getDirectory !== 'function') {
+    throw new TransferError('sink_error', 'Origin Private File System is unavailable');
+  }
+  return storage.getDirectory();
+}
+
+const crcTable = Array.from({ length: 256 }, (_, value) => {
+  let crc = value;
+  for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+  return crc >>> 0;
+});
+
+function crc32Update(crc: number, bytes: Uint8Array): number {
+  for (const byte of bytes) crc = (crc >>> 8) ^ crcTable[(crc ^ byte) & 0xff]!;
+  return crc >>> 0;
+}
+
+function record(size: number, write: (view: DataView) => void): Uint8Array {
+  const out = new Uint8Array(size);
+  write(new DataView(out.buffer));
+  return out;
+}
+
+function localHeader(name: Uint8Array): Uint8Array {
+  const header = record(30, (v) => {
+    v.setUint32(0, 0x04034b50, true);
+    v.setUint16(4, 20, true);
+    v.setUint16(6, 0x0808, true);
+    v.setUint16(26, name.length, true);
+  });
+  return join(header, name);
+}
+
+function dataDescriptor(crc: number, size: number): Uint8Array {
+  return record(16, (v) => {
+    v.setUint32(0, 0x08074b50, true);
+    v.setUint32(4, crc, true);
+    v.setUint32(8, size, true);
+    v.setUint32(12, size, true);
+  });
+}
+
+function centralHeader(entry: ZipEntry): Uint8Array {
+  const header = record(46, (v) => {
+    v.setUint32(0, 0x02014b50, true);
+    v.setUint16(4, 20, true);
+    v.setUint16(6, 20, true);
+    v.setUint16(8, 0x0808, true);
+    v.setUint32(16, entry.crc, true);
+    v.setUint32(20, entry.size, true);
+    v.setUint32(24, entry.size, true);
+    v.setUint16(28, entry.name.length, true);
+    v.setUint32(42, entry.offset, true);
+  });
+  return join(header, entry.name);
+}
+
+function endOfCentralDirectory(count: number, size: number, offset: number): Uint8Array {
+  return record(22, (v) => {
+    v.setUint32(0, 0x06054b50, true);
+    v.setUint16(8, count, true);
+    v.setUint16(10, count, true);
+    v.setUint32(12, size, true);
+    v.setUint32(16, offset, true);
+  });
+}
+
+function join(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((size, part) => size + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
 }

--- a/apps/web/src/lib/transfer/transfer-core.test.ts
+++ b/apps/web/src/lib/transfer/transfer-core.test.ts
@@ -42,9 +42,9 @@ describe('transfer-core loopback', () => {
     const recvPort = new FakePort();
     const sink = new MemorySink();
 
-    let senderDone: (WorkerToHost & { kind: 'done' }) | undefined;
-    let receiverDone: (WorkerToHost & { kind: 'done' }) | undefined;
-    let manifest: (WorkerToHost & { kind: 'manifest' }) | undefined;
+    let senderDone: Extract<WorkerToHost, { kind: 'done' }> | undefined;
+    let receiverDone: Extract<WorkerToHost, { kind: 'done' }> | undefined;
+    let manifest: Extract<WorkerToHost, { kind: 'manifest' }> | undefined;
     const senderStates: string[] = [];
 
     sendPort.onWorkerOut = (m) => {
@@ -78,6 +78,7 @@ describe('transfer-core loopback', () => {
 
     recvPort.toWorker({
       kind: 'start-recv',
+      destination: { kind: 'auto' },
       sendDir: keys.j2o,
       recvDir: keys.o2j,
       sendCounter: 1,
@@ -88,7 +89,7 @@ describe('transfer-core loopback', () => {
     sendPort.toWorker({ kind: 'control', op: 'pause' });
     sendPort.toWorker({
       kind: 'start-send',
-      file,
+      files: [file],
       sendDir: keys.o2j,
       recvDir: keys.j2o,
       sendCounter: 1,
@@ -109,10 +110,10 @@ describe('transfer-core loopback', () => {
     expect(sink.isClosed).toBe(true);
     expect(receiverDone?.digest).toBe(expected);
     expect(senderDone?.digest).toBe(expected);
-    expect(receiverDone?.name).toBe('loop.bin');
-    expect(receiverDone?.size).toBe(bytes.length);
-    expect(manifest?.name).toBe('loop.bin');
-    expect(manifest?.size).toBe(bytes.length);
+    expect(receiverDone?.files[0]?.name).toBe('loop.bin');
+    expect(receiverDone?.totalSize).toBe(bytes.length);
+    expect(manifest?.files[0]?.name).toBe('loop.bin');
+    expect(manifest?.totalSize).toBe(bytes.length);
     expect(senderStates).toEqual(['running', 'paused', 'running']);
   });
 
@@ -158,6 +159,7 @@ describe('transfer-core loopback', () => {
 
     recvPort.toWorker({
       kind: 'start-recv',
+      destination: { kind: 'auto' },
       sendDir: keys.j2o,
       recvDir: keys.o2j,
       sendCounter: 1,
@@ -165,7 +167,7 @@ describe('transfer-core loopback', () => {
     });
     sendPort.toWorker({
       kind: 'start-send',
-      file,
+      files: [file],
       sendDir: keys.o2j,
       recvDir: keys.j2o,
       sendCounter: 1,
@@ -175,5 +177,66 @@ describe('transfer-core loopback', () => {
     });
 
     await expect(Promise.all([recvP, sendP])).rejects.toThrow(/integrity/);
+  });
+
+  it('carries a nested file set through the worker protocol', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(9));
+    const files = [new File([new Uint8Array([1, 2, 3])], 'a.bin'), new File([], 'empty.txt')];
+    Object.defineProperty(files[0], 'webkitRelativePath', { value: 'folder/a.bin' });
+    Object.defineProperty(files[1], 'webkitRelativePath', { value: 'folder/empty.txt' });
+    const sendPort = new FakePort();
+    const recvPort = new FakePort();
+    const sinks = new Map<string, MemorySink>();
+    let received: Extract<WorkerToHost, { kind: 'done' }> | undefined;
+    sendPort.onWorkerOut = (message) => {
+      if (message.kind === 'outbound-frame') {
+        recvPort.toWorker({ kind: 'inbound-frame', frame: message.frame });
+      }
+    };
+    recvPort.onWorkerOut = (message) => {
+      if (message.kind === 'outbound-frame') {
+        sendPort.toWorker({ kind: 'inbound-frame', frame: message.frame });
+      } else if (message.kind === 'done') received = message;
+    };
+    const receiverDigest = await createSha256DigestFactory();
+    const senderDigest = await createSha256DigestFactory();
+    const recvP = runTransferCore(recvPort, {
+      createDigest: receiverDigest,
+      createSink: (file) => {
+        const sink = new MemorySink();
+        sinks.set(file.name, sink);
+        return sink;
+      },
+      fileSource: blobFileSource,
+    });
+    const sendP = runTransferCore(sendPort, {
+      createDigest: senderDigest,
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: blobFileSource,
+    });
+    recvPort.toWorker({
+      kind: 'start-recv',
+      destination: { kind: 'auto' },
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounter: 1,
+      recvCounter: 1,
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      files,
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+      blockSize: 8,
+      frameSize: 4,
+    });
+    await Promise.all([recvP, sendP]);
+    expect(received?.files.map((file) => file.name)).toEqual(['folder/a.bin', 'folder/empty.txt']);
+    expect(sinks.get('folder/a.bin')?.bytes()).toEqual(new Uint8Array([1, 2, 3]));
+    expect(sinks.get('folder/empty.txt')?.bytes()).toEqual(new Uint8Array());
   });
 });

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -13,17 +13,28 @@ import {
   TransferReceiver,
   TransferError,
   type Digest,
+  type Destination,
   type FileEntry,
   type FileSource,
   type Sink,
 } from '@sendarc/protocol';
-import type { DuplexPort, HostToWorker, StartSendMsg, StartRecvMsg, WorkerToHost } from './wire.js';
+import type {
+  DuplexPort,
+  HostToWorker,
+  ReceiveDestinationSpec,
+  StartSendMsg,
+  StartRecvMsg,
+  WorkerToHost,
+} from './wire.js';
+import type { BrowserDestination } from './sink.js';
 
 export interface TransferCoreDeps {
   /** Fresh streaming whole-file hasher (matches `sha256sum`). One live digest per call. */
   createDigest(): Digest;
   /** Open the receive destination once the manifest names the file. */
   createSink(file: FileEntry): Sink | Promise<Sink>;
+  /** Browser worker destination selection; tests may continue supplying createSink only. */
+  createDestination?(spec: ReceiveDestinationSpec): BrowserDestination;
   /** Adapt the sender's File into a re-callable byte source. */
   fileSource(file: File): FileSource;
 }
@@ -111,9 +122,10 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
 
     async function startSend(msg: StartSendMsg): Promise<void> {
       try {
-        const source = deps.fileSource(msg.file);
+        const sources = msg.files.map((file) => deps.fileSource(file));
+        let manifestFiles: FileEntry[] = [];
         const sender = new TransferSender({
-          file: source,
+          files: sources,
           send,
           sendDir: msg.sendDir,
           recvDir: msg.recvDir,
@@ -121,6 +133,9 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           recvCounterStart: msg.recvCounter,
           createDigest: deps.createDigest,
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
+          onManifest: (manifest) => {
+            manifestFiles = manifest.files;
+          },
           onStateChange: (state) => post({ kind: 'state', state }),
           ...(msg.blockSize !== undefined ? { blockSize: msg.blockSize } : {}),
           ...(msg.frameSize !== undefined ? { frameSize: msg.frameSize } : {}),
@@ -128,7 +143,16 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
         });
         bind(sender);
         const digest = await sender.run();
-        post({ kind: 'done', name: source.meta.name, size: source.meta.size, digest });
+        post({
+          kind: 'done',
+          files: manifestFiles.map((file) => ({
+            name: file.name,
+            size: file.size,
+            digest: file.fileDigest,
+          })),
+          totalSize: manifestFiles.reduce((total, file) => total + file.size, 0),
+          digest,
+        });
         resolve();
       } catch (e) {
         fail(e);
@@ -137,7 +161,9 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
 
     async function startRecv(_msg: StartRecvMsg): Promise<void> {
       try {
-        const deferred = new DeferredSink();
+        const destination = deps.createDestination
+          ? deps.createDestination(_msg.destination)
+          : sinkFactoryDestination(deps.createSink);
         const receiver = new TransferReceiver({
           send,
           sendDir: _msg.sendDir,
@@ -145,21 +171,34 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           sendCounterStart: _msg.sendCounter,
           recvCounterStart: _msg.recvCounter,
           createDigest: deps.createDigest,
-          sink: deferred,
+          destination,
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
           onStateChange: (state) => post({ kind: 'state', state }),
-          onManifest: async (file) => {
-            deferred.attach(await deps.createSink(file));
-            post({ kind: 'manifest', name: file.name, size: file.size, mime: file.mime });
+          onManifestSet: (manifest) => {
+            post({
+              kind: 'manifest',
+              files: manifest.files.map((file) => ({
+                name: file.name,
+                size: file.size,
+                mime: file.mime,
+              })),
+              totalSize: manifest.totalSize,
+            });
           },
         });
         bind(receiver);
         const result = await receiver.done;
+        const output = isBrowserDestination(destination) ? destination.result() : undefined;
         post({
           kind: 'done',
-          name: result.file.name,
-          size: result.file.size,
+          files: result.files.map((file, idx) => ({
+            name: file.name,
+            size: file.size,
+            digest: result.digests[idx]!,
+          })),
+          totalSize: result.totalSize,
           digest: result.digest,
+          ...(output?.kind === 'opfs' ? { output } : {}),
         });
         resolve();
       } catch (e) {
@@ -173,21 +212,26 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
  * A Sink whose destination is opened after construction — the receiver builds it before the
  * manifest arrives, then `onManifest` attaches the real sink before the first verified write.
  */
-class DeferredSink implements Sink {
-  private inner: Sink | undefined;
-  attach(sink: Sink): void {
-    this.inner = sink;
-  }
-  write(offset: number, bytes: Uint8Array): void | Promise<void> {
-    if (!this.inner) throw new TransferError('sink_error', 'sink not opened before write');
-    return this.inner.write(offset, bytes);
-  }
-  close(): void | Promise<void> {
-    return this.inner?.close();
-  }
-  abort(reason?: string): void | Promise<void> {
-    return this.inner?.abort(reason);
-  }
+function sinkFactoryDestination(
+  createSink: (file: FileEntry) => Sink | Promise<Sink>,
+): Destination {
+  const sinks: Sink[] = [];
+  return {
+    prepare: () => {},
+    async open(file) {
+      const sink = await createSink(file);
+      sinks.push(sink);
+      return sink;
+    },
+    close: () => {},
+    async abort(reason) {
+      await Promise.allSettled(sinks.map((sink) => sink.abort(reason)));
+    },
+  };
+}
+
+function isBrowserDestination(destination: Destination): destination is BrowserDestination {
+  return 'result' in destination;
 }
 
 /** A sealed frame's own ArrayBuffer when it fits exactly (the common case), else a fresh copy. */

--- a/apps/web/src/lib/transfer/transfer.worker.ts
+++ b/apps/web/src/lib/transfer/transfer.worker.ts
@@ -12,7 +12,7 @@
 import { runTransferCore } from './transfer-core.js';
 import { createSha256DigestFactory } from './digest.js';
 import { blobFileSource } from './file-source.js';
-import { openOpfsSink } from './sink.js';
+import { createBrowserDestination } from './sink.js';
 import type { DuplexPort, HostToWorker, WorkerToHost } from './wire.js';
 
 /** The slice of the worker global we touch, typed narrowly to avoid the DOM/WebWorker lib clash. */
@@ -35,7 +35,10 @@ async function main(): Promise<void> {
   post({ kind: 'ready' });
   await runTransferCore(port, {
     createDigest,
-    createSink: async (file) => (await openOpfsSink(file.name)).sink,
+    createSink: () => {
+      throw new Error('browser worker uses a destination factory');
+    },
+    createDestination: (spec) => createBrowserDestination(spec),
     fileSource: (file) => blobFileSource(file),
   });
 }

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -17,14 +17,19 @@ export interface SessionCrypto {
 
 export interface StartSendMsg extends SessionCrypto {
   kind: 'start-send';
-  file: File;
+  files: File[];
   blockSize?: number;
   frameSize?: number;
   window?: number;
 }
 export interface StartRecvMsg extends SessionCrypto {
   kind: 'start-recv';
+  destination: ReceiveDestinationSpec;
 }
+export type ReceiveDestinationSpec =
+  | { kind: 'auto' }
+  | { kind: 'direct-file'; handle: FileSystemFileHandle }
+  | { kind: 'direct-directory'; handle: FileSystemDirectoryHandle };
 export interface InboundFrameMsg {
   kind: 'inbound-frame';
   frame: ArrayBuffer;
@@ -50,9 +55,8 @@ export interface ReadyMsg {
 }
 export interface ManifestMsg {
   kind: 'manifest';
-  name: string;
-  size: number;
-  mime: string;
+  files: Array<{ name: string; size: number; mime: string }>;
+  totalSize: number;
 }
 export interface ProgressMsg {
   kind: 'progress';
@@ -64,9 +68,10 @@ export interface StateMsg {
 }
 export interface DoneMsg {
   kind: 'done';
-  name: string;
-  size: number;
+  files: Array<{ name: string; size: number; digest: string }>;
+  totalSize: number;
   digest: string;
+  output?: { kind: 'opfs'; key: string; name: string; mime: string };
 }
 export interface ErrorMsg {
   kind: 'error';

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -9,7 +9,7 @@
 
 import { open, seal, type FrameHeaderInput } from './aead.js';
 import type { DirectionalKey } from './keyschedule.js';
-import { FrameType, type ControlOp, type Fail } from './transfer.js';
+import { FrameType, type ControlOp, type Fail, type Manifest } from './transfer.js';
 import {
   DEFAULT_BLOCK_BYTES,
   DEFAULT_FRAME_BYTES,
@@ -51,6 +51,7 @@ export interface TransferSenderOptions {
   onProgress?(acknowledgedBytes: number): void;
   /** Reports verified progress for the active file plus aggregate acknowledged bytes. */
   onFileProgress?(fileIdx: number, fileBytes: number, acknowledgedBytes: number): void;
+  onManifest?(manifest: Manifest): void;
   onStateChange?(state: TransferRunState): void;
 }
 
@@ -188,6 +189,7 @@ export class TransferSender {
       totalSize,
     });
     const transferDigest = await completionDigest(manifest.files);
+    this.o.onManifest?.(manifest);
     await this.sendControl(FrameType.Manifest, manifest);
 
     for (const [fileIdx, source] of this.files.entries()) {


### PR DESCRIPTION
## Summary
- support browser multi-file and folder selection with negotiated capabilities
- stream verified output directly to File System Access destinations or an OPFS-backed ZIP fallback
- preflight browser quota, preserve nested paths safely, and keep staged downloads alive until UI cleanup

## Verification
- `pnpm run format:check`
- `just lint`
- `just typecheck`
- `just test`
- `just build`
- `go test -race ./packages/wire ./apps/cli/...`
- real CLI-to-Chrome nested folder transfer; downloaded ZIP passed `unzip -t` and byte-for-byte source comparison