### PR TITLE
feat(protocol): sequence relay-ready frames

### DIFF
--- a/apps/cli/internal/rendezvous/message.go
+++ b/apps/cli/internal/rendezvous/message.go
@@ -30,6 +30,16 @@ const (
 	typeError      = "error"
 )
 
+// Relay control tags are exported for the adopted transfer transport. They remain outside the
+// cryptographic handshake state machine and are handled only after establishment.
+const (
+	TypeRelayOpen     = "relay_open"
+	TypeRelayRequired = "relay_required"
+	TypeRelayReady    = "relay_ready"
+	TypeRelayCredit   = "relay_credit"
+	TypeCredit        = "credit"
+)
+
 // Message is the SendArc signaling envelope. One flat struct covers every message type;
 // the fields used depend on Type, and omitempty keeps each serialized frame minimal and
 // byte-compatible with the TypeScript union in signaling.ts. The word code is never a
@@ -59,6 +69,8 @@ type Message struct {
 	Reason string `json:"reason,omitempty"`
 	// Code is the machine-readable error code on error.
 	Code string `json:"code,omitempty"`
+	// Bytes carries bounded flow-control credit on relay_credit and credit messages.
+	Bytes int64 `json:"bytes,omitempty"`
 }
 
 // Sink is the outbound half of the signaling channel the session drives.
@@ -86,6 +98,14 @@ func NewSDP(seq int, sdp, mac string) Message {
 // and tagged exactly like [NewSDP].
 func NewICE(seq int, cand, mac string) Message {
 	return Message{Type: typeICE, Cand: cand, Seq: &seq, Mac: mac}
+}
+
+// NewRelayOpen opts this peer into the paired encrypted binary relay.
+func NewRelayOpen() Message { return Message{Type: TypeRelayOpen} }
+
+// NewRelayCredit grants bytes only after this peer has consumed the same amount.
+func NewRelayCredit(bytes int64) Message {
+	return Message{Type: TypeRelayCredit, Bytes: bytes}
 }
 
 // UnmarshalMessage decodes a JSON signaling frame. A frame missing a type is rejected so

--- a/apps/cli/internal/rendezvous/message_test.go
+++ b/apps/cli/internal/rendezvous/message_test.go
@@ -72,6 +72,23 @@ func TestHandshakeMessagesOmitSignalingFields(t *testing.T) {
 	}
 }
 
+func TestRelayControlWireShapes(t *testing.T) {
+	open, err := MarshalMessage(NewRelayOpen())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(open) != `{"type":"relay_open"}` {
+		t.Fatalf("relay open = %s", open)
+	}
+	credit, err := MarshalMessage(NewRelayCredit(524288))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(credit) != `{"type":"relay_credit","bytes":524288}` {
+		t.Fatalf("relay credit = %s", credit)
+	}
+}
+
 // TestMessageRoundTrip confirms an sdp message survives marshal→unmarshal intact,
 // including the pointer seq.
 func TestMessageRoundTrip(t *testing.T) {

--- a/packages/protocol/src/aead.test.ts
+++ b/packages/protocol/src/aead.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { deriveMaster, deriveTransferKeys } from './keyschedule.js';
-import { seal, open, type FrameHeaderInput } from './aead.js';
+import { FrameReplayError, open, openSequenced, seal, type FrameHeaderInput } from './aead.js';
+import { FRAME_COUNTER_BYTES } from './constants.js';
 import { FrameType } from './transfer.js';
 import { bytesToHex, hexToBytes, utf8 } from './bytes.js';
 
@@ -65,7 +66,9 @@ describe('AEAD frame codec — SendArc deterministic vector', () => {
   it('seals the caps payload to the committed frame bytes', async () => {
     const { o2j } = await deriveTransferKeys(hexToBytes(sa.keyschedule.master));
     const frame = await seal(o2j, sa.aead.counter, CAPS_HEADER, utf8(sa.aead.plaintextUtf8));
-    expect(bytesToHex(frame.slice(0, 16))).toBe(sa.aead.headerHex);
+    expect(bytesToHex(frame.slice(FRAME_COUNTER_BYTES, FRAME_COUNTER_BYTES + 16))).toBe(
+      sa.aead.headerHex,
+    );
     expect(bytesToHex(frame)).toBe(sa.aead.frameHex);
   });
 
@@ -95,6 +98,14 @@ describe('AEAD frame codec — round-trip and tamper detection', () => {
     await expect(open(o2j, 2, frame)).rejects.toThrow();
   });
 
+  it('accepts an authenticated forward gap and reports an old counter as replay', async () => {
+    const { o2j } = await deriveTransferKeys(hexToBytes(sa.keyschedule.master));
+    const frame = await seal(o2j, 9, CAPS_HEADER, utf8('after switch'));
+    const opened = await openSequenced(o2j, 4, frame);
+    expect(opened.counter).toBe(9);
+    await expect(openSequenced(o2j, 10, frame)).rejects.toBeInstanceOf(FrameReplayError);
+  });
+
   it('rejects a frame opened under the other direction key', async () => {
     const { o2j, j2o } = await deriveTransferKeys(hexToBytes(sa.keyschedule.master));
     const frame = await seal(o2j, 0, CAPS_HEADER, utf8('payload'));
@@ -111,7 +122,7 @@ describe('AEAD frame codec — round-trip and tamper detection', () => {
   it('rejects a frame with a tampered header (AAD) byte', async () => {
     const { o2j } = await deriveTransferKeys(hexToBytes(sa.keyschedule.master));
     const frame = await seal(o2j, 0, CAPS_HEADER, utf8('payload'));
-    frame[1] ^= 0x01; // flip the type byte inside the authenticated header
+    frame[FRAME_COUNTER_BYTES + 1] ^= 0x01; // flip the type byte inside authenticated AAD
     await expect(open(o2j, 0, frame)).rejects.toThrow();
   });
 

--- a/packages/protocol/src/aead.ts
+++ b/packages/protocol/src/aead.ts
@@ -1,7 +1,7 @@
 /**
- * AES-256-GCM frame codec. Each frame is a fixed 16-byte header followed
- * by the GCM output (ciphertext with appended 16-byte tag). The encoded header is the
- * GCM additional authenticated data, so any header tampering fails decryption.
+ * AES-256-GCM frame codec. Each frame is an 8-byte monotonic counter, a fixed 16-byte header,
+ * and the GCM output (ciphertext with appended 16-byte tag). Counter and header are the GCM
+ * additional authenticated data, so tampering with either fails decryption.
  *
  * The 12-byte nonce is the direction's 4-byte salt followed by a big-endian u64 frame
  * counter. Counters are per-direction and supplied by the caller (the session tracks
@@ -9,7 +9,12 @@
  * WebCrypto; mirrored by Go `crypto/cipher` in `packages/wire`.
  */
 
-import { AEAD_NONCE_BYTES, AEAD_TAG_BYTES, FRAME_HEADER_BYTES } from './constants.js';
+import {
+  AEAD_NONCE_BYTES,
+  AEAD_TAG_BYTES,
+  FRAME_COUNTER_BYTES,
+  FRAME_HEADER_BYTES,
+} from './constants.js';
 import { decodeFrameHeader, encodeFrameHeader } from './frame.js';
 import type { DirectionalKey } from './keyschedule.js';
 import type { FrameHeader } from './transfer.js';
@@ -21,7 +26,7 @@ export type FrameHeaderInput = Omit<FrameHeader, 'len'>;
 const U16_MAX = 0xffff;
 
 function nonce(salt: Uint8Array, counter: number): Uint8Array {
-  if (!Number.isInteger(counter) || counter < 0) {
+  if (!Number.isSafeInteger(counter) || counter < 0) {
     throw new RangeError(`frame counter ${counter} is not a non-negative integer`);
   }
   const out = new Uint8Array(AEAD_NONCE_BYTES);
@@ -31,8 +36,7 @@ function nonce(salt: Uint8Array, counter: number): Uint8Array {
 }
 
 /**
- * Encrypt `plaintext` into a frame: `header(16) || ciphertext || tag(16)`. The header's
- * `len` field is set to the plaintext length and authenticated as GCM AAD.
+ * Encrypt `plaintext` into `counter(8) || header(16) || ciphertext || tag(16)`.
  */
 export async function seal(
   dir: DirectionalKey,
@@ -43,7 +47,9 @@ export async function seal(
   if (plaintext.length > U16_MAX) {
     throw new RangeError(`frame payload ${plaintext.length} exceeds u16 max ${U16_MAX}`);
   }
-  const aad = encodeFrameHeader({ ...header, len: plaintext.length });
+  const aad = new Uint8Array(FRAME_COUNTER_BYTES + FRAME_HEADER_BYTES);
+  new DataView(aad.buffer).setBigUint64(0, BigInt(counter), false);
+  aad.set(encodeFrameHeader({ ...header, len: plaintext.length }), FRAME_COUNTER_BYTES);
   const sealed = await aesGcmSeal(dir.key, nonce(dir.salt, counter), aad, plaintext);
   const out = new Uint8Array(aad.length + sealed.length);
   out.set(aad, 0);
@@ -53,6 +59,7 @@ export async function seal(
 
 /** A decrypted frame: its parsed header and recovered plaintext. */
 export interface OpenedFrame {
+  readonly counter: number;
   readonly header: FrameHeader;
   readonly plaintext: Uint8Array;
 }
@@ -67,15 +74,63 @@ export async function open(
   counter: number,
   frame: Uint8Array,
 ): Promise<OpenedFrame> {
-  if (frame.length < FRAME_HEADER_BYTES + AEAD_TAG_BYTES) {
+  const embedded = readCounter(frame);
+  if (embedded !== counter) {
+    throw new Error(`frame counter ${embedded} does not match expected ${counter}`);
+  }
+  return openEmbedded(dir, embedded, frame);
+}
+
+/** A frame older than the next accepted counter; callers may safely ignore this replay. */
+export class FrameReplayError extends Error {
+  constructor(
+    readonly counter: number,
+    readonly minimum: number,
+  ) {
+    super(`frame counter ${counter} is below next accepted ${minimum}`);
+    this.name = 'FrameReplayError';
+  }
+}
+
+/**
+ * Open a transfer frame carrying its own authenticated counter. Forward gaps are permitted so a
+ * reliable transport can be replaced after losing a suffix; already-consumed counters are
+ * reported as replays and nonce values are never reset or guessed.
+ */
+export async function openSequenced(
+  dir: DirectionalKey,
+  minimumCounter: number,
+  frame: Uint8Array,
+): Promise<OpenedFrame> {
+  const embedded = readCounter(frame);
+  if (embedded < minimumCounter) throw new FrameReplayError(embedded, minimumCounter);
+  return openEmbedded(dir, embedded, frame);
+}
+
+function readCounter(frame: Uint8Array): number {
+  if (frame.length < FRAME_COUNTER_BYTES + FRAME_HEADER_BYTES + AEAD_TAG_BYTES) {
     throw new Error(`frame too short: ${frame.length} bytes`);
   }
-  const aad = frame.slice(0, FRAME_HEADER_BYTES);
-  const header = decodeFrameHeader(aad);
-  const body = frame.slice(FRAME_HEADER_BYTES);
+  const value = new DataView(frame.buffer, frame.byteOffset, FRAME_COUNTER_BYTES).getBigUint64(
+    0,
+    false,
+  );
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error('frame counter exceeds JS range');
+  return Number(value);
+}
+
+async function openEmbedded(
+  dir: DirectionalKey,
+  counter: number,
+  frame: Uint8Array,
+): Promise<OpenedFrame> {
+  const aadBytes = FRAME_COUNTER_BYTES + FRAME_HEADER_BYTES;
+  const aad = frame.slice(0, aadBytes);
+  const header = decodeFrameHeader(aad.subarray(FRAME_COUNTER_BYTES));
+  const body = frame.slice(aadBytes);
   if (body.length !== header.len + AEAD_TAG_BYTES) {
     throw new Error(`frame len field ${header.len} disagrees with body ${body.length}`);
   }
   const plaintext = await aesGcmOpen(dir.key, nonce(dir.salt, counter), aad, body);
-  return { header, plaintext };
+  return { counter, header, plaintext };
 }

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -18,6 +18,7 @@ export const WORDLIST_SIZE = 256; // one byte of entropy per word
 export const CODE_SEPARATOR = '-';
 
 /** Framing constants. The header is fixed-size and used as AES-GCM AAD. */
+export const FRAME_COUNTER_BYTES = 8;
 export const FRAME_HEADER_BYTES = 16;
 
 /** Frame-header format version (the header's first byte). Bumped only if the header layout changes. */

--- a/packages/protocol/src/signaling.ts
+++ b/packages/protocol/src/signaling.ts
@@ -77,6 +77,33 @@ export interface IceMsg {
   mac: string;
 }
 
+/** Peer → server: opt into the encrypted WebSocket data path for the current room. */
+export interface RelayOpenMsg {
+  type: 'relay_open';
+}
+
+/** Server → peer: the partner requested relay; opt in so both sides switch together. */
+export interface RelayRequiredMsg {
+  type: 'relay_required';
+}
+
+/** Server → both: both peers opted in and binary relay frames may now flow. */
+export interface RelayReadyMsg {
+  type: 'relay_ready';
+}
+
+/** Peer → server: grant the partner more receive capacity after consuming relay bytes. */
+export interface RelayCreditMsg {
+  type: 'relay_credit';
+  bytes: number;
+}
+
+/** Server → peer: bounded relay-send capacity granted by the receiving partner. */
+export interface CreditMsg {
+  type: 'credit';
+  bytes: number;
+}
+
 /** Any → any: graceful teardown. */
 export interface ByeMsg {
   type: 'bye';
@@ -111,6 +138,11 @@ export type SignalMsg =
   | CapsMsg
   | SdpMsg
   | IceMsg
+  | RelayOpenMsg
+  | RelayRequiredMsg
+  | RelayReadyMsg
+  | RelayCreditMsg
+  | CreditMsg
   | ByeMsg
   | ErrorMsg;
 

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -7,7 +7,7 @@
  * without being written or hashed twice. Any AEAD or block-hash failure aborts immediately.
  */
 
-import { open, seal, type FrameHeaderInput } from './aead.js';
+import { FrameReplayError, openSequenced, seal, type FrameHeaderInput } from './aead.js';
 import type { DirectionalKey } from './keyschedule.js';
 import { FrameType, type ControlOp, type FileEntry, type Manifest } from './transfer.js';
 import { DEFAULT_INFLIGHT_BLOCKS, FRAME_VERSION } from './constants.js';
@@ -144,8 +144,10 @@ export class TransferReceiver {
     if (this.settled) return;
     let opened;
     try {
-      opened = await open(this.o.recvDir, this.recvCounter++, frame);
+      opened = await openSequenced(this.o.recvDir, this.recvCounter, frame);
+      this.recvCounter = opened.counter + 1;
     } catch (e) {
+      if (e instanceof FrameReplayError) return;
       throw new TransferError(
         'integrity',
         e instanceof Error ? e.message : 'unable to authenticate transfer frame',

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -7,7 +7,7 @@
  * are resealed with fresh AEAD counters; integrity failures remain terminal.
  */
 
-import { open, seal, type FrameHeaderInput } from './aead.js';
+import { FrameReplayError, openSequenced, seal, type FrameHeaderInput } from './aead.js';
 import type { DirectionalKey } from './keyschedule.js';
 import { FrameType, type ControlOp, type Fail, type Manifest } from './transfer.js';
 import {
@@ -225,8 +225,10 @@ export class TransferSender {
     if (this.settled) return;
     let opened;
     try {
-      opened = await open(this.o.recvDir, this.recvCounter++, frame);
+      opened = await openSequenced(this.o.recvDir, this.recvCounter, frame);
+      this.recvCounter = opened.counter + 1;
     } catch (e) {
+      if (e instanceof FrameReplayError) return;
       throw new TransferError(
         'integrity',
         e instanceof Error ? e.message : 'unable to authenticate control frame',

--- a/packages/wire/aead.go
+++ b/packages/wire/aead.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/binary"
+	"errors"
 	"fmt"
 )
 
@@ -37,13 +38,13 @@ func gcmFor(key []byte) (cipher.AEAD, error) {
 	return cipher.NewGCM(block)
 }
 
-// Seal encrypts plaintext into a frame: header(16) || ciphertext || tag(16). The header's
-// Len field is set to the plaintext length and authenticated as GCM additional data.
+// Seal encrypts plaintext into counter(8) || header(16) || ciphertext || tag(16). Counter and
+// header are authenticated as GCM additional data.
 func Seal(dir DirectionalKey, counter uint64, h FrameHeaderInput, plaintext []byte) ([]byte, error) {
 	if len(plaintext) > u16Max {
 		return nil, fmt.Errorf("frame payload %d exceeds u16 max %d", len(plaintext), u16Max)
 	}
-	aad := encodeFrameHeader(FrameHeader{
+	header := encodeFrameHeader(FrameHeader{
 		Version:  h.Version,
 		Type:     h.Type,
 		Flags:    h.Flags,
@@ -52,6 +53,9 @@ func Seal(dir DirectionalKey, counter uint64, h FrameHeaderInput, plaintext []by
 		FrameOff: h.FrameOff,
 		Len:      uint16(len(plaintext)),
 	})
+	aad := make([]byte, frameCounterBytes+len(header))
+	binary.BigEndian.PutUint64(aad[:frameCounterBytes], counter)
+	copy(aad[frameCounterBytes:], header)
 	gcm, err := gcmFor(dir.Key)
 	if err != nil {
 		return nil, err
@@ -62,6 +66,7 @@ func Seal(dir DirectionalKey, counter uint64, h FrameHeaderInput, plaintext []by
 
 // OpenedFrame is a decrypted frame: its parsed header and recovered plaintext.
 type OpenedFrame struct {
+	Counter   uint64
 	Header    FrameHeader
 	Plaintext []byte
 }
@@ -70,15 +75,48 @@ type OpenedFrame struct {
 // the expected nonce, and fails if authentication fails, the frame is truncated, or the
 // header Len disagrees with the ciphertext length.
 func Open(dir DirectionalKey, counter uint64, frame []byte) (*OpenedFrame, error) {
-	if len(frame) < frameHeaderBytes+aeadTagBytes {
-		return nil, fmt.Errorf("frame too short: %d bytes", len(frame))
-	}
-	aad := frame[:frameHeaderBytes]
-	header, err := decodeFrameHeader(aad)
+	embedded, err := frameCounter(frame)
 	if err != nil {
 		return nil, err
 	}
-	body := frame[frameHeaderBytes:]
+	if embedded != counter {
+		return nil, fmt.Errorf("frame counter %d does not match expected %d", embedded, counter)
+	}
+	return openEmbedded(dir, embedded, frame)
+}
+
+// ErrFrameReplay identifies an already-consumed counter. Transfer engines ignore it while
+// keeping all forward counters authenticated, which makes transport replacement replay-safe.
+var ErrFrameReplay = errors.New("frame counter replay")
+
+// OpenSequenced opens a transfer frame using its authenticated wire counter. Forward gaps are
+// accepted after a transport loses a suffix; counters below minimum return ErrFrameReplay.
+func OpenSequenced(dir DirectionalKey, minimum uint64, frame []byte) (*OpenedFrame, error) {
+	embedded, err := frameCounter(frame)
+	if err != nil {
+		return nil, err
+	}
+	if embedded < minimum {
+		return nil, fmt.Errorf("%w: counter %d below %d", ErrFrameReplay, embedded, minimum)
+	}
+	return openEmbedded(dir, embedded, frame)
+}
+
+func frameCounter(frame []byte) (uint64, error) {
+	if len(frame) < frameCounterBytes+frameHeaderBytes+aeadTagBytes {
+		return 0, fmt.Errorf("frame too short: %d bytes", len(frame))
+	}
+	return binary.BigEndian.Uint64(frame[:frameCounterBytes]), nil
+}
+
+func openEmbedded(dir DirectionalKey, counter uint64, frame []byte) (*OpenedFrame, error) {
+	aadBytes := frameCounterBytes + frameHeaderBytes
+	aad := frame[:aadBytes]
+	header, err := decodeFrameHeader(aad[frameCounterBytes:])
+	if err != nil {
+		return nil, err
+	}
+	body := frame[aadBytes:]
 	if len(body) != int(header.Len)+aeadTagBytes {
 		return nil, fmt.Errorf("frame len field %d disagrees with body %d", header.Len, len(body))
 	}
@@ -90,5 +128,5 @@ func Open(dir DirectionalKey, counter uint64, frame []byte) (*OpenedFrame, error
 	if err != nil {
 		return nil, err
 	}
-	return &OpenedFrame{Header: header, Plaintext: plaintext}, nil
+	return &OpenedFrame{Counter: counter, Header: header, Plaintext: plaintext}, nil
 }

--- a/packages/wire/aead_test.go
+++ b/packages/wire/aead_test.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"testing"
 )
 
@@ -98,6 +99,21 @@ func TestAeadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestAeadSequencedGapAndReplay(t *testing.T) {
+	keys := testKeys(t)
+	frame, err := Seal(keys.O2J, 9, FrameHeaderInput{Version: 1, Type: FrameBlockData}, []byte("after switch"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	opened, err := OpenSequenced(keys.O2J, 4, frame)
+	if err != nil || opened.Counter != 9 {
+		t.Fatalf("OpenSequenced gap = counter %d, err %v", opened.Counter, err)
+	}
+	if _, err := OpenSequenced(keys.O2J, 10, frame); !errors.Is(err, ErrFrameReplay) {
+		t.Fatalf("old counter error = %v, want ErrFrameReplay", err)
+	}
+}
+
 func TestAeadRejectsTampering(t *testing.T) {
 	keys := testKeys(t)
 	in := FrameHeaderInput{Version: 1, Type: FrameBlockData}
@@ -118,20 +134,20 @@ func TestAeadRejectsTampering(t *testing.T) {
 	})
 	t.Run("tampered ciphertext", func(t *testing.T) {
 		bad := bytes.Clone(frame)
-		bad[frameHeaderBytes] ^= 0x01
+		bad[frameCounterBytes+frameHeaderBytes] ^= 0x01
 		if _, err := Open(keys.O2J, 0, bad); err == nil {
 			t.Error("expected auth failure on flipped ciphertext byte")
 		}
 	})
 	t.Run("tampered header", func(t *testing.T) {
 		bad := bytes.Clone(frame)
-		bad[1] ^= 0x01 // flip the Type field, which is authenticated as AAD
+		bad[frameCounterBytes+1] ^= 0x01 // flip the Type field, which is authenticated as AAD
 		if _, err := Open(keys.O2J, 0, bad); err == nil {
 			t.Error("expected auth failure on flipped header byte")
 		}
 	})
 	t.Run("truncated", func(t *testing.T) {
-		if _, err := Open(keys.O2J, 0, frame[:frameHeaderBytes+aeadTagBytes-1]); err == nil {
+		if _, err := Open(keys.O2J, 0, frame[:frameCounterBytes+frameHeaderBytes+aeadTagBytes-1]); err == nil {
 			t.Error("expected failure on truncated frame")
 		}
 	})

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -156,12 +156,14 @@ func (r *Receiver) process(frame []byte) error {
 	if r.isSettled() {
 		return nil
 	}
-	ctr := r.recvCounter
-	r.recvCounter++
-	opened, err := Open(r.o.RecvDir, ctr, frame)
+	opened, err := OpenSequenced(r.o.RecvDir, r.recvCounter, frame)
 	if err != nil {
+		if errors.Is(err, ErrFrameReplay) {
+			return nil
+		}
 		return NewTransferError(FailIntegrity, err.Error())
 	}
+	r.recvCounter = opened.Counter + 1
 	switch opened.Header.Type {
 	case FrameManifest:
 		return r.applyManifest(opened.Plaintext)

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -236,15 +236,19 @@ func (s *Sender) Handle(frame []byte) {
 		s.mu.Unlock()
 		return
 	}
-	ctr := s.recvCounter
-	s.recvCounter++
 	s.mu.Unlock()
 
-	opened, err := Open(s.o.RecvDir, ctr, frame)
+	opened, err := OpenSequenced(s.o.RecvDir, s.recvCounter, frame)
 	if err != nil {
+		if errors.Is(err, ErrFrameReplay) {
+			return
+		}
 		s.fail(NewTransferError(FailIntegrity, err.Error()))
 		return
 	}
+	s.mu.Lock()
+	s.recvCounter = opened.Counter + 1
+	s.mu.Unlock()
 	msg, err := DecodeControl(opened.Plaintext)
 	if err != nil {
 		s.fail(NewTransferError(FailIntegrity, err.Error()))

--- a/packages/wire/wire.go
+++ b/packages/wire/wire.go
@@ -30,10 +30,11 @@ const (
 
 // AES-256-GCM parameters for the frame AEAD (see aead.go).
 const (
-	aeadKeyBytes   = 32
-	aeadNonceBytes = 12
-	aeadTagBytes   = 16
-	aeadSaltBytes  = 4
+	aeadKeyBytes      = 32
+	aeadNonceBytes    = 12
+	aeadTagBytes      = 16
+	aeadSaltBytes     = 4
+	frameCounterBytes = 8
 )
 
 // HKDF info strings. confirmationKeys is fixed by RFC 9382 §4 and must not change; the

--- a/test-vectors/sendarc-crypto.json
+++ b/test-vectors/sendarc-crypto.json
@@ -28,7 +28,7 @@
     "counter": 0,
     "headerHex": "0101000000000000000000000000001b",
     "plaintextUtf8": "sendarc caps vector payload",
-    "frameHex": "0101000000000000000000000000001b9888677ac00c856a25561506dc2ee2f89b4b7fb356920d6819299d66f7a7cd4171213328dea32e0962fe5b"
+    "frameHex": "00000000000000000101000000000000000000000000001b9888677ac00c856a25561506dc2ee2f89b4b7fb356920d6819299dfa69233eb64e31703ccfff1b27e3ef0c"
   },
   "authmac": {
     "note": "mac = HMAC-SHA256(kAuth, type || ':' || u32be(room) || ':' || u32be(seq) || ':' || body). Self-contained kAuth (not derived from spake2 above).",


### PR DESCRIPTION
## Summary
- authenticate an explicit monotonic counter on every sealed frame
- permit forward counter gaps during transport replacement while ignoring consumed replays
- define matching browser and CLI relay negotiation and credit messages
- update the committed cross-language crypto vector

## Verification
- `pnpm run format:check`
- `just lint`
- `just typecheck`
- `just test`
- `just build`
- `go test -race ./packages/wire ./apps/cli/...`