### PR TITLE
feat(server): add bounded encrypted relay

### DIFF
--- a/apps/server/internal/signal/hub.go
+++ b/apps/server/internal/signal/hub.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/coder/websocket"
 )
 
 // Hub owns every room and the goroutine that reaps idle ones. A room holds at most
@@ -22,10 +24,105 @@ type Hub struct {
 }
 
 type room struct {
-	number   int
-	offerer  *peer
-	joiner   *peer
-	lastSeen time.Time
+	number     int
+	offerer    *peer
+	joiner     *peer
+	lastSeen   time.Time
+	relayBytes int64
+}
+
+// openRelay opts p into the binary path and coordinates a room-wide cutover. The first peer asks
+// its partner to follow; the second makes the path ready for both.
+func (h *Hub) openRelay(p *peer) (other *peer, ready bool, code string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r, ok := h.rooms[p.room]
+	if !ok {
+		return nil, false, errNotPaired
+	}
+	other = roomPartner(r, p)
+	if other == nil {
+		return nil, false, errNotPaired
+	}
+	p.relayOpen = true
+	r.lastSeen = time.Now()
+	return other, other.relayOpen, ""
+}
+
+// grantRelayCredit caps a receiver's grant to one configured window and returns the actual grant
+// forwarded to its sending partner.
+func (h *Hub) grantRelayCredit(receiver *peer, requested int64) (*peer, int64, string) {
+	if requested <= 0 || requested > h.cfg.RelayWindowBytes {
+		return nil, 0, errRelayCredit
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r, ok := h.rooms[receiver.room]
+	if !ok {
+		return nil, 0, errNotPaired
+	}
+	sender := roomPartner(r, receiver)
+	if sender == nil || !receiver.relayOpen || !sender.relayOpen {
+		return nil, 0, errRelayNotReady
+	}
+	grant := min(requested, h.cfg.RelayWindowBytes-sender.relayCredit)
+	if grant <= 0 {
+		return sender, 0, ""
+	}
+	sender.relayCredit += grant
+	r.lastSeen = time.Now()
+	return sender, grant, ""
+}
+
+// forwardRelay reserves sender credit and room byte budget before handing one opaque frame to the
+// partner's bounded writer queue. No encrypted frame contents are parsed or logged.
+func (h *Hub) forwardRelay(sender *peer, data []byte) string {
+	size := int64(len(data))
+	if size <= 0 || size > h.cfg.MaxRelayFrameBytes {
+		return errRelayLimit
+	}
+	if !sender.relayRate.allowN(float64(size)) {
+		return errRelayLimit
+	}
+
+	h.mu.Lock()
+	r, ok := h.rooms[sender.room]
+	if !ok {
+		h.mu.Unlock()
+		return errNotPaired
+	}
+	other := roomPartner(r, sender)
+	if other == nil || !sender.relayOpen || !other.relayOpen {
+		h.mu.Unlock()
+		return errRelayNotReady
+	}
+	if sender.relayCredit < size {
+		h.mu.Unlock()
+		return errRelayCredit
+	}
+	if size > h.cfg.RelayMaxSessionBytes-r.relayBytes {
+		h.mu.Unlock()
+		return errRelayLimit
+	}
+	sender.relayCredit -= size
+	r.relayBytes += size
+	r.lastSeen = time.Now()
+	h.mu.Unlock()
+
+	if !other.tryEnqueue(websocket.MessageBinary, append([]byte(nil), data...)) {
+		return errRelayLimit
+	}
+	return ""
+}
+
+func roomPartner(r *room, p *peer) *peer {
+	if p == r.offerer {
+		return r.joiner
+	}
+	if p == r.joiner {
+		return r.offerer
+	}
+	return nil
 }
 
 // NewHub builds a Hub and starts its reaper. The reaper stops when ctx is canceled.

--- a/apps/server/internal/signal/hub_test.go
+++ b/apps/server/internal/signal/hub_test.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/coder/websocket"
 )
 
 // newTestPeer builds a peer without a socket, for hub-logic tests that never write.
 func newTestPeer() *peer {
 	return &peer{
-		room:   -1,
-		send:   make(chan []byte, sendBuffer),
-		done:   make(chan struct{}),
-		closed: make(chan struct{}),
+		room:             -1,
+		send:             make(chan outboundFrame, sendBuffer),
+		relayRate:        newTokenBucket(1<<20, 1<<20),
+		relayControlRate: newTokenBucket(128, 64),
+		done:             make(chan struct{}),
+		closed:           make(chan struct{}),
 	}
 }
 
@@ -143,5 +147,35 @@ func TestTokenBucket(t *testing.T) {
 	}
 	if b.allowAt(t0.Add(time.Second)) {
 		t.Fatal("only one token should refill per second")
+	}
+}
+
+func TestTokenBucketWeightedBytes(t *testing.T) {
+	b := newTokenBucket(10, 10)
+	t0 := time.Now()
+	if !b.allowNAt(7, t0) || b.allowNAt(4, t0) {
+		t.Fatal("weighted burst accounting did not enforce the byte ceiling")
+	}
+	if !b.allowNAt(4, t0.Add(100*time.Millisecond)) {
+		t.Fatal("weighted bucket did not refill one byte")
+	}
+}
+
+func TestPeerRelayQueueIsByteBounded(t *testing.T) {
+	h := testHub(t)
+	h.cfg.RelayQueueBytes = 32
+	p := newTestPeer()
+	p.hub = h
+	if !p.tryEnqueue(websocket.MessageBinary, make([]byte, 24)) {
+		t.Fatal("first bounded relay frame was refused")
+	}
+	if p.tryEnqueue(websocket.MessageBinary, make([]byte, 9)) {
+		t.Fatal("queue accepted bytes above its configured ceiling")
+	}
+	p.queueMu.Lock()
+	queued := p.queuedBytes
+	p.queueMu.Unlock()
+	if queued != 24 {
+		t.Fatalf("queued bytes = %d, want 24", queued)
 	}
 }

--- a/apps/server/internal/signal/message.go
+++ b/apps/server/internal/signal/message.go
@@ -17,17 +17,22 @@ import (
 // Wire message types. Control types are handled by the server; the
 // forwardable types are relayed peer-to-peer as opaque bytes.
 const (
-	typeCreate     = "create"
-	typeCreated    = "created"
-	typeJoin       = "join"
-	typePeerJoined = "peer-joined"
-	typePake       = "pake"
-	typeConfirm    = "confirm"
-	typeCaps       = "caps"
-	typeSDP        = "sdp"
-	typeICE        = "ice"
-	typeBye        = "bye"
-	typeError      = "error"
+	typeCreate        = "create"
+	typeCreated       = "created"
+	typeJoin          = "join"
+	typePeerJoined    = "peer-joined"
+	typePake          = "pake"
+	typeConfirm       = "confirm"
+	typeCaps          = "caps"
+	typeSDP           = "sdp"
+	typeICE           = "ice"
+	typeRelayOpen     = "relay_open"
+	typeRelayRequired = "relay_required"
+	typeRelayReady    = "relay_ready"
+	typeRelayCredit   = "relay_credit"
+	typeCredit        = "credit"
+	typeBye           = "bye"
+	typeError         = "error"
 )
 
 // Role labels echoed to peers on pairing. These are routing labels only; their
@@ -50,20 +55,29 @@ var forwardable = map[string]bool{
 
 // Error codes carried in an error message's "code" field.
 const (
-	errBadMessage  = "bad_message"
-	errUnknownRoom = "unknown_room"
-	errRoomFull    = "room_full"
-	errNotPaired   = "not_paired"
-	errRateLimited = "rate_limited"
-	errProtocol    = "protocol"
+	errBadMessage    = "bad_message"
+	errUnknownRoom   = "unknown_room"
+	errRoomFull      = "room_full"
+	errNotPaired     = "not_paired"
+	errRateLimited   = "rate_limited"
+	errProtocol      = "protocol"
+	errRelayNotReady = "relay_not_ready"
+	errRelayCredit   = "relay_credit"
+	errRelayLimit    = "relay_limit"
 )
 
 // clientMsg is the envelope the server parses from a client. Only type and room are
 // read; the payloads of forwardable messages are relayed as raw bytes and never
 // decoded here, which is what keeps the server blind to handshake contents.
 type clientMsg struct {
-	Type string `json:"type"`
-	Room *int   `json:"room,omitempty"`
+	Type  string `json:"type"`
+	Room  *int   `json:"room,omitempty"`
+	Bytes int64  `json:"bytes,omitempty"`
+}
+
+type relayMsg struct {
+	Type  string `json:"type"`
+	Bytes int64  `json:"bytes,omitempty"`
 }
 
 // createdMsg tells the offerer which room number the server allocated.
@@ -117,6 +131,12 @@ func errorFrame(code, msg string) []byte {
 	return mustJSON(errorMsg{Type: typeError, Code: code, Msg: msg})
 }
 
+func relayFrame(typ string) []byte { return mustJSON(relayMsg{Type: typ}) }
+
+func creditFrame(bytes int64) []byte {
+	return mustJSON(relayMsg{Type: typeCredit, Bytes: bytes})
+}
+
 // Config controls the signaling server's limits and origin policy.
 type Config struct {
 	// AllowedOrigins is the WSS origin allowlist for browser clients. An empty list
@@ -140,18 +160,32 @@ type Config struct {
 	// upgrade time.
 	ConnBurst  int
 	ConnPerSec float64
+
+	// Relay limits bound every layer of the opaque binary data path.
+	MaxRelayFrameBytes   int64
+	RelayWindowBytes     int64
+	RelayQueueBytes      int64
+	RelayBurstBytes      int64
+	RelayBytesPerSec     int64
+	RelayMaxSessionBytes int64
 }
 
-// DefaultConfig returns limits sized for the rendezvous workload: a handful of tiny
-// JSON control messages per session, not a data path.
+// DefaultConfig returns conservative rendezvous and opaque relay limits. Relay ceilings are high
+// enough for ordinary transfers while keeping memory, bandwidth, and lifetime bytes explicit.
 func DefaultConfig() Config {
 	return Config{
-		IdleTimeout:     2 * time.Minute,
-		MaxMessageBytes: 64 * 1024,
-		MsgBurst:        32,
-		MsgPerSec:       16,
-		ConnBurst:       16,
-		ConnPerSec:      8,
+		IdleTimeout:          2 * time.Minute,
+		MaxMessageBytes:      64 * 1024,
+		MsgBurst:             32,
+		MsgPerSec:            16,
+		ConnBurst:            16,
+		ConnPerSec:           8,
+		MaxRelayFrameBytes:   128 * 1024,
+		RelayWindowBytes:     1 * 1024 * 1024,
+		RelayQueueBytes:      2 * 1024 * 1024,
+		RelayBurstBytes:      8 * 1024 * 1024,
+		RelayBytesPerSec:     32 * 1024 * 1024,
+		RelayMaxSessionBytes: 16 * 1024 * 1024 * 1024,
 	}
 }
 
@@ -170,6 +204,24 @@ func ConfigFromEnv() Config {
 	}
 	if n, ok := envInt("SENDARC_SIGNAL_MAX_MESSAGE_BYTES"); ok {
 		cfg.MaxMessageBytes = int64(n)
+	}
+	if n, ok := envInt64("SENDARC_RELAY_MAX_FRAME_BYTES"); ok {
+		cfg.MaxRelayFrameBytes = n
+	}
+	if n, ok := envInt64("SENDARC_RELAY_WINDOW_BYTES"); ok {
+		cfg.RelayWindowBytes = n
+	}
+	if n, ok := envInt64("SENDARC_RELAY_QUEUE_BYTES"); ok {
+		cfg.RelayQueueBytes = n
+	}
+	if n, ok := envInt64("SENDARC_RELAY_BURST_BYTES"); ok {
+		cfg.RelayBurstBytes = n
+	}
+	if n, ok := envInt64("SENDARC_RELAY_BYTES_PER_SEC"); ok {
+		cfg.RelayBytesPerSec = n
+	}
+	if n, ok := envInt64("SENDARC_RELAY_MAX_SESSION_BYTES"); ok {
+		cfg.RelayMaxSessionBytes = n
 	}
 	return cfg
 }
@@ -192,6 +244,18 @@ func envInt(key string) (int, bool) {
 		return 0, false
 	}
 	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+func envInt64(key string) (int64, bool) {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
 	if err != nil || n <= 0 {
 		return 0, false
 	}

--- a/apps/server/internal/signal/peer.go
+++ b/apps/server/internal/signal/peer.go
@@ -21,6 +21,11 @@ const (
 	sendBuffer = 16
 )
 
+type outboundFrame struct {
+	typ  websocket.MessageType
+	data []byte
+}
+
 // peer is one WebSocket connection and its place in a room. A single writer goroutine
 // owns every write to ws; all other goroutines hand it frames through send. done is
 // closed exactly once to unwind both the reader and the writer.
@@ -32,29 +37,37 @@ type peer struct {
 	room int    // -1 until the peer creates or joins a room
 	role string // set on create/join
 
-	send      chan []byte
-	closeOnce sync.Once
-	done      chan struct{}
-	farewell  []byte // final frame to flush before closing; set under closeOnce
-	closed    chan struct{}
+	send             chan outboundFrame
+	queueMu          sync.Mutex
+	queuedBytes      int64
+	relayOpen        bool  // guarded by hub.mu
+	relayCredit      int64 // guarded by hub.mu; bytes this peer may send
+	relayRate        *tokenBucket
+	relayControlRate *tokenBucket
+	closeOnce        sync.Once
+	done             chan struct{}
+	farewell         []byte // final frame to flush before closing; set under closeOnce
+	closed           chan struct{}
 }
 
 func newPeer(ws *websocket.Conn, h *Hub) *peer {
 	return &peer{
-		ws:     ws,
-		hub:    h,
-		logger: h.logger,
-		room:   -1,
-		send:   make(chan []byte, sendBuffer),
-		done:   make(chan struct{}),
-		closed: make(chan struct{}),
+		ws:               ws,
+		hub:              h,
+		logger:           h.logger,
+		room:             -1,
+		send:             make(chan outboundFrame, sendBuffer),
+		relayRate:        newTokenBucket(int(h.cfg.RelayBurstBytes), float64(h.cfg.RelayBytesPerSec)),
+		relayControlRate: newTokenBucket(128, 64),
+		done:             make(chan struct{}),
+		closed:           make(chan struct{}),
 	}
 }
 
 // serve runs the connection: it starts the writer, reads and dispatches frames until
 // the socket closes or a protocol error ends it, then tears the room down.
 func (p *peer) serve(ctx context.Context) {
-	p.ws.SetReadLimit(p.hub.cfg.MaxMessageBytes)
+	p.ws.SetReadLimit(max(p.hub.cfg.MaxMessageBytes, p.hub.cfg.MaxRelayFrameBytes))
 	msgLimiter := newTokenBucket(p.hub.cfg.MsgBurst, p.hub.cfg.MsgPerSec)
 
 	go p.writeLoop(ctx)
@@ -67,15 +80,22 @@ func (p *peer) serve(ctx context.Context) {
 		if err != nil {
 			return
 		}
-		if typ != websocket.MessageText {
-			p.close(errorFrame(errBadMessage, "expected a text frame"))
-			return
-		}
-		if !msgLimiter.allow() {
-			p.close(errorFrame(errRateLimited, "too many messages"))
-			return
-		}
-		if !p.dispatch(data) {
+		switch typ {
+		case websocket.MessageText:
+			if int64(len(data)) > p.hub.cfg.MaxMessageBytes {
+				p.close(errorFrame(errBadMessage, "message too large"))
+				return
+			}
+			if !p.dispatch(data, msgLimiter) {
+				return
+			}
+		case websocket.MessageBinary:
+			if code := p.hub.forwardRelay(p, data); code != "" {
+				p.close(errorFrame(code, "relay frame refused"))
+				return
+			}
+		default:
+			p.close(errorFrame(errBadMessage, "unsupported frame type"))
 			return
 		}
 	}
@@ -84,10 +104,19 @@ func (p *peer) serve(ctx context.Context) {
 // dispatch handles one inbound frame. It returns false when the connection should
 // end. Only type (and room, for join) is ever parsed; forwardable payloads are
 // relayed as the exact bytes received so the server stays blind to their contents.
-func (p *peer) dispatch(data []byte) bool {
+func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 	var m clientMsg
 	if err := json.Unmarshal(data, &m); err != nil || m.Type == "" {
 		p.close(errorFrame(errBadMessage, "invalid message"))
+		return false
+	}
+	if m.Type == typeRelayCredit {
+		if !p.relayControlRate.allow() {
+			p.close(errorFrame(errRateLimited, "too many relay credit messages"))
+			return false
+		}
+	} else if !msgLimiter.allow() {
+		p.close(errorFrame(errRateLimited, "too many messages"))
 		return false
 	}
 
@@ -128,6 +157,31 @@ func (p *peer) dispatch(data []byte) bool {
 		p.close(nil)
 		return false
 
+	case typeRelayOpen:
+		other, ready, code := p.hub.openRelay(p)
+		if code != "" {
+			p.close(errorFrame(code, "relay unavailable"))
+			return false
+		}
+		if ready {
+			p.enqueue(relayFrame(typeRelayReady))
+			other.enqueue(relayFrame(typeRelayReady))
+		} else {
+			other.enqueue(relayFrame(typeRelayRequired))
+		}
+		return true
+
+	case typeRelayCredit:
+		sender, granted, code := p.hub.grantRelayCredit(p, m.Bytes)
+		if code != "" {
+			p.close(errorFrame(code, "invalid relay credit"))
+			return false
+		}
+		if granted > 0 {
+			sender.enqueue(creditFrame(granted))
+		}
+		return true
+
 	default:
 		if !forwardable[m.Type] {
 			p.close(errorFrame(errBadMessage, "unknown message type"))
@@ -148,14 +202,15 @@ func (p *peer) dispatch(data []byte) bool {
 func (p *peer) writeLoop(ctx context.Context) {
 	for {
 		select {
-		case data := <-p.send:
-			if !p.rawWrite(ctx, data) {
+		case frame := <-p.send:
+			p.releaseQueued(int64(len(frame.data)))
+			if !p.rawWrite(ctx, frame.typ, frame.data) {
 				p.close(nil)
 				return
 			}
 		case <-p.done:
 			if p.farewell != nil {
-				p.rawWrite(ctx, p.farewell)
+				p.rawWrite(ctx, websocket.MessageText, p.farewell)
 			}
 			_ = p.ws.Close(websocket.StatusNormalClosure, "")
 			close(p.closed)
@@ -164,20 +219,46 @@ func (p *peer) writeLoop(ctx context.Context) {
 	}
 }
 
-func (p *peer) rawWrite(ctx context.Context, data []byte) bool {
+func (p *peer) rawWrite(ctx context.Context, typ websocket.MessageType, data []byte) bool {
 	writeCtx, cancel := context.WithTimeout(ctx, writeTimeout)
 	defer cancel()
-	return p.ws.Write(writeCtx, websocket.MessageText, data) == nil
+	return p.ws.Write(writeCtx, typ, data) == nil
 }
 
 // enqueue hands a frame to this peer's writer. It blocks only until the buffer has
 // room or the peer is closing, so a stalled partner cannot wedge the caller for
 // longer than that partner's own write timeout.
 func (p *peer) enqueue(data []byte) {
-	select {
-	case p.send <- data:
-	case <-p.done:
+	if !p.tryEnqueue(websocket.MessageText, data) {
+		p.close(errorFrame(errRelayLimit, "outbound queue full"))
 	}
+}
+
+func (p *peer) tryEnqueue(typ websocket.MessageType, data []byte) bool {
+	size := int64(len(data))
+	p.queueMu.Lock()
+	if size > p.hub.cfg.RelayQueueBytes-p.queuedBytes {
+		p.queueMu.Unlock()
+		return false
+	}
+	p.queuedBytes += size
+	p.queueMu.Unlock()
+	select {
+	case p.send <- outboundFrame{typ: typ, data: data}:
+		return true
+	case <-p.done:
+		p.releaseQueued(size)
+		return false
+	default:
+		p.releaseQueued(size)
+		return false
+	}
+}
+
+func (p *peer) releaseQueued(size int64) {
+	p.queueMu.Lock()
+	p.queuedBytes -= size
+	p.queueMu.Unlock()
 }
 
 // close signals teardown, optionally flushing one final frame first. It is safe to

--- a/apps/server/internal/signal/ratelimit.go
+++ b/apps/server/internal/signal/ratelimit.go
@@ -26,12 +26,18 @@ func newTokenBucket(burst int, perSec float64) *tokenBucket {
 }
 
 func (b *tokenBucket) allow() bool {
-	return b.allowAt(time.Now())
+	return b.allowNAt(1, time.Now())
 }
+
+func (b *tokenBucket) allowN(tokens float64) bool { return b.allowNAt(tokens, time.Now()) }
 
 // allowAt is the time-injectable core, kept separate so tests can drive it
 // deterministically.
 func (b *tokenBucket) allowAt(now time.Time) bool {
+	return b.allowNAt(1, now)
+}
+
+func (b *tokenBucket) allowNAt(tokens float64, now time.Time) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -39,9 +45,9 @@ func (b *tokenBucket) allowAt(now time.Time) bool {
 		b.tokens = min(b.burst, b.tokens+elapsed*b.rate)
 		b.last = now
 	}
-	if b.tokens < 1 {
+	if tokens <= 0 || b.tokens < tokens {
 		return false
 	}
-	b.tokens--
+	b.tokens -= tokens
 	return true
 }

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -80,6 +80,15 @@ func (c *client) sendRaw(data []byte) {
 	}
 }
 
+func (c *client) sendBinary(data []byte) {
+	c.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := c.conn.Write(ctx, websocket.MessageBinary, data); err != nil {
+		c.t.Fatalf("write binary: %v", err)
+	}
+}
+
 func (c *client) recv() map[string]any {
 	c.t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -105,6 +114,20 @@ func (c *client) recvRaw() []byte {
 	_, data, err := c.conn.Read(ctx)
 	if err != nil {
 		c.t.Fatalf("read raw: %v", err)
+	}
+	return data
+}
+
+func (c *client) recvBinary() []byte {
+	c.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	typ, data, err := c.conn.Read(ctx)
+	if err != nil {
+		c.t.Fatalf("read binary: %v", err)
+	}
+	if typ != websocket.MessageBinary {
+		c.t.Fatalf("frame type = %v, want binary (%s)", typ, data)
 	}
 	return data
 }
@@ -160,6 +183,84 @@ func TestBlindForwardVerbatim(t *testing.T) {
 	joiner.sendRaw(conf)
 	if got := offerer.recvRaw(); string(got) != string(conf) {
 		t.Fatalf("forwarded confirm = %s, want %s", got, conf)
+	}
+}
+
+func openRelay(t *testing.T, offerer, joiner *client) {
+	t.Helper()
+	offerer.send(map[string]any{"type": typeRelayOpen})
+	if got := joiner.recv(); got["type"] != typeRelayRequired {
+		t.Fatalf("relay required = %v", got)
+	}
+	joiner.send(map[string]any{"type": typeRelayOpen})
+	if got := offerer.recv(); got["type"] != typeRelayReady {
+		t.Fatalf("offerer relay ready = %v", got)
+	}
+	if got := joiner.recv(); got["type"] != typeRelayReady {
+		t.Fatalf("joiner relay ready = %v", got)
+	}
+}
+
+func TestRelayForwardsOpaqueBinaryWithinReceiverCredit(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RelayWindowBytes = 1024
+	url := testServer(t, cfg)
+	offerer, joiner, _ := pair(t, url)
+	openRelay(t, offerer, joiner)
+
+	joiner.send(map[string]any{"type": typeRelayCredit, "bytes": 64})
+	if got := offerer.recv(); got["type"] != typeCredit || got["bytes"] != float64(64) {
+		t.Fatalf("offerer credit = %v", got)
+	}
+	opaque := []byte{0, 255, 19, 88, 42, 7}
+	offerer.sendBinary(opaque)
+	if got := joiner.recvBinary(); string(got) != string(opaque) {
+		t.Fatalf("relay changed opaque bytes: %x != %x", got, opaque)
+	}
+
+	offerer.send(map[string]any{"type": typeRelayCredit, "bytes": 32})
+	if got := joiner.recv(); got["type"] != typeCredit || got["bytes"] != float64(32) {
+		t.Fatalf("joiner credit = %v", got)
+	}
+	joiner.sendBinary([]byte{9, 8, 7})
+	if got := offerer.recvBinary(); string(got) != string([]byte{9, 8, 7}) {
+		t.Fatalf("reverse relay bytes = %x", got)
+	}
+}
+
+func TestRelayRefusesBytesBeyondCredit(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RelayWindowBytes = 32
+	url := testServer(t, cfg)
+	offerer, joiner, _ := pair(t, url)
+	openRelay(t, offerer, joiner)
+	joiner.send(map[string]any{"type": typeRelayCredit, "bytes": 16})
+	_ = offerer.recv()
+	offerer.sendBinary(make([]byte, 17))
+	if got := offerer.recv(); got["type"] != typeError || got["code"] != errRelayCredit {
+		t.Fatalf("credit violation = %v", got)
+	}
+}
+
+func TestRelayEnforcesFrameAndSessionCeilings(t *testing.T) {
+	for name, configure := range map[string]func(*Config){
+		"frame":   func(cfg *Config) { cfg.MaxRelayFrameBytes = 8 },
+		"session": func(cfg *Config) { cfg.RelayMaxSessionBytes = 8 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.RelayWindowBytes = 64
+			configure(&cfg)
+			url := testServer(t, cfg)
+			offerer, joiner, _ := pair(t, url)
+			openRelay(t, offerer, joiner)
+			joiner.send(map[string]any{"type": typeRelayCredit, "bytes": 64})
+			_ = offerer.recv()
+			offerer.sendBinary(make([]byte, 9))
+			if got := offerer.recv(); got["type"] != typeError || got["code"] != errRelayLimit {
+				t.Fatalf("limit violation = %v", got)
+			}
+		})
 	}
 }
 
@@ -261,12 +362,18 @@ func TestMessageSizeCap(t *testing.T) {
 	for i := range big {
 		big[i] = 'a'
 	}
-	// Writing may succeed locally; the server closes the socket for exceeding the
-	// read limit, so a subsequent read fails.
+	// Writing may succeed locally; the server reports the protocol violation and closes.
 	c.sendRaw(big)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	if _, _, err := c.conn.Read(ctx); err == nil {
-		t.Fatal("expected the socket to close after an oversize message")
+	_, data, err := c.conn.Read(ctx)
+	if err == nil {
+		var got map[string]any
+		if json.Unmarshal(data, &got) != nil || got["type"] != typeError {
+			t.Fatalf("oversize response = %s", data)
+		}
+		if _, _, err = c.conn.Read(ctx); err == nil {
+			t.Fatal("expected the socket to close after the oversize error")
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- coordinate paired opt-in and room-wide relay readiness
- forward binary frames byte-for-byte without inspecting encrypted contents
- gate both directions with receiver credit
- enforce frame, queue, sustained/burst bandwidth, and session byte ceilings
- cover negotiation, bidirectional forwarding, credit refusal, limits, and queue accounting

## Verification
- `pnpm run format:check`
- `just lint`
- `just test`
- `(cd apps/server && go test -race ./...)`
- `just build`