### PR TITLE
feat(transfer): add encrypted relay fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 [![CI](https://github.com/Akshay7273/sendarc/actions/workflows/ci.yml/badge.svg)](https://github.com/Akshay7273/sendarc/actions/workflows/ci.yml)
 
-**Send files directly. Share only a short code. Keep the server out of your data.**
+**Send files securely. Share only a short code. Keep plaintext off the server.**
 
 SendArc is a self-hostable, end-to-end-encrypted file-transfer application for the browser
-and terminal. It authenticates two peers with a short invite code, establishes a direct
-WebRTC connection, and streams the file without loading it all into memory.
+and terminal. It authenticates two peers with a short invite code, prefers a direct WebRTC
+connection, and falls back to a bounded encrypted relay when a direct path is unavailable.
+Files stream without being loaded entirely into memory.
 
 > [!NOTE]
-> SendArc is pre-release software. Direct file and folder transfers are working, but there is
-> no stable release or compatibility guarantee yet.
+> SendArc is pre-release software. File and folder transfers are working over direct and relayed
+> connections, but there is no stable release or compatibility guarantee yet.
 
 ## Why SendArc
 
@@ -18,8 +19,9 @@ WebRTC connection, and streams the file without loading it all into memory.
   between the two peers. The rendezvous server cannot read them.
 - **Authenticated by a human-friendly code.** SPAKE2 binds the cryptographic handshake to
   the invite code and fails closed when the code is wrong.
-- **Direct peer-to-peer transport.** Files travel over an authenticated WebRTC DataChannel
-  instead of being uploaded to server-side storage.
+- **Direct when possible, relayed when necessary.** SendArc prefers an authenticated WebRTC
+  DataChannel and automatically falls back to an end-to-end-encrypted WebSocket relay. The relay
+  is credit-gated and bounded, and never stores transfer data.
 - **Streams large files with bounded memory.** Fixed-size blocks, transport backpressure,
   and a bounded in-flight window keep memory use independent of file size.
 - **Files and folders.** Each file is independently verified; browsers can write directly to a
@@ -41,26 +43,27 @@ WebRTC connection, and streams the file without loading it all into memory.
    │  SPAKE2 + key confirmation ◀───┼───▶ SPAKE2 + key confirmation │
    │  authenticated SDP / ICE   ◀───┼───▶ authenticated SDP / ICE   │
    │                                │                                │
-   └════════ encrypted WebRTC DataChannel, peer to peer ════════════┘
+   ├════ encrypted WebRTC DataChannel, direct when available ═══════┤
+   └──── or opaque encrypted frames through the bounded relay ──────┘
 ```
 
 The room number is only a routing token. The random words stay on the clients—in browser
 links they live after `#`, which is not sent in HTTP requests. Both peers use the complete
-code as the SPAKE2 password, confirm the derived key, and authenticate WebRTC signaling
-before transferring encrypted frames.
+code as the SPAKE2 password, confirm the derived key, and authenticate WebRTC signaling.
+Transfer frames remain end-to-end encrypted on both direct and relay paths.
 
-The rendezvous server can observe connection metadata and WebRTC signaling required to
-connect the peers. It cannot derive the session key or decrypt file metadata and content.
-The security section below summarizes the trust boundary.
+The server can observe connection metadata, WebRTC signaling, and—when relay fallback is
+used—encrypted frame sizes and timing. It cannot derive the session key or decrypt file
+metadata and content. The security section below summarizes the trust boundary.
 
 ## Supported paths
 
-| Sender  | Receiver | Transfer path          |
-| ------- | -------- | ---------------------- |
-| Browser | Browser  | Direct WebRTC          |
-| Browser | CLI      | Direct WebRTC          |
-| CLI     | Browser  | Direct WebRTC          |
-| CLI     | CLI      | Direct WebRTC via Pion |
+| Sender  | Receiver | Preferred path         | Fallback        |
+| ------- | -------- | ---------------------- | --------------- |
+| Browser | Browser  | Direct WebRTC          | Encrypted relay |
+| Browser | CLI      | Direct WebRTC          | Encrypted relay |
+| CLI     | Browser  | Direct WebRTC          | Encrypted relay |
+| CLI     | CLI      | Direct WebRTC via Pion | Encrypted relay |
 
 ## Run locally
 
@@ -106,7 +109,8 @@ bin/sendarc receive 4-brave-otter --out ./downloads --insecure-skip-verify
 ```
 
 `--insecure-skip-verify` is only for the self-signed local development certificate. Do not
-use it with a deployed server. Run `bin/sendarc help` for all options.
+use it with a deployed server. Add `--relay-only` to either command to require the encrypted
+relay path, which is useful for connectivity checks. Run `bin/sendarc help` for all options.
 
 ## Development
 
@@ -131,10 +135,10 @@ packages/wire       Go implementation of the shared wire protocol
 ## Security
 
 SendArc treats the rendezvous server and network as untrusted for confidentiality and
-integrity. Bulk encryption uses AES-256-GCM with monotonic per-direction nonces; the frame
-header is authenticated as associated data. SPAKE2 with RFC 9382 key confirmation protects
-the short invite code from offline guessing by the server and prevents an undetected
-man-in-the-middle handshake.
+integrity. Bulk encryption uses AES-256-GCM with monotonic per-direction nonces; the sequence
+counter and frame header are authenticated as associated data. SPAKE2 with RFC 9382 key
+confirmation protects the short invite code from offline guessing by the server and prevents
+an undetected man-in-the-middle handshake.
 
 SendArc has not yet received an independent security audit. Please do not use pre-release
 builds for irreplaceable or highly sensitive data.

--- a/apps/cli/cmd/sendarc/main.go
+++ b/apps/cli/cmd/sendarc/main.go
@@ -1,14 +1,14 @@
 // Command sendarc is the terminal client for SendArc. It authenticates through the blind
-// rendezvous server, then uses the same socket to negotiate an end-to-end-encrypted direct
+// rendezvous server, then negotiates an end-to-end-encrypted direct or relayed
 // file transfer:
 //
 //	sendarc send <file>     # allocate a room, print the invite code + link, send the file
 //	sendarc receive <code>  # join with a code (or a pasted invite link), receive the file
 //
 // Both ends run SPAKE2 over the invite code, confirm the key (failing closed on a
-// mismatch), exchange sealed capabilities, then bring up an authenticated WebRTC channel
-// and stream the file sealed under the session key. The word half of the code never
-// reaches the server, and the server never sees the file bytes.
+// mismatch), exchange sealed capabilities, then prefer an authenticated WebRTC channel
+// with an encrypted WebSocket relay fallback. The word half of the code never reaches
+// the server, and the server never sees plaintext file bytes.
 package main
 
 import (
@@ -60,6 +60,7 @@ Usage:
 Flags:
   --server URL             signaling server (default `+defaultServer+`)
   --insecure-skip-verify   skip TLS verification; self-signed dev certs only
+  --relay-only             force the encrypted WebSocket relay instead of WebRTC
   --words N                number of words in the invite code (send only; 0 = default)
   --out DIR                directory to write the received file into (receive only; default .)
 `)
@@ -70,6 +71,7 @@ func runSend(args []string) int {
 	server := fs.String("server", defaultServer, "signaling server URL")
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
 	words := fs.Int("words", 0, "number of words in the invite code (0 = default)")
+	relayOnly := fs.Bool("relay-only", false, "force the encrypted WebSocket relay")
 	positionals := parseArgs(fs, args)
 
 	if len(positionals) == 0 {
@@ -111,6 +113,8 @@ func runSend(args []string) int {
 			OnPhase:   phasePrinter(rendezvous.RoleOfferer),
 		},
 		Sources:        sources,
+		ForceRelay:     *relayOnly,
+		OnTransport:    transportPrinter,
 		OnConnect:      connectPrinter(fmt.Sprintf("Sending %s (%s) …", label, humanBytes(totalSize))),
 		OnFileProgress: progress.reportFile,
 		OnControls:     terminalControls(),
@@ -140,6 +144,7 @@ func runReceive(args []string) int {
 	server := fs.String("server", defaultServer, "signaling server URL")
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
 	outDir := fs.String("out", ".", "directory to write the received file into")
+	relayOnly := fs.Bool("relay-only", false, "force the encrypted WebSocket relay")
 	positionals := parseArgs(fs, args)
 
 	code := ""
@@ -173,7 +178,9 @@ func runReceive(args []string) int {
 			Code:    code,
 			OnPhase: phasePrinter(rendezvous.RoleJoiner),
 		},
-		DestDir: *outDir,
+		DestDir:     *outDir,
+		ForceRelay:  *relayOnly,
+		OnTransport: transportPrinter,
 		OnManifestSet: func(manifest wire.Manifest) {
 			progress.setTotal(manifest.TotalSize)
 			files := make([]progressFile, len(manifest.Files))
@@ -267,6 +274,14 @@ func phasePrinter(role rendezvous.Role) func(rendezvous.Phase) {
 // open, just before the bytes begin to move.
 func connectPrinter(line string) func() {
 	return func() { fmt.Fprintln(os.Stderr, line) }
+}
+
+func transportPrinter(path string) {
+	if path == "relay" {
+		fmt.Fprintln(os.Stderr, "Transport: encrypted WebSocket relay")
+	} else {
+		fmt.Fprintln(os.Stderr, "Transport: direct WebRTC")
+	}
 }
 
 // handshakeError renders a transfer failure as a human-readable line, translating the

--- a/apps/cli/internal/relay/conn.go
+++ b/apps/cli/internal/relay/conn.go
@@ -1,0 +1,187 @@
+// Package relay implements the CLI's credit-gated opaque binary transport over the adopted
+// signaling WebSocket. It never sees plaintext; transfer frames remain sealed end to end.
+package relay
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/sendarc/cli/internal/rendezvous"
+)
+
+const (
+	windowBytes = int64(1 * 1024 * 1024)
+	creditBatch = windowBytes / 2
+)
+
+var errClosed = errors.New("relay: connection closed")
+
+// Signal is the serialized WebSocket write surface supplied by the transfer driver.
+type Signal interface {
+	Send(rendezvous.Message) error
+	SendBinary([]byte) error
+}
+
+// Conn is a bounded, bidirectional transfer byte path.
+type Conn struct {
+	sig Signal
+
+	mu           sync.Mutex
+	cond         *sync.Cond
+	opened       bool
+	ready        bool
+	closed       bool
+	credit       int64
+	consumed     int64
+	handler      func([]byte)
+	pending      [][]byte
+	pendingBytes int64
+	readyCh      chan struct{}
+	readyOnce    sync.Once
+}
+
+// New creates an unopened relay connection over sig.
+func New(sig Signal) *Conn {
+	c := &Conn{sig: sig, readyCh: make(chan struct{})}
+	c.cond = sync.NewCond(&c.mu)
+	return c
+}
+
+// Open opts into relay once. The server asks the partner to do the same.
+func (c *Conn) Open() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return errClosed
+	}
+	if c.opened {
+		c.mu.Unlock()
+		return nil
+	}
+	c.opened = true
+	c.mu.Unlock()
+	return c.sig.Send(rendezvous.NewRelayOpen())
+}
+
+// WaitReady waits until both peers have opted in and initial receive credit is granted.
+func (c *Conn) WaitReady(ctx context.Context) error {
+	select {
+	case <-c.readyCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Ready is closed exactly once after the server confirms both peers opted in.
+func (c *Conn) Ready() <-chan struct{} { return c.readyCh }
+
+// HandleMessage consumes relay control messages and reports whether it recognized the type.
+func (c *Conn) HandleMessage(msg rendezvous.Message) bool {
+	switch msg.Type {
+	case rendezvous.TypeRelayRequired:
+		_ = c.Open()
+		return true
+	case rendezvous.TypeRelayReady:
+		c.readyOnce.Do(func() {
+			c.mu.Lock()
+			c.ready = true
+			c.mu.Unlock()
+			_ = c.sig.Send(rendezvous.NewRelayCredit(windowBytes))
+			close(c.readyCh)
+		})
+		return true
+	case rendezvous.TypeCredit:
+		if msg.Bytes <= 0 {
+			return true
+		}
+		c.mu.Lock()
+		c.credit += msg.Bytes
+		c.cond.Broadcast()
+		c.mu.Unlock()
+		return true
+	default:
+		return false
+	}
+}
+
+// Send waits for receiver-granted capacity, then emits one opaque binary frame.
+func (c *Conn) Send(frame []byte) error {
+	size := int64(len(frame))
+	c.mu.Lock()
+	for !c.closed && (!c.ready || c.credit < size) {
+		c.cond.Wait()
+	}
+	if c.closed {
+		c.mu.Unlock()
+		return errClosed
+	}
+	c.credit -= size
+	c.mu.Unlock()
+	return c.sig.SendBinary(frame)
+}
+
+// OnData installs the transfer consumer and drains the at-most-one-window early buffer.
+func (c *Conn) OnData(handler func([]byte)) {
+	c.mu.Lock()
+	if c.handler != nil {
+		c.mu.Unlock()
+		return
+	}
+	c.handler = handler
+	pending := c.pending
+	c.pending = nil
+	c.pendingBytes = 0
+	c.mu.Unlock()
+	for _, frame := range pending {
+		c.consume(frame, handler)
+	}
+}
+
+// HandleBinary is called serially by the WebSocket read loop.
+func (c *Conn) HandleBinary(frame []byte) {
+	copyFrame := append([]byte(nil), frame...)
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	handler := c.handler
+	if handler == nil {
+		if c.pendingBytes+int64(len(copyFrame)) <= windowBytes {
+			c.pending = append(c.pending, copyFrame)
+			c.pendingBytes += int64(len(copyFrame))
+		}
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Unlock()
+	c.consume(copyFrame, handler)
+}
+
+func (c *Conn) consume(frame []byte, handler func([]byte)) {
+	handler(frame)
+	c.mu.Lock()
+	c.consumed += int64(len(frame))
+	grant := int64(0)
+	if c.consumed >= creditBatch {
+		grant = c.consumed
+		c.consumed = 0
+	}
+	c.mu.Unlock()
+	if grant > 0 {
+		_ = c.sig.Send(rendezvous.NewRelayCredit(grant))
+	}
+}
+
+// Close is idempotent and wakes senders blocked on credit.
+func (c *Conn) Close() error {
+	c.mu.Lock()
+	if !c.closed {
+		c.closed = true
+		c.cond.Broadcast()
+	}
+	c.mu.Unlock()
+	return nil
+}

--- a/apps/cli/internal/relay/conn_test.go
+++ b/apps/cli/internal/relay/conn_test.go
@@ -1,0 +1,99 @@
+package relay
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sendarc/cli/internal/rendezvous"
+)
+
+type fakeSignal struct {
+	mu     sync.Mutex
+	msgs   []rendezvous.Message
+	binary [][]byte
+}
+
+func (s *fakeSignal) Send(msg rendezvous.Message) error {
+	s.mu.Lock()
+	s.msgs = append(s.msgs, msg)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *fakeSignal) SendBinary(frame []byte) error {
+	s.mu.Lock()
+	s.binary = append(s.binary, append([]byte(nil), frame...))
+	s.mu.Unlock()
+	return nil
+}
+
+func TestConnNegotiatesCreditAndSendsWithinIt(t *testing.T) {
+	sig := &fakeSignal{}
+	c := New(sig)
+	if err := c.Open(); err != nil {
+		t.Fatal(err)
+	}
+	if !c.HandleMessage(rendezvous.Message{Type: rendezvous.TypeRelayReady}) {
+		t.Fatal("relay_ready was not handled")
+	}
+	c.HandleMessage(rendezvous.Message{Type: rendezvous.TypeCredit, Bytes: 32})
+	if err := c.Send([]byte("sealed frame")); err != nil {
+		t.Fatal(err)
+	}
+	sig.mu.Lock()
+	defer sig.mu.Unlock()
+	if len(sig.msgs) != 2 || sig.msgs[0].Type != rendezvous.TypeRelayOpen ||
+		sig.msgs[1].Type != rendezvous.TypeRelayCredit || sig.msgs[1].Bytes != windowBytes {
+		t.Fatalf("control messages = %+v", sig.msgs)
+	}
+	if len(sig.binary) != 1 || string(sig.binary[0]) != "sealed frame" {
+		t.Fatalf("binary = %q", sig.binary)
+	}
+}
+
+func TestConnBuffersOneWindowUntilConsumerAndReplenishesAfterConsumption(t *testing.T) {
+	sig := &fakeSignal{}
+	c := New(sig)
+	c.HandleMessage(rendezvous.Message{Type: rendezvous.TypeRelayReady})
+	frame := make([]byte, creditBatch)
+	c.HandleBinary(frame)
+	got := make(chan int, 1)
+	c.OnData(func(data []byte) { got <- len(data) })
+	select {
+	case size := <-got:
+		if size != len(frame) {
+			t.Fatalf("size = %d", size)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("buffered frame was not delivered")
+	}
+	sig.mu.Lock()
+	defer sig.mu.Unlock()
+	if len(sig.msgs) != 2 || sig.msgs[1].Bytes != creditBatch {
+		t.Fatalf("credit messages = %+v", sig.msgs)
+	}
+}
+
+func TestConnCloseUnblocksCreditWaiter(t *testing.T) {
+	c := New(&fakeSignal{})
+	result := make(chan error, 1)
+	go func() { result <- c.Send([]byte("blocked")) }()
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("blocked send returned nil after close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("close did not unblock send")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := c.WaitReady(ctx); err == nil {
+		t.Fatal("closed unready relay unexpectedly became ready")
+	}
+}

--- a/apps/cli/internal/rendezvous/caps.go
+++ b/apps/cli/internal/rendezvous/caps.go
@@ -30,7 +30,7 @@ func DefaultCaps() Caps {
 		Version:   wire.ProtocolVersion,
 		MaxFrame:  defaultFrameBytes,
 		BlockSize: defaultBlockBytes,
-		Features:  []string{"folders"},
+		Features:  []string{"folders", "relay"},
 		SinkHints: []string{"direct-file"},
 	}
 }

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -1,7 +1,7 @@
-// Package transfer wires a completed rendezvous into a direct file transfer: it adopts
-// the open signaling socket, brings up the authenticated WebRTC DataChannel (internal/rtc), and
-// runs the transport-agnostic transfer engine (packages/wire) over it — the offerer sends the
-// file, the joiner writes it to disk. It is the CLI counterpart of
+// Package transfer wires a completed rendezvous into a direct-or-relayed file transfer: it adopts
+// the open signaling socket, prefers an authenticated WebRTC DataChannel (internal/rtc), and falls
+// back to the encrypted relay before running the transport-agnostic engine (packages/wire). The
+// offerer sends the file and the joiner writes it to disk. It is the CLI counterpart of
 // apps/web/src/lib/transfer/transfer-core.ts, adapted to Go concurrency and OS files.
 package transfer
 
@@ -11,19 +11,22 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pion/webrtc/v4"
+	relaytransport "github.com/sendarc/cli/internal/relay"
 	"github.com/sendarc/cli/internal/rendezvous"
 	"github.com/sendarc/cli/internal/rtc"
 	"github.com/sendarc/wire"
 )
 
 // Signal is the live signaling connection the driver adopts for the whole exchange — first the
-// handshake, then the sdp/ice negotiation. *wsclient.Client satisfies it; tests supply an
-// in-memory relay.
+// handshake, then SDP/ICE negotiation or opaque relay frames. *wsclient.Client satisfies it;
+// tests supply an in-memory relay.
 type Signal interface {
 	Send(rendezvous.Message) error
-	Run(ctx context.Context, onMessage func(rendezvous.Message)) error
+	SendBinary([]byte) error
+	Run(ctx context.Context, onMessage func(rendezvous.Message), onBinary func([]byte)) error
 	Close()
 }
 
@@ -48,6 +51,12 @@ type Spec struct {
 	// ICEServers overrides rtc.DefaultICEServers. An explicit empty slice uses host candidates
 	// only (loopback tests); nil takes the default STUN server.
 	ICEServers []webrtc.ICEServer
+	// ForceRelay skips direct negotiation. ConnectTimeout selects relay when direct negotiation
+	// does not finish in time; zero uses the production default.
+	ForceRelay     bool
+	ConnectTimeout time.Duration
+	// OnTransport reports "direct" or "relay" once the byte path is selected.
+	OnTransport func(string)
 	// OnConnect fires once the DataChannel opens, before the first byte moves.
 	OnConnect func()
 	// OnManifest fires on the receiver when the sender's manifest arrives (file named and sized).
@@ -100,6 +109,7 @@ type driver struct {
 	// peer and res are set once, by the read-loop goroutine, at establishment; peerCh publishes
 	// the peer to run once it exists.
 	peer   *rtc.Peer
+	relay  *relaytransport.Conn
 	res    *rendezvous.Result
 	peerCh chan *rtc.Peer
 }
@@ -112,6 +122,13 @@ func (d *driver) Send(m rendezvous.Message) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.sig.Send(m)
+}
+
+// SendBinary serializes opaque relay writes with signaling control writes on the WebSocket.
+func (d *driver) SendBinary(frame []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sig.SendBinary(frame)
 }
 
 func (d *driver) run(ctx context.Context) (*Outcome, error) {
@@ -129,7 +146,7 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	}()
 
 	readErr := make(chan error, 1)
-	go func() { readErr <- d.sig.Run(ctx, d.route) }()
+	go func() { readErr <- d.sig.Run(ctx, d.route, d.routeBinary) }()
 
 	d.sess.Start()
 
@@ -152,25 +169,64 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	}
 
 	res := d.res
-	conn, err := peer.Channel(ctx)
+	conn, path, err := d.selectTransport(ctx, peer, readErr)
 	if err != nil {
-		_ = peer.Close()
+		if peer != nil {
+			_ = peer.Close()
+		}
 		d.sig.Close()
-		return nil, fmt.Errorf("transfer: data channel: %w", err)
+		return nil, err
+	}
+	if d.spec.OnTransport != nil {
+		d.spec.OnTransport(path)
 	}
 	if d.spec.OnConnect != nil {
 		d.spec.OnConnect()
 	}
 
-	out, terr := d.transfer(ctx, conn, res)
+	var out *Outcome
+	var terr error
+	readEnded := false
+	if path == "relay" {
+		transferCtx, cancelTransfer := context.WithCancel(ctx)
+		type transferResult struct {
+			out *Outcome
+			err error
+		}
+		transferDone := make(chan transferResult, 1)
+		go func() {
+			result, transferErr := d.transfer(transferCtx, conn, res)
+			transferDone <- transferResult{out: result, err: transferErr}
+		}()
+		select {
+		case result := <-transferDone:
+			out, terr = result.out, result.err
+		case sigErr := <-readErr:
+			readEnded = true
+			cancelTransfer()
+			_ = conn.Close()
+			<-transferDone
+			if sigErr == nil {
+				sigErr = errors.New("signaling closed")
+			}
+			terr = fmt.Errorf("transfer: relay connection lost: %w", sigErr)
+		}
+		cancelTransfer()
+	} else {
+		out, terr = d.transfer(ctx, conn, res)
+	}
 
 	// Drain the data channel before tearing down the peer: the first side to finish (the
 	// receiver, once it has sent done) must let that final frame reach the wire, or closing the
 	// PeerConnection aborts SCTP and the waiting sender never learns the transfer completed.
 	_ = conn.Close()
-	_ = peer.Close()
+	if peer != nil {
+		_ = peer.Close()
+	}
 	d.sig.Close()
-	<-readErr // let the read loop drain once the socket is closed
+	if !readEnded {
+		<-readErr // let the read loop drain once the socket is closed
+	}
 
 	if terr != nil {
 		return nil, terr
@@ -179,17 +235,85 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	return out, nil
 }
 
+type dataConn interface {
+	Send([]byte) error
+	OnData(func([]byte))
+	Close() error
+}
+
+type rtcResult struct {
+	conn *rtc.DataConn
+	err  error
+}
+
+func (d *driver) selectTransport(ctx context.Context, peer *rtc.Peer, readErr <-chan error) (dataConn, string, error) {
+	if d.relay == nil {
+		return nil, "", errors.New("transfer: relay was not initialized")
+	}
+	direct := make(chan rtcResult, 1)
+	if peer != nil && !d.spec.ForceRelay {
+		go func() {
+			conn, err := peer.Channel(ctx)
+			direct <- rtcResult{conn: conn, err: err}
+		}()
+	} else if err := d.relay.Open(); err != nil {
+		return nil, "", err
+	}
+	timeout := d.spec.ConnectTimeout
+	if timeout <= 0 {
+		timeout = 8 * time.Second
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	timeoutCh := timer.C
+
+	for {
+		select {
+		case result := <-direct:
+			if result.err == nil {
+				return result.conn, "direct", nil
+			}
+			if err := d.relay.Open(); err != nil {
+				return nil, "", fmt.Errorf("transfer: direct failed (%v), relay open: %w", result.err, err)
+			}
+			direct = nil
+		case <-timeoutCh:
+			if err := d.relay.Open(); err != nil {
+				return nil, "", fmt.Errorf("transfer: relay fallback: %w", err)
+			}
+			timeoutCh = nil
+		case <-d.relay.Ready():
+			if peer != nil {
+				_ = peer.Close()
+			}
+			return d.relay, "relay", nil
+		case err := <-readErr:
+			if err == nil {
+				err = errors.New("signaling closed")
+			}
+			return nil, "", fmt.Errorf("transfer: signaling: %w", err)
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		}
+	}
+}
+
 // route is the single inbound dispatch. Before establishment it feeds the handshake session;
 // the instant the session establishes it builds the peer — synchronously, so the peer exists
 // before the next frame (the offer, for a joiner) is read — and thereafter feeds the peer.
 // Running entirely on the read-loop goroutine makes the switch race-free.
 func (d *driver) route(m rendezvous.Message) {
-	if d.peer != nil {
-		d.peer.Accept(m)
+	if d.res != nil {
+		if d.relay != nil && d.relay.HandleMessage(m) {
+			return
+		}
+		if d.peer != nil {
+			d.peer.Accept(m)
+		}
 		return
 	}
 	d.sess.Handle(m)
-	if d.peer != nil {
+	if d.res != nil {
 		return
 	}
 	select {
@@ -201,26 +325,37 @@ func (d *driver) route(m rendezvous.Message) {
 	if err != nil {
 		return // handshake failed; the watcher goroutine closes the socket
 	}
-	peer, perr := rtc.NewPeer(rtc.PeerOptions{
-		Role:       res.Role,
-		Auth:       rtc.FromSession(res.Role, res.Room, res.Spake2),
-		Send:       d.Send,
-		ICEServers: d.spec.ICEServers,
-	})
-	if perr != nil {
-		d.sig.Close() // unrecoverable; run's readErr branch reports it
-		return
+	var peer *rtc.Peer
+	if !d.spec.ForceRelay {
+		var perr error
+		peer, perr = rtc.NewPeer(rtc.PeerOptions{
+			Role:       res.Role,
+			Auth:       rtc.FromSession(res.Role, res.Room, res.Spake2),
+			Send:       d.Send,
+			ICEServers: d.spec.ICEServers,
+		})
+		if perr != nil {
+			d.sig.Close()
+			return
+		}
 	}
 	d.res = res
+	d.relay = relaytransport.New(d)
 	d.peer = peer
 	d.peerCh <- peer
+}
+
+func (d *driver) routeBinary(frame []byte) {
+	if d.relay != nil {
+		d.relay.HandleBinary(frame)
+	}
 }
 
 // transfer runs the engine over the open channel: the offerer sends its file, the joiner
 // receives one. Counters continue from the handshake so the AES-GCM nonce is never reused, and
 // block/frame sizes are the min of the two peers' announced caps. Canceling ctx aborts the
 // in-flight transfer.
-func (d *driver) transfer(ctx context.Context, conn *rtc.DataConn, res *rendezvous.Result) (*Outcome, error) {
+func (d *driver) transfer(ctx context.Context, conn dataConn, res *rendezvous.Result) (*Outcome, error) {
 	sendDir, recvDir := directionalKeys(res)
 	if res.Role == wire.RoleOfferer {
 		return d.send(ctx, conn, res, sendDir, recvDir)
@@ -228,7 +363,7 @@ func (d *driver) transfer(ctx context.Context, conn *rtc.DataConn, res *rendezvo
 	return d.receive(ctx, conn, res, sendDir, recvDir)
 }
 
-func (d *driver) send(ctx context.Context, conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+func (d *driver) send(ctx context.Context, conn dataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
 	if (d.spec.Source == nil) == (len(d.spec.Sources) == 0) {
 		return nil, errors.New("transfer: exactly one of Source or Sources is required to send")
 	}
@@ -285,7 +420,7 @@ func containsString(values []string, want string) bool {
 	return false
 }
 
-func (d *driver) receive(ctx context.Context, conn *rtc.DataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+func (d *driver) receive(ctx context.Context, conn dataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
 	destination, err := NewOSDestination(d.spec.DestDir)
 	if err != nil {
 		return nil, wire.NewTransferError(wire.FailSinkError, err.Error())

--- a/apps/cli/internal/transfer/driver_test.go
+++ b/apps/cli/internal/transfer/driver_test.go
@@ -20,11 +20,13 @@ import (
 // partner. It lets a complete offerer↔joiner exchange — SPAKE2 handshake, authenticated
 // SDP/ICE, and the sealed file transfer — run in one process with no sockets.
 type relay struct {
-	off     *relayEnd
-	join    *relayEnd
-	room    int
-	created chan struct{} // closed once the offerer has created the room
-	once    sync.Once
+	off      *relayEnd
+	join     *relayEnd
+	room     int
+	created  chan struct{} // closed once the offerer has created the room
+	once     sync.Once
+	mu       sync.Mutex
+	captured [][]byte
 }
 
 func newRelay() *relay {
@@ -57,6 +59,20 @@ func (r *relay) route(from *relayEnd, m rendezvous.Message) {
 		<-r.created
 		r.off.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.off.role})
 		r.join.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.join.role})
+	case rendezvous.TypeRelayOpen:
+		r.mu.Lock()
+		from.relayOpen = true
+		other := r.partner(from)
+		ready := other.relayOpen
+		r.mu.Unlock()
+		if ready {
+			from.enqueue(rendezvous.Message{Type: rendezvous.TypeRelayReady})
+			other.enqueue(rendezvous.Message{Type: rendezvous.TypeRelayReady})
+		} else {
+			other.enqueue(rendezvous.Message{Type: rendezvous.TypeRelayRequired})
+		}
+	case rendezvous.TypeRelayCredit:
+		r.partner(from).enqueue(rendezvous.Message{Type: rendezvous.TypeCredit, Bytes: m.Bytes})
 	default:
 		r.partner(from).enqueue(m)
 	}
@@ -65,15 +81,17 @@ func (r *relay) route(from *relayEnd, m rendezvous.Message) {
 // relayEnd is one side of the relay. It satisfies transfer.Signal, so a driver adopts it
 // exactly as it would a real *wsclient.Client.
 type relayEnd struct {
-	hub  *relay
-	role string
-	in   chan rendezvous.Message
-	once sync.Once
-	done chan struct{}
+	hub       *relay
+	role      string
+	in        chan rendezvous.Message
+	bin       chan []byte
+	relayOpen bool
+	once      sync.Once
+	done      chan struct{}
 }
 
 func newRelayEnd(hub *relay, role string) *relayEnd {
-	return &relayEnd{hub: hub, role: role, in: make(chan rendezvous.Message, 256), done: make(chan struct{})}
+	return &relayEnd{hub: hub, role: role, in: make(chan rendezvous.Message, 256), bin: make(chan []byte, 256), done: make(chan struct{})}
 }
 
 func (e *relayEnd) Send(m rendezvous.Message) error {
@@ -81,16 +99,33 @@ func (e *relayEnd) Send(m rendezvous.Message) error {
 	return nil
 }
 
-func (e *relayEnd) Run(ctx context.Context, onMessage func(rendezvous.Message)) error {
+func (e *relayEnd) SendBinary(frame []byte) error {
+	e.hub.mu.Lock()
+	e.hub.captured = append(e.hub.captured, append([]byte(nil), frame...))
+	e.hub.mu.Unlock()
+	e.hub.partner(e).enqueueBinary(frame)
+	return nil
+}
+
+func (e *relayEnd) Run(ctx context.Context, onMessage func(rendezvous.Message), onBinary func([]byte)) error {
 	for {
 		select {
 		case m := <-e.in:
 			onMessage(m)
+		case frame := <-e.bin:
+			onBinary(frame)
 		case <-e.done:
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+	}
+}
+
+func (e *relayEnd) enqueueBinary(frame []byte) {
+	select {
+	case e.bin <- append([]byte(nil), frame...):
+	case <-e.done:
 	}
 }
 
@@ -187,6 +222,73 @@ func TestDriverLoopbackTransfersFile(t *testing.T) {
 	// Both peers derived the same session key, so their SAS fingerprints would match.
 	if !bytes.Equal(send.out.Handshake.Master, recv.out.Handshake.Master) {
 		t.Error("master keys differ across peers")
+	}
+}
+
+func TestDriverForcedRelayTransfersEncryptedFile(t *testing.T) {
+	hub := newRelay()
+	payload := make([]byte, 512*1024+17)
+	for i := range payload {
+		payload[i] = byte(i*17 + 3)
+	}
+	meta := wire.FileMeta{Name: "relayed.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	type result struct {
+		out  *Outcome
+		err  error
+		path string
+	}
+	done := make(chan result, 2)
+	go func() {
+		path := ""
+		out, err := Run(ctx, hub.off, Spec{
+			Session: rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:  wire.BytesSource(payload, meta, 64*1024), ForceRelay: true,
+			OnTransport: func(selected string) { path = selected },
+		})
+		done <- result{out: out, err: err, path: path}
+	}()
+	go func() {
+		path := ""
+		out, err := Run(ctx, hub.join, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:     dir,
+			OnTransport: func(selected string) { path = selected },
+		})
+		done <- result{out: out, err: err, path: path}
+	}()
+	a, b := <-done, <-done
+	if a.err != nil || b.err != nil {
+		t.Fatalf("forced relay results: %v / %v", a.err, b.err)
+	}
+	if a.path != "relay" || b.path != "relay" {
+		t.Fatalf("selected paths = %q/%q", a.path, b.path)
+	}
+	var recv *Outcome
+	if a.out.Path != "" {
+		recv = a.out
+	} else {
+		recv = b.out
+	}
+	got, err := os.ReadFile(recv.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("forced relay output differs from source")
+	}
+	hub.mu.Lock()
+	captured := append([][]byte(nil), hub.captured...)
+	hub.mu.Unlock()
+	if len(captured) == 0 {
+		t.Fatal("relay did not observe any binary frames")
+	}
+	for _, frame := range captured {
+		if bytes.Contains(frame, []byte(meta.Name)) || bytes.Contains(frame, payload[:64]) {
+			t.Fatal("relay observed plaintext metadata or file content")
+		}
 	}
 }
 

--- a/apps/cli/internal/wsclient/client.go
+++ b/apps/cli/internal/wsclient/client.go
@@ -62,10 +62,9 @@ type DialOptions struct {
 	Backoff BackoffOptions
 }
 
-// Client is a live signaling connection. It implements rendezvous.Sink, writing each
-// message as a WebSocket text frame. All writes happen on the goroutine that drives the
-// session (Start plus the Run read loop), so there is never more than one concurrent
-// writer; Close is the only method safe to call from another goroutine.
+// Client is a live signaling connection. It implements rendezvous.Sink, writing control
+// messages as text frames and opaque relay data as binary frames. The transfer driver
+// serializes concurrent writes; Close is safe to call from another goroutine.
 type Client struct {
 	ws        *websocket.Conn
 	closeOnce sync.Once
@@ -134,17 +133,31 @@ func (c *Client) Send(m rendezvous.Message) error {
 	return c.ws.Write(ctx, websocket.MessageText, data)
 }
 
+// SendBinary writes one opaque encrypted transfer frame on the adopted relay socket.
+func (c *Client) SendBinary(frame []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
+	defer cancel()
+	return c.ws.Write(ctx, websocket.MessageBinary, frame)
+}
+
 // Run reads inbound frames and dispatches each to onMessage until the socket closes or
 // ctx is cancelled, then returns the terminating error. Closing the socket (Close) is the
 // clean way to stop it.
-func (c *Client) Run(ctx context.Context, onMessage func(rendezvous.Message)) error {
+func (c *Client) Run(ctx context.Context, onMessage func(rendezvous.Message), onBinary func([]byte)) error {
 	for {
 		typ, data, err := c.ws.Read(ctx)
 		if err != nil {
 			return err
 		}
+		if typ == websocket.MessageBinary {
+			if onBinary == nil {
+				return errors.New("wsclient: unexpected binary frame")
+			}
+			onBinary(data)
+			continue
+		}
 		if typ != websocket.MessageText {
-			return errors.New("wsclient: expected a text frame")
+			return errors.New("wsclient: unsupported frame type")
 		}
 		msg, err := rendezvous.UnmarshalMessage(data)
 		if err != nil {
@@ -183,7 +196,7 @@ func Rendezvous(ctx context.Context, url string, dopts DialOptions, sopts rendez
 	}()
 
 	sess.Start()
-	if err := client.Run(ctx, sess.Handle); err != nil {
+	if err := client.Run(ctx, sess.Handle, nil); err != nil {
 		// The read loop ended. If we were cancelled (Ctrl-C), abort with a best-effort
 		// bye; otherwise the socket dropped mid-handshake — fail closed. Either is a
 		// no-op if the session already settled (the normal close from the watcher).

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -52,6 +52,7 @@
   let rateBps = $state(0);
   let etaSeconds = $state<number | undefined>(undefined);
   let transferState = $state<'running' | 'paused' | 'canceled'>('running');
+  let transportPath = $state<'connecting' | 'direct' | 'relay'>('connecting');
   let outcome = $state<TransferOutcome | null>(null);
   let downloadUrl = $state<string | null>(null);
 
@@ -82,6 +83,7 @@
       sinkHints.push('opfs', 'archive');
     }
     if (pickerWindow.showSaveFilePicker) sinkHints.push('direct-file');
+    features.push('relay');
     return { features, sinkHints };
   }
 
@@ -202,6 +204,7 @@
       rateBps = snapshot.rateBps;
       etaSeconds = snapshot.etaSeconds;
       transferState = snapshot.state;
+      transportPath = ctrl.transport();
     }, 100);
     ctrl.done.then(
       (result) => {
@@ -253,6 +256,7 @@
     rateBps = 0;
     etaSeconds = undefined;
     transferState = 'running';
+    transportPath = 'connecting';
     outcome = null;
     phase = 'idle';
     code = '';
@@ -364,7 +368,7 @@
         <p class="transfer-detail" aria-live="polite">
           {transferState === 'paused'
             ? 'Paused'
-            : `${rateLabel(rateBps)} · ${etaLabel(etaSeconds)}`}
+            : `${rateLabel(rateBps)} · ${etaLabel(etaSeconds)}${transportPath === 'relay' ? ' · encrypted relay' : transportPath === 'direct' ? ' · direct' : ''}`}
         </p>
         <div class="transfer-controls">
           {#if transferState === 'paused'}

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -70,7 +70,14 @@ describe('App transfer completion', () => {
   it('renders the verified outcome when the active transfer resolves', async () => {
     const handshake = deferred<unknown>();
     const completed = deferred<unknown>();
-    const signaling = { send: vi.fn(), onMessage: vi.fn(), close: vi.fn() };
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
     const rendezvous = {
       code: undefined,
       phase: 'idle',
@@ -88,6 +95,7 @@ describe('App transfer completion', () => {
         etaSeconds: 0,
         state: 'running',
       })),
+      transport: vi.fn(() => 'direct'),
       done: completed.promise,
       pause: vi.fn(),
       resume: vi.fn(),

--- a/apps/web/src/lib/session/rendezvous.ts
+++ b/apps/web/src/lib/session/rendezvous.ts
@@ -95,6 +95,8 @@ function run(
   // which point `route` is swapped to the transfer's own handler. `adopted` also suppresses the
   // success auto-close, since the transfer layer then owns the socket's lifetime.
   let route: (msg: SignalMsg) => void = (msg) => session.handle(msg);
+  let routeBinary: (frame: ArrayBuffer) => void = () => session.abort('unexpected binary frame');
+  let routeClose: (err: Error) => void = (err) => session.abort(err.message);
   let adopted = false;
 
   // The two layers reference each other, so one closure must name the other before it is
@@ -105,10 +107,13 @@ function run(
   const client = new SignalingClient({
     url,
     onMessage: (msg) => route(msg),
+    onBinary: (frame) => routeBinary(frame),
     onClose: (clean, code, reason) => {
       // A post-open drop is terminal; translate it into a session failure. If the session
       // already settled (the normal close we trigger on `done`), abort is a no-op.
-      session.abort(clean ? `signaling closed (${code})` : `signaling lost (${code} ${reason})`);
+      routeClose(
+        new Error(clean ? `signaling closed (${code})` : `signaling lost (${code} ${reason})`),
+      );
     },
     onError: (err) => session.abort(err.message),
     ...(opts.backoff !== undefined ? { backoff: opts.backoff } : {}),
@@ -144,7 +149,10 @@ function run(
       adopted = true;
       return {
         send: (msg) => client.send(msg),
+        sendBinary: (frame) => client.sendBinary(frame),
         onMessage: (handler) => (route = handler),
+        onBinary: (handler) => (routeBinary = handler),
+        onClose: (handler) => (routeClose = handler),
         close: () => client.close(),
       };
     },

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -1,9 +1,9 @@
 /**
  * Transfer orchestrator — the main-thread conductor that turns a settled rendezvous into a running
- * file transfer. It adopts the still-open signaling socket, brings up the authenticated WebRTC data
- * channel ({@link createPeer}), spawns the transfer worker ({@link runTransferCore} host), and pumps
- * frames between the two: worker → channel with SCTP backpressure ({@link ChannelWriter}), channel →
- * worker as inbound frames. The worker owns crypto and disk; this module owns transport and the
+ * file transfer. It adopts the still-open signaling socket, prefers an authenticated WebRTC data
+ * channel ({@link createPeer}), and falls back to the encrypted relay when direct negotiation fails.
+ * It spawns the transfer worker ({@link runTransferCore} host) and pumps frames between the selected
+ * path and worker. The worker owns crypto and disk; this module owns transport selection and the
  * public {@link TransferController} the UI binds against (progress, a `done` promise, cancel).
  *
  * Browser-only (needs `Worker`, `RTCPeerConnection`); not unit-tested — the pieces it wires each
@@ -15,6 +15,7 @@ import type { SignalChannel } from '../signaling/client.js';
 import { SignalAuthenticator } from '../transfer/authed-signaling.js';
 import { createPeer, type Peer } from '../transfer/peer.js';
 import { ChannelWriter } from '../transfer/channel-writer.js';
+import { RelayTransport } from '../transfer/relay.js';
 import { ProgressTracker, type TransferSnapshot } from '../transfer/progress.js';
 import { readOpfsOutput, removeOpfsOutput } from '../transfer/sink.js';
 import type {
@@ -44,6 +45,8 @@ export interface TransferController {
   total(): number | undefined;
   /** A coherent acknowledged-byte, smoothed-rate, ETA, and run-state snapshot. */
   snapshot(): TransferSnapshot;
+  /** Active byte path, including automatic relay fallback. */
+  transport(): 'connecting' | 'direct' | 'relay';
   /** Resolves when the transfer completes and verifies; rejects on any failure. */
   readonly done: Promise<TransferOutcome>;
   /** Stop producing new data frames; already-buffered transport bytes may drain. */
@@ -101,6 +104,8 @@ function run(
   let peer: Peer | undefined;
   let worker: Worker | undefined;
   let writer: ChannelWriter | undefined;
+  let relay: RelayTransport | undefined;
+  let transport: 'connecting' | 'direct' | 'relay' = 'connecting';
   let cancelTimer: ReturnType<typeof setTimeout> | undefined;
 
   let resolveDone!: (o: TransferOutcome) => void;
@@ -114,6 +119,7 @@ function run(
     clearTimeout(cancelTimer);
     worker?.terminate();
     peer?.close();
+    relay?.close();
     signaling.close();
   };
   const finish = (o: TransferOutcome): void => {
@@ -138,9 +144,19 @@ function run(
       );
       const p = createPeer({ role: rendezvous.role, auth, send: (msg) => signaling.send(msg) });
       peer = p;
+      const relayPath = new RelayTransport(signaling);
+      relay = relayPath;
+      signaling.onClose((err) => {
+        if (transport !== 'direct') {
+          relayPath.fail(err);
+          fail(err);
+        }
+      });
       signaling.onMessage((msg) => {
+        if (relayPath.handleMessage(msg)) return;
         if (msg.type === 'sdp' || msg.type === 'ice') p.accept(msg);
       });
+      signaling.onBinary((frame) => relayPath.handleBinary(frame));
 
       const w = new Worker(new URL('../transfer/transfer.worker.ts', import.meta.url), {
         type: 'module',
@@ -150,8 +166,13 @@ function run(
       // which can beat the channel negotiation; a late listener would miss it and hang forever.
       const ready = workerReady(w);
 
-      const channel = await p.channel;
-      writer = new ChannelWriter(channel);
+      const selected = await selectTransport(p, relayPath);
+      transport = selected.kind;
+      if (selected.kind === 'direct') {
+        writer = new ChannelWriter(selected.channel);
+      } else {
+        p.close();
+      }
       await ready;
 
       // Worker → host events.
@@ -159,7 +180,16 @@ function run(
         const msg = ev.data as WorkerToHost;
         switch (msg.kind) {
           case 'outbound-frame':
-            writer?.write(msg.frame);
+            if (transport === 'relay') {
+              void relayPath
+                .write(msg.frame)
+                .catch((err: unknown) => fail(err instanceof Error ? err : new Error(String(err))));
+            } else {
+              writer?.write(msg.frame);
+            }
+            return;
+          case 'frame-consumed':
+            if (transport === 'relay') relayPath.consumed(msg.bytes);
             return;
           case 'progress':
             progress.update(msg.bytes);
@@ -190,9 +220,10 @@ function run(
       });
 
       // Channel → worker: forward every inbound data frame as a Transferable.
-      p.onData((frame) =>
-        w.postMessage({ kind: 'inbound-frame', frame } satisfies HostToWorker, [frame]),
-      );
+      const receive = (frame: ArrayBuffer): void =>
+        w.postMessage({ kind: 'inbound-frame', frame } satisfies HostToWorker, [frame]);
+      if (selected.kind === 'direct') p.onData(receive);
+      else relayPath.onData(receive);
 
       // Kick off the transfer in the worker.
       const startMsg = spec.start();
@@ -243,6 +274,7 @@ function run(
     progress: () => progress.snapshot().bytes,
     total: () => total,
     snapshot: () => progress.snapshot(),
+    transport: () => transport,
     done: donePromise,
     pause: () => {
       if (settled || progress.snapshot().state === 'paused') return;
@@ -265,6 +297,25 @@ function run(
       cancelTimer = setTimeout(() => fail(new Error(reason)), 1000);
     },
   };
+}
+
+type SelectedTransport = { kind: 'direct'; channel: RTCDataChannel } | { kind: 'relay' };
+
+async function selectTransport(peer: Peer, relay: RelayTransport): Promise<SelectedTransport> {
+  let timer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => relay.open(), 8000);
+  const direct = peer.channel.then(
+    (channel): SelectedTransport => ({ kind: 'direct', channel }),
+    async (): Promise<SelectedTransport> => {
+      relay.open();
+      await relay.ready;
+      return { kind: 'relay' };
+    },
+  );
+  const relayed = relay.ready.then((): SelectedTransport => ({ kind: 'relay' }));
+  const selected = await Promise.race([direct, relayed]);
+  clearTimeout(timer);
+  timer = undefined;
+  return selected;
 }
 
 /** Resolve once the worker posts its one-time `ready` handshake. */

--- a/apps/web/src/lib/signaling/client.ts
+++ b/apps/web/src/lib/signaling/client.ts
@@ -21,7 +21,10 @@ import type { SignalMsg } from '@sendarc/protocol';
  */
 export interface SignalChannel {
   send(msg: SignalMsg): void;
+  sendBinary(frame: ArrayBuffer): void;
   onMessage(handler: (msg: SignalMsg) => void): void;
+  onBinary(handler: (frame: ArrayBuffer) => void): void;
+  onClose(handler: (err: Error) => void): void;
   close(): void;
 }
 
@@ -48,6 +51,7 @@ export interface SignalingClientOptions {
   url: string;
   /** A parsed inbound signaling message. */
   onMessage: (msg: SignalMsg) => void;
+  onBinary?: (frame: ArrayBuffer) => void;
   /** The socket closed after having opened. `clean` is the WebSocket close cleanliness. */
   onClose?: (clean: boolean, code: number, reason: string) => void;
   /** A transport-level problem (connect exhausted, malformed inbound frame). */
@@ -94,6 +98,7 @@ export class SignalingClient {
       return;
     }
     this.ws = ws;
+    ws.binaryType = 'arraybuffer';
 
     ws.onopen = () => {
       this.opened = true;
@@ -135,8 +140,12 @@ export class SignalingClient {
   }
 
   private dispatch(ev: MessageEvent): void {
+    if (ev.data instanceof ArrayBuffer) {
+      this.opts.onBinary?.(ev.data);
+      return;
+    }
     if (typeof ev.data !== 'string') {
-      this.opts.onError?.(new Error('signaling: non-text frame'));
+      this.opts.onError?.(new Error('signaling: unsupported frame'));
       return;
     }
     let msg: SignalMsg;
@@ -161,6 +170,12 @@ export class SignalingClient {
   send(msg: SignalMsg): void {
     if (!this.isOpen) throw new Error('signaling: socket not open');
     this.ws!.send(JSON.stringify(msg));
+  }
+
+  /** Send one opaque encrypted transfer frame over the adopted relay socket. */
+  sendBinary(frame: ArrayBuffer): void {
+    if (!this.isOpen) throw new Error('signaling: socket not open');
+    this.ws!.send(frame);
   }
 
   /** Close the socket and cancel any pending reconnect. Idempotent. */

--- a/apps/web/src/lib/transfer/relay.test.ts
+++ b/apps/web/src/lib/transfer/relay.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SignalMsg } from '@sendarc/protocol';
+import type { SignalChannel } from '../signaling/client.js';
+import { RelayTransport } from './relay.js';
+
+function fakeChannel() {
+  const messages: SignalMsg[] = [];
+  const binary: ArrayBuffer[] = [];
+  const channel: SignalChannel = {
+    send: (message) => messages.push(message),
+    sendBinary: (frame) => binary.push(frame),
+    onMessage: vi.fn(),
+    onBinary: vi.fn(),
+    onClose: vi.fn(),
+    close: vi.fn(),
+  };
+  return { channel, messages, binary };
+}
+
+describe('RelayTransport', () => {
+  it('coordinates opt-in and sends only within granted credit', async () => {
+    const { channel, messages, binary } = fakeChannel();
+    const relay = new RelayTransport(channel);
+    relay.open();
+    expect(messages).toEqual([{ type: 'relay_open' }]);
+    relay.handleMessage({ type: 'relay_ready' });
+    relay.handleMessage({ type: 'credit', bytes: 32 });
+    const frame = new Uint8Array([1, 2, 3]).buffer;
+    await relay.write(frame);
+    expect(binary).toEqual([frame]);
+    expect(messages[1]).toEqual({ type: 'relay_credit', bytes: 1024 * 1024 });
+  });
+
+  it('buffers early binary within one window and credits only worker-consumed bytes', () => {
+    const { channel, messages } = fakeChannel();
+    const relay = new RelayTransport(channel);
+    relay.handleMessage({ type: 'relay_ready' });
+    const frame = new Uint8Array(512 * 1024).buffer;
+    relay.handleBinary(frame);
+    const received: ArrayBuffer[] = [];
+    relay.onData((data) => received.push(data));
+    expect(received).toEqual([frame]);
+    relay.consumed(frame.byteLength);
+    expect(messages.at(-1)).toEqual({ type: 'relay_credit', bytes: 512 * 1024 });
+  });
+
+  it('opens automatically when the partner requires relay', () => {
+    const { channel, messages } = fakeChannel();
+    const relay = new RelayTransport(channel);
+    expect(relay.handleMessage({ type: 'relay_required' })).toBe(true);
+    expect(messages).toEqual([{ type: 'relay_open' }]);
+  });
+
+  it('rejects readiness and blocked writes when the WebSocket is lost', async () => {
+    const { channel } = fakeChannel();
+    const relay = new RelayTransport(channel);
+    const ready = relay.ready;
+    const blocked = relay.write(new Uint8Array([1]).buffer);
+    relay.fail(new Error('signaling lost'));
+    await expect(ready).rejects.toThrow('signaling lost');
+    await expect(blocked).rejects.toThrow('relay closed');
+  });
+});

--- a/apps/web/src/lib/transfer/relay.ts
+++ b/apps/web/src/lib/transfer/relay.ts
@@ -1,0 +1,124 @@
+import type { SignalMsg } from '@sendarc/protocol';
+import type { SignalChannel } from '../signaling/client.js';
+
+const WINDOW_BYTES = 1024 * 1024;
+const CREDIT_BATCH = WINDOW_BYTES / 2;
+
+/** Credit-gated opaque binary transport over the adopted signaling WebSocket. */
+export class RelayTransport {
+  private opened = false;
+  private isReady = false;
+  private closed = false;
+  private credit = 0;
+  private consumedBytes = 0;
+  private handler: ((frame: ArrayBuffer) => void) | undefined;
+  private readonly pending: ArrayBuffer[] = [];
+  private pendingBytes = 0;
+  private readonly creditWaiters: Array<() => void> = [];
+  private outbound: Promise<void> = Promise.resolve();
+  private resolveReady!: () => void;
+  private rejectReady!: (err: Error) => void;
+  readonly ready = new Promise<void>((resolve, reject) => {
+    this.resolveReady = resolve;
+    this.rejectReady = reject;
+  });
+
+  constructor(private readonly signaling: SignalChannel) {}
+
+  open(): void {
+    if (this.opened || this.closed) return;
+    this.opened = true;
+    this.signaling.send({ type: 'relay_open' });
+  }
+
+  /** Consume a relay control message; false leaves SDP/ICE for the direct peer. */
+  handleMessage(msg: SignalMsg): boolean {
+    switch (msg.type) {
+      case 'relay_required':
+        this.open();
+        return true;
+      case 'relay_ready':
+        if (!this.isReady) {
+          this.isReady = true;
+          this.signaling.send({ type: 'relay_credit', bytes: WINDOW_BYTES });
+          this.resolveReady();
+          this.wakeCredit();
+        }
+        return true;
+      case 'credit':
+        if (Number.isSafeInteger(msg.bytes) && msg.bytes > 0) {
+          this.credit += msg.bytes;
+          this.wakeCredit();
+        }
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  handleBinary(frame: ArrayBuffer): void {
+    if (this.closed) return;
+    if (this.handler) {
+      this.handler(frame);
+      return;
+    }
+    if (this.pendingBytes + frame.byteLength <= WINDOW_BYTES) {
+      this.pending.push(frame);
+      this.pendingBytes += frame.byteLength;
+    }
+  }
+
+  onData(handler: (frame: ArrayBuffer) => void): void {
+    if (this.handler) return;
+    this.handler = handler;
+    for (const frame of this.pending) handler(frame);
+    this.pending.length = 0;
+    this.pendingBytes = 0;
+  }
+
+  /** Queue one frame in order; the promise resolves only after receiver credit permits the send. */
+  write(frame: ArrayBuffer): Promise<void> {
+    const task = this.outbound.then(async () => {
+      await this.waitForCredit(frame.byteLength);
+      if (this.closed) throw new Error('relay closed');
+      this.credit -= frame.byteLength;
+      this.signaling.sendBinary(frame);
+    });
+    this.outbound = task.catch(() => {});
+    return task;
+  }
+
+  /** Replenish server credit only after the worker has authenticated and consumed the frame. */
+  consumed(bytes: number): void {
+    if (!Number.isSafeInteger(bytes) || bytes <= 0 || this.closed) return;
+    this.consumedBytes += bytes;
+    if (this.consumedBytes >= CREDIT_BATCH) {
+      this.signaling.send({ type: 'relay_credit', bytes: this.consumedBytes });
+      this.consumedBytes = 0;
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    this.wakeCredit();
+  }
+
+  /** Fail pending readiness and credit waits when the carrying WebSocket is lost. */
+  fail(err: Error): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (!this.isReady) this.rejectReady(err);
+    this.wakeCredit();
+  }
+
+  private async waitForCredit(bytes: number): Promise<void> {
+    while (!this.closed && (!this.isReady || this.credit < bytes)) {
+      await new Promise<void>((resolve) => this.creditWaiters.push(resolve));
+    }
+  }
+
+  private wakeCredit(): void {
+    const waiters = this.creditWaiters.splice(0);
+    for (const resolve of waiters) resolve();
+  }
+}

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -46,7 +46,7 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
   return new Promise<void>((resolve, reject) => {
     let engine:
       | {
-          handle(frame: Uint8Array): void;
+          handle(frame: Uint8Array): void | Promise<void>;
           pause(): void;
           resume(): void;
           cancel(reason?: string): void;
@@ -62,14 +62,14 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
       port.postMessage({ kind: 'outbound-frame', frame: buf }, [buf]);
     };
     const bind = (e: {
-      handle(frame: Uint8Array): void;
+      handle(frame: Uint8Array): void | Promise<void>;
       pause(): void;
       resume(): void;
       cancel(reason?: string): void;
     }): void => {
       engine = e;
       post({ kind: 'state', state: 'running' });
-      for (const f of pending) e.handle(f);
+      for (const f of pending) consume(e, f);
       pending.length = 0;
       for (const op of pendingControls) {
         if (op === 'pause') e.pause();
@@ -83,6 +83,14 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
       const message = e instanceof Error ? e.message : String(e);
       post({ kind: 'error', reason, message });
       reject(e instanceof Error ? e : new Error(message));
+    };
+    const consume = (
+      target: { handle(frame: Uint8Array): void | Promise<void> },
+      frame: Uint8Array,
+    ): void => {
+      void Promise.resolve(target.handle(frame)).finally(() =>
+        post({ kind: 'frame-consumed', bytes: frame.byteLength }),
+      );
     };
 
     port.addEventListener('message', (ev) => {
@@ -102,7 +110,7 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           return;
         case 'inbound-frame': {
           const frame = new Uint8Array(msg.frame);
-          if (engine) engine.handle(frame);
+          if (engine) consume(engine, frame);
           else pending.push(frame);
           return;
         }

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -49,6 +49,10 @@ export interface OutboundFrameMsg {
   kind: 'outbound-frame';
   frame: ArrayBuffer;
 }
+export interface FrameConsumedMsg {
+  kind: 'frame-consumed';
+  bytes: number;
+}
 /** Worker → host, emitted once the core is wired and ready to accept a start message. */
 export interface ReadyMsg {
   kind: 'ready';
@@ -79,7 +83,14 @@ export interface ErrorMsg {
   message: string;
 }
 export type WorkerToHost =
-  ReadyMsg | OutboundFrameMsg | ManifestMsg | ProgressMsg | StateMsg | DoneMsg | ErrorMsg;
+  | ReadyMsg
+  | OutboundFrameMsg
+  | FrameConsumedMsg
+  | ManifestMsg
+  | ProgressMsg
+  | StateMsg
+  | DoneMsg
+  | ErrorMsg;
 
 /** The slice of Worker / DedicatedWorkerGlobalScope the core needs, so a test can inject a fake. */
 export interface DuplexPort<In, Out> {

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -99,7 +99,7 @@ export class TransferReceiver {
   }
 
   /** Feed one inbound encrypted frame from the sender. */
-  handle(frame: Uint8Array): void {
+  handle(frame: Uint8Array): Promise<void> {
     this.inbound = this.inbound
       .then(() => this.process(frame))
       .catch((e: unknown) => {
@@ -109,6 +109,7 @@ export class TransferReceiver {
             : new TransferError('integrity', e instanceof Error ? e.message : String(e)),
         );
       });
+    return this.inbound;
   }
 
   /** Ask the sender to stop producing data frames. Buffered transport bytes may still drain. */

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -129,12 +129,13 @@ export class TransferSender {
   }
 
   /** Feed one inbound encrypted control frame from the receiver. */
-  handle(frame: Uint8Array): void {
+  handle(frame: Uint8Array): Promise<void> {
     this.inbound = this.inbound
       .then(() => this.processInbound(frame))
       .catch((e: unknown) => {
         this.fail(e instanceof Error ? e : new Error(String(e)));
       });
+    return this.inbound;
   }
 
   /** Pause locally and ask the peer to reflect the paused state. */


### PR DESCRIPTION
## Summary
- prefer direct WebRTC and automatically coordinate onto the bounded encrypted relay when direct negotiation fails or times out
- add credit-gated browser and CLI relay transports, binary signaling support, and transport-path UI/CLI feedback
- replenish relay credit only after authenticated frames are consumed
- expose an optional CLI relay-only connectivity check and document the public direct/relay behavior

## Security
- transfer metadata and content remain sealed end to end on the relay path
- integration coverage rejects plaintext filename and payload fragments at the relay boundary
- signaling loss terminates an active relay transfer instead of hanging

## Verification
- pnpm format:check, lint, typecheck, test, build
- go vet ./... in all modules
- go test -race ./... in all modules
- real CLI-to-CLI 1.25 MiB relay transfer through sendarcd with matching SHA-256