### PR TITLE
feat(transfer): recover live sessions through relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Files stream without being loaded entirely into memory.
 - **Files and folders.** Each file is independently verified; browsers can write directly to a
   chosen destination or stream a portable ZIP fallback without buffering the file set in memory.
 - **Reliable and controllable.** Verified block acknowledgements drive progress and recovery;
-  missing blocks are retried, and either peer can pause, resume, or cancel a transfer.
+  missing blocks are retried, an interrupted direct path can continue through the relay, and either
+  peer can pause, resume, or cancel a transfer.
 - **Verifiable completion.** Every block is authenticated and hashed; the final streaming
   SHA-256 digest is compatible with `sha256sum`.
 - **Browser and CLI interoperability.** Send or receive with either client using the same

--- a/apps/cli/internal/rtc/conn.go
+++ b/apps/cli/internal/rtc/conn.go
@@ -100,6 +100,9 @@ func (c *DataConn) OnData(handler func(frame []byte)) {
 	close(c.handlerReady)
 }
 
+// Done closes when the data channel closes locally or remotely.
+func (c *DataConn) Done() <-chan struct{} { return c.done }
+
 // Close closes the underlying channel. It drains the SCTP send buffer (bounded) so a final
 // frame reaches the wire before teardown, then closes the channel. It is idempotent and unblocks
 // any waiting Send.

--- a/apps/cli/internal/rtc/peer.go
+++ b/apps/cli/internal/rtc/peer.go
@@ -96,7 +96,14 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 	})
 	pc.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
 		if s == webrtc.PeerConnectionStateFailed {
-			p.fail(errors.New("rtc: peer connection failed"))
+			p.mu.Lock()
+			established := p.settled
+			p.mu.Unlock()
+			if established {
+				_ = p.pc.Close() // DataConn.OnClose publishes the active-path failure.
+			} else {
+				p.fail(errors.New("rtc: peer connection failed"))
+			}
 		}
 	})
 
@@ -242,7 +249,10 @@ func (p *Peer) wireChannel(dc *webrtc.DataChannel) {
 		p.mu.Unlock()
 		p.connCh <- conn
 	})
-	dc.OnError(func(err error) { p.fail(fmt.Errorf("rtc: data channel: %w", err)) })
+	dc.OnError(func(error) {
+		conn.shutdown()
+		_ = p.pc.Close()
+	})
 }
 
 // fail records the first fatal error and closes the PeerConnection; later calls are no-ops.

--- a/apps/cli/internal/transfer/adaptive_conn.go
+++ b/apps/cli/internal/transfer/adaptive_conn.go
@@ -1,0 +1,180 @@
+package transfer
+
+import (
+	"errors"
+	"sync"
+
+	relaytransport "github.com/sendarc/cli/internal/relay"
+	"github.com/sendarc/cli/internal/rtc"
+)
+
+// adaptiveConn starts on an open direct channel and atomically converges onto the session relay.
+// Frames accepted by the old channel may be lost during cutover; the transfer engines recover
+// their unacknowledged block window after the switch callback.
+type adaptiveConn struct {
+	direct *rtc.DataConn
+	relay  *relaytransport.Conn
+
+	mu          sync.Mutex
+	path        string
+	closed      bool
+	switchErr   error
+	switchDone  chan struct{}
+	switchOnce  sync.Once
+	onSwitch    func()
+	hookCalled  bool
+	onTransport func(string)
+}
+
+func newAdaptiveConn(
+	direct *rtc.DataConn,
+	relay *relaytransport.Conn,
+	onTransport func(string),
+) *adaptiveConn {
+	c := &adaptiveConn{
+		direct: direct, relay: relay, path: "direct", switchDone: make(chan struct{}),
+		onTransport: onTransport,
+	}
+	go func() {
+		select {
+		case <-direct.Done():
+			c.requestRelay()
+		case <-c.switchDone:
+		}
+	}()
+	go func() {
+		select {
+		case <-relay.Ready():
+			c.activateRelay()
+		case <-c.switchDone:
+		}
+	}()
+	return c
+}
+
+func (c *adaptiveConn) Send(frame []byte) error {
+	c.mu.Lock()
+	path, closed := c.path, c.closed
+	c.mu.Unlock()
+	if closed {
+		return errors.New("transfer: connection closed")
+	}
+	if path == "relay" {
+		return c.relay.Send(frame)
+	}
+	if err := c.direct.Send(frame); err == nil {
+		return nil
+	}
+	c.requestRelay()
+	<-c.switchDone
+	c.mu.Lock()
+	err := c.switchErr
+	path = c.path
+	c.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if path != "relay" {
+		return errors.New("transfer: relay switch did not complete")
+	}
+	return c.relay.Send(frame)
+}
+
+func (c *adaptiveConn) OnData(handler func([]byte)) {
+	c.direct.OnData(func(frame []byte) {
+		c.mu.Lock()
+		active := !c.closed && c.path == "direct"
+		c.mu.Unlock()
+		if active {
+			handler(frame)
+		}
+	})
+	c.relay.OnData(func(frame []byte) {
+		c.activateRelay()
+		c.mu.Lock()
+		active := !c.closed && c.path == "relay"
+		c.mu.Unlock()
+		if active {
+			handler(frame)
+		}
+	})
+}
+
+func (c *adaptiveConn) Close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+	c.finishSwitch(errors.New("transfer: connection closed"))
+	_ = c.relay.Close()
+	return c.direct.Close()
+}
+
+func (c *adaptiveConn) SetOnSwitch(handler func()) {
+	c.mu.Lock()
+	c.onSwitch = handler
+	call := c.path == "relay" && !c.hookCalled
+	if call {
+		c.hookCalled = true
+	}
+	c.mu.Unlock()
+	if call {
+		handler()
+	}
+}
+
+func (c *adaptiveConn) IsRelay() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.path == "relay"
+}
+
+// SignalingLost keeps a healthy direct path alive but makes relay activation fail promptly.
+func (c *adaptiveConn) SignalingLost(err error) {
+	c.finishSwitch(err)
+	_ = c.relay.Close()
+}
+
+func (c *adaptiveConn) requestRelay() {
+	c.mu.Lock()
+	blocked := c.closed || c.path == "relay" || c.switchErr != nil
+	c.mu.Unlock()
+	if blocked {
+		return
+	}
+	if err := c.relay.Open(); err != nil {
+		c.finishSwitch(err)
+	}
+}
+
+func (c *adaptiveConn) activateRelay() {
+	c.mu.Lock()
+	if c.closed || c.path == "relay" || c.switchErr != nil {
+		c.mu.Unlock()
+		return
+	}
+	c.path = "relay"
+	hook := c.onSwitch
+	if hook != nil {
+		c.hookCalled = true
+	}
+	onTransport := c.onTransport
+	c.mu.Unlock()
+
+	if hook != nil {
+		hook()
+	}
+	if onTransport != nil {
+		onTransport("relay")
+	}
+	c.finishSwitch(nil)
+	go func() { _ = c.direct.Close() }()
+}
+
+func (c *adaptiveConn) finishSwitch(err error) {
+	c.switchOnce.Do(func() {
+		c.mu.Lock()
+		c.switchErr = err
+		c.mu.Unlock()
+		close(c.switchDone)
+	})
+}

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -55,7 +55,7 @@ type Spec struct {
 	// does not finish in time; zero uses the production default.
 	ForceRelay     bool
 	ConnectTimeout time.Duration
-	// OnTransport reports "direct" or "relay" once the byte path is selected.
+	// OnTransport reports "direct" or "relay" when the selected byte path changes.
 	OnTransport func(string)
 	// OnConnect fires once the DataChannel opens, before the first byte moves.
 	OnConnect func()
@@ -70,6 +70,8 @@ type Spec struct {
 	OnControls func(Controls)
 	// OnStateChange reports pause, resume, and remote cancellation.
 	OnStateChange func(wire.TransferState)
+	// breakDirect is a deterministic in-package integration hook.
+	breakDirect <-chan struct{}
 }
 
 // Outcome is the result of a completed transfer.
@@ -180,41 +182,67 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	if d.spec.OnTransport != nil {
 		d.spec.OnTransport(path)
 	}
+	var adaptive *adaptiveConn
+	if path == "direct" {
+		adaptive = newAdaptiveConn(conn.(*rtc.DataConn), d.relay, d.spec.OnTransport)
+		conn = adaptive
+		if d.spec.breakDirect != nil {
+			go func() {
+				select {
+				case <-d.spec.breakDirect:
+					_ = peer.Close()
+				case <-ctx.Done():
+				}
+			}()
+		}
+	}
 	if d.spec.OnConnect != nil {
 		d.spec.OnConnect()
 	}
 
+	transferCtx, cancelTransfer := context.WithCancel(ctx)
+	type transferResult struct {
+		out *Outcome
+		err error
+	}
+	transferDone := make(chan transferResult, 1)
+	go func() {
+		result, transferErr := d.transfer(transferCtx, conn, res)
+		transferDone <- transferResult{out: result, err: transferErr}
+	}()
 	var out *Outcome
 	var terr error
 	readEnded := false
-	if path == "relay" {
-		transferCtx, cancelTransfer := context.WithCancel(ctx)
-		type transferResult struct {
-			out *Outcome
-			err error
-		}
-		transferDone := make(chan transferResult, 1)
-		go func() {
-			result, transferErr := d.transfer(transferCtx, conn, res)
-			transferDone <- transferResult{out: result, err: transferErr}
-		}()
+	readCh := (<-chan error)(readErr)
+	for {
 		select {
 		case result := <-transferDone:
 			out, terr = result.out, result.err
-		case sigErr := <-readErr:
-			readEnded = true
 			cancelTransfer()
-			_ = conn.Close()
-			<-transferDone
+			goto transferSettled
+		case sigErr := <-readCh:
+			readEnded = true
 			if sigErr == nil {
 				sigErr = errors.New("signaling closed")
 			}
-			terr = fmt.Errorf("transfer: relay connection lost: %w", sigErr)
+			if adaptive != nil && !adaptive.IsRelay() {
+				adaptive.SignalingLost(sigErr)
+				readCh = nil // a healthy direct channel can finish without signaling
+				continue
+			}
+			cancelTransfer()
+			_ = conn.Close()
+			<-transferDone
+			if ctx.Err() != nil {
+				terr = ctx.Err()
+			} else {
+				terr = fmt.Errorf("transfer: relay connection lost: %w", sigErr)
+			}
+			goto transferSettled
 		}
-		cancelTransfer()
-	} else {
-		out, terr = d.transfer(ctx, conn, res)
 	}
+
+transferSettled:
 
 	// Drain the data channel before tearing down the peer: the first side to finish (the
 	// receiver, once it has sent done) must let that final frame reach the wire, or closing the
@@ -393,6 +421,9 @@ func (d *driver) send(ctx context.Context, conn dataConn, res *rendezvous.Result
 		OnFileProgress:   d.spec.OnFileProgress,
 		OnStateChange:    d.spec.OnStateChange,
 	})
+	if switched, ok := conn.(*adaptiveConn); ok {
+		switched.SetOnSwitch(sender.TransportChanged)
+	}
 	conn.OnData(sender.Handle)
 	if d.spec.OnControls != nil {
 		d.spec.OnControls(sender)
@@ -448,6 +479,9 @@ func (d *driver) receive(ctx context.Context, conn dataConn, res *rendezvous.Res
 			return nil
 		},
 	})
+	if switched, ok := conn.(*adaptiveConn); ok {
+		switched.SetOnSwitch(receiver.TransportChanged)
+	}
 	conn.OnData(receiver.Handle)
 	if d.spec.OnControls != nil {
 		d.spec.OnControls(receiver)

--- a/apps/cli/internal/transfer/driver_test.go
+++ b/apps/cli/internal/transfer/driver_test.go
@@ -292,6 +292,88 @@ func TestDriverForcedRelayTransfersEncryptedFile(t *testing.T) {
 	}
 }
 
+func TestDriverSwitchesActiveDirectTransferToRelay(t *testing.T) {
+	hub := newRelay()
+	payload := make([]byte, 6*1024*1024+29)
+	for i := range payload {
+		payload[i] = byte(i*23 + 11)
+	}
+	meta := wire.FileMeta{Name: "switched.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	type pathLog struct {
+		mu    sync.Mutex
+		paths []string
+	}
+	appendPath := func(log *pathLog) func(string) {
+		return func(path string) {
+			log.mu.Lock()
+			log.paths = append(log.paths, path)
+			log.mu.Unlock()
+		}
+	}
+	trigger := make(chan struct{})
+	var triggerOnce sync.Once
+	sendPaths, recvPaths := &pathLog{}, &pathLog{}
+	type result struct {
+		out *Outcome
+		err error
+	}
+	done := make(chan result, 2)
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:      wire.BytesSource(payload, meta, 64*1024),
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(sendPaths),
+			breakDirect: trigger,
+			OnProgress: func(bytes int64) {
+				if bytes >= 1024*1024 {
+					triggerOnce.Do(func() { close(trigger) })
+				}
+			},
+		})
+		done <- result{out: out, err: err}
+	}()
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:     dir,
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(recvPaths),
+		})
+		done <- result{out: out, err: err}
+	}()
+
+	a, b := <-done, <-done
+	if a.err != nil || b.err != nil {
+		t.Fatalf("switched transfer results: %v / %v", a.err, b.err)
+	}
+	var recv *Outcome
+	if a.out.Path != "" {
+		recv = a.out
+	} else {
+		recv = b.out
+	}
+	got, err := os.ReadFile(recv.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("switched transfer output differs from source")
+	}
+	for name, log := range map[string]*pathLog{"sender": sendPaths, "receiver": recvPaths} {
+		log.mu.Lock()
+		paths := append([]string(nil), log.paths...)
+		log.mu.Unlock()
+		if len(paths) != 2 || paths[0] != "direct" || paths[1] != "relay" {
+			t.Fatalf("%s paths = %v, want [direct relay]", name, paths)
+		}
+	}
+}
+
 // TestDriverReceiverRejectsMismatchedCode proves the handshake still fails closed when
 // adopted by the driver: a joiner with the wrong code never reaches a channel, and both
 // sides surface a confirmation failure rather than hanging or transferring.

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -1,9 +1,9 @@
 /**
  * Transfer orchestrator — the main-thread conductor that turns a settled rendezvous into a running
  * file transfer. It adopts the still-open signaling socket, prefers an authenticated WebRTC data
- * channel ({@link createPeer}), and falls back to the encrypted relay when direct negotiation fails.
- * It spawns the transfer worker ({@link runTransferCore} host) and pumps frames between the selected
- * path and worker. The worker owns crypto and disk; this module owns transport selection and the
+ * channel ({@link createPeer}), and falls back to the encrypted relay when negotiation or an active
+ * direct path fails. It spawns the transfer worker ({@link runTransferCore} host) and pumps frames
+ * between the selected path and worker. The worker owns crypto and disk; this module owns transport selection and the
  * public {@link TransferController} the UI binds against (progress, a `done` promise, cancel).
  *
  * Browser-only (needs `Worker`, `RTCPeerConnection`); not unit-tested — the pieces it wires each
@@ -106,6 +106,7 @@ function run(
   let writer: ChannelWriter | undefined;
   let relay: RelayTransport | undefined;
   let transport: 'connecting' | 'direct' | 'relay' = 'connecting';
+  let switchPromise: Promise<void> | undefined;
   let cancelTimer: ReturnType<typeof setTimeout> | undefined;
 
   let resolveDone!: (o: TransferOutcome) => void;
@@ -147,8 +148,8 @@ function run(
       const relayPath = new RelayTransport(signaling);
       relay = relayPath;
       signaling.onClose((err) => {
-        if (transport !== 'direct') {
-          relayPath.fail(err);
+        relayPath.fail(err);
+        if (transport !== 'direct' || switchPromise) {
           fail(err);
         }
       });
@@ -175,18 +176,68 @@ function run(
       }
       await ready;
 
+      // Channel → worker: forward every inbound data frame as a Transferable.
+      const receive = (frame: ArrayBuffer): void =>
+        w.postMessage({ kind: 'inbound-frame', frame } satisfies HostToWorker, [frame]);
+      const switchToRelay = (): Promise<void> => {
+        if (transport === 'relay') return Promise.resolve();
+        if (switchPromise) return switchPromise;
+        switchPromise = (async () => {
+          relayPath.open();
+          await relayPath.ready;
+          if (settled) return;
+          transport = 'relay';
+          w.postMessage({ kind: 'transport-changed' } satisfies HostToWorker);
+          writer = undefined;
+          p.close();
+        })().catch((err: unknown) => {
+          const failure = err instanceof Error ? err : new Error(String(err));
+          fail(failure);
+          throw failure;
+        });
+        return switchPromise;
+      };
+      const sendOutbound = async (frame: ArrayBuffer): Promise<void> => {
+        if (transport === 'relay') {
+          await relayPath.write(frame);
+          return;
+        }
+        if (switchPromise) {
+          await switchPromise;
+          await relayPath.write(frame);
+          return;
+        }
+        try {
+          writer!.write(frame);
+        } catch {
+          await switchToRelay();
+          await relayPath.write(frame);
+        }
+      };
+
+      if (selected.kind === 'direct') {
+        p.onData((frame) => {
+          if (transport === 'direct' && !switchPromise) receive(frame);
+        });
+        p.onDisconnect(() => void switchToRelay().catch(() => {}));
+        void relayPath.ready.then(switchToRelay).catch(() => {});
+        relayPath.onData((frame) => {
+          void switchToRelay()
+            .then(() => receive(frame))
+            .catch(() => {});
+        });
+      } else {
+        relayPath.onData(receive);
+      }
+
       // Worker → host events.
       w.addEventListener('message', (ev: MessageEvent) => {
         const msg = ev.data as WorkerToHost;
         switch (msg.kind) {
           case 'outbound-frame':
-            if (transport === 'relay') {
-              void relayPath
-                .write(msg.frame)
-                .catch((err: unknown) => fail(err instanceof Error ? err : new Error(String(err))));
-            } else {
-              writer?.write(msg.frame);
-            }
+            void sendOutbound(msg.frame).catch((err: unknown) =>
+              fail(err instanceof Error ? err : new Error(String(err))),
+            );
             return;
           case 'frame-consumed':
             if (transport === 'relay') relayPath.consumed(msg.bytes);
@@ -218,12 +269,6 @@ function run(
             return;
         }
       });
-
-      // Channel → worker: forward every inbound data frame as a Transferable.
-      const receive = (frame: ArrayBuffer): void =>
-        w.postMessage({ kind: 'inbound-frame', frame } satisfies HostToWorker, [frame]);
-      if (selected.kind === 'direct') p.onData(receive);
-      else relayPath.onData(receive);
 
       // Kick off the transfer in the worker.
       const startMsg = spec.start();

--- a/apps/web/src/lib/transfer/peer.ts
+++ b/apps/web/src/lib/transfer/peer.ts
@@ -32,6 +32,8 @@ export interface Peer {
    * call are buffered and flushed here, so the first blocks a fast sender emits are never lost.
    */
   onData(handler: (frame: ArrayBuffer) => void): void;
+  /** Register for an established channel becoming unusable. */
+  onDisconnect(handler: (err: Error) => void): void;
   /** Tear down the peer connection. Idempotent. */
   close(): void;
 }
@@ -46,6 +48,10 @@ export function createPeer(opts: CreatePeerOptions): Peer {
     rejectChannel = reject;
   });
   let settled = false;
+  let channelOpen = false;
+  let closedByUser = false;
+  let disconnectHandler: ((err: Error) => void) | undefined;
+  let disconnectError: Error | undefined;
 
   // Remote ICE can arrive before the remote description is set (network reorder, or the peer
   // trickling early). Buffer such candidates and flush them once the description lands.
@@ -68,6 +74,7 @@ export function createPeer(opts: CreatePeerOptions): Peer {
     ch.onopen = () => {
       if (settled) return;
       settled = true;
+      channelOpen = true;
       resolveChannel(ch);
     };
     ch.onmessage = (ev: MessageEvent) => {
@@ -75,14 +82,25 @@ export function createPeer(opts: CreatePeerOptions): Peer {
       if (dataHandler) dataHandler(frame);
       else dataBuffer.push(frame);
     };
-    ch.onerror = () => fail(new Error('data channel error'));
+    ch.onerror = () => disconnected(new Error('data channel error'));
+    ch.onclose = () => disconnected(new Error('data channel closed'));
+  };
+
+  const disconnected = (err: Error): void => {
+    if (closedByUser || disconnectError) return;
+    if (!channelOpen) {
+      fail(err);
+      return;
+    }
+    disconnectError = err;
+    disconnectHandler?.(err);
   };
 
   pc.onicecandidate = (ev) => {
     if (ev.candidate) void opts.auth.signIce(JSON.stringify(ev.candidate)).then(opts.send);
   };
   pc.onconnectionstatechange = () => {
-    if (pc.connectionState === 'failed') fail(new Error('peer connection failed'));
+    if (pc.connectionState === 'failed') disconnected(new Error('peer connection failed'));
   };
 
   if (opts.role === 'offerer') {
@@ -134,7 +152,12 @@ export function createPeer(opts: CreatePeerOptions): Peer {
       for (const frame of dataBuffer) handler(frame);
       dataBuffer.length = 0;
     },
+    onDisconnect: (handler) => {
+      disconnectHandler = handler;
+      if (disconnectError) handler(disconnectError);
+    },
     close: () => {
+      closedByUser = true;
       settled = true;
       pc.close();
     },

--- a/apps/web/src/lib/transfer/relay.ts
+++ b/apps/web/src/lib/transfer/relay.ts
@@ -23,7 +23,11 @@ export class RelayTransport {
     this.rejectReady = reject;
   });
 
-  constructor(private readonly signaling: SignalChannel) {}
+  constructor(private readonly signaling: SignalChannel) {
+    // A direct path may remain healthy after signaling disappears; suppress an unhandled
+    // readiness rejection while preserving it for a later attempted relay switch.
+    this.ready.catch(() => {});
+  }
 
   open(): void {
     if (this.opened || this.closed) return;

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -50,11 +50,13 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           pause(): void;
           resume(): void;
           cancel(reason?: string): void;
+          transportChanged(): void | Promise<void>;
         }
       | undefined;
     let started = false;
     const pending: Uint8Array[] = [];
     const pendingControls: Array<'pause' | 'resume' | 'cancel'> = [];
+    let pendingTransportChange = false;
 
     const post = (msg: WorkerToHost): void => port.postMessage(msg);
     const send = (frame: Uint8Array): void => {
@@ -66,9 +68,12 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
       pause(): void;
       resume(): void;
       cancel(reason?: string): void;
+      transportChanged(): void | Promise<void>;
     }): void => {
       engine = e;
       post({ kind: 'state', state: 'running' });
+      if (pendingTransportChange) void e.transportChanged();
+      pendingTransportChange = false;
       for (const f of pending) consume(e, f);
       pending.length = 0;
       for (const op of pendingControls) {
@@ -114,6 +119,10 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           else pending.push(frame);
           return;
         }
+        case 'transport-changed':
+          if (engine) void engine.transportChanged();
+          else pendingTransportChange = true;
+          return;
         case 'cancel':
           if (engine) engine.cancel(msg.reason);
           else pendingControls.push('cancel');

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -42,8 +42,16 @@ export interface TransferControlMsg {
   kind: 'control';
   op: ControlOp;
 }
+export interface TransportChangedMsg {
+  kind: 'transport-changed';
+}
 export type HostToWorker =
-  StartSendMsg | StartRecvMsg | InboundFrameMsg | TransferControlMsg | CancelMsg;
+  | StartSendMsg
+  | StartRecvMsg
+  | InboundFrameMsg
+  | TransferControlMsg
+  | TransportChangedMsg
+  | CancelMsg;
 
 export interface OutboundFrameMsg {
   kind: 'outbound-frame';

--- a/packages/protocol/src/transfer-receiver.test.ts
+++ b/packages/protocol/src/transfer-receiver.test.ts
@@ -360,4 +360,74 @@ describe('TransferReceiver', () => {
       { type: FrameType.Done },
     ]);
   });
+
+  it('discards an unverified partial block when the ordered transport changes', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const fileDigest = createHash('sha256').update(data).digest('hex');
+    const b = await build(keys);
+    await b.ctrl(FrameType.Manifest, {
+      type: FrameType.Manifest,
+      files: [
+        {
+          idx: 0,
+          name: 'switched.bin',
+          size: data.length,
+          mime: '',
+          lastModified: 0,
+          blockSize: 8,
+          blocks: 1,
+          fileDigest,
+        },
+      ],
+      totalSize: data.length,
+    });
+    await b.push(
+      {
+        version: FRAME_VERSION,
+        type: FrameType.BlockData,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      data.subarray(0, 4),
+    );
+    const partialEnd = b.frames.length;
+    await b.push(
+      {
+        version: FRAME_VERSION,
+        type: FrameType.BlockData,
+        flags: 1,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      data,
+    );
+    await b.ctrl(FrameType.BlockHash, {
+      type: FrameType.BlockHash,
+      fileIdx: 0,
+      blockIdx: 0,
+      sha256: bytesToHex(await sha256(data)),
+    });
+    await b.ctrl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
+
+    const sink = new MemorySink();
+    const receiver = new TransferReceiver({
+      send: () => {},
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+    });
+    for (const frame of b.frames.slice(0, partialEnd)) await receiver.handle(frame);
+    await receiver.transportChanged();
+    for (const frame of b.frames.slice(partialEnd)) await receiver.handle(frame);
+    const result = await receiver.done;
+    expect(result.digest).toBe(fileDigest);
+    expect(sink.bytes()).toEqual(data);
+  });
 });

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -72,6 +72,7 @@ export class TransferReceiver {
   private assemblingFileIdx = -1;
   private blockBuf: Uint8Array | undefined;
   private blockReceived = 0;
+  private awaitingRestart = false;
   private readonly seenAhead = new Set<number>();
   private nackOutstanding: number | undefined;
   private paused = false;
@@ -109,6 +110,20 @@ export class TransferReceiver {
             : new TransferError('integrity', e instanceof Error ? e.message : String(e)),
         );
       });
+    return this.inbound;
+  }
+
+  /** Discard an unverified partial block when the host replaces the ordered byte path. */
+  transportChanged(): Promise<void> {
+    this.inbound = this.inbound.then(() => {
+      this.blockBuf = undefined;
+      this.blockReceived = 0;
+      this.assemblingBlock = -1;
+      this.assemblingFileIdx = -1;
+      this.seenAhead.clear();
+      this.nackOutstanding = undefined;
+      this.awaitingRestart = true;
+    });
     return this.inbound;
   }
 
@@ -265,6 +280,7 @@ export class TransferReceiver {
     if (!entry || fileIdx > this.fileIdx || blockIdx < 0 || blockIdx >= entry.blocks) {
       throw new TransferError('integrity', `block_data outside manifest: ${blockIdx}`);
     }
+    if (this.awaitingRestart && frameOff !== 0) return;
     if (frameOff === 0) {
       if (this.blockBuf) throw new TransferError('integrity', 'new block before block_hash');
       const blockLen = Math.min(entry.blockSize, entry.size - blockIdx * entry.blockSize);
@@ -272,6 +288,7 @@ export class TransferReceiver {
       this.assemblingBlock = blockIdx;
       this.blockBuf = new Uint8Array(blockLen);
       this.blockReceived = 0;
+      this.awaitingRestart = false;
     }
     if (!this.blockBuf || this.assemblingFileIdx !== fileIdx || this.assemblingBlock !== blockIdx) {
       throw new TransferError('integrity', `unexpected block fragment ${blockIdx}`);
@@ -285,6 +302,7 @@ export class TransferReceiver {
 
   private async onBlockHash(payload: Uint8Array): Promise<void> {
     const block = this.blockBuf;
+    if (!block && this.awaitingRestart) return;
     if (!this.manifest || !block) {
       throw new TransferError('integrity', 'block_hash without a block');
     }

--- a/packages/protocol/src/transfer-sender.test.ts
+++ b/packages/protocol/src/transfer-sender.test.ts
@@ -234,6 +234,44 @@ describe('TransferSender', () => {
     expect(outbound[1]).not.toEqual(outbound[3]); // retransmission uses a fresh GCM nonce
   });
 
+  it('immediately retransmits the unacknowledged window after a transport change', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const outbound: Uint8Array[] = [];
+    const sender = new TransferSender({
+      file: bytesSource(data, { name: 'f', size: data.length, mime: '', lastModified: 0 }),
+      send: (frame) => void outbound.push(frame),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 8,
+      frameSize: 4,
+      window: 1,
+      ackTimeoutMs: 60_000,
+    });
+
+    const run = sender.run();
+    await waitFor(() => outbound.length === 3);
+    sender.transportChanged();
+    await waitFor(() => outbound.length === 5);
+    sender.cancel('test complete');
+    await expect(run).rejects.toThrow(/test complete/);
+
+    let counter = 0;
+    const opened = [];
+    for (const frame of outbound.slice(0, 5)) opened.push(await open(keys.o2j, counter++, frame));
+    expect(opened.map((frame) => frame.header.type)).toEqual([
+      FrameType.Manifest,
+      FrameType.BlockData,
+      FrameType.BlockHash,
+      FrameType.BlockData,
+      FrameType.BlockHash,
+    ]);
+    expect(outbound[1]).not.toEqual(outbound[3]);
+  });
+
   it('halts new data while paused and resumes without losing the window', async () => {
     const keys = await deriveTransferKeys(master);
     const outbound: Uint8Array[] = [];

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -138,6 +138,15 @@ export class TransferSender {
     return this.inbound;
   }
 
+  /** Retransmit every unacknowledged block after the host selects a new ordered byte path. */
+  transportChanged(): void {
+    if (this.settled) return;
+    for (const [blockIdx, state] of this.inflight) {
+      state.retries = 0;
+      this.queueRetry(blockIdx);
+    }
+  }
+
   /** Pause locally and ask the peer to reflect the paused state. */
   pause(): void {
     if (this.settled || this.paused) return;

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -48,6 +48,7 @@ type Receiver struct {
 
 	sendMu      sync.Mutex
 	sendCounter uint64
+	handleMu    sync.Mutex
 
 	// Assembly state belongs to the serial Handle path.
 	recvCounter     uint64
@@ -63,6 +64,7 @@ type Receiver struct {
 	assembling      int
 	blockBuf        []byte
 	blockReceived   int
+	awaitingRestart bool
 	seenAhead       map[int]bool
 	nackOutstanding int
 
@@ -111,6 +113,8 @@ func (r *Receiver) Wait(ctx context.Context) (ReceiveResult, error) {
 
 // Handle consumes one encrypted sender frame. Any malformed or unauthenticated frame aborts.
 func (r *Receiver) Handle(frame []byte) {
+	r.handleMu.Lock()
+	defer r.handleMu.Unlock()
 	if err := r.process(frame); err != nil {
 		var te *TransferError
 		if !errors.As(err, &te) {
@@ -118,6 +122,20 @@ func (r *Receiver) Handle(frame []byte) {
 		}
 		r.abortWith(te, true)
 	}
+}
+
+// TransportChanged discards an unverified partial block from the old ordered path. The sender
+// retransmits its unacknowledged window on the new path; already committed blocks stay intact.
+func (r *Receiver) TransportChanged() {
+	r.handleMu.Lock()
+	r.blockBuf = nil
+	r.blockReceived = 0
+	r.assembling = -1
+	r.assemblingFile = -1
+	r.seenAhead = make(map[int]bool)
+	r.nackOutstanding = -1
+	r.awaitingRestart = true
+	r.handleMu.Unlock()
 }
 
 // Pause asks the sender to stop producing data frames.
@@ -285,6 +303,9 @@ func (r *Receiver) onBlockData(fileIdx uint16, blockIdx uint32, frameOff uint32,
 	if idx < 0 || idx >= entry.Blocks {
 		return NewTransferError(FailIntegrity, fmt.Sprintf("block_data outside manifest: %d", idx))
 	}
+	if r.awaitingRestart && frameOff != 0 {
+		return nil // discard the abandoned old-path tail until a fresh block begins
+	}
 	if frameOff == 0 {
 		if r.blockBuf != nil {
 			return NewTransferError(FailIntegrity, "new block before block_hash")
@@ -297,6 +318,7 @@ func (r *Receiver) onBlockData(fileIdx uint16, blockIdx uint32, frameOff uint32,
 		r.assembling = idx
 		r.blockBuf = make([]byte, blockLen)
 		r.blockReceived = 0
+		r.awaitingRestart = false
 	}
 	if r.blockBuf == nil || r.assemblingFile != fileNumber || r.assembling != idx {
 		return NewTransferError(FailIntegrity, fmt.Sprintf("unexpected block fragment %d", idx))
@@ -311,6 +333,9 @@ func (r *Receiver) onBlockData(fileIdx uint16, blockIdx uint32, frameOff uint32,
 }
 
 func (r *Receiver) onBlockHash(payload []byte) error {
+	if r.blockBuf == nil && r.awaitingRestart {
+		return nil // hash for the abandoned partial block
+	}
 	if r.manifest == nil || r.blockBuf == nil {
 		return NewTransferError(FailIntegrity, "block_hash without a block")
 	}

--- a/packages/wire/transfer_receiver_test.go
+++ b/packages/wire/transfer_receiver_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -332,6 +333,45 @@ func TestReceiverRequestsMissingAndRecoversReorderedBlocks(t *testing.T) {
 		if string(gotJSON) != string(wantJSON) {
 			t.Errorf("back frame %d = %s, want %s", i, gotJSON, wantJSON)
 		}
+	}
+}
+
+func TestReceiverDiscardsPartialBlockAcrossTransportChange(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := seq(8)
+	fileDigest := hexSHA256(data)
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(NewManifest([]FileEntry{{
+		Idx: 0, Name: "switched.bin", Size: 8, BlockSize: 8, Blocks: 1, FileDigest: fileDigest,
+	}}, 8))
+	sf.push(FrameHeaderInput{
+		Version: FrameVersion, Type: FrameBlockData, FileIdx: 0, BlockIdx: 0, FrameOff: 0,
+	}, data[:4])
+	partialEnd := len(sf.frames)
+	sf.oneBlock(0, data, 8)
+	sf.ctrl(NewComplete(fileDigest))
+
+	sink := &MemorySink{}
+	var back outbox
+	r := NewReceiver(ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+	})
+	for _, frame := range sf.frames[:partialEnd] {
+		r.Handle(frame)
+	}
+	r.TransportChanged()
+	for _, frame := range sf.frames[partialEnd:] {
+		r.Handle(frame)
+	}
+	result, err := r.Wait(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Digest != fileDigest || !bytes.Equal(sink.Bytes(), data) {
+		t.Fatalf("recovered digest=%s bytes=%v", result.Digest, sink.Bytes())
 	}
 }
 

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -293,6 +293,28 @@ func (s *Sender) Handle(frame []byte) {
 	}
 }
 
+// TransportChanged immediately retransmits every unacknowledged block on the new byte path.
+// Fresh counters are used, while replays arriving late from the old path remain harmless.
+func (s *Sender) TransportChanged() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.settled {
+		return
+	}
+	for idx, state := range s.inflight {
+		if state.timer != nil {
+			state.timer.Stop()
+			state.timer = nil
+		}
+		state.retries = 0
+		if !s.retryQueued[idx] {
+			s.retryQueued[idx] = true
+			s.retryQueue = append(s.retryQueue, idx)
+		}
+	}
+	s.cond.Broadcast()
+}
+
 // Pause stops new data frames locally and notifies the peer.
 func (s *Sender) Pause() error {
 	if !s.setPaused(true) {


### PR DESCRIPTION
## Summary
- detect established WebRTC/DataChannel failure in browser and CLI clients and coordinate both peers onto the encrypted relay
- stop accepting old-path frames, discard unverified partial receive state, and immediately reseal/retry the unacknowledged block window with fresh counters
- keep a healthy direct transfer alive if signaling disappears, while failing relay-dependent sessions promptly
- report live path transitions in existing browser and CLI transport status

## Recovery coverage
- forcibly close an active Pion WebRTC connection after verified progress in a 6 MiB end-to-end transfer
- assert both peers transition from direct to relay and the received file remains byte-identical
- run the forced-failure case repeatedly under the race detector
- cover TypeScript and Go sender-window retry and partial-block reset behavior

## Verification
- pnpm format:check, lint, typecheck, test, build
- go vet and go build in all modules
- go test -race ./... in all modules
- forced mid-transfer recovery passed 10 consecutive race-enabled runs