### PR TITLE
feat(server): linger half-empty rooms for reload recovery

### DIFF
--- a/apps/server/internal/signal/hub.go
+++ b/apps/server/internal/signal/hub.go
@@ -189,6 +189,39 @@ func (h *Hub) join(p *peer, number int) (*peer, string) {
 	return r.offerer, ""
 }
 
+// resume re-attaches p to a vacated slot of an existing (lingering) room after the peer
+// reloaded and lost its ephemeral session. Only the slot for the claimed role may be
+// filled, and only if empty; the room and its number are unchanged. It returns the
+// surviving partner so the caller can prompt both sides to re-run the handshake.
+func (h *Hub) resume(p *peer, number int, role string) (*peer, string) {
+	if role != roleOfferer && role != roleJoiner {
+		return nil, errBadMessage
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[number]
+	if !ok {
+		return nil, errUnknownRoom
+	}
+	switch role {
+	case roleOfferer:
+		if r.offerer != nil {
+			return nil, errRoomFull
+		}
+		r.offerer = p
+	case roleJoiner:
+		if r.joiner != nil {
+			return nil, errRoomFull
+		}
+		r.joiner = p
+	}
+	p.room = number
+	p.role = role
+	r.lastSeen = time.Now()
+	return roomPartner(r, p), ""
+}
+
 // partner returns the other peer in p's room, or nil if the room is gone or p is not
 // yet paired. It also refreshes the room's activity timestamp.
 func (h *Hub) partner(p *peer) *peer {
@@ -210,9 +243,11 @@ func (h *Hub) partner(p *peer) *peer {
 	}
 }
 
-// remove drops p from its room. If a partner remains it is returned so the caller can
-// notify it; the room is then deleted when either peer leaves.
-func (h *Hub) remove(p *peer) *peer {
+// vacate frees p's slot after an unexpected socket drop. If a partner remains, the room
+// is kept — only p's slot is cleared — so the departed peer can reload and re-attach
+// (see resume) within the idle window; the partner is returned so the caller can tell it
+// to wait. If p was the last peer, the room is deleted and nil is returned.
+func (h *Hub) vacate(p *peer) *peer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -224,11 +259,33 @@ func (h *Hub) remove(p *peer) *peer {
 	switch p {
 	case r.offerer:
 		other = r.joiner
+		r.offerer = nil
 	case r.joiner:
 		other = r.offerer
+		r.joiner = nil
 	default:
 		return nil
 	}
+	if other == nil {
+		delete(h.rooms, r.number)
+		return nil
+	}
+	r.lastSeen = time.Now()
+	return other
+}
+
+// discard tears down p's whole room after a graceful bye. Any remaining partner is
+// returned so the caller can close it too — a bye ends the session for both peers and is
+// never resumable.
+func (h *Hub) discard(p *peer) *peer {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[p.room]
+	if !ok {
+		return nil
+	}
+	other := roomPartner(r, p)
 	delete(h.rooms, r.number)
 	return other
 }

--- a/apps/server/internal/signal/hub_test.go
+++ b/apps/server/internal/signal/hub_test.go
@@ -41,8 +41,9 @@ func TestCreateRoomAllocatesSmallestFree(t *testing.T) {
 		t.Fatalf("third room = %d, want 2", n)
 	}
 
-	// Freeing room 1 makes it the smallest free slot again.
-	h.remove(b)
+	// Freeing room 1 makes it the smallest free slot again. b is the lone peer, so
+	// vacate deletes the room outright.
+	h.vacate(b)
 	d := newTestPeer()
 	if n := h.createRoom(d); n != 1 {
 		t.Fatalf("reused room = %d, want 1", n)
@@ -80,7 +81,7 @@ func TestJoinUnknownRoom(t *testing.T) {
 	}
 }
 
-func TestPartnerAndRemove(t *testing.T) {
+func TestPartnerLookup(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
 	room := h.createRoom(off)
@@ -92,16 +93,138 @@ func TestPartnerAndRemove(t *testing.T) {
 	if h.partner(off) != join || h.partner(join) != off {
 		t.Fatal("partner lookup wrong")
 	}
+}
 
-	// Removing one peer returns the other and deletes the room.
-	if other := h.remove(off); other != join {
-		t.Fatal("remove did not surface the partner")
+// A partnered peer that drops leaves the room lingering with its slot vacated, so the
+// dropped peer can reload and re-attach. The room is only deleted when the last peer goes.
+func TestVacateLingersThenDeletes(t *testing.T) {
+	h := testHub(t)
+	off := newTestPeer()
+	room := h.createRoom(off)
+	join := newTestPeer()
+	if _, code := h.join(join, room); code != "" {
+		t.Fatalf("join: %s", code)
 	}
-	if h.roomCount() != 0 {
-		t.Fatalf("room count = %d, want 0", h.roomCount())
+
+	// The offerer drops: its slot is vacated, the joiner surfaces, and the room lingers.
+	if other := h.vacate(off); other != join {
+		t.Fatal("vacate did not surface the surviving partner")
+	}
+	if h.roomCount() != 1 {
+		t.Fatalf("room count after one drop = %d, want 1 (lingering)", h.roomCount())
 	}
 	if h.partner(join) != nil {
-		t.Fatal("partner of a removed room should be nil")
+		t.Fatal("partner of a vacated slot should be nil until a peer re-attaches")
+	}
+
+	// The joiner drops too: now the room is empty and deleted.
+	if other := h.vacate(join); other != nil {
+		t.Fatalf("vacating the last peer should return nil, got %v", other)
+	}
+	if h.roomCount() != 0 {
+		t.Fatalf("room count after last drop = %d, want 0", h.roomCount())
+	}
+}
+
+// resume re-attaches a reloaded peer to its vacated slot and surfaces the waiting partner.
+func TestResumeReattachesVacatedSlot(t *testing.T) {
+	h := testHub(t)
+	off := newTestPeer()
+	room := h.createRoom(off)
+	join := newTestPeer()
+	if _, code := h.join(join, room); code != "" {
+		t.Fatalf("join: %s", code)
+	}
+
+	// The offerer drops; the room lingers with the offerer slot empty.
+	h.vacate(off)
+
+	// A reloaded offerer resumes into the vacated slot and gets the waiting joiner back.
+	reoff := newTestPeer()
+	other, code := h.resume(reoff, room, roleOfferer)
+	if code != "" {
+		t.Fatalf("resume failed: %s", code)
+	}
+	if other != join {
+		t.Fatal("resume did not surface the waiting partner")
+	}
+	if reoff.room != room || reoff.role != roleOfferer {
+		t.Fatalf("resumed peer state = room %d role %q", reoff.room, reoff.role)
+	}
+	if h.partner(join) != reoff || h.partner(reoff) != join {
+		t.Fatal("pairing not restored after resume")
+	}
+}
+
+// resume is refused when the target slot is still occupied or the room is unknown.
+func TestResumeRefusesOccupiedOrUnknown(t *testing.T) {
+	h := testHub(t)
+	off := newTestPeer()
+	room := h.createRoom(off)
+	join := newTestPeer()
+	if _, code := h.join(join, room); code != "" {
+		t.Fatalf("join: %s", code)
+	}
+
+	// Both slots are occupied: claiming the offerer role is refused.
+	if _, code := h.resume(newTestPeer(), room, roleOfferer); code != errRoomFull {
+		t.Fatalf("resume into occupied slot code = %q, want %q", code, errRoomFull)
+	}
+	// An unknown room is refused.
+	if _, code := h.resume(newTestPeer(), 999, roleJoiner); code != errUnknownRoom {
+		t.Fatalf("resume into unknown room code = %q, want %q", code, errUnknownRoom)
+	}
+	// A bad role is rejected before any room lookup.
+	if _, code := h.resume(newTestPeer(), room, "bogus"); code != errBadMessage {
+		t.Fatalf("resume with bad role code = %q, want %q", code, errBadMessage)
+	}
+}
+
+// discard tears down the whole room on a graceful bye and surfaces the partner to close.
+func TestDiscardTearsDownRoom(t *testing.T) {
+	h := testHub(t)
+	off := newTestPeer()
+	room := h.createRoom(off)
+	join := newTestPeer()
+	if _, code := h.join(join, room); code != "" {
+		t.Fatalf("join: %s", code)
+	}
+
+	if other := h.discard(off); other != join {
+		t.Fatal("discard did not surface the partner")
+	}
+	if h.roomCount() != 0 {
+		t.Fatalf("room count after discard = %d, want 0", h.roomCount())
+	}
+}
+
+// A lingering half-empty room is still bounded by the idle reaper: a peer that drops and
+// never returns cannot pin server memory beyond the idle timeout.
+func TestReapClosesLingeringRoom(t *testing.T) {
+	h := testHub(t)
+	off := newTestPeer()
+	room := h.createRoom(off)
+	join := newTestPeer()
+	if _, code := h.join(join, room); code != "" {
+		t.Fatalf("join: %s", code)
+	}
+	h.vacate(off) // room now lingers with only the joiner attached
+
+	h.mu.Lock()
+	for _, r := range h.rooms {
+		r.lastSeen = time.Now().Add(-2 * h.cfg.IdleTimeout)
+	}
+	h.mu.Unlock()
+
+	h.reapOnce(time.Now())
+	if h.roomCount() != 0 {
+		t.Fatalf("room count after reap = %d, want 0", h.roomCount())
+	}
+	select {
+	case <-join.done:
+		// the surviving peer was closed as expected
+	default:
+		t.Fatal("reaped lingering room did not close its surviving peer")
 	}
 }
 

--- a/apps/server/internal/signal/message.go
+++ b/apps/server/internal/signal/message.go
@@ -33,6 +33,13 @@ const (
 	typeCredit        = "credit"
 	typeBye           = "bye"
 	typeError         = "error"
+
+	// Resumable-room control types. A peer whose socket drops unexpectedly leaves its
+	// room lingering (see hub.vacate); it re-attaches to the vacated slot with resume.
+	typeResume       = "resume"
+	typeResumed      = "resumed"
+	typePeerLeft     = "peer_left"
+	typePeerRejoined = "peer_rejoined"
 )
 
 // Role labels echoed to peers on pairing. These are routing labels only; their
@@ -66,12 +73,13 @@ const (
 	errRelayLimit    = "relay_limit"
 )
 
-// clientMsg is the envelope the server parses from a client. Only type and room are
-// read; the payloads of forwardable messages are relayed as raw bytes and never
+// clientMsg is the envelope the server parses from a client. Only type, room, and role
+// are read; the payloads of forwardable messages are relayed as raw bytes and never
 // decoded here, which is what keeps the server blind to handshake contents.
 type clientMsg struct {
 	Type  string `json:"type"`
 	Room  *int   `json:"room,omitempty"`
+	Role  string `json:"role,omitempty"`
 	Bytes int64  `json:"bytes,omitempty"`
 }
 
@@ -96,6 +104,19 @@ type peerJoinedMsg struct {
 type byeMsg struct {
 	Type   string `json:"type"`
 	Reason string `json:"reason,omitempty"`
+}
+
+// resumedMsg confirms a peer re-attached to a lingering room's vacated slot.
+type resumedMsg struct {
+	Type string `json:"type"`
+	Room int    `json:"room"`
+}
+
+// peerLeftMsg tells the surviving peer its partner's socket dropped. resumable reports
+// whether the room lingered for a re-attach (true) or was torn down (false).
+type peerLeftMsg struct {
+	Type      string `json:"type"`
+	Resumable bool   `json:"resumable"`
 }
 
 // errorMsg reports a protocol or limit error to a single socket.
@@ -125,6 +146,18 @@ func peerJoinedFrame(role string) []byte {
 
 func byeFrame(reason string) []byte {
 	return mustJSON(byeMsg{Type: typeBye, Reason: reason})
+}
+
+func resumedFrame(room int) []byte {
+	return mustJSON(resumedMsg{Type: typeResumed, Room: room})
+}
+
+func peerLeftFrame(resumable bool) []byte {
+	return mustJSON(peerLeftMsg{Type: typePeerLeft, Resumable: resumable})
+}
+
+func peerRejoinedFrame() []byte {
+	return mustJSON(relayMsg{Type: typePeerRejoined})
 }
 
 func errorFrame(code, msg string) []byte {

--- a/apps/server/internal/signal/peer.go
+++ b/apps/server/internal/signal/peer.go
@@ -48,6 +48,7 @@ type peer struct {
 	done             chan struct{}
 	farewell         []byte // final frame to flush before closing; set under closeOnce
 	closed           chan struct{}
+	graceful         bool // set when this peer sent a bye; makes teardown non-resumable
 }
 
 func newPeer(ws *websocket.Conn, h *Hub) *peer {
@@ -150,7 +151,31 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 		other.enqueue(peerJoinedFrame(other.role))
 		return true
 
+	case typeResume:
+		if p.room >= 0 {
+			p.close(errorFrame(errProtocol, "already in a room"))
+			return false
+		}
+		if m.Room == nil {
+			p.close(errorFrame(errBadMessage, "resume requires a room"))
+			return false
+		}
+		other, code := p.hub.resume(p, *m.Room, m.Role)
+		if code != "" {
+			p.close(errorFrame(code, ""))
+			return false
+		}
+		p.logger.Info("signal: room resumed", "room", p.room)
+		p.enqueue(resumedFrame(p.room))
+		if other != nil {
+			other.enqueue(peerRejoinedFrame())
+		}
+		return true
+
 	case typeBye:
+		// A bye ends the session for both peers: mark this teardown non-resumable so the
+		// partner is closed rather than left waiting for a reload.
+		p.graceful = true
 		if other := p.hub.partner(p); other != nil {
 			other.enqueue(data)
 		}
@@ -268,11 +293,17 @@ func (p *peer) close(farewell []byte) {
 	})
 }
 
-// teardown removes the peer from its room and notifies any remaining partner, then
-// ensures this peer's socket is closed.
+// teardown detaches the peer from its room and notifies any remaining partner, then
+// ensures this peer's socket is closed. A graceful bye tears the whole room down and
+// closes the survivor; an unexpected drop only vacates this peer's slot, leaving the
+// room lingering so the departed peer can reload and re-attach within the idle window.
 func (p *peer) teardown() {
-	if other := p.hub.remove(p); other != nil {
-		other.close(byeFrame("peer left"))
+	if p.graceful {
+		if other := p.hub.discard(p); other != nil {
+			other.close(byeFrame("peer left"))
+		}
+	} else if other := p.hub.vacate(p); other != nil {
+		other.enqueue(peerLeftFrame(true))
 	}
 	p.close(nil)
 	// Wait for the writer to finish closing the socket so the goroutine cannot

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -311,15 +311,60 @@ func TestByeNotifiesPartner(t *testing.T) {
 	}
 }
 
-func TestDisconnectNotifiesPartner(t *testing.T) {
+func TestDisconnectLingersAndNotifiesPartner(t *testing.T) {
 	url := testServer(t, DefaultConfig())
 	offerer, joiner, _ := pair(t, url)
 
-	// Offerer drops abruptly; the joiner should be told the peer left.
+	// Offerer drops abruptly; the room lingers and the joiner is told the peer left
+	// resumably rather than being closed, so it can wait for a reload.
 	_ = offerer.conn.Close(websocket.StatusNormalClosure, "")
 	m := joiner.recv()
-	if m["type"] != typeBye {
-		t.Fatalf("expected bye on partner disconnect, got %v", m)
+	if m["type"] != typePeerLeft {
+		t.Fatalf("expected peer_left on partner disconnect, got %v", m)
+	}
+	if m["resumable"] != true {
+		t.Fatalf("expected resumable peer_left, got %v", m)
+	}
+}
+
+func TestResumeReattachOverWire(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	offerer, joiner, room := pair(t, url)
+
+	// The offerer drops; the joiner sees a resumable peer_left and keeps its socket.
+	_ = offerer.conn.Close(websocket.StatusNormalClosure, "")
+	if m := joiner.recv(); m["type"] != typePeerLeft || m["resumable"] != true {
+		t.Fatalf("expected resumable peer_left, got %v", m)
+	}
+
+	// A reloaded offerer re-attaches to the vacated slot with resume.
+	reoff := mustDial(t, url)
+	reoff.send(map[string]any{"type": typeResume, "room": room, "role": roleOfferer})
+	if m := reoff.recv(); m["type"] != typeResumed || int(m["room"].(float64)) != room {
+		t.Fatalf("expected resumed for room %d, got %v", room, m)
+	}
+	// The waiting joiner is told its partner re-attached so both re-run the handshake.
+	if m := joiner.recv(); m["type"] != typePeerRejoined {
+		t.Fatalf("expected peer_rejoined, got %v", m)
+	}
+
+	// The room is paired again: a pake frame flows offerer→joiner verbatim.
+	frame := []byte(`{"type":"pake","msg":"resumed-session"}`)
+	reoff.sendRaw(frame)
+	if got := joiner.recvRaw(); string(got) != string(frame) {
+		t.Fatalf("forwarded frame after resume = %s, want %s", got, frame)
+	}
+}
+
+func TestResumeIntoOccupiedSlotRejected(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	_, _, room := pair(t, url)
+
+	// Both slots are still occupied, so resuming the offerer role is refused.
+	c := mustDial(t, url)
+	c.send(map[string]any{"type": typeResume, "room": room, "role": roleOfferer})
+	if m := c.recv(); m["type"] != typeError || m["code"] != errRoomFull {
+		t.Fatalf("expected room_full error, got %v", m)
 	}
 }
 

--- a/packages/protocol/src/signaling.ts
+++ b/packages/protocol/src/signaling.ts
@@ -110,6 +110,43 @@ export interface ByeMsg {
   reason: string;
 }
 
+/**
+ * Client → server: re-attach to a room whose partner is still present but from which
+ * this peer's socket dropped (e.g. a reload). The server seats this peer back into the
+ * vacated slot for `role`; the room and its number are unchanged. Only ever fills a
+ * previously-occupied slot — fresh pairing still goes through {@link JoinMsg}.
+ */
+export interface ResumeMsg {
+  type: 'resume';
+  room: number;
+  role: Role;
+}
+
+/** Server → client: a {@link ResumeMsg} was accepted; the partner state follows. */
+export interface ResumedMsg {
+  type: 'resumed';
+  room: number;
+}
+
+/**
+ * Server → the surviving peer: the partner's socket dropped. `resumable` reports whether
+ * the room lingered for a re-attach (`true`; wait for {@link PeerRejoinedMsg}) or was torn
+ * down (`false`, e.g. after a graceful bye or the last peer leaving — treat like `bye`).
+ */
+export interface PeerLeftMsg {
+  type: 'peer_left';
+  resumable: boolean;
+}
+
+/**
+ * Server → the waiting peer: the partner re-attached via {@link ResumeMsg}. Both sides
+ * must re-run the SPAKE2 handshake to build a fresh session; the reload discarded the old
+ * key and AEAD counters, which must never be resumed (nonce-reuse hazard).
+ */
+export interface PeerRejoinedMsg {
+  type: 'peer_rejoined';
+}
+
 /** Server → peer: protocol or limit error. */
 export interface ErrorMsg {
   type: 'error';
@@ -120,6 +157,7 @@ export interface ErrorMsg {
 export type SignalErrorCode =
   | 'unknown_room'
   | 'room_taken'
+  | 'room_full'
   | 'already_paired'
   | 'peer_gone'
   | 'rate_limited'
@@ -144,6 +182,10 @@ export type SignalMsg =
   | RelayCreditMsg
   | CreditMsg
   | ByeMsg
+  | ResumeMsg
+  | ResumedMsg
+  | PeerLeftMsg
+  | PeerRejoinedMsg
   | ErrorMsg;
 
 export type SignalMsgType = SignalMsg['type'];


### PR DESCRIPTION
## Summary

First PR of M6 (recovery & compatibility). Makes the signaling server tolerate a peer reload so recovery is even possible — today any disconnect deletes the room and closes the survivor, so a reloaded peer can never find its partner.

Distinguishes an **unexpected drop** from a **graceful bye**:

- **Drop with a surviving partner** → vacate only the dropped peer's slot, keep the room lingering, and tell the survivor `peer_left {resumable:true}` so it waits instead of being closed.
- **Graceful bye / last peer leaving** → discard the whole room and close the survivor (non-resumable, unchanged behaviour).

A reloaded peer re-attaches with `resume {room, role}`, which fills only the matching vacated slot and only if empty, then wakes the waiting partner with `peer_rejoined` so both re-run SPAKE2 into a fresh session.

## Invariants preserved

- Still at most two peers per room; `resume` is refused on an occupied slot (`room_full`) or unknown room (`unknown_room`).
- Server stays blind: the wire carries only the room integer and role enum — no code, SDP, keys, or plaintext.
- Bounded lifetime: a lingering half-empty room is still reaped at `IdleTimeout`, so a peer that drops and never returns cannot pin memory.

## Protocol

New control messages twinned in `@sendarc/protocol`: `resume`, `resumed`, `peer_left`, `peer_rejoined` (+ `room_full` error code). Client behaviour that consumes these lands in a later PR; this one is server + wire types.

## Testing

- New hub unit tests: vacate lingers-then-deletes, resume re-attaches vacated slot, resume refuses occupied/unknown/bad-role, discard tears down room, reaper closes a lingering room.
- New over-the-wire tests: resumable `peer_left` on drop, full `resume` → `resumed` + `peer_rejoined` → verbatim forward, resume-into-occupied rejected.
- `go test -race ./...`, `go vet`, `golangci-lint` (0 issues), `pnpm --filter @sendarc/protocol build/test/lint`, web `typecheck` — all green.

Part of the M6 design of record (`docs/superpowers/specs/2026-08-09-m6-recovery-compatibility-design.md`, §3–§4).