### PR TITLE
feat(protocol): add resume_state message and manifest transferId

### DIFF
--- a/packages/protocol/src/safe-path.ts
+++ b/packages/protocol/src/safe-path.ts
@@ -75,5 +75,10 @@ export function validateManifest(manifest: Manifest): Manifest {
   if (!Number.isSafeInteger(manifest.totalSize) || manifest.totalSize !== totalSize) {
     throw new Error('manifest total size mismatch');
   }
-  return { type: FrameType.Manifest, files, totalSize };
+  return {
+    type: FrameType.Manifest,
+    ...(manifest.transferId !== undefined ? { transferId: manifest.transferId } : {}),
+    files,
+    totalSize,
+  };
 }

--- a/packages/protocol/src/transfer-messages.test.ts
+++ b/packages/protocol/src/transfer-messages.test.ts
@@ -23,6 +23,47 @@ describe('control-message codec', () => {
     expect(decodeControl(encodeControl(manifest))).toEqual(manifest);
   });
 
+  it('round-trips a manifest carrying a transferId', () => {
+    const manifest: Manifest = {
+      type: FrameType.Manifest,
+      transferId: '0123456789abcdef0123456789abcdef',
+      files: [
+        {
+          idx: 0,
+          name: 'a.bin',
+          size: 10,
+          mime: 'application/octet-stream',
+          lastModified: 5,
+          blockSize: 8,
+          blocks: 2,
+          fileDigest: 'ab',
+        },
+      ],
+      totalSize: 10,
+    };
+    const wire = encodeControl(manifest);
+    expect(new TextDecoder().decode(wire)).toBe(
+      '{"type":2,"transferId":"0123456789abcdef0123456789abcdef","files":[{"idx":0,"name":"a.bin","size":10,"mime":"application/octet-stream","lastModified":5,"blockSize":8,"blocks":2,"fileDigest":"ab"}],"totalSize":10}',
+    );
+    expect(decodeControl(wire)).toEqual(manifest);
+  });
+
+  it('round-trips a resume_state', () => {
+    const msg = {
+      type: FrameType.ResumeState,
+      transferId: '0123456789abcdef0123456789abcdef',
+      files: [
+        { idx: 0, haveBlocks: 3 },
+        { idx: 1, haveBlocks: 0 },
+      ],
+    } as const;
+    const wire = encodeControl(msg);
+    expect(new TextDecoder().decode(wire)).toBe(
+      '{"type":12,"transferId":"0123456789abcdef0123456789abcdef","files":[{"idx":0,"haveBlocks":3},{"idx":1,"haveBlocks":0}]}',
+    );
+    expect(decodeControl(wire)).toEqual(msg);
+  });
+
   it('round-trips block and terminal messages', () => {
     const msgs = [
       { type: FrameType.BlockHash, fileIdx: 0, blockIdx: 1, sha256: 'ff' },
@@ -56,5 +97,22 @@ describe('control-message codec', () => {
       decodeControl(encodeControl({ type: FrameType.Control, op: 'stop' } as never)),
     ).toThrow();
     expect(() => decodeControl(encodeControl({ type: FrameType.Complete } as never))).toThrow(); // missing fileDigest
+    expect(() =>
+      decodeControl(encodeControl({ type: FrameType.ResumeState, files: [] } as never)),
+    ).toThrow(); // missing transferId + empty files
+    expect(() =>
+      decodeControl(
+        encodeControl({ type: FrameType.ResumeState, transferId: 'x', files: [] } as never),
+      ),
+    ).toThrow(); // empty files
+    expect(() =>
+      decodeControl(
+        encodeControl({
+          type: FrameType.ResumeState,
+          transferId: 'x',
+          files: [{ idx: 0 }],
+        } as never),
+      ),
+    ).toThrow(); // resume file missing haveBlocks
   });
 });

--- a/packages/protocol/src/transfer-messages.ts
+++ b/packages/protocol/src/transfer-messages.ts
@@ -140,8 +140,7 @@ function asComplete(m: Record<string, unknown>): Complete {
   return { type: FrameType.Complete, fileDigest: str(m, 'fileDigest') };
 }
 function asResumeFileState(v: unknown): ResumeFileState {
-  if (typeof v !== 'object' || v === null)
-    throw new Error('control frame: bad resume file state');
+  if (typeof v !== 'object' || v === null) throw new Error('control frame: bad resume file state');
   const f = v as Record<string, unknown>;
   return { idx: num(f, 'idx'), haveBlocks: num(f, 'haveBlocks') };
 }

--- a/packages/protocol/src/transfer-messages.ts
+++ b/packages/protocol/src/transfer-messages.ts
@@ -16,6 +16,8 @@ import {
   type FileEntry,
   type Manifest,
   type Nack,
+  type ResumeFileState,
+  type ResumeState,
   type TransferMsg,
 } from './transfer.js';
 import { utf8 } from './bytes.js';
@@ -54,6 +56,8 @@ export function decodeControl(payload: Uint8Array): TransferMsg {
       return { type: FrameType.Done };
     case FrameType.Fail:
       return asFail(m);
+    case FrameType.ResumeState:
+      return asResumeState(m);
     default:
       throw new Error(`control frame: unexpected type ${String(m.type)}`);
   }
@@ -89,8 +93,12 @@ function asFileEntry(v: unknown): FileEntry {
 function asManifest(m: Record<string, unknown>): Manifest {
   if (!Array.isArray(m.files) || m.files.length === 0)
     throw new Error('control frame: manifest.files');
+  // transferId is optional; when present it must be a string and keeps its position right after
+  // `type` so the re-encoded wire bytes match the original ordering.
+  const transferId = m.transferId === undefined ? undefined : str(m, 'transferId');
   return {
     type: FrameType.Manifest,
+    ...(transferId !== undefined ? { transferId } : {}),
     files: m.files.map(asFileEntry),
     totalSize: num(m, 'totalSize'),
   };
@@ -130,6 +138,21 @@ function asControl(m: Record<string, unknown>): Control {
 }
 function asComplete(m: Record<string, unknown>): Complete {
   return { type: FrameType.Complete, fileDigest: str(m, 'fileDigest') };
+}
+function asResumeFileState(v: unknown): ResumeFileState {
+  if (typeof v !== 'object' || v === null)
+    throw new Error('control frame: bad resume file state');
+  const f = v as Record<string, unknown>;
+  return { idx: num(f, 'idx'), haveBlocks: num(f, 'haveBlocks') };
+}
+function asResumeState(m: Record<string, unknown>): ResumeState {
+  if (!Array.isArray(m.files) || m.files.length === 0)
+    throw new Error('control frame: resume_state.files');
+  return {
+    type: FrameType.ResumeState,
+    transferId: str(m, 'transferId'),
+    files: m.files.map(asResumeFileState),
+  };
 }
 function asFail(m: Record<string, unknown>): Fail {
   const reason = str(m, 'reason');

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -148,4 +148,14 @@ export interface ResumeState {
 }
 
 export type TransferMsg =
-  Caps | Manifest | BlockHash | BlockRecv | Ack | Nack | Control | Complete | Done | Fail | ResumeState;
+  | Caps
+  | Manifest
+  | BlockHash
+  | BlockRecv
+  | Ack
+  | Nack
+  | Control
+  | Complete
+  | Done
+  | Fail
+  | ResumeState;

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -27,6 +27,7 @@ export enum FrameType {
   Complete = 9,
   Done = 10,
   Fail = 11,
+  ResumeState = 12,
 }
 
 /** Feature flags negotiated in caps. */
@@ -60,6 +61,12 @@ export interface FileEntry {
 
 export interface Manifest {
   type: FrameType.Manifest;
+  /**
+   * Random 128-bit id (hex) minted by the sender so a resumed receiver can prove it is
+   * resuming *this* transfer, not a different file set that reused the room. Optional: older
+   * senders omit it, and a transfer that is never resumed never needs it.
+   */
+  transferId?: string;
   files: FileEntry[];
   totalSize: number;
 }
@@ -117,5 +124,28 @@ export interface Fail {
   reason: 'digest_mismatch' | 'integrity' | 'sink_error' | 'canceled' | 'quota' | 'retry_exhausted';
 }
 
+/** One file's resume position within a {@link ResumeState}. */
+export interface ResumeFileState {
+  idx: number;
+  /**
+   * Per-file high-water mark: the count of consecutively-committed blocks the receiver already
+   * holds (its `nextBlock`). Because commitment is strictly in order, a single integer fully
+   * describes what is held — no sparse bitmap on the wire.
+   */
+  haveBlocks: number;
+}
+
+/**
+ * Receiver → sender (forwarded), sent once immediately after the manifest is re-confirmed on a
+ * fresh session: "I already hold blocks `[0, haveBlocks)` of each file — restart there." The
+ * sender validates it against its own manifest (same `transferId`, `haveBlocks ≤ file.blocks`)
+ * and streams only the missing blocks; a mismatch fails the transfer closed.
+ */
+export interface ResumeState {
+  type: FrameType.ResumeState;
+  transferId: string;
+  files: ResumeFileState[];
+}
+
 export type TransferMsg =
-  Caps | Manifest | BlockHash | BlockRecv | Ack | Nack | Control | Complete | Done | Fail;
+  Caps | Manifest | BlockHash | BlockRecv | Ack | Nack | Control | Complete | Done | Fail | ResumeState;

--- a/packages/wire/frame.go
+++ b/packages/wire/frame.go
@@ -36,17 +36,18 @@ type FrameHeader struct {
 
 // Frame type tags (the Type byte). Mirrors FrameType in transfer.ts.
 const (
-	FrameCaps      uint8 = 1
-	FrameManifest  uint8 = 2
-	FrameBlockData uint8 = 3
-	FrameBlockHash uint8 = 4
-	FrameBlockRecv uint8 = 5
-	FrameAck       uint8 = 6
-	FrameNack      uint8 = 7
-	FrameControl   uint8 = 8
-	FrameComplete  uint8 = 9
-	FrameDone      uint8 = 10
-	FrameFail      uint8 = 11
+	FrameCaps        uint8 = 1
+	FrameManifest    uint8 = 2
+	FrameBlockData   uint8 = 3
+	FrameBlockHash   uint8 = 4
+	FrameBlockRecv   uint8 = 5
+	FrameAck         uint8 = 6
+	FrameNack        uint8 = 7
+	FrameControl     uint8 = 8
+	FrameComplete    uint8 = 9
+	FrameDone        uint8 = 10
+	FrameFail        uint8 = 11
+	FrameResumeState uint8 = 12
 )
 
 // encodeFrameHeader encodes h into a fresh 16-byte buffer.

--- a/packages/wire/transfer_messages.go
+++ b/packages/wire/transfer_messages.go
@@ -34,9 +34,13 @@ type FileEntry struct {
 
 // Manifest lists the files a transfer will deliver.
 type Manifest struct {
-	Type      uint8       `json:"type"`
-	Files     []FileEntry `json:"files"`
-	TotalSize int64       `json:"totalSize"`
+	Type uint8 `json:"type"`
+	// TransferID is a random 128-bit id (hex) minted by the sender so a resumed receiver can
+	// prove it is resuming this transfer. Optional (omitempty): older senders and transfers that
+	// are never resumed omit it, matching the TS optional field.
+	TransferID string      `json:"transferId,omitempty"`
+	Files      []FileEntry `json:"files"`
+	TotalSize  int64       `json:"totalSize"`
 }
 
 // BlockHash carries a block's SHA-256 so the receiver can verify before acking.
@@ -114,6 +118,21 @@ type Fail struct {
 	Reason FailReason `json:"reason"`
 }
 
+// ResumeFileState is one file's resume position within a ResumeState.
+type ResumeFileState struct {
+	Idx        int `json:"idx"`
+	HaveBlocks int `json:"haveBlocks"` // per-file high-water mark (receiver's nextBlock)
+}
+
+// ResumeState tells the sender where to restart each file after the receiver reloaded and
+// re-handshaked. The sender validates it against its manifest (same TransferID, HaveBlocks
+// within bounds) and streams only the missing blocks.
+type ResumeState struct {
+	Type       uint8             `json:"type"`
+	TransferID string            `json:"transferId"`
+	Files      []ResumeFileState `json:"files"`
+}
+
 // FrameType returns the frame-header tag for each message; the JSON "type" field carries the
 // same value, so the field is the single source of truth and cannot drift from the header.
 func (m Manifest) FrameType() uint8 { return m.Type }
@@ -141,6 +160,9 @@ func (m Done) FrameType() uint8 { return m.Type }
 
 // FrameType reports the fail frame tag.
 func (m Fail) FrameType() uint8 { return m.Type }
+
+// FrameType reports the resume_state frame tag.
+func (m ResumeState) FrameType() uint8 { return m.Type }
 
 // NewManifest builds a manifest message with the correct frame tag.
 func NewManifest(files []FileEntry, totalSize int64) *Manifest {
@@ -180,6 +202,12 @@ func NewDone() *Done { return &Done{Type: FrameDone} }
 
 // NewFail builds a fail message with the given reason.
 func NewFail(reason FailReason) *Fail { return &Fail{Type: FrameFail, Reason: reason} }
+
+// NewResumeState builds a resume_state message carrying the transfer id and per-file high-water
+// marks.
+func NewResumeState(transferID string, files []ResumeFileState) *ResumeState {
+	return &ResumeState{Type: FrameResumeState, TransferID: transferID, Files: files}
+}
 
 // EncodeControl serializes a control message to its wire JSON. HTML escaping is disabled and
 // the encoder's trailing newline stripped so the bytes match JavaScript's JSON.stringify.
@@ -227,6 +255,8 @@ func DecodeControl(payload []byte) (ControlMsg, error) {
 		return &Done{Type: FrameDone}, nil
 	case FrameFail:
 		return decodeFail(payload)
+	case FrameResumeState:
+		return decodeResumeState(payload)
 	default:
 		return nil, fmt.Errorf("control frame: unexpected type %d", *head.Type)
 	}
@@ -259,8 +289,11 @@ func (r rawFileEntry) build() (FileEntry, error) {
 
 func decodeManifest(payload []byte) (ControlMsg, error) {
 	var raw struct {
-		Files     []rawFileEntry `json:"files"`
-		TotalSize *int64         `json:"totalSize"`
+		// TransferID is optional; an absent key decodes to "" and re-encodes as omitted (omitempty),
+		// so a manifest without it round-trips byte-identically.
+		TransferID string         `json:"transferId"`
+		Files      []rawFileEntry `json:"files"`
+		TotalSize  *int64         `json:"totalSize"`
 	}
 	if err := json.Unmarshal(payload, &raw); err != nil {
 		return nil, errors.New("control frame: invalid manifest")
@@ -279,7 +312,7 @@ func decodeManifest(payload []byte) (ControlMsg, error) {
 		}
 		files[i] = f
 	}
-	return &Manifest{Type: FrameManifest, Files: files, TotalSize: *raw.TotalSize}, nil
+	return &Manifest{Type: FrameManifest, TransferID: raw.TransferID, Files: files, TotalSize: *raw.TotalSize}, nil
 }
 
 func decodeBlockHash(payload []byte) (ControlMsg, error) {
@@ -390,4 +423,35 @@ func decodeFail(payload []byte) (ControlMsg, error) {
 	default:
 		return nil, fmt.Errorf("control frame: bad fail reason %q", *raw.Reason)
 	}
+}
+
+// rawResumeFileState uses pointer fields so a missing key is distinguishable from a zero value
+// (e.g. idx 0 or haveBlocks 0), matching the TS num() presence checks.
+type rawResumeFileState struct {
+	Idx        *int `json:"idx"`
+	HaveBlocks *int `json:"haveBlocks"`
+}
+
+func decodeResumeState(payload []byte) (ControlMsg, error) {
+	var raw struct {
+		TransferID *string              `json:"transferId"`
+		Files      []rawResumeFileState `json:"files"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil, errors.New("control frame: invalid resume_state")
+	}
+	if raw.TransferID == nil {
+		return nil, errors.New("control frame: resume_state.transferId missing")
+	}
+	if len(raw.Files) == 0 {
+		return nil, errors.New("control frame: resume_state.files empty")
+	}
+	files := make([]ResumeFileState, len(raw.Files))
+	for i, rf := range raw.Files {
+		if rf.Idx == nil || rf.HaveBlocks == nil {
+			return nil, errors.New("control frame: incomplete resume file state")
+		}
+		files[i] = ResumeFileState{Idx: *rf.Idx, HaveBlocks: *rf.HaveBlocks}
+	}
+	return &ResumeState{Type: FrameResumeState, TransferID: *raw.TransferID, Files: files}, nil
 }

--- a/packages/wire/transfer_messages_test.go
+++ b/packages/wire/transfer_messages_test.go
@@ -19,6 +19,17 @@ func TestEncodeControlWireBytes(t *testing.T) {
 			}}, 10),
 			`{"type":2,"files":[{"idx":0,"name":"a.bin","size":10,"mime":"application/octet-stream","lastModified":5,"blockSize":8,"blocks":2,"fileDigest":"ab"}],"totalSize":10}`,
 		},
+		{
+			"manifest with transferId",
+			&Manifest{
+				Type: FrameManifest, TransferID: "0123456789abcdef0123456789abcdef",
+				Files: []FileEntry{{
+					Idx: 0, Name: "a.bin", Size: 10, Mime: "application/octet-stream",
+					LastModified: 5, BlockSize: 8, Blocks: 2, FileDigest: "ab",
+				}}, TotalSize: 10,
+			},
+			`{"type":2,"transferId":"0123456789abcdef0123456789abcdef","files":[{"idx":0,"name":"a.bin","size":10,"mime":"application/octet-stream","lastModified":5,"blockSize":8,"blocks":2,"fileDigest":"ab"}],"totalSize":10}`,
+		},
 		{"block_hash", NewBlockHash(0, 1, "ff"), `{"type":4,"fileIdx":0,"blockIdx":1,"sha256":"ff"}`},
 		{"block_recv", NewBlockRecv(0, 1), `{"type":5,"fileIdx":0,"blockIdx":1}`},
 		{"ack", NewAck(0, 1), `{"type":6,"fileIdx":0,"blockIdx":1}`},
@@ -29,6 +40,11 @@ func TestEncodeControlWireBytes(t *testing.T) {
 		{"complete", NewComplete("deadbeef"), `{"type":9,"fileDigest":"deadbeef"}`},
 		{"done", NewDone(), `{"type":10}`},
 		{"fail", NewFail(FailDigestMismatch), `{"type":11,"reason":"digest_mismatch"}`},
+		{
+			"resume_state",
+			NewResumeState("0123456789abcdef0123456789abcdef", []ResumeFileState{{Idx: 0, HaveBlocks: 3}, {Idx: 1, HaveBlocks: 0}}),
+			`{"type":12,"transferId":"0123456789abcdef0123456789abcdef","files":[{"idx":0,"haveBlocks":3},{"idx":1,"haveBlocks":0}]}`,
+		},
 	}
 	for _, c := range cases {
 		got, err := EncodeControl(c.msg)
@@ -71,6 +87,14 @@ func TestDecodeControlRoundTrip(t *testing.T) {
 		NewComplete("deadbeef"),
 		NewDone(),
 		NewFail(FailDigestMismatch),
+		&Manifest{
+			Type: FrameManifest, TransferID: "0123456789abcdef0123456789abcdef",
+			Files: []FileEntry{{
+				Idx: 0, Name: "a.bin", Size: 10, Mime: "application/octet-stream",
+				LastModified: 5, BlockSize: 8, Blocks: 2, FileDigest: "ab",
+			}}, TotalSize: 10,
+		},
+		NewResumeState("0123456789abcdef0123456789abcdef", []ResumeFileState{{Idx: 0, HaveBlocks: 3}, {Idx: 1, HaveBlocks: 0}}),
 	}
 	for _, m := range msgs {
 		enc, err := EncodeControl(m)
@@ -101,6 +125,25 @@ func TestDecodeControlFromTSShapes(t *testing.T) {
 	if !ok || nack.FileIdx != 2 || nack.BlockIdx != 7 || nack.Reason != NackTimeout {
 		t.Fatalf("decoded nack = %#v", m)
 	}
+
+	m, err = DecodeControl([]byte(`{"type":12,"transferId":"abc123","files":[{"idx":0,"haveBlocks":5},{"idx":1,"haveBlocks":0}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs, ok := m.(*ResumeState)
+	if !ok || rs.TransferID != "abc123" || len(rs.Files) != 2 ||
+		rs.Files[0] != (ResumeFileState{Idx: 0, HaveBlocks: 5}) || rs.Files[1] != (ResumeFileState{Idx: 1, HaveBlocks: 0}) {
+		t.Fatalf("decoded resume_state = %#v", m)
+	}
+
+	// A manifest carrying a transferId decodes with the id preserved.
+	m, err = DecodeControl([]byte(`{"type":2,"transferId":"abc123","files":[{"idx":0,"name":"a","size":0,"mime":"x","lastModified":0,"blockSize":1,"blocks":0,"fileDigest":"y"}],"totalSize":0}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if man, ok := m.(*Manifest); !ok || man.TransferID != "abc123" {
+		t.Fatalf("decoded manifest transferId = %#v", m)
+	}
 }
 
 func TestDecodeControlRejectsMalformed(t *testing.T) {
@@ -114,6 +157,9 @@ func TestDecodeControlRejectsMalformed(t *testing.T) {
 		`{"type":9}`,                                               // complete missing fileDigest
 		`{"type":2,"files":[],"totalSize":0}`,                      // empty manifest files
 		`{"type":4,"fileIdx":0}`,                                   // block_hash missing sha256/blockIdx
+		`{"type":12,"files":[{"idx":0,"haveBlocks":0}]}`,           // resume_state missing transferId
+		`{"type":12,"transferId":"x","files":[]}`,                  // resume_state empty files
+		`{"type":12,"transferId":"x","files":[{"idx":0}]}`,         // resume file missing haveBlocks
 		`{"fileIdx":0}`,                                            // missing type
 	}
 	for _, s := range bad {


### PR DESCRIPTION
## What

M6 PR2 of 8 — the resume-handshake **wire vocabulary**, twinned across the TS `@sendarc/protocol` and Go `packages/wire` codecs. This is the protocol layer only; the transfer engine that mints and consumes these messages lands in PR3.

Design of record: `docs/superpowers/specs/2026-08-09-m6-recovery-compatibility-design.md` §4.1.

## Changes

- **Manifest `transferId`** — optional random 128-bit hex id. It lets a reloaded receiver prove it is resuming *this* transfer, not a different file set that happens to reuse the room number. Optional + `omitempty` means existing manifests serialize byte-for-byte as before and `NewManifest`'s signature is unchanged; the sender-side minting is deferred to PR3.
- **`resume_state` (frame type 12)** — `{ transferId, files: [{ idx, haveBlocks }] }`, receiver → sender. `haveBlocks` is the per-file high-water mark (the receiver's `nextBlock`); because commitment is strictly in order, one integer per file fully describes what is held — no sparse bitmap on the wire.
- Encode / decode / shape-validate on **both** sides, with the new field placed immediately after `type` in the TS interface and the Go struct so the two encoders emit identical bytes.

## Tests

- New cross-language byte vectors for manifest-with-`transferId` and `resume_state` (Go `TestEncodeControlWireBytes`, TS explicit-wire assertions).
- Round-trip stability + decode-from-TS-shape interop + malformed-rejection cases on both codecs.
- Full gate green locally: `just typecheck` (0 errors), `just lint` (0 issues, JS + Go), all JS tests (141 protocol + 52 web) and all Go modules under `go test -race`.