### PR TITLE
feat(transfer): resume transfers from the committed high-water mark

### DIFF
--- a/packages/protocol/src/transfer-loopback.test.ts
+++ b/packages/protocol/src/transfer-loopback.test.ts
@@ -167,4 +167,107 @@ describe('transfer loopback (no browser)', () => {
     expect(progress.at(-1)).toBe(contents.reduce((total, bytes) => total + bytes.length, 0));
     expect(committed).toBe(true);
   });
+
+  it('resumes a partially received transfer from the committed high-water mark', async () => {
+    const keys = await deriveTransferKeys(master);
+    const blockSize = 1024;
+    const data = new Uint8Array(100_000).map((_, i) => (i * 131 + 7) & 0xff);
+    const blocks = Math.ceil(data.length / blockSize);
+    const stop = 10;
+    const prefixLen = stop * blockSize;
+    const transferId = 'a'.repeat(32);
+
+    // Model a reloaded receiver: the first `stop` blocks are already persisted, so restore a
+    // prefilled sink and a digest already fed exactly those bytes.
+    const sink = new MemorySink();
+    sink.write(0, data.subarray(0, prefixLen));
+    const seed = nodeDigest();
+    seed.update(data.subarray(0, prefixLen));
+
+    let commits = 0;
+    const box: { receiver?: TransferReceiver } = {};
+    const sender = new TransferSender({
+      file: bytesSource(data, { name: 'f', size: data.length, mime: '', lastModified: 1 }),
+      send: (f) => queueMicrotask(() => box.receiver!.handle(f)),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize,
+      frameSize: 256,
+      window: 4,
+      transferId,
+    });
+    const receiver = new TransferReceiver({
+      send: (f) => queueMicrotask(() => sender.handle(f)),
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+      resume: { transferId, files: new Map([[0, { haveBlocks: stop, seedDigest: seed }]]) },
+      onProgress: () => void commits++,
+    });
+    box.receiver = receiver;
+
+    const [digest, result] = await Promise.all([sender.run(), receiver.done]);
+    expect([...sink.bytes()]).toEqual([...data]);
+    expect(result.digest).toBe(createHash('sha256').update(data).digest('hex'));
+    expect(digest).toBe(result.digest);
+    // Only the blocks the receiver lacked are streamed and committed on resume.
+    expect(commits).toBe(blocks - stop);
+  });
+
+  it('ignores a resume seed whose transferId does not match the manifest', async () => {
+    const keys = await deriveTransferKeys(master);
+    const blockSize = 1024;
+    const data = new Uint8Array(20_000).map((_, i) => (i * 131 + 7) & 0xff);
+    const blocks = Math.ceil(data.length / blockSize);
+
+    // A seed for a *different* transfer must be discarded: wrong high-water and a poisoned digest.
+    // If it were wrongly applied, the whole-file digest would fail and receiver.done would reject.
+    const staleSeed = nodeDigest();
+    staleSeed.update(new Uint8Array(blockSize).fill(0xff));
+
+    let commits = 0;
+    const sink = new MemorySink();
+    const box: { receiver?: TransferReceiver } = {};
+    const sender = new TransferSender({
+      file: bytesSource(data, { name: 'f', size: data.length, mime: '', lastModified: 1 }),
+      send: (f) => queueMicrotask(() => box.receiver!.handle(f)),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize,
+      frameSize: 256,
+      window: 4,
+      transferId: 'b'.repeat(32),
+    });
+    const receiver = new TransferReceiver({
+      send: (f) => queueMicrotask(() => sender.handle(f)),
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+      resume: {
+        transferId: 'a'.repeat(32),
+        files: new Map([[0, { haveBlocks: 1, seedDigest: staleSeed }]]),
+      },
+      onProgress: () => void commits++,
+    });
+    box.receiver = receiver;
+
+    const [digest, result] = await Promise.all([sender.run(), receiver.done]);
+    expect([...sink.bytes()]).toEqual([...data]);
+    expect(result.digest).toBe(createHash('sha256').update(data).digest('hex'));
+    expect(digest).toBe(result.digest);
+    // Fresh receive: every block is streamed because the stale seed was rejected.
+    expect(commits).toBe(blocks);
+  });
 });

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -34,6 +34,28 @@ export interface ReceiveResult {
   digest: string;
 }
 
+/** Per-file seed a reloaded receiver restores so held blocks are neither re-fetched nor re-hashed. */
+export interface ReceiverResumeFile {
+  /** Consecutively-committed blocks already persisted for this file — its restored `nextBlock`. */
+  haveBlocks: number;
+  /**
+   * A digest already fed exactly the persisted bytes `[0, haveBlocks)`. The receiver continues
+   * updating it with the streamed remainder, so the whole-file digest still matches at completion.
+   * The host owns this seam because only it can read the persisted bytes back.
+   */
+  seedDigest: Digest;
+}
+
+/** State a reloaded receiver restores to resume a transfer in place. */
+export interface ReceiverResumeState {
+  /**
+   * Must equal the manifest's `transferId`. A mismatch means the room was reused for a different
+   * file set, so the persisted offsets are ignored and a fresh receive starts.
+   */
+  transferId: string;
+  files: ReadonlyMap<number, ReceiverResumeFile>;
+}
+
 export interface TransferReceiverOptions {
   send(frame: Uint8Array): void | Promise<void>;
   sendDir: DirectionalKey;
@@ -52,6 +74,12 @@ export interface TransferReceiverOptions {
   onManifestSet?(manifest: Manifest): void | Promise<void>;
   /** Called for each file immediately before its sink opens. */
   onManifest?(file: FileEntry): void | Promise<void>;
+  /**
+   * Restored progress for a reloaded receiver. When the arriving manifest carries a matching
+   * `transferId`, each file restarts at its `haveBlocks` high-water mark and the sender is asked to
+   * stream only the missing blocks. Absent (or a `transferId` mismatch) means a fresh receive.
+   */
+  resume?: ReceiverResumeState;
 }
 
 export class TransferReceiver {
@@ -76,6 +104,8 @@ export class TransferReceiver {
   private readonly seenAhead = new Set<number>();
   private nackOutstanding: number | undefined;
   private paused = false;
+  /** The caller's resume seed, kept only once its transferId matches the arriving manifest. */
+  private activeResume: ReceiverResumeState | undefined;
 
   private resolveDone!: (r: ReceiveResult) => void;
   private rejectDone!: (e: Error) => void;
@@ -214,7 +244,28 @@ export class TransferReceiver {
         : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
     }
     this.manifest = manifest;
+    if (manifest.transferId !== undefined) {
+      // The sender opted into resumption. Apply persisted offsets only when they belong to this
+      // exact transfer, then report each file's high-water mark so the sender skips held blocks.
+      this.activeResume =
+        this.o.resume && this.o.resume.transferId === manifest.transferId
+          ? this.o.resume
+          : undefined;
+      await this.sendResumeState(manifest);
+    }
     await this.openNextFile();
+  }
+
+  private async sendResumeState(manifest: Manifest): Promise<void> {
+    const files = manifest.files.map((file) => ({
+      idx: file.idx,
+      haveBlocks: Math.min(this.activeResume?.files.get(file.idx)?.haveBlocks ?? 0, file.blocks),
+    }));
+    await this.sendControl(FrameType.ResumeState, {
+      type: FrameType.ResumeState,
+      transferId: manifest.transferId!,
+      files,
+    });
   }
 
   /** Open the next file and immediately verify/close consecutive empty files. */
@@ -224,10 +275,15 @@ export class TransferReceiver {
     while (this.fileIdx < manifest.files.length) {
       const file = manifest.files[this.fileIdx]!;
       this.file = file;
-      this.nextBlock = 0;
+      const rf = this.activeResume?.files.get(file.idx);
+      this.nextBlock = rf ? Math.min(rf.haveBlocks, file.blocks) : 0;
       this.seenAhead.clear();
       this.nackOutstanding = undefined;
-      this.digest = this.o.createDigest();
+      // The seed digest already holds the persisted prefix; the streamed remainder appends to it.
+      this.digest = rf?.seedDigest ?? this.o.createDigest();
+      // Persisted bytes count as acknowledged so progress resumes without a backwards jump.
+      this.acknowledged +=
+        this.nextBlock >= file.blocks ? file.size : this.nextBlock * file.blockSize;
       try {
         await this.o.onManifest?.(file);
         this.sink = await this.destination.open(file);
@@ -236,7 +292,8 @@ export class TransferReceiver {
           ? e
           : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
       }
-      if (file.blocks > 0) return;
+      // Return to receive blocks only when some remain; empty and fully-held files finish now.
+      if (this.nextBlock < file.blocks) return;
       await this.finishCurrentFile();
     }
     this.file = undefined;

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -40,6 +40,16 @@ export interface TransferSenderOptions {
   sendCounterStart: number;
   recvCounterStart: number;
   createDigest(): Digest;
+  /**
+   * A stable transfer id (hex) advertised in the manifest so a reloaded receiver can prove it is
+   * resuming *this* transfer. Supply it when the caller controls the id across attempts; otherwise
+   * {@link newTransferId} mints one. Either enables the resume handshake: the manifest carries the
+   * id and the sender waits for the receiver's `resume_state` before streaming, restarting each
+   * file at the acknowledged high-water mark.
+   */
+  transferId?: string;
+  /** Mint a fresh transfer id when {@link transferId} is not supplied. */
+  newTransferId?(): string;
   blockSize?: number;
   frameSize?: number;
   window?: number;
@@ -81,6 +91,16 @@ export class TransferSender {
   private activeFileIdx = -1;
   private activeFileAcknowledged = 0;
 
+  /** Set when a transfer id is advertised: the manifest carries it and a resume handshake runs. */
+  private readonly transferId: string | undefined;
+  /** Per-file high-water marks the receiver reported; each file restarts at its value. */
+  private readonly resumePlan = new Map<number, number>();
+  /** Resolves when the receiver's `resume_state` has been validated (resume mode only). */
+  private resolveResumeReady!: () => void;
+  private rejectResumeReady!: (e: Error) => void;
+  private readonly resumeReady: Promise<void>;
+  private resumeSettled = false;
+
   private readonly inflight = new Map<number, InflightBlock>();
   private readonly retryQueue: number[] = [];
   private readonly retryQueued = new Set<number>();
@@ -107,11 +127,17 @@ export class TransferSender {
     this.maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.sendCounter = opts.sendCounterStart;
     this.recvCounter = opts.recvCounterStart;
+    this.transferId = opts.transferId ?? opts.newTransferId?.();
     this.done = new Promise<void>((res, rej) => {
       this.resolveDone = res;
       this.rejectDone = rej;
     });
     this.done.catch(() => {});
+    this.resumeReady = new Promise<void>((res, rej) => {
+      this.resolveResumeReady = res;
+      this.rejectResumeReady = rej;
+    });
+    this.resumeReady.catch(() => {});
   }
 
   /**
@@ -195,6 +221,7 @@ export class TransferSender {
     }
     const manifest = validateManifest({
       type: FrameType.Manifest,
+      ...(this.transferId !== undefined ? { transferId: this.transferId } : {}),
       files: entries,
       totalSize,
     });
@@ -202,12 +229,27 @@ export class TransferSender {
     this.o.onManifest?.(manifest);
     await this.sendControl(FrameType.Manifest, manifest);
 
+    // A transfer id opts into resumption: the receiver answers the manifest with a resume_state
+    // carrying each file's high-water mark (all zero on a first attempt). Wait for it before
+    // streaming so skipped blocks are never sent. Fresh transfers never take this branch.
+    if (this.transferId !== undefined) {
+      await this.resumeReady;
+    }
+
     for (const [fileIdx, source] of this.files.entries()) {
       this.activeFileIdx = fileIdx;
-      this.activeFileAcknowledged = 0;
+      const file = manifest.files[fileIdx]!;
+      const haveBlocks = Math.min(this.resumePlan.get(fileIdx) ?? 0, file.blocks);
+      // Bytes the receiver already holds count as acknowledged up front so progress is continuous
+      // across a resume. Only the final block may be partial, so a full prefix is haveBlocks blocks.
+      const committed = haveBlocks >= file.blocks ? file.size : haveBlocks * this.blockSize;
+      this.activeFileAcknowledged = committed;
+      this.acknowledged += committed;
       // Asking reChunk for block-sized pieces yields one retained buffer per logical block. The
-      // block is then split into transport-sized frames by sendBlock.
+      // block is then split into transport-sized frames by sendBlock. Blocks the receiver already
+      // holds are read past (the source is streamed for the digest regardless) but never sent.
       for await (const piece of reChunk(source.stream(), this.blockSize, this.blockSize)) {
+        if (piece.blockIdx < haveBlocks) continue;
         await this.beforeNewBlock();
         await this.propagateSettlement();
         const bytes = piece.payload.slice();
@@ -273,6 +315,31 @@ export class TransferSender {
         }
         this.queueRetry(msg.blockIdx);
         return;
+      case FrameType.ResumeState: {
+        if (this.transferId === undefined) {
+          throw new TransferError('integrity', 'unexpected resume_state');
+        }
+        if (this.resumeSettled) {
+          throw new TransferError('integrity', 'duplicate resume_state');
+        }
+        if (msg.transferId !== this.transferId) {
+          throw new TransferError('integrity', 'resume_state transfer id mismatch');
+        }
+        for (const entry of msg.files) {
+          const file = this.files[entry.idx];
+          const blocks = file ? Math.ceil(file.meta.size / this.blockSize) : -1;
+          if (blocks < 0 || this.resumePlan.has(entry.idx)) {
+            throw new TransferError('integrity', 'resume_state references an unknown file');
+          }
+          if (entry.haveBlocks < 0 || entry.haveBlocks > blocks) {
+            throw new TransferError('integrity', 'resume_state haveBlocks out of range');
+          }
+          this.resumePlan.set(entry.idx, entry.haveBlocks);
+        }
+        this.resumeSettled = true;
+        this.resolveResumeReady();
+        return;
+      }
       case FrameType.Control:
         this.applyRemoteControl(msg.op);
         return;
@@ -457,6 +524,7 @@ export class TransferSender {
     if (this.settled) return;
     this.settled = true;
     this.clearTimers();
+    this.rejectResumeReady(err);
     this.rejectDone(err);
     this.wake();
   }

--- a/packages/wire/transfer_loopback_test.go
+++ b/packages/wire/transfer_loopback_test.go
@@ -123,6 +123,125 @@ func TestLoopbackStreamsVariousSizes(t *testing.T) {
 	}
 }
 
+// runResumeLoopback wires a resumable sender to a reloaded receiver whose sink and digest are
+// pre-seeded with the first haveBlocks blocks, mirroring a real reload from durable storage.
+func runResumeLoopback(t *testing.T, data []byte, blockSize, haveBlocks int, senderID, resumeID string) (loopbackResult, int) {
+	t.Helper()
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix := haveBlocks * blockSize
+	if prefix > len(data) {
+		prefix = len(data)
+	}
+	sink := &MemorySink{}
+	if resumeID == senderID && prefix > 0 {
+		_ = sink.Write(0, data[:prefix])
+	}
+	seed := NewSHA256Digest()
+	if resumeID == senderID {
+		seed.Update(data[:prefix])
+	}
+
+	s2r := make(chan []byte, 4096)
+	r2s := make(chan []byte, 4096)
+	cp := func(f []byte) []byte { return append([]byte(nil), f...) }
+
+	sender := NewSender(SenderOptions{
+		File:       BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:       func(f []byte) error { s2r <- cp(f); return nil },
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  blockSize,
+		FrameSize:  256,
+		Window:     4,
+		TransferID: senderID,
+	})
+	var commits int
+	receiver := NewReceiver(ReceiverOptions{
+		Send:       func(f []byte) error { r2s <- cp(f); return nil },
+		SendDir:    keys.J2O,
+		RecvDir:    keys.O2J,
+		Sink:       sink,
+		OnProgress: func(int64) { commits++ },
+		Resume: &ReceiverResume{
+			TransferID: resumeID,
+			Files:      map[int]ResumeFileProgress{0: {HaveBlocks: haveBlocks, SeedDigest: seed}},
+		},
+	})
+
+	go func() {
+		for f := range s2r {
+			receiver.Handle(f)
+		}
+	}()
+	go func() {
+		for f := range r2s {
+			sender.Handle(f)
+		}
+	}()
+	runErrCh := make(chan error, 1)
+	go func() { _, e := sender.Run(context.Background()); runErrCh <- e }()
+	recvRes, recvErr := receiver.Wait(context.Background())
+	var runErr error
+	select {
+	case runErr = <-runErrCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sender.Run did not return after the receiver settled")
+	}
+	close(s2r)
+	close(r2s)
+	return loopbackResult{runErr: runErr, recvRes: recvRes, recvErr: recvErr, sink: sink}, commits
+}
+
+func TestLoopbackResumesFromHighWaterMark(t *testing.T) {
+	blockSize := 1024
+	data := make([]byte, 100_000)
+	for i := range data {
+		data[i] = byte((i*131 + 7) & 0xff)
+	}
+	blocks := (len(data)-1)/blockSize + 1
+	haveBlocks := 10
+	id := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	res, commits := runResumeLoopback(t, data, blockSize, haveBlocks, id, id)
+	if res.runErr != nil || res.recvErr != nil {
+		t.Fatalf("send=%v receive=%v", res.runErr, res.recvErr)
+	}
+	if string(res.sink.Bytes()) != string(data) {
+		t.Fatal("resumed transfer did not reassemble the full file")
+	}
+	want := sha256.Sum256(data)
+	if res.recvRes.Digest != hex.EncodeToString(want[:]) {
+		t.Errorf("digest = %s, want %s", res.recvRes.Digest, hex.EncodeToString(want[:]))
+	}
+	if commits != blocks-haveBlocks {
+		t.Errorf("committed %d blocks, want %d (only the missing suffix)", commits, blocks-haveBlocks)
+	}
+}
+
+func TestLoopbackIgnoresResumeOnTransferIDMismatch(t *testing.T) {
+	blockSize := 1024
+	data := make([]byte, 20_000)
+	for i := range data {
+		data[i] = byte((i*131 + 7) & 0xff)
+	}
+	blocks := (len(data)-1)/blockSize + 1
+
+	// The seed carries a stale id, so the receiver must discard it and receive every block fresh.
+	res, commits := runResumeLoopback(t, data, blockSize, 5, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if res.runErr != nil || res.recvErr != nil {
+		t.Fatalf("send=%v receive=%v", res.runErr, res.recvErr)
+	}
+	if string(res.sink.Bytes()) != string(data) {
+		t.Fatal("mismatched-resume transfer did not reassemble the full file")
+	}
+	if commits != blocks {
+		t.Errorf("committed %d blocks, want %d (a full fresh receive)", commits, blocks)
+	}
+}
+
 func TestLoopbackAbortsOnCorruptedFrame(t *testing.T) {
 	data := make([]byte, 4096)
 	for i := range data {

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -23,6 +23,22 @@ type ReceiveResult struct {
 	Digest    string
 }
 
+// ResumeFileProgress is a reloaded receiver's restored seed for one file: the persisted
+// high-water mark and a digest already fed exactly the persisted bytes [0, HaveBlocks). The
+// host owns SeedDigest because only it can read those bytes back from durable storage.
+type ResumeFileProgress struct {
+	HaveBlocks int
+	SeedDigest Digest
+}
+
+// ReceiverResume is the state a reloaded receiver restores to resume a transfer in place. It is
+// applied only when TransferID equals the arriving manifest's; a mismatch means the room was
+// reused for a different file set, so the offsets are ignored and a fresh receive starts.
+type ReceiverResume struct {
+	TransferID string
+	Files      map[int]ResumeFileProgress
+}
+
 // ReceiverOptions configures a Receiver.
 type ReceiverOptions struct {
 	Send             func(frame []byte) error
@@ -39,6 +55,10 @@ type ReceiverOptions struct {
 	OnStateChange  func(TransferState)
 	OnManifestSet  func(manifest Manifest) error
 	OnManifest     func(file FileEntry) error
+	// Resume restores a reloaded receiver's progress. When the arriving manifest carries a matching
+	// TransferID, each file restarts at its HaveBlocks high-water mark and the sender is asked to
+	// stream only the missing blocks. Nil (or a TransferID mismatch) means a fresh receive.
+	Resume *ReceiverResume
 }
 
 // Receiver drives one file receive. Handle calls must remain ordered.
@@ -67,6 +87,8 @@ type Receiver struct {
 	awaitingRestart bool
 	seenAhead       map[int]bool
 	nackOutstanding int
+	// activeResume is the caller's seed, kept only once its TransferID matches the manifest.
+	activeResume *ReceiverResume
 
 	mu      sync.Mutex
 	done    chan struct{}
@@ -231,7 +253,34 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	}
 	r.manifest = &validated
 	r.digests = make([]string, len(validated.Files))
+	if validated.TransferID != "" {
+		// The sender opted into resumption. Apply persisted offsets only when they belong to this
+		// exact transfer, then report each file's high-water mark so the sender skips held blocks.
+		if r.o.Resume != nil && r.o.Resume.TransferID == validated.TransferID {
+			r.activeResume = r.o.Resume
+		}
+		if err := r.sendResumeState(&validated); err != nil {
+			return err
+		}
+	}
 	return r.openNextFile()
+}
+
+func (r *Receiver) sendResumeState(manifest *Manifest) error {
+	files := make([]ResumeFileState, len(manifest.Files))
+	for i, file := range manifest.Files {
+		have := 0
+		if r.activeResume != nil {
+			if p, ok := r.activeResume.Files[file.Idx]; ok {
+				have = p.HaveBlocks
+			}
+		}
+		if have > file.Blocks {
+			have = file.Blocks
+		}
+		files[i] = ResumeFileState{Idx: file.Idx, HaveBlocks: have}
+	}
+	return r.sendControl(NewResumeState(manifest.TransferID, files))
 }
 
 func (r *Receiver) openNextFile() error {
@@ -242,9 +291,27 @@ func (r *Receiver) openNextFile() error {
 		file := r.manifest.Files[r.fileIdx]
 		r.file = &file
 		r.nextBlock = 0
+		r.digest = r.o.CreateDigest()
+		if r.activeResume != nil {
+			if p, ok := r.activeResume.Files[file.Idx]; ok {
+				r.nextBlock = p.HaveBlocks
+				if r.nextBlock > file.Blocks {
+					r.nextBlock = file.Blocks
+				}
+				if p.SeedDigest != nil {
+					// The seed digest already holds the persisted prefix; the remainder appends.
+					r.digest = p.SeedDigest
+				}
+			}
+		}
+		// Persisted bytes count as acknowledged so progress resumes without a backwards jump.
+		if r.nextBlock >= file.Blocks {
+			r.acknowledged += file.Size
+		} else {
+			r.acknowledged += int64(r.nextBlock) * int64(file.BlockSize)
+		}
 		r.seenAhead = make(map[int]bool)
 		r.nackOutstanding = -1
-		r.digest = r.o.CreateDigest()
 		if r.o.OnManifest != nil {
 			if err := r.o.OnManifest(file); err != nil {
 				return asTransferError(err, FailSinkError)
@@ -255,7 +322,8 @@ func (r *Receiver) openNextFile() error {
 			return asTransferError(err, FailSinkError)
 		}
 		r.sink = sink
-		if file.Blocks > 0 {
+		// Return to receive blocks only when some remain; empty and fully-held files finish now.
+		if r.nextBlock < file.Blocks {
 			return nil
 		}
 		if err := r.finishCurrentFile(); err != nil {

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -36,11 +36,17 @@ type SenderOptions struct {
 	SendCounterStart uint64
 	RecvCounterStart uint64
 	CreateDigest     func() Digest
-	BlockSize        int
-	FrameSize        int
-	Window           int
-	AckTimeout       time.Duration
-	MaxRetries       int
+	// TransferID, when set, is advertised in the manifest so a reloaded receiver can prove it is
+	// resuming this transfer. It enables the resume handshake: the sender waits for the receiver's
+	// resume_state and restarts each file at the reported high-water mark. NewTransferID mints one
+	// when TransferID is empty; leaving both unset disables resumption.
+	TransferID    string
+	NewTransferID func() string
+	BlockSize     int
+	FrameSize     int
+	Window        int
+	AckTimeout    time.Duration
+	MaxRetries    int
 	// OnProgress reports bytes acknowledged after verify-and-sink.
 	OnProgress     func(acknowledgedBytes int64)
 	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
@@ -66,6 +72,8 @@ type Sender struct {
 	sendMu      sync.Mutex
 	sendCounter uint64
 
+	transferID string
+
 	mu                     sync.Mutex
 	cond                   *sync.Cond
 	recvCounter            uint64
@@ -79,6 +87,10 @@ type Sender struct {
 	completeSent           bool
 	settled                bool
 	err                    error
+	// resumePlan maps file index to the receiver's high-water mark; each file restarts there.
+	resumePlan map[int]int
+	// resumeReceived is set once a valid resume_state has been applied (resume mode only).
+	resumeReceived bool
 }
 
 var errSenderSettled = errors.New("sender settled")
@@ -103,6 +115,10 @@ func NewSender(opts SenderOptions) *Sender {
 	if opts.CreateDigest == nil {
 		opts.CreateDigest = NewSHA256Digest
 	}
+	transferID := opts.TransferID
+	if transferID == "" && opts.NewTransferID != nil {
+		transferID = opts.NewTransferID()
+	}
 	files := opts.Files
 	if len(files) == 0 && opts.File != nil {
 		files = []FileSource{opts.File}
@@ -120,6 +136,8 @@ func NewSender(opts SenderOptions) *Sender {
 		inflight:      make(map[int]*inflightBlock),
 		retryQueued:   make(map[int]bool),
 		activeFileIdx: -1,
+		transferID:    transferID,
+		resumePlan:    make(map[int]int),
 	}
 	s.cond = sync.NewCond(&s.mu)
 	return s
@@ -171,7 +189,9 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 		}
 		totalSize += meta.Size
 	}
-	manifest, err := ValidateManifest(*NewManifest(entries, totalSize))
+	base := NewManifest(entries, totalSize)
+	base.TransferID = s.transferID
+	manifest, err := ValidateManifest(*base)
 	if err != nil {
 		s.fail(err)
 		return "", err
@@ -182,12 +202,37 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 		return "", err
 	}
 
+	// A transfer id opts into resumption: wait for the receiver's resume_state (all zero on a
+	// first attempt) before streaming so blocks it already holds are never sent. Fresh transfers
+	// skip the wait entirely.
+	if s.transferID != "" {
+		if err := s.waitResume(); err != nil {
+			return "", err
+		}
+	}
+
 	for fileIdx, source := range s.files {
 		s.mu.Lock()
 		s.activeFileIdx = fileIdx
-		s.activeFileAcknowledged = 0
+		haveBlocks := s.resumePlan[fileIdx]
+		if haveBlocks > entries[fileIdx].Blocks {
+			haveBlocks = entries[fileIdx].Blocks
+		}
+		// Bytes the receiver already holds count as acknowledged up front so progress is continuous
+		// across a resume. Only a file's final block may be partial, so a full prefix is N blocks.
+		committed := int64(haveBlocks) * int64(s.blockSize)
+		if haveBlocks >= entries[fileIdx].Blocks {
+			committed = entries[fileIdx].Size
+		}
+		s.activeFileAcknowledged = committed
+		s.acknowledged += committed
 		s.mu.Unlock()
 		streamErr := ReChunk(StreamFunc(source.Stream), s.blockSize, s.blockSize, func(p FramePiece) error {
+			// Held blocks are read past (the source is streamed for the digest regardless) but
+			// never sent.
+			if p.BlockIdx < haveBlocks {
+				return nil
+			}
 			if err := s.beforeNewBlock(); err != nil {
 				return err
 			}
@@ -274,6 +319,8 @@ func (s *Sender) Handle(frame []byte) {
 			return
 		}
 		s.queueRetry(m.BlockIdx)
+	case *ResumeState:
+		s.onResumeState(m)
 	case *Control:
 		s.applyRemoteControl(m.Op)
 	case *Done:
@@ -378,6 +425,68 @@ func (s *Sender) onAck(ack *Ack) {
 	if s.o.OnFileProgress != nil {
 		s.o.OnFileProgress(fileIdx, fileAcknowledged, acknowledged)
 	}
+}
+
+// waitResume blocks until a valid resume_state has been applied or the sender settles.
+func (s *Sender) waitResume() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for !s.resumeReceived && !s.settled {
+		s.cond.Wait()
+	}
+	if s.settled {
+		if s.err != nil {
+			return s.err
+		}
+		return errSenderSettled
+	}
+	return nil
+}
+
+// onResumeState validates the receiver's resume_state against the manifest and records each
+// file's high-water mark, then unblocks the driver. Any inconsistency fails the transfer closed.
+func (s *Sender) onResumeState(m *ResumeState) {
+	s.mu.Lock()
+	plan, failErr := s.buildResumePlanLocked(m)
+	if failErr == nil {
+		s.resumePlan = plan
+		s.resumeReceived = true
+		s.cond.Broadcast()
+	}
+	s.mu.Unlock()
+	if failErr != nil {
+		s.fail(failErr)
+	}
+}
+
+func (s *Sender) buildResumePlanLocked(m *ResumeState) (map[int]int, *TransferError) {
+	if s.transferID == "" {
+		return nil, NewTransferError(FailIntegrity, "unexpected resume_state")
+	}
+	if s.resumeReceived {
+		return nil, NewTransferError(FailIntegrity, "duplicate resume_state")
+	}
+	if m.TransferID != s.transferID {
+		return nil, NewTransferError(FailIntegrity, "resume_state transfer id mismatch")
+	}
+	plan := make(map[int]int, len(m.Files))
+	for _, f := range m.Files {
+		if f.Idx < 0 || f.Idx >= len(s.files) {
+			return nil, NewTransferError(FailIntegrity, "resume_state references an unknown file")
+		}
+		if _, dup := plan[f.Idx]; dup {
+			return nil, NewTransferError(FailIntegrity, "resume_state references an unknown file")
+		}
+		blocks := 0
+		if size := s.files[f.Idx].Meta().Size; size > 0 {
+			blocks = int((size-1)/int64(s.blockSize) + 1)
+		}
+		if f.HaveBlocks < 0 || f.HaveBlocks > blocks {
+			return nil, NewTransferError(FailIntegrity, "resume_state haveBlocks out of range")
+		}
+		plan[f.Idx] = f.HaveBlocks
+	}
+	return plan, nil
 }
 
 func (s *Sender) applyRemoteControl(op ControlOp) {


### PR DESCRIPTION
## What

Teaches both transfer engines (TypeScript `@sendarc/protocol` and its Go `packages/wire` twin) to resume an interrupted transfer in place, so a reloaded receiver re-fetches only the blocks it still lacks rather than the whole file.

A `transferId` on the manifest opts both sides into a resume handshake:

1. Sender advertises the id in the manifest and **waits** before streaming.
2. Receiver answers with a `resume_state` carrying each file's high-water mark (all zero on a first attempt).
3. Sender validates it and streams only the missing suffix, restarting each file at its mark.

Non-resume transfers never send or await `resume_state`, so existing behaviour is untouched.

## Receiver

- `ReceiverResumeState` restores per-file `haveBlocks` and a **seed digest** already fed exactly the persisted prefix `[0, haveBlocks)`. The streamed remainder appends to it, so the whole-file digest still matches at completion. The host owns this seam because only it can read persisted bytes back from durable storage.
- A resume seed is applied **only** when its `transferId` equals the arriving manifest's. A mismatch (room reused for a different file set) is ignored and a fresh receive starts — never a stale-offset apply.
- Persisted bytes count as acknowledged up front, so progress resumes without a backwards jump. Empty and fully-held files finish in place.

## Sender

- `transferId` / `newTransferId` advertise a stable id in the manifest.
- `resume_state` is validated against the manifest (id match, known files, no duplicates, `haveBlocks` in range) before any block is streamed. Held blocks are read past for the digest but never sent.

## Safety

- The old crypto key and AEAD counter are **never** persisted or resumed — only durable transfer progress is. The session's keys are always rebuilt fresh.
- The wire encoding stays byte-identical across the TypeScript and Go engines.

## Tests

New loopback tests on both engines:
- Resume from a partial transfer → only the missing suffix is streamed and committed; full bytes and digest match.
- A `transferId` mismatch → the poisoned seed is discarded and every block is received fresh.

Full gate green: `just build/lint/typecheck/test`, `go test -race`, `golangci-lint`, `gofmt`, and `prettier --check`.