### PR TITLE
feat(web): add durable OPFS file and resume-metadata store

### DIFF
--- a/apps/web/src/lib/transfer/opfs-file.test.ts
+++ b/apps/web/src/lib/transfer/opfs-file.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DurableOpfsFile, openDurableOpfsFile, type SyncAccessHandleLike } from './opfs-file.js';
+
+/** In-memory sync access handle: a growable buffer with the read/write/truncate surface we use. */
+class FakeSyncHandle implements SyncAccessHandleLike {
+  buf: Uint8Array;
+  flushes = 0;
+  closed = false;
+  constructor(initial: Uint8Array = new Uint8Array()) {
+    this.buf = initial;
+  }
+  write(buffer: Uint8Array, options?: { at?: number }): number {
+    const at = options?.at ?? 0;
+    const end = at + buffer.length;
+    if (end > this.buf.length) {
+      const grown = new Uint8Array(end);
+      grown.set(this.buf);
+      this.buf = grown;
+    }
+    this.buf.set(buffer, at);
+    return buffer.length;
+  }
+  read(buffer: Uint8Array, options?: { at?: number }): number {
+    const at = options?.at ?? 0;
+    const n = Math.max(0, Math.min(buffer.length, this.buf.length - at));
+    buffer.set(this.buf.subarray(at, at + n));
+    return n;
+  }
+  truncate(newSize: number): void {
+    const next = new Uint8Array(newSize);
+    next.set(this.buf.subarray(0, Math.min(newSize, this.buf.length)));
+    this.buf = next;
+  }
+  getSize(): number {
+    return this.buf.length;
+  }
+  flush(): void {
+    this.flushes++;
+  }
+  close(): void {
+    this.closed = true;
+  }
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('DurableOpfsFile', () => {
+  it('writes positioned blocks and reads the committed prefix back', () => {
+    const handle = new FakeSyncHandle();
+    const file = new DurableOpfsFile(handle);
+    file.write(0, new Uint8Array([1, 2, 3, 4]));
+    file.write(4, new Uint8Array([5, 6, 7, 8]));
+    expect(file.size()).toBe(8);
+    const into = new Uint8Array(8);
+    expect(file.read(0, into)).toBe(8);
+    expect(into).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+  });
+
+  it('truncates a torn tail down to the recorded high-water mark', () => {
+    const handle = new FakeSyncHandle();
+    const file = new DurableOpfsFile(handle);
+    file.write(0, new Uint8Array([1, 2, 3, 4]));
+    file.write(4, new Uint8Array([9, 9])); // a partial, unrecorded tail
+    file.truncate(4);
+    expect(file.size()).toBe(4);
+    const into = new Uint8Array(4);
+    expect(file.read(0, into)).toBe(4);
+    expect(into).toEqual(new Uint8Array([1, 2, 3, 4]));
+  });
+
+  it('flushes then releases the handle on close, and is idempotent', () => {
+    const handle = new FakeSyncHandle();
+    const file = new DurableOpfsFile(handle);
+    file.close();
+    file.close();
+    expect(handle.flushes).toBe(1);
+    expect(handle.closed).toBe(true);
+  });
+
+  it('releases the handle without flushing on abort', () => {
+    const handle = new FakeSyncHandle();
+    const file = new DurableOpfsFile(handle);
+    file.abort();
+    expect(handle.flushes).toBe(0);
+    expect(handle.closed).toBe(true);
+  });
+
+  it('rejects a write after close and a short write', () => {
+    const closedFile = new DurableOpfsFile(new FakeSyncHandle());
+    closedFile.close();
+    expect(() => closedFile.write(0, new Uint8Array([1]))).toThrow(/write after close/);
+
+    const short = new FakeSyncHandle();
+    short.write = () => 1; // report fewer bytes written than requested
+    expect(() => new DurableOpfsFile(short).write(0, new Uint8Array([1, 2]))).toThrow(
+      /short OPFS write/,
+    );
+  });
+});
+
+describe('openDurableOpfsFile', () => {
+  function stubStorage(handle: FakeSyncHandle | undefined): void {
+    const fileHandle =
+      handle === undefined ? {} : { createSyncAccessHandle: vi.fn(async () => handle) };
+    vi.stubGlobal('navigator', {
+      storage: {
+        getDirectory: vi.fn(async () => ({ getFileHandle: vi.fn(async () => fileHandle) })),
+      },
+    });
+  }
+
+  it('opens a sync-access-backed durable file and round-trips through it', async () => {
+    const handle = new FakeSyncHandle();
+    stubStorage(handle);
+    const file = await openDurableOpfsFile('sendarc-key');
+    file.write(0, new Uint8Array([42, 43]));
+    file.close();
+    expect(handle.buf).toEqual(new Uint8Array([42, 43]));
+    expect(handle.closed).toBe(true);
+  });
+
+  it('fails when synchronous OPFS access is unavailable', async () => {
+    stubStorage(undefined);
+    await expect(openDurableOpfsFile('sendarc-key')).rejects.toThrow(/synchronous OPFS access/);
+  });
+});

--- a/apps/web/src/lib/transfer/opfs-file.ts
+++ b/apps/web/src/lib/transfer/opfs-file.ts
@@ -1,0 +1,102 @@
+/**
+ * Durable, resumable OPFS file backed by a synchronous access handle. Unlike a
+ * `FileSystemWritableFileStream` (which truncates on open and only commits at close), a
+ * `createSyncAccessHandle` keeps existing bytes, writes straight through, and exposes read,
+ * truncate, getSize, and flush — everything a reloaded receiver needs to pick a transfer back up.
+ *
+ * The handle type lives in the WebWorker lib, which this package deliberately omits to avoid the
+ * DOM/WebWorker clash (see transfer.worker.ts), so the surface we use is declared narrowly here.
+ * Sync access handles are worker-only; construct these inside the transfer worker.
+ */
+
+import { TransferError, type Sink } from '@sendarc/protocol';
+
+/** The slice of `FileSystemSyncAccessHandle` we depend on. */
+export interface SyncAccessHandleLike {
+  read(buffer: Uint8Array, options?: { at?: number }): number;
+  write(buffer: Uint8Array, options?: { at?: number }): number;
+  truncate(newSize: number): void;
+  getSize(): number;
+  flush(): void;
+  close(): void;
+}
+
+interface SyncFileHandleLike {
+  createSyncAccessHandle(): Promise<SyncAccessHandleLike>;
+}
+
+/**
+ * A block-addressed durable file. `write` positions every block explicitly (blocks arrive verified
+ * and in order); `flush` forces the committed prefix to disk before its high-water mark is
+ * recorded; `read`/`truncate`/`size` let a reload re-seed the whole-file digest from what survived.
+ */
+export class DurableOpfsFile implements Sink {
+  private closed = false;
+  constructor(private readonly handle: SyncAccessHandleLike) {}
+
+  /** Bytes currently on disk. A mid-transfer prefix is always a whole number of blocks. */
+  size(): number {
+    return this.handle.getSize();
+  }
+
+  write(offset: number, bytes: Uint8Array): void {
+    if (this.closed) throw new TransferError('sink_error', 'write after close');
+    const wrote = this.handle.write(bytes, { at: offset });
+    if (wrote !== bytes.length) {
+      throw new TransferError('sink_error', `short OPFS write: ${wrote}/${bytes.length}`);
+    }
+  }
+
+  /** Read up to `into.length` bytes starting at `offset`; returns the count actually read. */
+  read(offset: number, into: Uint8Array): number {
+    return this.handle.read(into, { at: offset });
+  }
+
+  /** Drop any bytes past `length`, discarding a torn tail beyond the recorded high-water mark. */
+  truncate(length: number): void {
+    this.handle.truncate(length);
+  }
+
+  /** Force the OS to persist prior writes. Call before recording a new high-water mark. */
+  flush(): void {
+    this.handle.flush();
+  }
+
+  /** Finalise a completed file: flush, then release the handle so the main thread can read it. */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.handle.flush();
+    this.handle.close();
+  }
+
+  /**
+   * Release the handle without a final flush; the caller discards the backing entry afterwards.
+   * The exclusive lock a sync access handle holds must drop first or the removal blocks.
+   */
+  abort(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.handle.close();
+  }
+}
+
+/** OPFS root, or a typed failure when the origin private file system is unavailable. */
+export async function opfsRoot(): Promise<FileSystemDirectoryHandle> {
+  const storage = navigator.storage as StorageManager | undefined;
+  if (!storage || typeof storage.getDirectory !== 'function') {
+    throw new TransferError('sink_error', 'Origin Private File System is unavailable');
+  }
+  return storage.getDirectory();
+}
+
+/** Open (creating if absent) a durable file by OPFS key. Worker-only — needs a sync access handle. */
+export async function openDurableOpfsFile(key: string): Promise<DurableOpfsFile> {
+  const root = await opfsRoot();
+  const handle = (await root.getFileHandle(key, { create: true })) as unknown as SyncFileHandleLike;
+  if (typeof handle.createSyncAccessHandle !== 'function') {
+    throw new TransferError('sink_error', 'synchronous OPFS access is unavailable');
+  }
+  const access = await handle.createSyncAccessHandle();
+  return new DurableOpfsFile(access);
+}

--- a/apps/web/src/lib/transfer/resume-store.test.ts
+++ b/apps/web/src/lib/transfer/resume-store.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { opfsResumeStore, type ResumeRecord } from './resume-store.js';
+import type { WritableFileLike } from './stream-sink.js';
+
+/** A single OPFS file entry backed by a byte buffer, exposing the getFile/createWritable seam. */
+class FakeEntry {
+  kind = 'file' as const;
+  bytes = new Uint8Array();
+  constructor(public name: string) {}
+  async getFile(): Promise<{ text(): Promise<string> }> {
+    const bytes = this.bytes;
+    return { text: async () => new TextDecoder().decode(bytes) };
+  }
+  createWritable(): Promise<WritableFileLike> {
+    return Promise.resolve({
+      write: async (request: {
+        type: 'write';
+        position: number;
+        data: Uint8Array;
+      }): Promise<void> => {
+        this.bytes = request.data.slice();
+      },
+      close: async (): Promise<void> => {},
+      abort: async (): Promise<void> => {},
+    });
+  }
+}
+
+/** An in-memory OPFS root implementing just the handle/iterator surface the store touches. */
+class FakeRoot {
+  entries = new Map<string, FakeEntry>();
+  async getFileHandle(name: string, options?: { create?: boolean }): Promise<FakeEntry> {
+    let entry = this.entries.get(name);
+    if (!entry) {
+      if (!options?.create) {
+        throw new DOMException(`${name} not found`, 'NotFoundError');
+      }
+      entry = new FakeEntry(name);
+      this.entries.set(name, entry);
+    }
+    return entry;
+  }
+  async removeEntry(name: string): Promise<void> {
+    this.entries.delete(name);
+  }
+  async *values(): AsyncIterable<FakeEntry> {
+    yield* this.entries.values();
+  }
+}
+
+function stubRoot(root: FakeRoot): void {
+  vi.stubGlobal('navigator', {
+    storage: { getDirectory: vi.fn(async () => root) },
+  });
+}
+
+function record(room: number, over: Partial<ResumeRecord> = {}): ResumeRecord {
+  return {
+    room,
+    transferId: 'ffeeddccbbaa99887766554433221100',
+    opfsKey: `sendarc-key-${room}`,
+    name: 'movie.bin',
+    mime: 'application/octet-stream',
+    size: 1000,
+    blockSize: 64,
+    haveBlocks: 5,
+    updatedAt: 1,
+    ...over,
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('opfsResumeStore', () => {
+  it('round-trips a record by room', async () => {
+    stubRoot(new FakeRoot());
+    const store = opfsResumeStore();
+    await store.put(record(7));
+    expect(await store.get(7)).toEqual(record(7));
+  });
+
+  it('returns undefined for an absent room', async () => {
+    stubRoot(new FakeRoot());
+    expect(await opfsResumeStore().get(404)).toBeUndefined();
+  });
+
+  it('overwrites an earlier record for the same room', async () => {
+    stubRoot(new FakeRoot());
+    const store = opfsResumeStore();
+    await store.put(record(3, { haveBlocks: 2 }));
+    await store.put(record(3, { haveBlocks: 9, updatedAt: 2 }));
+    expect((await store.get(3))?.haveBlocks).toBe(9);
+  });
+
+  it('deletes a record', async () => {
+    stubRoot(new FakeRoot());
+    const store = opfsResumeStore();
+    await store.put(record(1));
+    await store.delete(1);
+    expect(await store.get(1)).toBeUndefined();
+  });
+
+  it('lists only well-formed resume sidecars', async () => {
+    const root = new FakeRoot();
+    stubRoot(root);
+    const store = opfsResumeStore();
+    await store.put(record(1));
+    await store.put(record(2));
+    // An unrelated OPFS entry and a torn sidecar must both be skipped.
+    root.entries.set('sendarc-uuid-movie.bin', new FakeEntry('sendarc-uuid-movie.bin'));
+    const torn = new FakeEntry('sendarc-resume-3.json');
+    torn.bytes = new TextEncoder().encode('{ not json');
+    root.entries.set('sendarc-resume-3.json', torn);
+
+    const rooms = (await store.list()).map((r) => r.room).sort();
+    expect(rooms).toEqual([1, 2]);
+  });
+
+  it('discards a sidecar whose JSON is not a resume record', async () => {
+    const root = new FakeRoot();
+    stubRoot(root);
+    const bad = new FakeEntry('sendarc-resume-8.json');
+    bad.bytes = new TextEncoder().encode(JSON.stringify({ room: 8 })); // missing fields
+    root.entries.set('sendarc-resume-8.json', bad);
+    expect(await opfsResumeStore().get(8)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/transfer/resume-store.ts
+++ b/apps/web/src/lib/transfer/resume-store.ts
@@ -1,0 +1,130 @@
+/**
+ * Resume metadata store. A reloaded receiver re-joins the same room, so we key one small JSON
+ * sidecar per room in OPFS: it records which durable file holds the committed prefix and how far
+ * that prefix reaches. The sidecar is written only after the data file is flushed, so it can lag
+ * the data but never lead it — a lost update just re-receives a few blocks, never corrupts.
+ *
+ * The transferId lets the receiver prove the arriving manifest is the same transfer; a room reused
+ * for a different file set carries a new id, the seed is ignored, and a fresh receive begins.
+ */
+
+import { TransferError } from '@sendarc/protocol';
+import type { WritableFileLike } from './stream-sink.js';
+import { opfsRoot } from './opfs-file.js';
+
+/** One room's persisted resume point. Scoped to the single-file OPFS destination. */
+export interface ResumeRecord {
+  room: number;
+  transferId: string;
+  /** OPFS key of the durable file holding the committed prefix. */
+  opfsKey: string;
+  name: string;
+  mime: string;
+  size: number;
+  blockSize: number;
+  /** Consecutively-committed, flushed blocks — the receiver's restored high-water mark. */
+  haveBlocks: number;
+  updatedAt: number;
+}
+
+export interface ResumeStore {
+  get(room: number): Promise<ResumeRecord | undefined>;
+  put(record: ResumeRecord): Promise<void>;
+  delete(room: number): Promise<void>;
+  /** Every stored record, for surfacing or pruning abandoned transfers. Torn entries are skipped. */
+  list(): Promise<ResumeRecord[]>;
+}
+
+const PREFIX = 'sendarc-resume-';
+const SUFFIX = '.json';
+
+function sidecarKey(room: number): string {
+  return `${PREFIX}${room}${SUFFIX}`;
+}
+
+/** Narrow view of the async directory iterator, which the DOM lib does not always type. */
+interface DirectoryWithValues extends FileSystemDirectoryHandle {
+  values?(): AsyncIterable<FileSystemHandle>;
+}
+
+function isRecord(value: unknown): value is ResumeRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.room === 'number' &&
+    typeof r.transferId === 'string' &&
+    typeof r.opfsKey === 'string' &&
+    typeof r.name === 'string' &&
+    typeof r.mime === 'string' &&
+    typeof r.size === 'number' &&
+    typeof r.blockSize === 'number' &&
+    typeof r.haveBlocks === 'number' &&
+    typeof r.updatedAt === 'number'
+  );
+}
+
+async function readSidecar(
+  root: FileSystemDirectoryHandle,
+  key: string,
+): Promise<ResumeRecord | undefined> {
+  let handle: FileSystemFileHandle;
+  try {
+    handle = await root.getFileHandle(key, { create: false });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'NotFoundError') return undefined;
+    throw err;
+  }
+  try {
+    const text = await (await handle.getFile()).text();
+    const parsed: unknown = JSON.parse(text);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    // A torn or malformed sidecar is discarded; the receive falls back to a fresh start.
+    return undefined;
+  }
+}
+
+/** OPFS-backed resume store. Reads and writes tolerate a missing or half-written sidecar. */
+export function opfsResumeStore(): ResumeStore {
+  return {
+    async get(room) {
+      return readSidecar(await opfsRoot(), sidecarKey(room));
+    },
+    async put(record) {
+      const root = await opfsRoot();
+      const handle = await root.getFileHandle(sidecarKey(record.room), { create: true });
+      const writable = (await handle.createWritable({
+        keepExistingData: false,
+      })) as WritableFileLike;
+      const bytes = new TextEncoder().encode(JSON.stringify(record));
+      try {
+        await writable.write({ type: 'write', position: 0, data: bytes });
+        await writable.close();
+      } catch (err) {
+        await writable.abort?.();
+        throw new TransferError('sink_error', err instanceof Error ? err.message : String(err));
+      }
+    },
+    async delete(room) {
+      const root = await opfsRoot();
+      await root.removeEntry(sidecarKey(room)).catch(() => {});
+    },
+    async list() {
+      const root = (await opfsRoot()) as DirectoryWithValues;
+      if (typeof root.values !== 'function') return [];
+      const records: ResumeRecord[] = [];
+      for await (const entry of root.values()) {
+        if (
+          entry.kind !== 'file' ||
+          !entry.name.startsWith(PREFIX) ||
+          !entry.name.endsWith(SUFFIX)
+        ) {
+          continue;
+        }
+        const record = await readSidecar(root, entry.name);
+        if (record) records.push(record);
+      }
+      return records;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Two OPFS-backed storage primitives that a resumable receive is built on. Today's web sink opens a `FileSystemWritableFileStream` — it truncates on open and only commits at close, so nothing written mid-transfer is durable across a reload.

- **`DurableOpfsFile`** wraps a `createSyncAccessHandle` (worker-only): keeps existing bytes, writes positioned blocks straight through, and exposes `read`/`truncate`/`getSize`/`flush`. That is everything a reloaded receiver needs to re-seed its whole-file digest from the committed prefix and drop a torn tail.
- **`opfsResumeStore`** keys one small JSON sidecar per room recording the durable file and its flushed high-water mark. The sidecar is written *after* the data file flushes, so it can lag the data but never lead it — a lost update re-receives a few blocks, never corrupts.

Both are pure storage primitives; the worker wiring that consumes them lands in the next PR.

## Testing

- `just typecheck` — 0 errors
- `just lint` — 0 issues
- `prettier --check` — clean
- `just test` — 65 web tests pass (13 files), protocol + Go green
- `just build` — passes

New unit tests cover positioned write + prefix read-back, torn-tail truncation, flush-then-close idempotency, abort-without-flush, write-after-close and short-write rejection; and for the store: round-trip, absent room, overwrite, delete, and skipping torn/malformed sidecars.