### PR TITLE
feat(web): back single-file OPFS receive with a durable handle

### DIFF
--- a/apps/web/src/lib/transfer/sink.test.ts
+++ b/apps/web/src/lib/transfer/sink.test.ts
@@ -35,6 +35,41 @@ class FakeWritable implements WritableFileLike {
   }
 }
 
+/** A growable buffer exposing the synchronous read/write/truncate surface the durable sink uses. */
+class FakeSyncHandle {
+  bytes = new Uint8Array();
+  closed = false;
+  write(buffer: Uint8Array, options?: { at?: number }): number {
+    const at = options?.at ?? 0;
+    const end = at + buffer.length;
+    if (end > this.bytes.length) {
+      const grown = new Uint8Array(end);
+      grown.set(this.bytes);
+      this.bytes = grown;
+    }
+    this.bytes.set(buffer, at);
+    return buffer.length;
+  }
+  read(buffer: Uint8Array, options?: { at?: number }): number {
+    const at = options?.at ?? 0;
+    const n = Math.max(0, Math.min(buffer.length, this.bytes.length - at));
+    buffer.set(this.bytes.subarray(at, at + n));
+    return n;
+  }
+  truncate(size: number): void {
+    const next = new Uint8Array(size);
+    next.set(this.bytes.subarray(0, Math.min(size, this.bytes.length)));
+    this.bytes = next;
+  }
+  getSize(): number {
+    return this.bytes.length;
+  }
+  flush(): void {}
+  close(): void {
+    this.closed = true;
+  }
+}
+
 function manifest(names: Array<[string, number]>): Manifest {
   return {
     type: FrameType.Manifest,
@@ -123,6 +158,60 @@ describe('browser destinations', () => {
       reason: 'quota',
     });
     expect(root.getFileHandle).not.toHaveBeenCalled();
+  });
+
+  it('routes a single auto-selected file through a durable sync-access handle', async () => {
+    const handle = new FakeSyncHandle();
+    const removeEntry = vi.fn(async () => {});
+    vi.stubGlobal('navigator', {
+      storage: {
+        estimate: vi.fn(async () => ({ quota: 1 << 30, usage: 0 })),
+        getDirectory: vi.fn(async () => ({
+          getFileHandle: vi.fn(async () => ({
+            createSyncAccessHandle: vi.fn(async () => handle),
+          })),
+          removeEntry,
+        })),
+      },
+    });
+
+    const one = manifest([['clip.bin', 3]]);
+    const destination = createBrowserDestination({ kind: 'auto' });
+    await destination.prepare(one);
+    const sink = await destination.open(one.files[0]!);
+    await sink.write(0, new Uint8Array([1, 2]));
+    await sink.write(2, new Uint8Array([3]));
+    await sink.close();
+    expect(handle.bytes).toEqual(new Uint8Array([1, 2, 3]));
+    expect(handle.closed).toBe(true);
+    expect(destination.result()).toMatchObject({ kind: 'opfs', name: 'clip.bin' });
+    expect(removeEntry).not.toHaveBeenCalled();
+  });
+
+  it('drops the durable handle and removes the entry on abort', async () => {
+    const handle = new FakeSyncHandle();
+    const removeEntry = vi.fn(async () => {});
+    vi.stubGlobal('navigator', {
+      storage: {
+        estimate: vi.fn(async () => ({ quota: 1 << 30, usage: 0 })),
+        getDirectory: vi.fn(async () => ({
+          getFileHandle: vi.fn(async () => ({
+            createSyncAccessHandle: vi.fn(async () => handle),
+          })),
+          removeEntry,
+        })),
+      },
+    });
+
+    const one = manifest([['clip.bin', 3]]);
+    const destination = createBrowserDestination({ kind: 'auto' });
+    await destination.prepare(one);
+    await destination.open(one.files[0]!);
+    await destination.abort('canceled');
+    expect(handle.closed).toBe(true);
+    const output = destination.result();
+    expect(output?.kind).toBe('opfs');
+    expect(removeEntry).toHaveBeenCalledWith(output?.kind === 'opfs' ? output.key : '');
   });
 
   it('writes a direct single-file destination without staging in memory', async () => {

--- a/apps/web/src/lib/transfer/sink.ts
+++ b/apps/web/src/lib/transfer/sink.ts
@@ -7,6 +7,7 @@ import {
   type Sink,
 } from '@sendarc/protocol';
 import { streamSink, type WritableFileLike } from './stream-sink.js';
+import { opfsRoot, openDurableOpfsFile, type DurableOpfsFile } from './opfs-file.js';
 import type { ReceiveDestinationSpec } from './wire.js';
 
 export type DestinationOutput =
@@ -112,30 +113,34 @@ class DirectDirectoryDestination implements BrowserDestination {
   }
 }
 
+/**
+ * Single-file OPFS receive backed by a durable sync-access handle. Unlike a writable stream (which
+ * truncates on open and only commits at close), the handle keeps existing bytes, writes straight
+ * through, and can read its committed prefix back — the substrate a reloaded receiver resumes from.
+ * A fresh unique key names an empty file per transfer, so this stays behaviour-identical to the
+ * writable-stream path until a resume seed is threaded in.
+ */
 class OpfsFileDestination implements BrowserDestination {
-  private root: FileSystemDirectoryHandle | undefined;
   private key = '';
   private outputName = '';
   private mime = '';
-  private sink: Sink | undefined;
+  private sink: DurableOpfsFile | undefined;
   async prepare(manifest: Manifest): Promise<void> {
     await ensureQuota(manifest.totalSize);
     const file = manifest.files[0]!;
-    this.root = await opfsRoot();
     this.outputName = file.name;
     this.mime = file.mime;
     this.key = uniqueKey(file.name);
   }
   async open(): Promise<Sink> {
-    if (!this.root || this.sink) throw new TransferError('sink_error', 'OPFS destination state');
-    const handle = await this.root.getFileHandle(this.key, { create: true });
-    const writable = (await handle.createWritable({ keepExistingData: false })) as WritableFileLike;
-    return (this.sink = streamSink(writable));
+    if (this.sink) throw new TransferError('sink_error', 'OPFS destination state');
+    return (this.sink = await openDurableOpfsFile(this.key));
   }
   close(): void {}
-  async abort(reason?: string): Promise<void> {
-    await this.sink?.abort(reason);
-    if (this.root && this.key) await this.root.removeEntry(this.key).catch(() => {});
+  async abort(): Promise<void> {
+    // Drop the handle's exclusive lock before removing the entry, or the removal blocks.
+    this.sink?.abort();
+    if (this.key) await (await opfsRoot()).removeEntry(this.key).catch(() => {});
   }
   result(): DestinationOutput {
     return { kind: 'opfs', key: this.key, name: this.outputName, mime: this.mime };
@@ -284,14 +289,6 @@ export async function readOpfsOutput(key: string, name: string, mime: string): P
 export async function removeOpfsOutput(key: string): Promise<void> {
   const root = await opfsRoot();
   await root.removeEntry(key).catch(() => {});
-}
-
-async function opfsRoot(): Promise<FileSystemDirectoryHandle> {
-  const storage = navigator.storage as StorageManager | undefined;
-  if (!storage || typeof storage.getDirectory !== 'function') {
-    throw new TransferError('sink_error', 'Origin Private File System is unavailable');
-  }
-  return storage.getDirectory();
 }
 
 const crcTable = Array.from({ length: 256 }, (_, value) => {


### PR DESCRIPTION
## Summary

Routes the auto-selected single-file OPFS receive destination through a durable **sync-access handle** (`DurableOpfsFile`, added in #67) instead of a `FileSystemWritableFileStream`.

A writable stream truncates on open and only commits at close. The sync-access handle keeps existing bytes, writes straight through, and can read its committed prefix back — the substrate a reloaded receiver resumes from. This PR lays that substrate without changing behaviour: each transfer still mints a fresh unique key, so the file starts empty and the observable result (received file lands in OPFS, download link works) is identical.

Also dedupes the private `opfsRoot()` in `sink.ts` in favour of the one exported from `opfs-file.ts`.

## What changed
- `OpfsFileDestination` now opens via `openDurableOpfsFile(key)` and returns the `DurableOpfsFile` directly (it already implements `Sink`).
- `abort()` drops the handle's exclusive lock before removing the entry (a sync-access handle blocks removal while locked).
- Removed the duplicate private `opfsRoot()`.

## Tests
- Added two focused tests covering the `auto`→durable path: a positioned-write round-trip through a fake sync-access handle, and lock-drop-then-remove on abort.
- Full gate green locally: typecheck, lint, `format:check`, test (web 67 / protocol 143 / Go), build.

Foundation for the resume-across-reload wiring that follows.