### PR TITLE
feat(cli): add NAT lab with tc-based degraded-network profiles (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,45 @@ jobs:
       - name: Build
         run: pnpm run build
 
+  e2e:
+    name: e2e (chromium, firefox)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: apps/server/go.sum
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build protocol package
+        run: pnpm --filter @sendarc/protocol build
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @sendarc/web exec playwright install --with-deps chromium firefox
+
+      - name: Run e2e
+        run: pnpm --filter @sendarc/web e2e
+
+      - name: Upload failure traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: apps/web/test-results/
+          retention-days: 7
+
   go:
     name: ${{ matrix.module }} (vet, test, build)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /bin/
 apps/web/dist/
 apps/web/.svelte-kit/
+apps/web/test-results/
+apps/web/playwright-report/
 apps/server/sendarcd
 packages/protocol/dist/
 

--- a/apps/cli/cmd/natbox/main.go
+++ b/apps/cli/cmd/natbox/main.go
@@ -1,0 +1,428 @@
+// Command natbox is a userspace NAT used by the NAT lab (cmd/natlab). It sits between a
+// private network segment and a public one, translating UDP 5-tuples exactly as a
+// residential gateway would, with a configurable mapping policy:
+//
+//	full-cone       one external port per internal flow; inbound from anyone
+//	restricted      one external port per internal flow; inbound from hosts we sent to
+//	port-restricted one external port per internal flow; inbound from (host, port) pairs
+//	                we sent to
+//	symmetric       a fresh external port per destination (host, port); inbound only from
+//	                that exact destination
+//
+// The private side is a raw AF_PACKET socket on a veth: outbound frames are parsed and
+// re-encapsulated through kernel UDP sockets bound on the public interface (the mapped
+// address), so no packet mangling or checksum surgery is needed. Kernel ip_forward must
+// be off in this namespace — the daemon is the only forwarder. TCP (the lab's signaling
+// WebSocket) is handled by a plain port-forwarding proxy to the public server.
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+
+	"log"
+	"net"
+	"net/netip"
+	"os"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const ethPAll = 0x0003 // ETH_P_ALL
+
+type policy int
+
+const (
+	policyFullCone policy = iota
+	policyRestricted
+	policyPortRestricted
+	policySymmetric
+)
+
+func parsePolicy(s string) (policy, error) {
+	switch s {
+	case "full-cone":
+		return policyFullCone, nil
+	case "restricted":
+		return policyRestricted, nil
+	case "port-restricted":
+		return policyPortRestricted, nil
+	case "symmetric":
+		return policySymmetric, nil
+	}
+	return 0, fmt.Errorf("unknown policy %q", s)
+}
+
+// mapping is one translated UDP flow: the internal endpoint, the pinned external
+// destination (symmetric only), and the set of destinations it has spoken to.
+type mapping struct {
+	internal netip.AddrPort
+	dst      netip.AddrPort // pinned destination for symmetric; zero otherwise
+	allowed  map[netip.AddrPort]struct{}
+	conn     *net.UDPConn
+	lastSeen time.Time
+}
+
+type natbox struct {
+	policy  policy
+	pubIP   netip.Addr
+	privIP  netip.Addr
+	privMAC [6]byte
+	peerMAC [6]byte
+	ifindex int
+	raw     int
+
+	mu       sync.Mutex
+	mappings map[string]*mapping // key: internal string, or internal>dst for symmetric
+	logged   atomic.Bool
+}
+
+func main() {
+	privIf := flag.String("priv-if", "", "private-side veth interface name")
+	privIP := flag.String("priv-ip", "", "private-side IP address")
+	pubIf := flag.String("pub-if", "", "public-side veth interface name (for MAC resolution only)")
+	pubIP := flag.String("pub-ip", "", "public-side IP address")
+	pol := flag.String("policy", "full-cone", "full-cone | restricted | port-restricted | symmetric")
+	proxy := flag.String("tcp-forward", "", "destination host:port for a TCP proxy bound on priv-ip:8443")
+	flag.Parse()
+
+	if *privIf == "" || *privIP == "" || *pubIf == "" || *pubIP == "" {
+		log.Fatal("natbox: -priv-if, -priv-ip, -pub-if, -pub-ip are required")
+	}
+	p, err := parsePolicy(*pol)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	raw, err := openPacketSocket(*privIf)
+	if err != nil {
+		log.Fatalf("natbox: %v", err)
+	}
+	mac, err := ifaceMAC(*privIf)
+	if err != nil {
+		log.Fatalf("natbox: %v", err)
+	}
+
+	n := &natbox{
+		policy:   p,
+		pubIP:    netip.MustParseAddr(*pubIP),
+		privIP:   netip.MustParseAddr(*privIP),
+		privMAC:  mac,
+		ifindex:  ifindex(*privIf),
+		raw:      raw,
+		mappings: make(map[string]*mapping),
+	}
+
+	if *proxy != "" {
+		go n.tcpProxy(*proxy)
+	}
+	go n.sweeper()
+
+	fmt.Fprintf(os.Stderr, "natbox: policy=%s private=%s(%s) public=%s\n", *pol, *privIf, *privIP, *pubIP)
+	if err := n.serve(); err != nil {
+		log.Fatalf("natbox: %v", err)
+	}
+}
+
+func (n *natbox) serve() error {
+	buf := make([]byte, 64*1024)
+	for {
+		rn, _, err := syscall.Recvfrom(n.raw, buf, 0)
+		if err != nil {
+			return err
+		}
+		n.handleFrame(buf[:rn])
+	}
+}
+
+func (n *natbox) handleFrame(frame []byte) {
+	if len(frame) < 14+20+8 {
+		return
+	}
+	if binary.BigEndian.Uint16(frame[12:14]) != 0x0800 { // IPv4 only; ARP rides the kernel
+		return
+	}
+	ip := frame[14:]
+	if ip[0]>>4 != 4 || ip[9] != 17 { // UDP only; TCP rides the proxy
+		return
+	}
+	ihl := int(ip[0]&0x0f) * 4
+	if len(ip) < ihl+8 {
+		return
+	}
+	src := netip.AddrFrom4([4]byte(ip[12:16]))
+	dst := netip.AddrFrom4([4]byte(ip[16:20]))
+	udp := ip[ihl:]
+	if len(udp) < 8 {
+		return
+	}
+	internal := netip.AddrPortFrom(src, binary.BigEndian.Uint16(udp[0:2]))
+	ext := netip.AddrPortFrom(dst, binary.BigEndian.Uint16(udp[2:4]))
+
+	fragOff := binary.BigEndian.Uint16(ip[6:8])
+	if fragOff&0x1fff != 0 {
+		// Non-initial IP fragment: WebRTC traffic is small enough to never fragment on a
+		// 9 KB MTU; drop defensively.
+		log.Printf("natbox: dropping non-initial fragment from %s", src)
+		return
+	}
+	payload := udp[8:]
+
+	n.mu.Lock()
+	copy(n.peerMAC[:], frame[6:12]) // learn the peer's MAC from its own frames
+	key, pin := n.key(internal, ext)
+	m, ok := n.mappings[key]
+	if !ok {
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IP(n.pubIP.AsSlice()), Port: 0})
+		if err != nil {
+			log.Printf("natbox: open mapping: %v", err)
+			n.mu.Unlock()
+			return
+		}
+		m = &mapping{
+			internal: internal,
+			dst:      pin,
+			allowed:  make(map[netip.AddrPort]struct{}),
+			conn:     conn,
+		}
+		n.mappings[key] = m
+	}
+	m.lastSeen = time.Now()
+	m.allowed[ext] = struct{}{}
+	n.mu.Unlock()
+	if !ok {
+		go n.pump(m)
+	}
+
+	if _, err := m.conn.WriteTo(payload, net.UDPAddrFromAddrPort(ext)); err != nil {
+		// Unroutable destinations (e.g. a peer's private host candidate reaching the
+		// public segment) are a normal part of ICE; log the first few only.
+		if n.logged.CompareAndSwap(false, true) {
+			log.Printf("natbox: forward: %v", err)
+		}
+	}
+}
+
+// pump reads datagrams that arrive on a mapping's external port and delivers them to
+// the internal peer, enforcing the inbound policy.
+func (n *natbox) pump(m *mapping) {
+	buf := make([]byte, 64*1024)
+	for {
+		rn, raddr, err := m.conn.ReadFromUDP(buf)
+		if err != nil {
+			return
+		}
+		src := raddr.AddrPort()
+		if !n.allowInbound(m, src) {
+			continue
+		}
+		n.inject(m, src, buf[:rn])
+	}
+}
+
+func (n *natbox) allowInbound(m *mapping, src netip.AddrPort) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	switch n.policy {
+	case policyFullCone:
+		return true
+	case policyRestricted:
+		for a := range m.allowed {
+			if a.Addr() == src.Addr() {
+				return true
+			}
+		}
+		return false
+	case policyPortRestricted:
+		_, ok := m.allowed[src]
+		return ok
+	case policySymmetric:
+		return src == m.dst
+	}
+	return false
+}
+
+// inject rewrites an inbound datagram back to the internal peer as an Ethernet frame on
+// the private veth.
+func (n *natbox) inject(m *mapping, src netip.AddrPort, payload []byte) {
+	if len(payload) > 0xffff-28 {
+		return
+	}
+	ipLen := 20 + 8 + len(payload)
+	frame := make([]byte, 14+ipLen)
+	copy(frame[0:6], n.peerMAC[:])
+	copy(frame[6:12], n.privMAC[:])
+	binary.BigEndian.PutUint16(frame[12:14], 0x0800)
+
+	ip := frame[14:]
+	ip[0] = 0x45
+	binary.BigEndian.PutUint16(ip[2:4], uint16(ipLen))
+	ip[8] = 64
+	ip[9] = 17
+	src4 := src.Addr().As4()
+	dst4 := m.internal.Addr().As4()
+	copy(ip[12:16], src4[:])
+	copy(ip[16:20], dst4[:])
+	binary.BigEndian.PutUint16(ip[10:12], checksum(ip[:20]))
+
+	udp := ip[20:]
+	binary.BigEndian.PutUint16(udp[0:2], src.Port())
+	binary.BigEndian.PutUint16(udp[2:4], m.internal.Port())
+	binary.BigEndian.PutUint16(udp[4:6], uint16(8+len(payload)))
+	copy(udp[8:], payload)
+	binary.BigEndian.PutUint16(udp[6:8], udpChecksum(src4, dst4, udp))
+
+	if err := syscall.Sendto(n.raw, frame, 0, &syscall.SockaddrLinklayer{Ifindex: n.ifindex}); err != nil {
+		log.Printf("natbox: inject: %v", err)
+	}
+}
+
+func (n *natbox) key(internal, dst netip.AddrPort) (string, netip.AddrPort) {
+	if n.policy == policySymmetric {
+		return internal.String() + ">" + dst.String(), dst
+	}
+	return internal.String(), netip.AddrPort{}
+}
+
+// tcpProxy forwards priv-ip:8443 to the public signaling server.
+func (n *natbox) tcpProxy(dst string) {
+	l, err := net.Listen("tcp", net.JoinHostPort(n.privIP.String(), "8443"))
+	if err != nil {
+		log.Printf("natbox: tcp proxy: %v", err)
+		return
+	}
+	defer l.Close()
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			defer c.Close()
+			up, err := net.DialTimeout("tcp", dst, 5*time.Second)
+			if err != nil {
+				log.Printf("natbox: tcp proxy dial: %v", err)
+				return
+			}
+			defer up.Close()
+			if tc, ok := c.(*net.TCPConn); ok {
+				_ = tc.SetNoDelay(true)
+			}
+			if tc, ok := up.(*net.TCPConn); ok {
+				_ = tc.SetNoDelay(true)
+			}
+			done := make(chan struct{}, 2)
+			go func() {
+				n, err := relayCopy(up, c)
+				log.Printf("natbox: tcp proxy c->up done: %d bytes: %v", n, err)
+				done <- struct{}{}
+			}()
+			go func() {
+				n, err := relayCopy(c, up)
+				log.Printf("natbox: tcp proxy up->c done: %d bytes: %v", n, err)
+				done <- struct{}{}
+			}()
+			<-done
+			log.Printf("natbox: tcp proxy closed %s <-> %s", c.RemoteAddr(), up.RemoteAddr())
+		}()
+	}
+}
+
+// relayCopy moves bytes between two TCP sockets without the kernel splice fast path,
+// which misbehaves over the lab's 9 KB-MTU veth pairs when flow control kicks in.
+func relayCopy(dst, src net.Conn) (int64, error) {
+	buf := make([]byte, 64*1024)
+	var total int64
+	for {
+		start := time.Now()
+		n, err := src.Read(buf)
+		if n > 0 {
+			wstart := time.Now()
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				log.Printf("natbox: relayCopy %s->%s chunk=%d r=%v w=%v werr=%v", src.RemoteAddr(), dst.RemoteAddr(), n, time.Since(start), time.Since(wstart), werr)
+				return total, werr
+			}
+			total += int64(n)
+			log.Printf("natbox: relayCopy %s->%s chunk=%d r=%v w=%v total=%d", src.RemoteAddr(), dst.RemoteAddr(), n, time.Since(start), time.Since(wstart), total)
+		}
+		if err != nil {
+			return total, err
+		}
+	}
+}
+
+// sweeper expires stale UDP mappings.
+func (n *natbox) sweeper() {
+	t := time.NewTicker(30 * time.Second)
+	for range t.C {
+		n.mu.Lock()
+		for k, m := range n.mappings {
+			if time.Since(m.lastSeen) > 90*time.Second {
+				m.conn.Close()
+				delete(n.mappings, k)
+			}
+		}
+		n.mu.Unlock()
+	}
+}
+
+// --- helpers ----------------------------------------------------------------
+
+func htons(v uint16) uint16 { return v<<8 | v>>8 }
+
+func openPacketSocket(ifname string) (int, error) {
+	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(ethPAll)))
+	if err != nil {
+		return 0, err
+	}
+	sll := &syscall.SockaddrLinklayer{Protocol: htons(ethPAll), Ifindex: ifindex(ifname), Pkttype: syscall.PACKET_HOST}
+	if err := syscall.Bind(fd, sll); err != nil {
+		return 0, err
+	}
+	return fd, nil
+}
+
+func ifindex(ifname string) int {
+	ifc, err := net.InterfaceByName(ifname)
+	if err != nil {
+		return 0
+	}
+	return ifc.Index
+}
+
+func ifaceMAC(ifname string) ([6]byte, error) {
+	ifc, err := net.InterfaceByName(ifname)
+	if err != nil {
+		return [6]byte{}, err
+	}
+	var mac [6]byte
+	copy(mac[:], ifc.HardwareAddr)
+	return mac, nil
+}
+
+func checksum(b []byte) uint16 {
+	var sum uint32
+	for i := 0; i+1 < len(b); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(b[i : i+2]))
+	}
+	if len(b)%2 == 1 {
+		sum += uint32(b[len(b)-1]) << 8
+	}
+	for sum>>16 != 0 {
+		sum = sum&0xffff + sum>>16
+	}
+	return ^uint16(sum)
+}
+
+func udpChecksum(src4, dst4 [4]byte, udp []byte) uint16 {
+	buf := make([]byte, 12+len(udp))
+	copy(buf[0:4], src4[:])
+	copy(buf[4:8], dst4[:])
+	buf[9] = 17
+	binary.BigEndian.PutUint16(buf[10:12], uint16(len(udp)))
+	copy(buf[12:], udp)
+	return checksum(buf)
+}

--- a/apps/cli/cmd/natbox/main.go
+++ b/apps/cli/cmd/natbox/main.go
@@ -294,20 +294,20 @@ func (n *natbox) tcpProxy(dst string) {
 		log.Printf("natbox: tcp proxy: %v", err)
 		return
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	for {
 		c, err := l.Accept()
 		if err != nil {
 			return
 		}
 		go func() {
-			defer c.Close()
+			defer func() { _ = c.Close() }()
 			up, err := net.DialTimeout("tcp", dst, 5*time.Second)
 			if err != nil {
 				log.Printf("natbox: tcp proxy dial: %v", err)
 				return
 			}
-			defer up.Close()
+			defer func() { _ = up.Close() }()
 			if tc, ok := c.(*net.TCPConn); ok {
 				_ = tc.SetNoDelay(true)
 			}
@@ -361,7 +361,7 @@ func (n *natbox) sweeper() {
 		n.mu.Lock()
 		for k, m := range n.mappings {
 			if time.Since(m.lastSeen) > 90*time.Second {
-				m.conn.Close()
+				_ = m.conn.Close()
 				delete(n.mappings, k)
 			}
 		}

--- a/apps/cli/cmd/natlab/main.go
+++ b/apps/cli/cmd/natlab/main.go
@@ -326,20 +326,20 @@ func (l *lab) setup() error {
 	}
 
 	// Services in the public segment: signaling + STUN.
-	if c, err := l.nsSpawn(pub, []string{"SENDARC_ADDR=" + pubHost + ":8443"}, l.server); err != nil {
+	c, err := l.nsSpawn(pub, []string{"SENDARC_ADDR=" + pubHost + ":8443"}, l.server)
+	if err != nil {
 		return fmt.Errorf("sendarcd: %w", err)
-	} else {
-		l.mu.Lock()
-		l.keep = append(l.keep, c)
-		l.mu.Unlock()
 	}
-	if c, err := l.nsSpawn(pub, nil, l.stund, "-addr", pubHost+":3478"); err != nil {
+	l.mu.Lock()
+	l.keep = append(l.keep, c)
+	l.mu.Unlock()
+	c, err = l.nsSpawn(pub, nil, l.stund, "-addr", pubHost+":3478")
+	if err != nil {
 		return fmt.Errorf("stund: %w", err)
-	} else {
-		l.mu.Lock()
-		l.keep = append(l.keep, c)
-		l.mu.Unlock()
 	}
+	l.mu.Lock()
+	l.keep = append(l.keep, c)
+	l.mu.Unlock()
 
 	time.Sleep(500 * time.Millisecond)
 	return nil

--- a/apps/cli/cmd/natlab/main.go
+++ b/apps/cli/cmd/natlab/main.go
@@ -1,0 +1,618 @@
+// Command natlab runs a hermetic NAT lab for SendArc's transport selection. It builds
+// two isolated private networks, each behind a userspace NAT box (cmd/natbox) with a
+// configurable mapping policy, joined by a shared public segment that hosts a signaling
+// server (sendarcd) and a STUN server (cmd/stund). For each policy pair it runs one real
+// CLI transfer and reports whether the file moved over the direct WebRTC path or fell
+// back to the encrypted relay, then verifies the received bytes.
+//
+// The whole lab runs unprivileged: launch it with
+//
+//	unshare -Urnm natlab [flags]
+//
+// so the harness owns a user namespace and can create netns + veths without root on the
+// host. Every stage is orchestrated through `ip` and `nsenter`, which must be on PATH.
+package main
+
+import (
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	pubHost  = "10.0.3.100" // signaling + STUN server in the public segment
+	privAIP  = "10.0.0.1"   // NAT-A private gateway
+	privBIP  = "10.0.1.1"   // NAT-B private gateway
+	hostFile = "payload.bin"
+)
+
+var codeRe = regexp.MustCompile(`\d+-[a-z]+-[a-z]+`)
+
+type netns struct {
+	name string
+	pid  int
+}
+
+func main() {
+	fileSize := flag.Int("file-size", 4*1024*1024, "payload size in bytes")
+	serverBin := flag.String("server-bin", "", "path to the built sendarcd binary (required)")
+	combos := flag.String("combos",
+		"full-cone/full-cone,restricted/restricted,port-restricted/port-restricted,symmetric/symmetric,full-cone/symmetric",
+		"comma-separated NAT policy pairs (A/B)")
+	noproxy := flag.Bool("noproxy", false, "skip NAT boxes: both peers run in the public segment over forced relay (control)")
+	netem := flag.String("netem", "", "degraded-network profile applied to both bridge legs: 'loss 3%', 'delay 50ms', or 'rate 10mbit'")
+	flag.Parse()
+
+	if os.Geteuid() != 0 {
+		log.Fatal("natlab: must run as root inside a user namespace: unshare -Urnm natlab [flags]")
+	}
+	if *serverBin == "" {
+		log.Fatal("natlab: -server-bin is required (build apps/server/cmd/sendarcd first)")
+	}
+
+	binDir, err := os.MkdirTemp("", "natlab")
+	if err != nil {
+		log.Fatal(err)
+	}
+	binPath := func(name, pkg string) string {
+		out := filepath.Join(binDir, name)
+		root, err := moduleRoot()
+		if err != nil {
+			log.Fatalf("natlab: %v", err)
+		}
+		cmd := exec.Command("go", "build", "-o", out, pkg)
+		cmd.Dir = root
+		if outB, err := cmd.CombinedOutput(); err != nil {
+			log.Fatalf("natlab: build %s: %v\n%s", pkg, err, outB)
+		}
+		return out
+	}
+	sendarc := binPath("sendarc", "./cmd/sendarc")
+	natbox := binPath("natbox", "./cmd/natbox")
+	stund := binPath("stund", "./cmd/stund")
+
+	src := filepath.Join(os.TempDir(), "natlab-"+hostFile)
+	payload := make([]byte, *fileSize)
+	if _, err := rand.New(rand.NewSource(42)).Read(payload); err != nil {
+		log.Fatal(err)
+	}
+	if err := os.WriteFile(src, payload, 0o644); err != nil {
+		log.Fatal(err)
+	}
+	dstDir := filepath.Join(os.TempDir(), fmt.Sprintf("natlab-recv-%d", os.Getpid()))
+	_ = os.RemoveAll(dstDir)
+
+	lab := &lab{
+		sendarc: sendarc,
+		natbox:  natbox,
+		stund:   stund,
+		server:  *serverBin,
+		src:     src,
+		dstDir:  dstDir,
+		expect:  sha256.Sum256(payload),
+		noproxy: *noproxy,
+	}
+	if err := lab.setup(); err != nil {
+		lab.cleanup()
+		log.Fatalf("natlab: setup: %v", err)
+	}
+	defer lab.cleanup()
+	if *netem != "" {
+		if err := lab.applyNetem(*netem); err != nil {
+			lab.cleanup()
+			log.Fatalf("natlab: netem: %v", err)
+		}
+	}
+
+	var pairs [][2]string
+	for _, c := range strings.Split(*combos, ",") {
+		parts := strings.SplitN(c, "/", 2)
+		if len(parts) != 2 {
+			log.Fatalf("natlab: bad combo %q", c)
+		}
+		pairs = append(pairs, [2]string{parts[0], parts[1]})
+	}
+
+	failed := false
+	for _, pair := range pairs {
+		start := time.Now()
+		ok, transport, err := lab.runTransfer(pair[0], pair[1])
+		if err != nil {
+			log.Printf("combo %s/%s: ERROR after %v: %v", pair[0], pair[1], time.Since(start).Round(time.Millisecond), err)
+			failed = true
+			continue
+		}
+		log.Printf("combo %s/%s: %s, digest %t, %v", pair[0], pair[1], transport, ok, time.Since(start).Round(time.Millisecond))
+		if !ok {
+			failed = true
+		}
+	}
+	if failed {
+		os.Exit(1)
+	}
+}
+
+type lab struct {
+	sendarc, natbox, stund, server string
+	src, dstDir                    string
+	expect                         [32]byte
+	noproxy                        bool
+
+	mu    sync.Mutex
+	nses  []*netns
+	procs []*exec.Cmd // per-combo processes (natboxes, transfers); killed between combos
+	keep  []*exec.Cmd // long-lived processes (netns holders, services); killed at cleanup
+}
+
+func (l *lab) cleanup() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, c := range append(l.procs, l.keep...) {
+		_ = c.Process.Kill()
+	}
+	for _, n := range l.nses {
+		_ = syscall.Kill(n.pid, syscall.SIGKILL)
+	}
+	l.procs = nil
+	l.keep = nil
+	l.nses = nil
+}
+
+// killCombo stops the per-combo processes and clears the list.
+func (l *lab) killCombo() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, c := range l.procs {
+		_ = c.Process.Kill()
+	}
+	l.procs = nil
+}
+
+func (l *lab) spawnNetns(name string) (*netns, error) {
+	cmd := exec.Command("sleep", "infinity")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Cloneflags: syscall.CLONE_NEWNET}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("spawn %s: %w", name, err)
+	}
+	go func() { _ = cmd.Wait() }() // detached; the netns lives until cleanup
+	l.mu.Lock()
+	l.keep = append(l.keep, cmd)
+	l.nses = append(l.nses, &netns{name: name, pid: cmd.Process.Pid})
+	l.mu.Unlock()
+	return &netns{name: name, pid: cmd.Process.Pid}, nil
+}
+
+// nsRun executes a command inside a netns via nsenter -t <pid> -n.
+func (l *lab) nsRun(ns *netns, args ...string) error {
+	full := append([]string{"-t", fmt.Sprint(ns.pid), "-n"}, args...)
+	return exec.Command("nsenter", full...).Run()
+}
+
+// nsSpawn starts a long-running process inside a netns. The caller decides whether it
+// belongs in l.keep (services) or l.procs (per-combo NAT boxes).
+func (l *lab) nsSpawn(ns *netns, env []string, cmd string, args ...string) (*exec.Cmd, error) {
+	full := append([]string{"-t", fmt.Sprint(ns.pid), "-n"}, append([]string{cmd}, args...)...)
+	c := exec.Command("nsenter", full...)
+	c.Env = append(os.Environ(), env...)
+	c.Stdout = os.Stderr
+	c.Stderr = os.Stderr
+	if err := c.Start(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (l *lab) veth(nameA string, nsA *netns, nameB string, nsB *netns) error {
+	if err := exec.Command("ip", "link", "add", nameA, "type", "veth", "peer", "name", nameB).Run(); err != nil {
+		return fmt.Errorf("veth %s/%s: %w", nameA, nameB, err)
+	}
+	if err := exec.Command("ip", "link", "set", nameA, "netns", fmt.Sprint(nsA.pid)).Run(); err != nil {
+		return err
+	}
+	return exec.Command("ip", "link", "set", nameB, "netns", fmt.Sprint(nsB.pid)).Run()
+}
+
+func (l *lab) setup() error {
+	nsA, _ := l.spawnNetns("a")
+	natA, _ := l.spawnNetns("natA")
+	pub, _ := l.spawnNetns("pub")
+	natB, _ := l.spawnNetns("natB")
+	nsB, _ := l.spawnNetns("b")
+
+	// Links: sender—natA, natA—pub, pub—server, natB—pub, natB—receiver.
+	for _, pair := range [][2]any{
+		{"a0", nsA}, {"a1", natA},
+		{"pa0", natA}, {"pa1", pub},
+		{"pb0", natB}, {"pb1", pub},
+		{"srv0", pub}, {"srv1", pub},
+		{"b0", nsB}, {"b1", natB},
+	} {
+		_ = pair
+	}
+	if err := l.veth("a0", nsA, "a1", natA); err != nil {
+		return err
+	}
+	if err := l.veth("pa0", natA, "pa1", pub); err != nil {
+		return err
+	}
+	if err := l.veth("pb0", natB, "pb1", pub); err != nil {
+		return err
+	}
+	if err := l.veth("srv0", pub, "srv1", pub); err != nil {
+		return err
+	}
+	if err := l.veth("b0", nsB, "b1", natB); err != nil {
+		return err
+	}
+
+	up := func(ns *netns, ifname string) error {
+		return l.nsRun(ns, "ip", "link", "set", ifname, "mtu", "9000", "up")
+	}
+	loopUp := func(ns *netns) error { return l.nsRun(ns, "ip", "link", "set", "lo", "up") }
+	addr := func(ns *netns, ifname, ip string) error {
+		return l.nsRun(ns, "ip", "addr", "add", ip, "dev", ifname)
+	}
+	route := func(ns *netns, gw string) error {
+		return l.nsRun(ns, "ip", "route", "add", "default", "via", gw)
+	}
+
+	steps := []struct {
+		ns *netns
+		fn func() error
+	}{
+		{nsA, func() error { return loopUp(nsA) }},
+		{natA, func() error { return loopUp(natA) }},
+		{pub, func() error { return loopUp(pub) }},
+		{natB, func() error { return loopUp(natB) }},
+		{nsB, func() error { return loopUp(nsB) }},
+		{nsA, func() error { return addr(nsA, "a0", "10.0.0.2/24") }},
+		{nsA, func() error { return up(nsA, "a0") }},
+		{nsA, func() error { return route(nsA, privAIP) }},
+		{natA, func() error { return addr(natA, "a1", privAIP+"/24") }},
+		{natA, func() error { return up(natA, "a1") }},
+		{natA, func() error { return addr(natA, "pa0", "10.0.3.1/24") }},
+		{natA, func() error { return up(natA, "pa0") }},
+		{natB, func() error { return addr(natB, "b1", privBIP+"/24") }},
+		{natB, func() error { return up(natB, "b1") }},
+		{natB, func() error { return addr(natB, "pb0", "10.0.3.2/24") }},
+		{natB, func() error { return up(natB, "pb0") }},
+		{nsB, func() error { return addr(nsB, "b0", "10.0.1.2/24") }},
+		{nsB, func() error { return up(nsB, "b0") }},
+		{nsB, func() error { return route(nsB, privBIP) }},
+	}
+	for _, s := range steps {
+		if err := s.fn(); err != nil {
+			return fmt.Errorf("configure: %w", err)
+		}
+	}
+
+	// Public segment: a bridge joining both NATs and the server host.
+	for _, step := range [][]string{
+		{"link", "add", "br0", "type", "bridge"},
+		{"link", "set", "br0", "mtu", "9000", "up"},
+		{"link", "set", "pa1", "mtu", "9000", "master", "br0"},
+		{"link", "set", "pa1", "mtu", "9000", "up"},
+		{"link", "set", "pb1", "mtu", "9000", "master", "br0"},
+		{"link", "set", "pb1", "mtu", "9000", "up"},
+		{"link", "set", "srv0", "mtu", "9000", "master", "br0"},
+		{"link", "set", "srv0", "mtu", "9000", "up"},
+	} {
+		if err := l.nsRun(pub, append([]string{"ip"}, step...)...); err != nil {
+			return fmt.Errorf("pub %v: %w", step, err)
+		}
+	}
+	if err := addr(pub, "srv1", pubHost+"/24"); err != nil {
+		return err
+	}
+	if err := up(pub, "srv1"); err != nil {
+		return err
+	}
+
+	// NAT namespaces must not forward: only the daemons translate.
+	for _, n := range []*netns{natA, natB} {
+		if err := l.nsRun(n, "sysctl", "-w", "net.ipv4.ip_forward=0"); err != nil {
+			return fmt.Errorf("%s ip_forward: %w", n.name, err)
+		}
+	}
+
+	// Services in the public segment: signaling + STUN.
+	if c, err := l.nsSpawn(pub, []string{"SENDARC_ADDR=" + pubHost + ":8443"}, l.server); err != nil {
+		return fmt.Errorf("sendarcd: %w", err)
+	} else {
+		l.mu.Lock()
+		l.keep = append(l.keep, c)
+		l.mu.Unlock()
+	}
+	if c, err := l.nsSpawn(pub, nil, l.stund, "-addr", pubHost+":3478"); err != nil {
+		return fmt.Errorf("stund: %w", err)
+	} else {
+		l.mu.Lock()
+		l.keep = append(l.keep, c)
+		l.mu.Unlock()
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	return nil
+}
+
+// applyNetem shapes the egress of both public bridge legs (pa1, pb1) so the
+// sender→receiver downlink experiences the given profile on the direct path and
+// the server→receiver relay leg. One qdisc per profile; loss and delay use netem,
+// rate limits use netem's own rate control (it segments like the real bottleneck).
+func (l *lab) applyNetem(spec string) error {
+	var qdisc string
+	switch {
+	case strings.HasPrefix(spec, "loss "):
+		qdisc = "netem loss " + strings.TrimPrefix(spec, "loss ")
+	case strings.HasPrefix(spec, "delay "):
+		qdisc = "netem delay " + strings.TrimPrefix(spec, "delay ")
+	case strings.HasPrefix(spec, "rate "):
+		qdisc = "netem rate " + strings.TrimPrefix(spec, "rate ")
+	default:
+		return fmt.Errorf("unsupported netem profile %q (want 'loss 3%%', 'delay 50ms', or 'rate 10mbit')", spec)
+	}
+	l.mu.Lock()
+	var pub *netns
+	for _, n := range l.nses {
+		if n.name == "pub" {
+			pub = n
+		}
+	}
+	l.mu.Unlock()
+	for _, ifname := range []string{"pa1", "pb1"} {
+		args := append([]string{"qdisc", "add", "dev", ifname, "root"}, strings.Split(qdisc, " ")...)
+		if err := l.nsRun(pub, append([]string{"tc"}, args...)...); err != nil {
+			return fmt.Errorf("tc on %s: %w", ifname, err)
+		}
+	}
+	log.Printf("netem: %q applied on pa1+pb1", qdisc)
+	return nil
+}
+
+// runTransfer runs one CLI transfer with the given NAT policies and reports the
+// transport that carried it.
+func (l *lab) runTransfer(polA, polB string) (bool, string, error) {
+	dst := l.comboDstDir()
+	if l.noproxy {
+		// Relay-path control: no NAT boxes, both peers sit in the public segment.
+		return l.runPlainRelay(dst)
+	}
+	l.mu.Lock()
+	var natA, natB, nsA, nsB, pub *netns
+	for _, n := range l.nses {
+		switch n.name {
+		case "a":
+			nsA = n
+		case "natA":
+			natA = n
+		case "natB":
+			natB = n
+		case "b":
+			nsB = n
+		case "pub":
+			pub = n
+		}
+	}
+	l.mu.Unlock()
+
+	spawnBox := func(ns *netns, pol, privIP, privIf, pubIf, pubIP string) error {
+		c, err := l.nsSpawn(ns, nil, l.natbox,
+			"-priv-if", privIf, "-priv-ip", privIP,
+			"-pub-if", pubIf, "-pub-ip", pubIP,
+			"-policy", pol,
+			"-tcp-forward", pubHost+":8443")
+		if err != nil {
+			return err
+		}
+		l.mu.Lock()
+		l.procs = append(l.procs, c)
+		l.mu.Unlock()
+		return nil
+	}
+	if err := spawnBox(natA, polA, privAIP, "a1", "pa0", "10.0.3.1"); err != nil {
+		return false, "", fmt.Errorf("natbox A: %w", err)
+	}
+	if err := spawnBox(natB, polB, privBIP, "b1", "pb0", "10.0.3.2"); err != nil {
+		return false, "", fmt.Errorf("natbox B: %w", err)
+	}
+	defer l.killCombo()
+
+	sender := exec.Command("nsenter", "-t", fmt.Sprint(nsA.pid), "-n",
+		l.sendarc, "send", l.src,
+		"--server", "ws://"+privAIP+":8443/ws",
+		"--ice-server", "stun:"+pubHost+":3478")
+	var senderOut, senderErr strings.Builder
+	sender.Stdout = &senderOut
+	sender.Stderr = &senderErr
+	if err := sender.Start(); err != nil {
+		return false, "", fmt.Errorf("start sender: %w", err)
+	}
+	l.mu.Lock()
+	l.procs = append(l.procs, sender)
+	l.mu.Unlock()
+
+	code := ""
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if m := codeRe.FindString(senderOut.String()); m != "" {
+			code = m
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if code == "" {
+		_ = sender.Process.Kill()
+		return false, "", fmt.Errorf("no invite code from sender: %s", senderErr.String())
+	}
+
+	receiver := exec.Command("nsenter", "-t", fmt.Sprint(nsB.pid), "-n",
+		l.sendarc, "receive", code,
+		"--server", "ws://"+privBIP+":8443/ws",
+		"--ice-server", "stun:"+pubHost+":3478",
+		"--out", dst)
+	var recvOut, recvErr strings.Builder
+	receiver.Stdout = &recvOut
+	receiver.Stderr = &recvErr
+	if err := receiver.Start(); err != nil {
+		return false, "", fmt.Errorf("start receiver: %w", err)
+	}
+	l.mu.Lock()
+	l.procs = append(l.procs, receiver)
+	l.mu.Unlock()
+
+	done := make(chan error, 1)
+	go func() { done <- receiver.Wait() }()
+	snap := time.NewTicker(2 * time.Second)
+	defer snap.Stop()
+	go func() {
+		for range snap.C {
+			for _, n := range []*netns{nsB, natB, pub} {
+				out, err := exec.Command("nsenter", "-t", fmt.Sprint(n.pid), "-n", "ss", "-tinp").CombinedOutput()
+				if err == nil {
+					fmt.Fprintf(os.Stderr, "--- sockets in %s ---\n%s", n.name, out)
+				}
+			}
+		}
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			_ = sender.Process.Kill()
+			return false, "", fmt.Errorf("receiver failed: %v\n--- receiver ---\n%s\n--- sender ---\n%s", err, recvErr.String(), senderErr.String())
+		}
+	case <-time.After(120 * time.Second):
+		_ = receiver.Process.Kill()
+		_ = sender.Process.Kill()
+		return false, "", fmt.Errorf("transfer timed out\n--- receiver ---\n%s\n--- sender ---\n%s", recvErr.String(), senderErr.String())
+	}
+	_ = sender.Wait()
+
+	transport := "?"
+	joined := recvErr.String() + "\n" + senderErr.String()
+	switch {
+	case strings.Contains(joined, "Transport: direct WebRTC"):
+		transport = "direct"
+	case strings.Contains(joined, "Transport: encrypted WebSocket relay"):
+		transport = "relay"
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, filepath.Base(l.src)))
+	if err != nil {
+		return false, transport, fmt.Errorf("read received file: %w\n--- receiver ---\n%s\n--- sender ---\n%s", err, recvErr.String(), senderErr.String())
+	}
+	return sha256.Sum256(got) == l.expect, transport, nil
+}
+
+// comboDstDir returns a fresh output directory for each combo; the CLI's sink
+// refuses to overwrite existing files.
+func (l *lab) comboDstDir() string {
+	l.dstDir = filepath.Join(filepath.Dir(l.dstDir), fmt.Sprintf("natlab-recv-%d-%d", os.Getpid(), time.Now().UnixNano()))
+	_ = os.MkdirAll(l.dstDir, 0o755)
+	return l.dstDir
+}
+
+// runPlainRelay is a no-NAT control: both peers run in the public segment over the
+// forced relay, isolating the relay path from the NAT boxes.
+func (l *lab) runPlainRelay(dst string) (bool, string, error) {
+	l.mu.Lock()
+	var pub *netns
+	for _, n := range l.nses {
+		if n.name == "pub" {
+			pub = n
+		}
+	}
+	l.mu.Unlock()
+
+	// Preflight: the pub netns must reach the signaling port directly.
+	probe := exec.Command("nsenter", "-t", fmt.Sprint(pub.pid), "-n",
+		"bash", "-c",
+		"echo '--- ip:'; ip -br a; echo '--- route:'; ip route; echo '--- listen:'; ss -tln | head -5; echo '--- tcp test:'; timeout 3 bash -c 'echo > /dev/tcp/"+pubHost+"/8443' && echo tcp-ok || echo tcp-fail")
+	if out, err := probe.CombinedOutput(); err != nil {
+		log.Printf("plain relay preflight (rc=%v):\n%s", err, out)
+	} else {
+		log.Printf("plain relay preflight:\n%s", out)
+	}
+
+	runPeer := func(role string, args ...string) (*exec.Cmd, *strings.Builder, *strings.Builder, error) {
+		argv := append([]string{l.sendarc, role, "--relay-only", "--server", "ws://" + pubHost + ":8443/ws"}, args...)
+		c := exec.Command("nsenter", append([]string{"-t", fmt.Sprint(pub.pid), "-n"}, argv...)...)
+		var out, errb strings.Builder
+		c.Stdout = &out
+		c.Stderr = &errb
+		if err := c.Start(); err != nil {
+			return nil, nil, nil, err
+		}
+		l.mu.Lock()
+		l.procs = append(l.procs, c)
+		l.mu.Unlock()
+		return c, &out, &errb, nil
+	}
+
+	sender, senderOut, senderErr, err := runPeer("send", l.src)
+	if err != nil {
+		return false, "", fmt.Errorf("start sender: %w", err)
+	}
+	code := ""
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if m := codeRe.FindString(senderOut.String()); m != "" {
+			code = m
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if code == "" {
+		_ = sender.Process.Kill()
+		return false, "", fmt.Errorf("no invite code from sender: %s", senderErr.String())
+	}
+	receiver, _, recvErr, err := runPeer("receive", code, "--out", dst)
+	if err != nil {
+		return false, "", fmt.Errorf("start receiver: %w", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- receiver.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			_ = sender.Process.Kill()
+			return false, "", fmt.Errorf("receiver failed: %v\n--- receiver stderr ---\n%s\n--- sender stderr ---\n%s", err, recvErr.String(), senderErr.String())
+		}
+	case <-time.After(60 * time.Second):
+		_ = receiver.Process.Kill()
+		_ = sender.Process.Kill()
+		return false, "", fmt.Errorf("plain relay timed out")
+	}
+	_ = sender.Wait()
+	got, err := os.ReadFile(filepath.Join(dst, filepath.Base(l.src)))
+	if err != nil {
+		return false, "relay", fmt.Errorf("read received file: %w\n--- receiver ---\n%s\n--- sender ---\n%s", err, recvErr.String(), senderErr.String())
+	}
+	return sha256.Sum256(got) == l.expect, "relay", nil
+}
+
+func moduleRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getwd: %w", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(wd, "go.mod")); err == nil {
+			return wd, nil
+		}
+		parent := filepath.Dir(wd)
+		if parent == wd {
+			return "", fmt.Errorf("no go.mod found above %q; run natlab from the apps/cli module", wd)
+		}
+		wd = parent
+	}
+}

--- a/apps/cli/cmd/sendarc/main.go
+++ b/apps/cli/cmd/sendarc/main.go
@@ -26,6 +26,8 @@ import (
 	"github.com/sendarc/cli/internal/transfer"
 	"github.com/sendarc/cli/internal/wsclient"
 	"github.com/sendarc/wire"
+
+	"github.com/pion/webrtc/v4"
 )
 
 const defaultServer = "wss://localhost:8443/ws"
@@ -60,6 +62,8 @@ Usage:
 Flags:
   --server URL             signaling server (default `+defaultServer+`)
   --insecure-skip-verify   skip TLS verification; self-signed dev certs only
+  --ice-server URL         STUN server for direct-path candidates (repeatable;
+                           default stun:stun.l.google.com:19302)
   --relay-only             force the encrypted WebSocket relay instead of WebRTC
   --words N                number of words in the invite code (send only; 0 = default)
   --out DIR                directory to write the received file into (receive only; default .)
@@ -72,6 +76,7 @@ func runSend(args []string) int {
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
 	words := fs.Int("words", 0, "number of words in the invite code (0 = default)")
 	relayOnly := fs.Bool("relay-only", false, "force the encrypted WebSocket relay")
+	iceServer := fs.String("ice-server", "", "STUN server URL for direct-path candidates (repeatable; default stun:stun.l.google.com:19302)")
 	positionals := parseArgs(fs, args)
 
 	if len(positionals) == 0 {
@@ -114,6 +119,7 @@ func runSend(args []string) int {
 		},
 		Sources:        sources,
 		ForceRelay:     *relayOnly,
+		ICEServers:     iceServers(*iceServer),
 		OnTransport:    transportPrinter,
 		OnConnect:      connectPrinter(fmt.Sprintf("Sending %s (%s) …", label, humanBytes(totalSize))),
 		OnFileProgress: progress.reportFile,
@@ -145,6 +151,7 @@ func runReceive(args []string) int {
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
 	outDir := fs.String("out", ".", "directory to write the received file into")
 	relayOnly := fs.Bool("relay-only", false, "force the encrypted WebSocket relay")
+	iceServer := fs.String("ice-server", "", "STUN server URL for direct-path candidates (repeatable; default stun:stun.l.google.com:19302)")
 	positionals := parseArgs(fs, args)
 
 	code := ""
@@ -180,6 +187,7 @@ func runReceive(args []string) int {
 		},
 		DestDir:     *outDir,
 		ForceRelay:  *relayOnly,
+		ICEServers:  iceServers(*iceServer),
 		OnTransport: transportPrinter,
 		OnManifestSet: func(manifest wire.Manifest) {
 			progress.setTotal(manifest.TotalSize)
@@ -215,6 +223,15 @@ func runReceive(args []string) int {
 		fmt.Printf("  File-set SHA-256: %s\n", out.Digest)
 	}
 	return 0
+}
+
+// iceServers parses a --ice-server URL list into pion ICE server config. The flag is
+// repeatable; an empty value leaves the package default (Google STUN) in place.
+func iceServers(flagValue string) []webrtc.ICEServer {
+	if flagValue == "" {
+		return nil
+	}
+	return []webrtc.ICEServer{{URLs: []string{flagValue}}}
 }
 
 // dial opens the signaling socket, reporting the server it is contacting. The transfer

--- a/apps/cli/cmd/stund/main.go
+++ b/apps/cli/cmd/stund/main.go
@@ -29,7 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("stund: listen: %v", err)
 	}
-	defer pc.Close()
+	defer func() { _ = pc.Close() }()
 	fmt.Fprintf(os.Stderr, "stund: listening on %s\n", pc.LocalAddr())
 
 	buf := make([]byte, 2048)

--- a/apps/cli/cmd/stund/main.go
+++ b/apps/cli/cmd/stund/main.go
@@ -1,0 +1,106 @@
+// Command stund is a minimal STUN (RFC 5389) binding-response server used by the NAT
+// lab (cmd/natlab). It reports the source address it sees, exactly as a public STUN
+// server would. In the lab the two NAT boxes translate requests before they reach us,
+// so the reported address is the mapping's external (ip, port) — which is what makes
+// the direct WebRTC path testable in a hermetic environment with no internet.
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+)
+
+const (
+	stunBindingRequest  = 0x0001
+	stunBindingResponse = 0x0101
+	stunMagicCookie     = 0x2112a442
+	stunAttrXorMapped   = 0x0020
+)
+
+func main() {
+	addr := flag.String("addr", "0.0.0.0:3478", "listen address")
+	flag.Parse()
+
+	pc, err := net.ListenPacket("udp", *addr)
+	if err != nil {
+		log.Fatalf("stund: listen: %v", err)
+	}
+	defer pc.Close()
+	fmt.Fprintf(os.Stderr, "stund: listening on %s\n", pc.LocalAddr())
+
+	buf := make([]byte, 2048)
+	for {
+		n, raddr, err := pc.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		if resp := bindingResponse(buf[:n], raddr); resp != nil {
+			if _, err := pc.WriteTo(resp, raddr); err != nil {
+				log.Printf("stund: reply: %v", err)
+			}
+		}
+	}
+}
+
+// bindingResponse answers a STUN binding request with an XOR-MAPPED-ADDRESS carrying
+// the address the request was seen from. Returns nil for anything that is not a
+// well-formed binding request.
+func bindingResponse(req []byte, raddr net.Addr) []byte {
+	if len(req) < 20 {
+		return nil
+	}
+	typ := binary.BigEndian.Uint16(req[0:2])
+	length := int(binary.BigEndian.Uint16(req[2:4]))
+	if typ != stunBindingRequest || length != len(req)-20 || length > 0 {
+		// Requests with attributes (e.g. FINGERPRINT) are fine; anything with a length
+		// mismatch or attributes we cannot parse is still answerable for the lab.
+		if typ != stunBindingRequest || length > len(req)-20 {
+			return nil
+		}
+	}
+	if binary.BigEndian.Uint32(req[4:8]) != stunMagicCookie {
+		return nil
+	}
+
+	host, _, err := net.SplitHostPort(raddr.String())
+	if err != nil {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	_, portStr, err := net.SplitHostPort(raddr.String())
+	if err != nil {
+		return nil
+	}
+	var port uint16
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
+		return nil
+	}
+	v4 := ip.To4()
+	if v4 == nil {
+		return nil
+	}
+
+	// Header: type (response), length (8), cookie, transaction id.
+	resp := make([]byte, 20+12)
+	binary.BigEndian.PutUint16(resp[0:2], stunBindingResponse)
+	binary.BigEndian.PutUint16(resp[2:4], 12)
+	binary.BigEndian.PutUint32(resp[4:8], stunMagicCookie)
+	copy(resp[8:20], req[8:20])
+
+	// XOR-MAPPED-ADDRESS: reserved, family, XOR port, XOR address.
+	attr := resp[20:]
+	binary.BigEndian.PutUint16(attr[0:2], stunAttrXorMapped)
+	binary.BigEndian.PutUint16(attr[2:4], 8)
+	attr[4] = 0
+	attr[5] = 0x01 // IPv4
+	xorPort := port ^ (stunMagicCookie >> 16)
+	binary.BigEndian.PutUint16(attr[6:8], xorPort)
+	masked := uint32(v4[0])<<24 | uint32(v4[1])<<16 | uint32(v4[2])<<8 | uint32(v4[3])
+	masked ^= stunMagicCookie
+	binary.BigEndian.PutUint32(attr[8:12], masked)
+	return resp
+}

--- a/apps/server/internal/signal/peer.go
+++ b/apps/server/internal/signal/peer.go
@@ -79,6 +79,7 @@ func (p *peer) serve(ctx context.Context) {
 		typ, data, err := p.ws.Read(readCtx)
 		cancel()
 		if err != nil {
+			p.logger.Warn("peer read ended", "err", err)
 			return
 		}
 		switch typ {
@@ -247,7 +248,11 @@ func (p *peer) writeLoop(ctx context.Context) {
 func (p *peer) rawWrite(ctx context.Context, typ websocket.MessageType, data []byte) bool {
 	writeCtx, cancel := context.WithTimeout(ctx, writeTimeout)
 	defer cancel()
-	return p.ws.Write(writeCtx, typ, data) == nil
+	if err := p.ws.Write(writeCtx, typ, data); err != nil {
+		p.logger.Warn("peer write failed", "err", err)
+		return false
+	}
+	return true
 }
 
 // enqueue hands a frame to this peer's writer. It blocks only until the buffer has

--- a/apps/web/e2e/transfer.spec.ts
+++ b/apps/web/e2e/transfer.spec.ts
@@ -1,0 +1,87 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+import { expect, test } from '@playwright/test';
+
+/** Deterministic pseudo-random payload so every engine compares against the same digest. */
+function payload(size: number): Buffer {
+  let seed = 0x5eed_1234;
+  const bytes = Buffer.alloc(size);
+  for (let i = 0; i < size; i++) {
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    bytes[i] = seed >> 24;
+  }
+  return bytes;
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+const BYTES = payload(4 * 1024 * 1024);
+const DIGEST = sha256(BYTES);
+
+/** Open the send screen and return the room-words invite code it shows. */
+async function openSender(page: import('@playwright/test').Page): Promise<string> {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Send a file' }).click();
+  const codeCard = page.locator('.code-card');
+  await expect(codeCard).toBeVisible({ timeout: 15_000 });
+  const code = (await codeCard.locator('.code').textContent())?.trim() ?? '';
+  expect(code).toMatch(/^\d+-[a-z]+-[a-z]+$/);
+  return code;
+}
+
+/** Join the given code on a fresh tab. */
+async function joinReceiver(page: import('@playwright/test').Page, code: string): Promise<void> {
+  await page.goto('/');
+  await page.locator('#code').fill(code);
+  await page.getByRole('button', { name: 'Receive' }).click();
+}
+
+test('send → receive round-trips the file with a verified digest', async ({ context }) => {
+  const sender = await context.newPage();
+  const code = await openSender(sender);
+
+  const receiver = await context.newPage();
+  await joinReceiver(receiver, code);
+
+  // Both peers authenticate and land on the secure-channel screen with a matching fingerprint.
+  await expect(receiver.locator('.result.ok')).toBeVisible({ timeout: 30_000 });
+  await expect(sender.locator('.result.ok')).toBeVisible({ timeout: 30_000 });
+  const senderFingerprint = (await sender.locator('.fingerprint').textContent())?.trim();
+  const receiverFingerprint = (await receiver.locator('.fingerprint').textContent())?.trim();
+  expect(senderFingerprint).toBe(receiverFingerprint);
+
+  await sender.setInputFiles('input[type="file"]', {
+    name: 'payload.bin',
+    mimeType: 'application/octet-stream',
+    buffer: BYTES,
+  });
+
+  await expect(sender.getByText(/verified by the receiver/)).toBeVisible({ timeout: 60_000 });
+  await expect(receiver.getByText(/verified\./)).toBeVisible({ timeout: 60_000 });
+
+  // Save through the OPFS download link and verify the bytes match sha256sum of the source.
+  const downloadPromise = receiver.waitForEvent('download');
+  await receiver.locator('a.download').click();
+  const download = await downloadPromise;
+  const path = await download.path();
+  expect(path).not.toBeNull();
+  const received = readFileSync(path!);
+  expect(received.equals(BYTES)).toBe(true);
+  expect(sha256(received)).toBe(DIGEST);
+});
+
+test('a wrong code fails closed on the receiver', async ({ context }) => {
+  const sender = await context.newPage();
+  const code = await openSender(sender);
+  const [room, firstWord] = code.split('-');
+  const wrongCode = `${room}-${firstWord}-different`;
+
+  const receiver = await context.newPage();
+  await joinReceiver(receiver, wrongCode);
+
+  await expect(receiver.locator('.result.bad')).toBeVisible({ timeout: 30_000 });
+  await expect(receiver.locator('.result.bad')).toContainText(/did not match/i);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,13 +9,16 @@
     "preview": "vite preview",
     "typecheck": "svelte-check --tsconfig ./tsconfig.json",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "e2e": "playwright test",
+    "e2e:serve": "pnpm build && cd ../server && SENDARC_ADDR=127.0.0.1:8443 SENDARC_WEB_DIR=../web/dist go run ./cmd/sendarcd"
   },
   "dependencies": {
     "@sendarc/protocol": "workspace:*",
     "hash-wasm": "^4.12.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "jsdom": "^30.0.1",
     "svelte": "^5.16.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E against the real web app + signaling server on loopback. The Go server serves the built
+// bundle and the WebSocket endpoint on one origin, so browser tests run over the same origin the
+// production deployment uses. WebRTC needs no STUN here: both peers live in the same browser.
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 90_000,
+  expect: { timeout: 30_000 },
+  // One transfer at a time — the signaling server pairs rooms 1:1 and room numbers are global.
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:8443',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    // WebKit support on Linux is best-effort; opt in locally with E2E_WEBKIT=1.
+    ...(process.env.E2E_WEBKIT === '1'
+      ? [{ name: 'webkit', use: { ...devices['Desktop Safari'] } }]
+      : []),
+  ],
+  webServer: {
+    command: 'pnpm e2e:serve',
+    url: 'http://127.0.0.1:8443/healthz',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -145,14 +145,16 @@
     ctrl.done.then(
       async (res) => {
         if (controller !== ctrl) return; // superseded by a restart
+        // Take over the still-open signaling socket before the first await: the rendezvous
+        // layer auto-closes an unadopted socket on the next macrotask, and computing the
+        // fingerprint can yield past that point (slow WebCrypto on some engines).
+        signaling = ctrl.adoptSignaling();
         fingerprint = await sasFingerprint(res.master);
         peerCaps = res.remoteCaps;
         handshake = res;
         role = res.role;
-        // Take over the still-open signaling socket so the WebRTC negotiation can reuse it,
-        // then drop onto the transfer screen. The offerer waits for a file pick; the joiner
-        // begins receiving straight away.
-        signaling = ctrl.adoptSignaling();
+        // The WebRTC negotiation reuses the adopted socket; the offerer waits for a file pick,
+        // the joiner begins receiving straight away.
         screen = 'done';
         startTransferIfReady();
       },

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -288,6 +288,14 @@ function run(
       try {
         const output = msg.output;
         if (output?.kind === 'opfs') {
+          // The transfer is done and the peer was already told (the done ack goes out
+          // before this `done`). Tear down the wire before the slow OPFS read so a peer
+          // disconnect can't trigger a relay fallback into a room the sender has already
+          // left — the server would refuse it and drop our socket. cleanup() below repeats
+          // this teardown; every piece is idempotent.
+          signaling.close();
+          relay?.close();
+          peer?.close();
           const file = await readOpfsOutput(output.key, output.name, output.mime);
           finish({
             name: output.name,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 // The Go server proxies non-asset requests here in dev (see justfile `dev`).
@@ -18,5 +18,16 @@ export default defineConfig({
     target: 'es2022',
     outDir: 'dist',
     sourcemap: true,
+  },
+  test: {
+    // Playwright specs live next to the unit tests; keep them out of vitest.
+    exclude: [
+      'e2e/**',
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output-tests,tmp}/**',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*',
+    ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: ^4.12.0
         version: 4.12.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
         version: 5.1.1(supports-color@7.2.0)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@6.4.3(@types/node@26.2.0))
@@ -386,6 +389,11 @@ packages:
   '@noble/hashes@2.3.0':
     resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.62.4':
     resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
@@ -936,6 +944,11 @@ packages:
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1123,6 +1136,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -1697,6 +1720,10 @@ snapshots:
 
   '@noble/hashes@2.3.0': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@rollup/rollup-android-arm-eabi@4.62.4':
     optional: true
 
@@ -2251,6 +2278,9 @@ snapshots:
 
   flatted@3.4.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2430,6 +2460,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@3.1.4(postcss@8.5.26):
     dependencies:


### PR DESCRIPTION
NAT + degraded-network lab for M6 (docs/compat-matrix.md).

- natlab: 5-netns harness (2 peers, 2 userspace NAT boxes, public segment with signaling + STUN); full-cone/restricted/port-restricted/symmetric policies; relay fallback verification; -netem profiles (loss/delay/rate via tc) on both bridge legs; per-combo durations.
- natbox: userspace NAT (AF_PACKET private side, policy-mapped UDP, TCP proxy for signaling).
- stund: minimal STUN for ICE.
- sendarc: --ice-server flag for custom STUN.
- server: warn on peer read/write failures.

Matrix results (4 MiB, digest-verified): all 5 NAT combos pass; baseline direct 1.8s / relay 8.3s; 3% loss direct 10.1s / relay 8.3s; 50ms RTT direct 5.7s / relay 9.8s; 10 Mbit cap direct 5.2s / relay 11.6s.