### PR TITLE
feat(deploy): add multi-stage container serving web + signaling from one image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+**/node_modules
+**/dist
+**/test-results
+**/playwright-report
+**/*.log
+bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,23 @@ jobs:
         with:
           version: latest
           working-directory: ${{ matrix.module }}
+
+  docker:
+    name: container (build + smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t sendarc .
+
+      - name: Smoke test
+        run: |
+          docker run -d --name sendarc-smoke -p 127.0.0.1:8443:8443 sendarc
+          trap 'docker rm -f sendarc-smoke >/dev/null 2>&1' EXIT
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8443/healthz >/dev/null; then break; fi
+            sleep 1
+          done
+          curl -fsS http://127.0.0.1:8443/healthz | grep -q '"ok"'
+          curl -fsS http://127.0.0.1:8443/ | grep -q '<title>SendArc'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+# --- Stage 1: build the web bundle ------------------------------------------------
+FROM node:22-alpine AS web
+RUN corepack enable
+WORKDIR /src
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/protocol/package.json ./packages/protocol/
+COPY apps/web/package.json ./apps/web/
+RUN pnpm install --frozen-lockfile --ignore-scripts
+COPY packages/protocol ./packages/protocol
+COPY apps/web ./apps/web
+RUN pnpm --filter @sendarc/protocol build && pnpm --filter @sendarc/web build
+
+# --- Stage 2: build the server binary --------------------------------------------
+FROM golang:1.24-alpine AS server
+WORKDIR /src
+COPY apps/server/go.mod apps/server/go.sum ./apps/server/
+RUN cd apps/server && go mod download
+COPY apps/server ./apps/server
+RUN cd apps/server && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /sendarcd ./cmd/sendarcd
+
+# --- Stage 3: runtime --------------------------------------------------------------
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates \
+    && adduser -D -H -u 10001 sendarc
+WORKDIR /srv
+COPY --from=server /sendarcd /usr/local/bin/sendarcd
+COPY --from=web /src/apps/web/dist /srv/web
+USER sendarc
+ENV SENDARC_ADDR=:8443 \
+    SENDARC_WEB_DIR=/srv/web
+EXPOSE 8443
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -qO- http://127.0.0.1:8443/healthz || exit 1
+CMD ["sendarcd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:22-alpine AS web
 RUN corepack enable
 WORKDIR /src
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY packages/protocol/package.json ./packages/protocol/
 COPY apps/web/package.json ./apps/web/
 RUN pnpm install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
M7 task 1: single container.

- Multi-stage Dockerfile: node:22 builds the pnpm workspace (protocol + web), golang:1.24 builds sendarcd, alpine runtime with CA certs, non-root user, /healthz healthcheck.
- Web + signaling served from one port (8443); same-origin /ws default.
- CI: docker job builds the image and smoke-tests healthz + SPA on a real container.