### PR TITLE
docs(benchmarks): publish compat matrix + reproducible engine benchmarks

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,74 @@
+# Benchmarks
+
+Reproducible numbers for the `sendarc/1` transfer engine. These measure the engine
+itself (crypto + block/ack state machine) on loopback; end-to-end throughput is bounded
+by the transport and the network, not by these figures — see the notes and
+[compat-matrix.md](./compat-matrix.md) for path-level numbers.
+
+## Reproducing
+
+```sh
+cd packages/wire
+go test -bench . -benchmem -run xxx -benchtime 2s .
+```
+
+## Results
+
+Machine: Intel Core i5-6200U @ 2.30 GHz (4 cores), Linux, `go test` without `-race`.
+
+| Benchmark                                                                                 |       ns/op |  MB/s |        B/op | allocs/op |
+| ----------------------------------------------------------------------------------------- | ----------: | ----: | ----------: | --------: |
+| `BenchmarkSeal` (AES-256-GCM frame, 16 KiB payload)                                       |      12,474 | 1,313 |      19,752 |         5 |
+| `BenchmarkOpen` (verify + decrypt 16 KiB frame)                                           |      12,473 | 1,313 |      17,744 |         5 |
+| `BenchmarkSignSignal` (SDP/ICE HMAC)                                                      |       1,890 |    16 |         560 |         7 |
+| `BenchmarkTransferLoopback` (full 16 MiB transfer, 1 MiB blocks, 16 KiB frames, window 8) | 266,403,435 |    63 | 252,657,719 |    12,870 |
+
+### Reading the numbers
+
+- **Frame crypto is ~1.3 GB/s per core**: a 16 KiB frame seals or opens in ~12.5 µs. The
+  19.7 KB allocation per seal is the frame buffer itself, recycled per transfer.
+- **The engine sustains ~63 MB/s on this laptop** in the in-memory loopback — the same
+  state machine the DataChannel and relay paths run. The ~252 MB/op allocation is the
+  loopback's copy-heavy plumbing (frame copies + sink buffering), not a leak; real
+  transfers bound memory differently (below).
+- **Signaling MACs are negligible**: ~1.9 µs each, a handful per session.
+
+## Memory model (independent of transport)
+
+- **Frames are 16 KiB** on both paths (`DEFAULT_FRAME_BYTES`); the relay caps a single
+  frame at 128 KiB (`SENDARC_RELAY_MAX_FRAME_BYTES`).
+- **Sender side**: at most `DEFAULT_INFLIGHT_BLOCKS = 8` blocks (1 MiB each) in flight
+  ahead of receiver confirmation, and the DataChannel buffered-amount watermark paces at
+  ~8 MiB (`BUFFERED_AMOUNT_HIGH`).
+- **Receiver side**: RAM is bounded by the same 8-block window regardless of sink speed —
+  a slow sink causes backpressure, never growth.
+- **Relay**: per-connection window 1 MiB, queue 2 MiB, throughput token bucket 32 MiB/s
+  (`SENDARC_RELAY_*`); a busy instance stays in the low tens of MiB.
+
+So a 100 MiB file does not imply 100 MiB of buffers anywhere in the chain: the memory
+ceiling is a small constant, not the file size.
+
+## Path-level throughput
+
+Measured in the NAT lab (netns, 9 KB MTU, 4 MiB payload; see compat-matrix.md):
+
+| Path                | Scenario      | Wall-clock |                 Implied throughput |
+| ------------------- | ------------- | ---------: | ---------------------------------: |
+| Direct (WebRTC)     | baseline      |      1.8 s |           ~2.2 MB/s (lab loopback) |
+| Relay (WS over TCP) | baseline      |      8.3 s | ~0.5 MB/s incl. ~7.6 s ICE timeout |
+| Relay (WS over TCP) | transfer only |       <1 s |                                  — |
+| Direct              | 10 Mbit cap   |      5.2 s |                          ~0.8 MB/s |
+| Direct              | 3% loss       |     10.1 s |        ~0.4 MB/s (SCTP retransmit) |
+| Relay               | 3% loss       |      8.3 s |               TCP absorbs the loss |
+
+These are lab-loopback figures (both peers on one machine); real internet transfers are
+faster on the direct path (no veth overhead) and slower on the relay (internet RTT and
+the 32 MiB/s relay ceiling). Browser-level E2E (100 MiB round-trip, Playwright) passes in
+CI on Chromium and Firefox; timing is CI-host-dependent and not a spec number.
+
+## CPU
+
+Crypto is the only CPU-heavy step: ~12.5 µs per 16 KiB frame, or ~0.8 s of one core per
+gigabyte (split between the peers). Hashing is off-thread (Web Worker on the web side)
+and never blocks the transfer loop. The relay does no crypto at all — it forwards sealed
+bytes — so server CPU per byte is memcpy-class.

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -1,0 +1,99 @@
+# Compatibility matrix
+
+Scope: how SendArc behaves across NAT topologies, degraded networks, and browsers — on
+both the direct WebRTC path and the WebSocket relay path. The network data comes from the
+NAT lab (`apps/cli/cmd/natlab`), which builds five Linux network namespaces — two peer
+hosts, two userspace NAT boxes, and a public segment with the signaling/relay server and a
+STUN server — connected by 9 KB-MTU veths through a bridge. Each row below was run as a
+real CLI transfer (`sendarc send` / `sendarc receive`, 4 MiB payload, SHA-256 verified).
+
+## NAT topologies (no degradation)
+
+| NAT A / NAT B                   | Transport | Digest | Notes                                             |
+| ------------------------------- | --------- | ------ | ------------------------------------------------- |
+| full-cone/full-cone             | direct    | ✓      |                                                   |
+| restricted/restricted           | direct    | ✓      |                                                   |
+| port-restricted/port-restricted | direct    | ✓      |                                                   |
+| symmetric/symmetric             | relay     | ✓      | Direct ICE fails; relay fallback picks up         |
+| full-cone/symmetric             | direct    | ✓      | Full-cone maps to the symmetric box's pinned port |
+
+## Degraded networks (4 MiB transfer, wall-clock per combo)
+
+| Scenario    | Direct (full-cone/full-cone) | Relay (symmetric/symmetric) |
+| ----------- | ---------------------------- | --------------------------- |
+| Baseline    | 1.8s ✓                       | 8.3s ✓                      |
+| 3% loss     | 10.1s ✓ (retransmits)        | 8.3s ✓ (TCP hides it)       |
+| 50 ms RTT   | 5.7s ✓                       | 9.8s ✓                      |
+| 10 Mbit cap | 5.2s ✓                       | 11.6s ✓                     |
+
+All rows end with the receiver's recomputed SHA-256 matching the sender's (digest ✓).
+
+### How to reproduce
+
+```sh
+cd apps/cli
+go build -o ../../bin/natlab ./cmd/natlab
+go build -o ../../bin/sendarcd ../server/cmd/sendarcd
+# All NAT combos, no degradation:
+sudo unshare -Urnm ../../bin/natlab -server-bin ../../bin/sendarcd
+# Degraded networks (loss / delay / bandwidth cap), direct + relay:
+sudo unshare -Urnm ../../bin/natlab -server-bin ../../bin/sendarcd \
+  -combos full-cone/full-cone,symmetric/symmetric -netem "loss 3%"
+```
+
+The `-netem` profile is applied with `tc` to the egress of both public bridge legs, so it
+shapes the sender→receiver downlink on the direct path and the server→receiver relay leg.
+Profiles: `loss 3%`, `delay 50ms`, `rate 10mbit`.
+
+## Browser compatibility
+
+SendArc targets evergreen desktop browsers. The browser E2E suite (Playwright) runs in CI
+on every change and round-trips a 100 MiB file both ways through the real server; WebKit
+is opt-in locally and not part of CI.
+
+| Capability                                   | Chromium (Chrome/Edge) | Firefox       | WebKit (Safari)     |
+| -------------------------------------------- | ---------------------- | ------------- | ------------------- |
+| WebRTC DataChannel (direct path)             | ✓ CI-tested            | ✓ CI-tested   | opt-in, best-effort |
+| WebSocket + encrypted relay fallback         | ✓ CI-tested            | ✓ CI-tested   | opt-in, best-effort |
+| WebCrypto (AES-GCM, HKDF-SHA256, SHA-256)    | ✓ CI-tested            | ✓ CI-tested   | supported, untested |
+| OPFS sink (`navigator.storage.getDirectory`) | ✓ CI-tested            | ✓ CI-tested   | supported, untested |
+| File System Access API (direct-file sink)    | ✓ Chromium             | ✗ not exposed | ✗ not exposed       |
+| ZIP archive sink (fallback)                  | ✓                      | ✓             | best-effort         |
+| Quota checks (`navigator.storage.estimate`)  | ✓                      | ✓             | supported, untested |
+
+Sink fallback ladder, in order of preference: **direct-file** (File System Access API,
+Chromium-only) → **OPFS** (all evergreen engines) → **ZIP archive** (always available).
+A sender that picks a folder triggers the receiver's archive sink; single files prefer
+direct-file/OPFS. The ZIP fallback is capped at 4 GiB.
+
+### Mobile
+
+Not yet CI-tested. iOS Safari and Android Chrome share the WebKit/Chromium engines above,
+so WebRTC/WebCrypto/OPFS are expected to work, but file-handle behavior and OPFS support
+differ by version; treat mobile as best-effort until the opt-in suite covers it.
+
+## Interpretation
+
+- **Relay baseline is ~8s, not the transfer**: symmetric NAT has no usable direct path,
+  so the client waits out the ICE gathering/connectivity phase (~7.6s) before the relay
+  is selected. The relay transfer itself adds well under a second at these sizes.
+- **Packet loss**: the direct path degrades markedly (SCTP/DTLS retransmission backoff),
+  while the relay (TCP) is unaffected — TCP's retransmission and congestion control hide
+  3% loss behind the scenes.
+- **Latency and bandwidth caps** slow both paths proportionally; neither path has a
+  fixed timeout that a 50 ms RTT or a 10 Mbit cap can trip. The relay's byte-credit flow
+  control (receiver-granted window) paces a slow network correctly instead of buffering
+  without bound.
+- **Bounded memory is unaffected** by any scenario: frames are 16 KiB on both paths,
+  the relay is credit-bounded, and the direct path is bounded by the datachannel's
+  buffered-amount watermark. See `BENCHMARKS.md` for the engine numbers.
+
+## Lab history worth keeping
+
+- The public bridge and its ports must match the endpoint MTU (9000). With the bridge at
+  the default 1500 while endpoints negotiated MSS 8948, relayed TCP connections wedged
+  irreversibly once flow control forced a non-GSO partial segment — it was silently
+  dropped, congestion window collapsed to 2, retransmissions vanished, and the connection
+  died with `connection timed out` at ~7.8 s. The stall point varied (≈52 KiB–527 KiB)
+  because it was a race, not a fixed buffer. Direct (UDP) transfers were unaffected,
+  which made the relay failure look like a relay bug rather than a lab bug.

--- a/packages/wire/benchmarks_test.go
+++ b/packages/wire/benchmarks_test.go
@@ -1,0 +1,85 @@
+package wire
+
+import (
+	"testing"
+)
+
+// Benchmarks for the transfer engine's hot path. Run with:
+//
+//	go test -bench . -benchmem ./...
+//
+// The loopback benchmark drives a full sender→receiver transfer over in-memory channels
+// and reports aggregate throughput; Seal/Open and the MAC bench the per-frame crypto.
+
+var benchPayload = func() []byte {
+	p := make([]byte, 16*1024)
+	for i := range p {
+		p[i] = byte((i*131 + 7) & 0xff)
+	}
+	return p
+}()
+
+func benchDir() DirectionalKey {
+	key := make([]byte, 32)
+	salt := []byte{0x01, 0x02, 0x03, 0x04}
+	for i := range key {
+		key[i] = byte(i)
+	}
+	return DirectionalKey{Key: key, Salt: salt}
+}
+
+func BenchmarkSeal(b *testing.B) {
+	dir := benchDir()
+	h := FrameHeaderInput{Version: 1, Type: 3, FileIdx: 0, BlockIdx: 1, FrameOff: 2}
+	b.SetBytes(int64(len(benchPayload)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := Seal(dir, uint64(i), h, benchPayload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkOpen(b *testing.B) {
+	dir := benchDir()
+	h := FrameHeaderInput{Version: 1, Type: 3, FileIdx: 0, BlockIdx: 1, FrameOff: 2}
+	sealed, err := Seal(dir, 0, h, benchPayload)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(benchPayload)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := Open(dir, 0, sealed); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSignSignal(b *testing.B) {
+	kAuth := benchDir().Key
+	body := "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\n"
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		SignSignal(kAuth, SignalSDP, 7, uint32(i), body)
+	}
+}
+
+func BenchmarkTransferLoopback(b *testing.B) {
+	data := make([]byte, 16<<20) // 16 MiB
+	for i := range data {
+		data[i] = byte((i*131 + 7) & 0xff)
+	}
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		res := runLoopback(b, data, 1<<20, 16<<10, 8, false)
+		if res.runErr != nil {
+			b.Fatalf("sender: %v", res.runErr)
+		}
+		if res.recvErr != nil {
+			b.Fatalf("receiver: %v", res.recvErr)
+		}
+	}
+}

--- a/packages/wire/transfer_loopback_test.go
+++ b/packages/wire/transfer_loopback_test.go
@@ -26,11 +26,18 @@ type loopbackResult struct {
 	sink    *MemorySink
 }
 
+// testTB is the shared subset of *testing.T / *testing.B used by loopback helpers so the
+// same harness drives both the correctness tests and the throughput benchmarks.
+type testTB interface {
+	Helper()
+	Fatal(args ...any)
+}
+
 // runLoopback wires a Sender (offerer, o2j) to a Receiver (joiner) over two buffered channels,
 // each drained by its own goroutine so delivery is ordered and genuinely concurrent — the same
 // shape as a real reliable, ordered DataChannel. When corrupt is set, one byte of the second
 // frame the sender emits is flipped in flight, forcing an integrity abort.
-func runLoopback(t *testing.T, data []byte, blockSize, frameSize, window int, corrupt bool) loopbackResult {
+func runLoopback(t testTB, data []byte, blockSize, frameSize, window int, corrupt bool) loopbackResult {
 	t.Helper()
 	keys, err := DeriveTransferKeys(loopbackMaster())
 	if err != nil {


### PR DESCRIPTION
M7 task 6.

- Browser compat matrix (Chromium/Firefox CI-tested, WebKit opt-in, mobile best-effort, sink fallback ladder) + the NAT/degraded-network lab matrix in-repo.
- BENCHMARKS.md with reproducible go test -bench numbers (Seal/Open ~1.3 GB/s, loopback 63 MB/s) and the memory model.
- packages/wire benchmarks_test.go + loopback helper generalized for testing.B.