### PR TITLE
feat(ops): publish public image to GHCR + docker run quickstart

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: publish
 on:
   push:
     branches: [main]
-    tags: ["v*"]
+    tags: ['v*']
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image:
+    name: build + publish image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set image tag
+        id: tag
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ metadata and content. The security section below summarizes the trust boundary.
 | CLI     | Browser  | Direct WebRTC          | Encrypted relay |
 | CLI     | CLI      | Direct WebRTC via Pion | Encrypted relay |
 
+## Quickstart with Docker
+
+The public image is published to GHCR on every push to `main` (and each `v*` tag) for
+`linux/amd64` and `linux/arm64`. Run it with Docker alone:
+
+```bash
+docker run -d --name sendarc -p 8443:8443 ghcr.io/akshay7273/sendarc
+```
+
+Open `http://localhost:8443` on both peers and send your first file. Plain HTTP on
+`localhost` counts as a secure context for WebRTC; for access from other machines,
+put TLS in front — see `docs/HOSTING.md` for TLS, STUN/TURN, and relay limits.
+
 ## Run locally
 
 ### Requirements

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -9,7 +9,7 @@ covers running it yourself, including TLS, STUN/TURN, and relay limits.
 Requires Docker (or any OCI-compatible runtime) and nothing else:
 
 ```sh
-docker run -d --name sendarc -p 8443:8443 ghcr.io/sendarc/sendarc
+docker run -d --name sendarc -p 8443:8443 ghcr.io/akshay7273/sendarc
 ```
 
 Then open <http://localhost:8443> and send your first file. Plain HTTP on
@@ -65,7 +65,7 @@ docker run -d --name sendarc \
   -e SENDARC_TLS_CERT=/certs/fullchain.pem \
   -e SENDARC_TLS_KEY=/certs/privkey.pem \
   -e SENDARC_ALLOWED_ORIGINS=https://example.com \
-  ghcr.io/sendarc/sendarc
+  ghcr.io/akshay7273/sendarc
 ```
 
 Minimum TLS 1.2 is enforced server-side.
@@ -82,7 +82,7 @@ example.com {
 ```sh
 docker run -d --name sendarc -p 127.0.0.1:8443:8443 \
   -e SENDARC_ALLOWED_ORIGINS=https://example.com \
-  ghcr.io/sendarc/sendarc
+  ghcr.io/akshay7273/sendarc
 ```
 
 With a proxy, set `SENDARC_ALLOWED_ORIGINS` to your public origin so the
@@ -137,7 +137,7 @@ how many transfers run.
 ## Updating
 
 ```sh
-docker pull ghcr.io/sendarc/sendarc
+docker pull ghcr.io/akshay7273/sendarc
 docker restart sendarc
 ```
 


### PR DESCRIPTION
M7 task 7 (final).

- New publish workflow: on push to main and v* tags, builds linux/amd64 + linux/arm64 and pushes to ghcr.io/akshay7273/sendarc (latest + commit sha; tag name on releases). The image is then pullable by anyone: docker run ghcr.io/akshay7273/sendarc.
- README gains a Docker quickstart (one-liner + pointers to docs/HOSTING.md).
- docs/HOSTING.md image refs moved from the placeholder namespace to the real one.

Note: GHCR package visibility starts private; flip it to public in the repo's Packages settings after this merges.