### PR TITLE
feat(web): SRI integrity attributes on built assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,4 @@ jobs:
           done
           curl -fsS http://127.0.0.1:8443/healthz | grep -q '"ok"'
           curl -fsS http://127.0.0.1:8443/ | grep -q '<title>SendArc'
+          curl -fsS http://127.0.0.1:8443/ | grep -q 'integrity="sha384-'

--- a/apps/web/sri.test.ts
+++ b/apps/web/sri.test.ts
@@ -1,0 +1,62 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { computeIntegrity, injectSriAttributes } from './sri';
+
+describe('computeIntegrity', () => {
+  it('returns the sha384 base64 digest with the sha384- prefix', () => {
+    const expected = `sha384-${createHash('sha384').update('hello world').digest('base64')}`;
+    expect(computeIntegrity('hello world')).toBe(expected);
+  });
+
+  it('hashes raw bytes, not the string encoding', () => {
+    const bytes = new Uint8Array([0x00, 0xff, 0x10]);
+    expect(computeIntegrity(bytes)).toBe(
+      `sha384-${createHash('sha384').update(bytes).digest('base64')}`,
+    );
+  });
+});
+
+describe('injectSriAttributes', () => {
+  const integrity = new Map([
+    ['assets/main-abc123.js', 'sha384-JS'],
+    ['assets/main-abc123.css', 'sha384-CSS'],
+  ]);
+
+  it('adds integrity and crossorigin to local scripts and stylesheets', () => {
+    const html = `
+      <script type="module" src="/assets/main-abc123.js"></script>
+      <link rel="stylesheet" href="/assets/main-abc123.css" />
+    `;
+    const out = injectSriAttributes(html, integrity);
+    expect(out).toContain(
+      'src="/assets/main-abc123.js" integrity="sha384-JS" crossorigin="anonymous"',
+    );
+    expect(out).toContain(
+      'href="/assets/main-abc123.css" integrity="sha384-CSS" crossorigin="anonymous"',
+    );
+  });
+
+  it('handles hashed filenames with query strings', () => {
+    const out = injectSriAttributes(
+      '<script src="/assets/main-abc123.js?v=1"></script>',
+      integrity,
+    );
+    expect(out).toContain('integrity="sha384-JS"');
+  });
+
+  it('does not duplicate crossorigin when the tag already has it', () => {
+    const html = '<script type="module" crossorigin src="/assets/main-abc123.js"></script>';
+    const out = injectSriAttributes(html, integrity);
+    expect(out).toContain('integrity="sha384-JS"');
+    expect(out.match(/crossorigin/g)).toHaveLength(1);
+  });
+
+  it('leaves external and unknown URLs untouched', () => {
+    const html = `
+      <script src="https://cdn.example.com/x.js"></script>
+      <script src="/assets/unknown.js"></script>
+    `;
+    const out = injectSriAttributes(html, integrity);
+    expect(out).not.toContain('integrity');
+  });
+});

--- a/apps/web/sri.ts
+++ b/apps/web/sri.ts
@@ -1,0 +1,60 @@
+import { createHash } from 'node:crypto';
+import type { IndexHtmlTransformContext, Plugin } from 'vite';
+
+/**
+ * SRI hashing for the built bundle. Vite emits content-addressed filenames, so a
+ * hash recorded at build time stays valid for as long as the served files are the
+ * built ones. The Go server serves the dist directory byte-for-byte, so the
+ * integrity attributes hold in production.
+ */
+
+export function computeIntegrity(content: Uint8Array | string): string {
+  const buf = typeof content === 'string' ? Buffer.from(content, 'utf8') : Buffer.from(content);
+  return `sha384-${createHash('sha384').update(buf).digest('base64')}`;
+}
+
+/** Inject integrity + crossorigin attributes into script and stylesheet tags. */
+export function injectSriAttributes(html: string, integrity: ReadonlyMap<string, string>): string {
+  return html
+    .replace(/<script([^>]*)src="([^"]+)"([^>]*)>/g, (match, pre, src, post) => {
+      const hash = integrity.get(bareName(src));
+      if (!hash) return match;
+      const cross = /\bcrossorigin\b/.test(pre + post) ? '' : ' crossorigin="anonymous"';
+      return `<script${pre}src="${src}" integrity="${hash}"${cross}${post}>`;
+    })
+    .replace(/<link([^>]*)href="([^"]+)"([^>]*)(?:\/?>)/g, (match, pre, href, post) => {
+      const hash = integrity.get(bareName(href));
+      if (!hash) return match;
+      const cross = /\bcrossorigin\b/.test(pre + post) ? '' : ' crossorigin="anonymous"';
+      return `<link${pre}href="${href}" integrity="${hash}"${cross}${post}>`;
+    });
+}
+
+function bareName(url: string): string {
+  const [path] = url.split('?');
+  return (path ?? url).replace(/^\//, '');
+}
+
+/** Vite plugin: add SRI to every local script and stylesheet in the built HTML. */
+export function viteSri(): Plugin {
+  return {
+    name: 'sendarc-sri',
+    apply: 'build',
+    enforce: 'post',
+    transformIndexHtml: {
+      order: 'post',
+      handler(html: string, ctx: IndexHtmlTransformContext) {
+        if (!ctx.bundle) return html;
+        const integrity = new Map<string, string>();
+        for (const [name, item] of Object.entries(ctx.bundle)) {
+          if (item.type === 'chunk') {
+            integrity.set(name, computeIntegrity(item.code));
+          } else if (item.type === 'asset') {
+            integrity.set(name, computeIntegrity(item.source));
+          }
+        }
+        return injectSriAttributes(html, integrity);
+      },
+    },
+  };
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { viteSri } from './sri';
 
 // The Go server proxies non-asset requests here in dev (see justfile `dev`).
 // We keep this a static SPA — no SSR — so it can be served by the Go binary in prod.
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), viteSri()],
   // Component tests run in jsdom and must resolve Svelte's browser runtime rather than its
   // SSR-only export (where mount/unmount intentionally throw).
   resolve: {


### PR DESCRIPTION
Closes the last §14 hardening item (SRI on built assets).

- Zero-dependency Vite plugin (apps/web/sri.ts), build-only: SHA-384-hashes every emitted JS/CSS asset and injects integrity= into dist/index.html, adding crossorigin only when the tag lacks it.
- Verified against the real build: embedded hashes byte-match the dist files (openssl cross-check).
- Unit tests cover the digest, raw-byte hashing, query-string filenames, skipping external/unknown URLs, and no crossorigin duplication.
- Container smoke test now asserts served HTML carries integrity attributes.