### PR TITLE
feat(server): SENDARC_PUBLIC_URL for cross-device invite links

### DIFF
--- a/apps/server/internal/httpserver/server.go
+++ b/apps/server/internal/httpserver/server.go
@@ -6,6 +6,7 @@ package httpserver
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -23,11 +24,12 @@ import (
 
 // Config controls how sendarcd serves the web app and terminates TLS.
 type Config struct {
-	Addr     string // listen address, e.g. ":8443"
-	TLSCert  string // path to TLS cert (PEM); empty => plain HTTP (dev/testing only)
-	TLSKey   string // path to TLS key (PEM)
-	WebDir   string // directory of the built web bundle to serve (prod)
-	DevProxy string // URL of the Vite dev server to proxy to (dev); overrides WebDir
+	Addr      string // listen address, e.g. ":8443"
+	TLSCert   string // path to TLS cert (PEM); empty => plain HTTP (dev/testing only)
+	TLSKey    string // path to TLS key (PEM)
+	WebDir    string // directory of the built web bundle to serve (prod)
+	DevProxy  string // URL of the Vite dev server to proxy to (dev); overrides WebDir
+	PublicURL string // public base URL for invite links (e.g. https://send.example.com/); empty = auto-detect from page
 
 	Signal signal.Config // signaling limits + WSS origin allowlist
 }
@@ -35,12 +37,13 @@ type Config struct {
 // ConfigFromEnv reads configuration from SENDARC_* environment variables with defaults.
 func ConfigFromEnv() Config {
 	return Config{
-		Addr:     env("SENDARC_ADDR", ":8443"),
-		TLSCert:  os.Getenv("SENDARC_TLS_CERT"),
-		TLSKey:   os.Getenv("SENDARC_TLS_KEY"),
-		WebDir:   os.Getenv("SENDARC_WEB_DIR"),
-		DevProxy: os.Getenv("SENDARC_WEB_DEV_PROXY"),
-		Signal:   signal.ConfigFromEnv(),
+		Addr:      env("SENDARC_ADDR", ":8443"),
+		TLSCert:   os.Getenv("SENDARC_TLS_CERT"),
+		TLSKey:    os.Getenv("SENDARC_TLS_KEY"),
+		WebDir:    os.Getenv("SENDARC_WEB_DIR"),
+		DevProxy:  os.Getenv("SENDARC_WEB_DEV_PROXY"),
+		PublicURL: os.Getenv("SENDARC_PUBLIC_URL"),
+		Signal:    signal.ConfigFromEnv(),
 	}
 }
 
@@ -109,6 +112,12 @@ func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler,
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	r.Get("/config.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-cache")
+		_ = json.NewEncoder(w).Encode(map[string]string{"publicUrl": cfg.PublicURL})
 	})
 
 	// Signaling endpoint: origin-checked WebSocket rendezvous.

--- a/apps/server/internal/httpserver/server_test.go
+++ b/apps/server/internal/httpserver/server_test.go
@@ -116,7 +116,7 @@ func TestConfigEndpointEmpty(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/config.json", nil))
 	var body map[string]string
-	json.Unmarshal(rec.Body.Bytes(), &body)
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
 	if body["publicUrl"] != "" {
 		t.Errorf("publicUrl = %q, want empty when not configured", body["publicUrl"])
 	}

--- a/apps/server/internal/httpserver/server_test.go
+++ b/apps/server/internal/httpserver/server_test.go
@@ -95,6 +95,33 @@ func TestMetricsEndpoint(t *testing.T) {
 	}
 }
 
+func TestConfigEndpoint(t *testing.T) {
+	h := testRouter(t, Config{PublicURL: "https://send.example.com"})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/config.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if body["publicUrl"] != "https://send.example.com" {
+		t.Errorf("publicUrl = %q, want https://send.example.com", body["publicUrl"])
+	}
+}
+
+func TestConfigEndpointEmpty(t *testing.T) {
+	h := testRouter(t, Config{})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/config.json", nil))
+	var body map[string]string
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["publicUrl"] != "" {
+		t.Errorf("publicUrl = %q, want empty when not configured", body["publicUrl"])
+	}
+}
+
 func TestModeReporting(t *testing.T) {
 	cases := map[string]Config{
 		"dev-proxy": {DevProxy: "http://localhost:5173"},

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -5,6 +5,9 @@
   import { offer, join, type RendezvousController } from './lib/session/rendezvous.js';
   import type { SignalChannel } from './lib/signaling/client.js';
   import type { ReceiveDestinationSpec } from './lib/transfer/wire.js';
+  import { baseUrl, loadConfig } from "./lib/config.js";
+
+loadConfig();
   import {
     runSend,
     runReceive,
@@ -96,7 +99,7 @@
         onPhase: (p) => (phase = p),
         onCode: (c) => {
           code = c;
-          link = typeof window === 'undefined' ? '' : inviteLinkFor(window.location.href, c);
+          link = inviteLinkFor(baseUrl(), c);
         },
       }),
     );

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -5,9 +5,9 @@
   import { offer, join, type RendezvousController } from './lib/session/rendezvous.js';
   import type { SignalChannel } from './lib/signaling/client.js';
   import type { ReceiveDestinationSpec } from './lib/transfer/wire.js';
-  import { baseUrl, loadConfig } from "./lib/config.js";
+  import { baseUrl, loadConfig } from './lib/config.js';
 
-loadConfig();
+  loadConfig();
   import {
     runSend,
     runReceive,

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -1,0 +1,16 @@
+let publicUrl: string | undefined;
+
+export async function loadConfig(): Promise<void> {
+  try {
+    const res = await fetch('/config.json');
+    if (!res.ok) return;
+    const data = await res.json();
+    publicUrl = data.publicUrl || undefined;
+  } catch {
+    // config.json is optional; fall through to auto-detection.
+  }
+}
+
+export function baseUrl(): string {
+  return publicUrl ?? (typeof window === 'undefined' ? '' : window.location.href);
+}


### PR DESCRIPTION
When deploying SendArc on a LAN or public domain, the invite link should point at the right host — not localhost. This env var lets self-hosters fix that.

**How it works**
- Server: Config.PublicURL (from SENDARC_PUBLIC_URL env), served as /config.json
- Web app: fetches it once at load, uses the public URL as the base for invite links. Unset = auto-detect (existing window.location behavior), no behavior change.
- Tested: empty and configured paths both covered by unit tests.

**After this is deployed**, self-hosters can run:
  ```sh
  docker run -e SENDARC_PUBLIC_URL=https://192.168.1.100:8443 ... ghcr.io/akshay7273/sendarc
  ```
  and invite links will contain the correct address.