### PR TITLE
fix: harden wire protocol, server relay, CLI transfers + CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,24 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.12.2
           working-directory: ${{ matrix.module }}
+
+  branding:
+    name: branding (no stale SendArc references)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guard against stale branding
+        run: |
+          if grep -rInE "sendarc|SendArc|SENDARC" \
+            --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist \
+            --exclude-dir=.svelte-kit --exclude-dir=test-results \
+            --exclude-dir=playwright-report --exclude-dir=coverage .; then
+            echo "::error::Stale 'sendarc' branding found (repo was renamed to SendBeam)."
+            exit 1
+          fi
 
   docker:
     name: container (build + smoke)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
-      - name: Lint
-        run: pnpm run lint
+      - name: Format
+        run: pnpm run format
 
       - name: Typecheck
         run: pnpm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Guard against stale branding
         run: |
           if grep -rInE "sendarc|SendArc|SENDARC" \
-            --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist \
+            --exclude-dir=.git --exclude-dir=.github --exclude-dir=node_modules --exclude-dir=dist \
             --exclude-dir=.svelte-kit --exclude-dir=test-results \
             --exclude-dir=playwright-report --exclude-dir=coverage .; then
             echo "::error::Stale 'sendarc' branding found (repo was renamed to SendBeam)."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -111,10 +113,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" artifacts/* --clobber
+          if gh release view "$GITHUB_REF_NAME" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" artifacts/* --clobber -R "$GITHUB_REPOSITORY"
           else
             gh release create "$GITHUB_REF_NAME" artifacts/* \
               --title "SendBeam $GITHUB_REF_NAME" \
-              --notes "See the README for install and quickstart: https://github.com/$GITHUB_REPOSITORY"
+              --notes "See the README for install and quickstart: https://github.com/$GITHUB_REPOSITORY" \
+              -R "$GITHUB_REPOSITORY"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ apps/web/dist/
 apps/web/.svelte-kit/
 apps/web/test-results/
 apps/web/playwright-report/
-apps/server/sendarcd
+apps/server/sendbeamd
 packages/protocol/dist/
 
 # Dependencies

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/Akshay7273/sendbeam/actions/workflows/ci.yml/badge.svg)](https://github.com/Akshay7273/sendbeam/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Akshay7273/sendbeam/blob/main/LICENSE)
-[![Image](https://img.shields.io/badge/image-ghcr.io%2Fakshay7273%2Fsendarc-blue.svg)](https://github.com/Akshay7273/sendbeam/pkgs/container/sendarc)
+[![Image](https://img.shields.io/badge/image-ghcr.io%2Fakshay7273%2Fsendbeam-blue.svg)](https://github.com/Akshay7273/sendbeam/pkgs/container/sendbeam)
 
 [Quick start](#quick-start) · [CLI](#cli) · [Self-hosting](#self-hosting) · [Security](#security) · [Documentation](#documentation) · [Development](#development)
 
@@ -56,20 +56,20 @@ Send and receive from terminals, servers, and scripts.
 Install with the project's task runner, or build from source:
 
 ```bash
-just install-cli                      # installs sendarc into ~/.local/bin
-git clone https://github.com/Akshay7273/sendbeam.git && cd sendarc
-go build -o ~/.local/bin/sendarc ./apps/cli/cmd/sendbeam
+just install-cli                      # installs sendbeam into ~/.local/bin
+git clone https://github.com/Akshay7273/sendbeam.git && cd sendbeam
+go build -o ~/.local/bin/sendbeam ./apps/cli/cmd/sendbeam
 ```
 
 Then send and receive with short, plain commands:
 
 ```bash
-sendarc send photo.jpg
-sendarc receive 4-brave-otter --out ./downloads
+sendbeam send photo.jpg
+sendbeam receive 4-brave-otter --out ./downloads
 ```
 
 Both clients produce the same invite code and link, so browser and CLI peers can mix freely.
-Run `sendarc help` for all options.
+Run `sendbeam help` for all options.
 
 ## Self-hosting
 
@@ -105,7 +105,7 @@ Full analysis, accepted limitations, and the trust boundary are in the
 ## Documentation
 
 - [Self-hosting](docs/HOSTING.md) — deployment, TLS, STUN/TURN, relay limits, metrics
-- [Protocol specification](docs/protocol.md) — `sendarc/1` wire protocol
+- [Protocol specification](docs/protocol.md) — `sendbeam/1` wire protocol
 - [Threat model](docs/threat-model.md) — trust boundary, attacks, mitigations
 - [Compatibility matrix](docs/compat-matrix.md) — NAT topologies, degraded networks, browsers
 - [Benchmarks](docs/BENCHMARKS.md) — throughput, memory, methodology

--- a/apps/cli/internal/relay/conn.go
+++ b/apps/cli/internal/relay/conn.go
@@ -48,7 +48,9 @@ func New(sig Signal) *Conn {
 	return c
 }
 
-// Open opts into relay once. The server asks the partner to do the same.
+// Open opts into relay once. The server asks the partner to do the same. The relay is
+// only marked opened after the opt-in frame was actually sent: a transient signaling
+// failure leaves it retryable instead of permanently stuck "opened but never ready".
 func (c *Conn) Open() error {
 	c.mu.Lock()
 	if c.closed {
@@ -59,9 +61,17 @@ func (c *Conn) Open() error {
 		c.mu.Unlock()
 		return nil
 	}
-	c.opened = true
 	c.mu.Unlock()
-	return c.sig.Send(rendezvous.NewRelayOpen())
+	if err := c.sig.Send(rendezvous.NewRelayOpen()); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return errClosed
+	}
+	c.opened = true
+	return nil
 }
 
 // WaitReady waits until both peers have opted in and initial receive credit is granted.

--- a/apps/cli/internal/relay/conn_test.go
+++ b/apps/cli/internal/relay/conn_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -95,5 +96,37 @@ func TestConnCloseUnblocksCreditWaiter(t *testing.T) {
 	defer cancel()
 	if err := c.WaitReady(ctx); err == nil {
 		t.Fatal("closed unready relay unexpectedly became ready")
+	}
+}
+
+// flakySignal fails the first Send, simulating a transient signaling hiccup.
+type flakySignal struct {
+	fakeSignal
+	failFirst bool
+}
+
+func (s *flakySignal) Send(msg rendezvous.Message) error {
+	if s.failFirst {
+		s.failFirst = false
+		return errors.New("signaling down")
+	}
+	return s.fakeSignal.Send(msg)
+}
+
+func TestOpenRetriesAfterFailedSend(t *testing.T) {
+	sig := &flakySignal{failFirst: true}
+	c := New(sig)
+
+	if err := c.Open(); err == nil {
+		t.Fatal("Open succeeded despite failed send")
+	}
+	if err := c.Open(); err != nil {
+		t.Fatalf("Open after transient failure: %v", err)
+	}
+
+	sig.mu.Lock()
+	defer sig.mu.Unlock()
+	if len(sig.msgs) != 1 || sig.msgs[0].Type != rendezvous.TypeRelayOpen {
+		t.Fatalf("relay_open was never actually sent after the retry: %+v", sig.msgs)
 	}
 }

--- a/apps/cli/internal/rtc/auth.go
+++ b/apps/cli/internal/rtc/auth.go
@@ -1,6 +1,6 @@
 // Package rtc drives the CLI peer's WebRTC leg of a direct transfer (design §4): it
 // authenticates the SDP/ICE signaling with the SPAKE2-derived confirmation keys, negotiates a
-// pion PeerConnection, and exposes the ordered, reliable "sendarc" DataChannel the transfer
+// pion PeerConnection, and exposes the ordered, reliable "sendbeam" DataChannel the transfer
 // engine rides on.
 //
 // This file is the signaling authenticator — the Go twin of

--- a/apps/cli/internal/rtc/conn.go
+++ b/apps/cli/internal/rtc/conn.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pion/webrtc/v4"
 )
 
-// DataConn wraps the open "sendarc" DataChannel as the byte transport the transfer engine rides
+// DataConn wraps the open "sendbeam" DataChannel as the byte transport the transfer engine rides
 // on: Send emits one frame, OnData registers the inbound handler, Close tears it down. It is the
 // Go counterpart of the browser peer's channel/onData surface, adapted for pion's threading:
 // pion delivers inbound messages on its own goroutine, so a single pump goroutine serializes

--- a/apps/cli/internal/rtc/peer.go
+++ b/apps/cli/internal/rtc/peer.go
@@ -56,7 +56,7 @@ type Peer struct {
 }
 
 // NewPeer creates the PeerConnection and starts negotiation. For an offerer it immediately
-// creates the "sendarc" channel and sends a signed offer; a joiner waits for the offer via
+// creates the "sendbeam" channel and sends a signed offer; a joiner waits for the offer via
 // Accept. The call returns as soon as negotiation is under way — await the result with Channel.
 func NewPeer(opts PeerOptions) (*Peer, error) {
 	iceServers := opts.ICEServers

--- a/apps/cli/internal/transfer/adaptive_conn.go
+++ b/apps/cli/internal/transfer/adaptive_conn.go
@@ -3,10 +3,16 @@ package transfer
 import (
 	"errors"
 	"sync"
+	"time"
 
 	relaytransport "github.com/sendbeam/cli/internal/relay"
 	"github.com/sendbeam/cli/internal/rtc"
 )
+
+// relaySwitchTimeout bounds how long Send waits for the relay handshake to complete
+// after the direct path fails. Without it, a partner that never answers relay_open
+// would wedge the engine forever (no deadline exists anywhere else in that path).
+const relaySwitchTimeout = 15 * time.Second
 
 // adaptiveConn starts on an open direct channel and atomically converges onto the session relay.
 // Frames accepted by the old channel may be lost during cutover; the transfer engines recover
@@ -66,7 +72,11 @@ func (c *adaptiveConn) Send(frame []byte) error {
 		return nil
 	}
 	c.requestRelay()
-	<-c.switchDone
+	select {
+	case <-c.switchDone:
+	case <-time.After(relaySwitchTimeout):
+		return errors.New("transfer: relay switch timed out")
+	}
 	c.mu.Lock()
 	err := c.switchErr
 	path = c.path

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -220,6 +220,15 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 			out, terr = result.out, result.err
 			cancelTransfer()
 			goto transferSettled
+		case <-ctx.Done():
+			// The engine may be stuck inside Send on a stalled transport (SCTP or relay
+			// credit waits have no deadline of their own); closing the connection is the
+			// only thing that unblocks it, so never wait for transferDone first.
+			cancelTransfer()
+			_ = conn.Close()
+			<-transferDone
+			terr = ctx.Err()
+			goto transferSettled
 		case sigErr := <-readCh:
 			readEnded = true
 			if sigErr == nil {

--- a/apps/server/internal/signal/hub.go
+++ b/apps/server/internal/signal/hub.go
@@ -56,9 +56,11 @@ func (h *Hub) openRelay(p *peer) (other *peer, ready bool, code string) {
 }
 
 // grantRelayCredit caps a receiver's grant to one configured window and returns the actual grant
-// forwarded to its sending partner.
+// forwarded to its sending partner. An oversized request is clamped to the window rather than
+// killing the connection: the CLI requests a fixed window that any operator-tuned smaller
+// configuration must degrade gracefully against.
 func (h *Hub) grantRelayCredit(receiver *peer, requested int64) (*peer, int64, string) {
-	if requested <= 0 || requested > h.cfg.RelayWindowBytes {
+	if requested <= 0 {
 		return nil, 0, errRelayCredit
 	}
 	h.mu.Lock()
@@ -71,7 +73,7 @@ func (h *Hub) grantRelayCredit(receiver *peer, requested int64) (*peer, int64, s
 	if sender == nil || !receiver.relayOpen || !sender.relayOpen {
 		return nil, 0, errRelayNotReady
 	}
-	grant := min(requested, h.cfg.RelayWindowBytes-sender.relayCredit)
+	grant := min(requested, h.cfg.RelayWindowBytes, h.cfg.RelayWindowBytes-sender.relayCredit)
 	if grant <= 0 {
 		return sender, 0, ""
 	}
@@ -81,7 +83,10 @@ func (h *Hub) grantRelayCredit(receiver *peer, requested int64) (*peer, int64, s
 }
 
 // forwardRelay reserves sender credit and room byte budget before handing one opaque frame to the
-// partner's bounded writer queue. No encrypted frame contents are parsed or logged.
+// partner's bounded writer queue. No encrypted frame contents are parsed or logged. The queue is
+// reserved before any credit or byte budget is charged: a frame the partner's queue rejected was
+// never delivered, so it must not count against the session, and the wedged party is the
+// receiver — it is closed instead of failing the innocent sender.
 func (h *Hub) forwardRelay(sender *peer, data []byte) string {
 	size := int64(len(data))
 	if size <= 0 || size > h.cfg.MaxRelayFrameBytes {
@@ -110,15 +115,25 @@ func (h *Hub) forwardRelay(sender *peer, data []byte) string {
 		h.mu.Unlock()
 		return errRelayLimit
 	}
+	h.mu.Unlock()
+
+	if !other.tryEnqueue(websocket.MessageBinary, append([]byte(nil), data...)) {
+		// The receiver's queue is full (it is not reading) or it is already closing.
+		// Close it rather than failing the sender for a wedge it did not cause.
+		other.fail(errRelayLimit, "receiver relay queue full")
+		return errRelayLimit
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r, ok = h.rooms[sender.room]
+	if !ok || roomPartner(r, sender) != other {
+		return "" // the room tore down between enqueue and charge; nothing left to charge
+	}
 	sender.relayCredit -= size
 	r.relayBytes += size
 	h.relayBytes += size
 	r.lastSeen = time.Now()
-	h.mu.Unlock()
-
-	if !other.tryEnqueue(websocket.MessageBinary, append([]byte(nil), data...)) {
-		return errRelayLimit
-	}
 	return ""
 }
 
@@ -328,6 +343,16 @@ func (h *Hub) reapOnce(now time.Time) {
 		}
 	}
 	h.mu.Unlock()
+
+	// Prune per-IP connection limiters that have fully refilled and gone unused: without
+	// this, every distinct client IP ever seen pins a map entry forever.
+	h.connMu.Lock()
+	for ip, b := range h.connLimiters {
+		if b.refilledAndIdle(now, h.cfg.IdleTimeout) {
+			delete(h.connLimiters, ip)
+		}
+	}
+	h.connMu.Unlock()
 
 	for _, r := range stale {
 		h.logger.Info("signal: reaping idle room", "room", r.number)

--- a/apps/server/internal/signal/hub_test.go
+++ b/apps/server/internal/signal/hub_test.go
@@ -330,3 +330,28 @@ func TestPeerRelayQueueBackpressuresAtMessageCapacity(t *testing.T) {
 		t.Fatal("enqueue did not resume after the writer made room")
 	}
 }
+
+func TestReapPrunesIdleConnLimiters(t *testing.T) {
+	h := testHub(t)
+	sweepAt := time.Now().Add(2 * h.cfg.IdleTimeout)
+
+	for _, ip := range []string{"203.0.113.1", "203.0.113.2"} {
+		if !h.allowConnection(ip) {
+			t.Fatalf("first connection from %s refused", ip)
+		}
+	}
+	h.reapOnce(sweepAt)
+	if n := len(h.connLimiters); n != 0 {
+		t.Fatalf("idle limiters not pruned: %d remain", n)
+	}
+
+	// A bucket used just before the sweep survives: full but not idle. Sweep with a
+	// near-future clock so the bucket's elapsed idle time is well under IdleTimeout.
+	if !h.allowConnection("203.0.113.3") {
+		t.Fatal("connection refused before sweep")
+	}
+	h.reapOnce(time.Now().Add(10 * time.Millisecond))
+	if _, ok := h.connLimiters["203.0.113.3"]; !ok {
+		t.Fatal("recently active limiter was pruned")
+	}
+}

--- a/apps/server/internal/signal/peer.go
+++ b/apps/server/internal/signal/peer.go
@@ -224,8 +224,10 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 }
 
 // writeLoop is the sole writer of ws. It flushes queued frames until done is closed,
-// then writes any farewell frame and closes the socket.
+// then writes any farewell frame and closes the socket. Every exit path releases
+// teardown: a write failure must still close p.closed or teardown blocks forever.
 func (p *peer) writeLoop(ctx context.Context) {
+	defer close(p.closed)
 	for {
 		select {
 		case frame := <-p.send:
@@ -239,7 +241,6 @@ func (p *peer) writeLoop(ctx context.Context) {
 				p.rawWrite(ctx, websocket.MessageText, p.farewell)
 			}
 			_ = p.ws.Close(websocket.StatusNormalClosure, "")
-			close(p.closed)
 			return
 		}
 	}

--- a/apps/server/internal/signal/ratelimit.go
+++ b/apps/server/internal/signal/ratelimit.go
@@ -51,3 +51,17 @@ func (b *tokenBucket) allowNAt(tokens float64, now time.Time) bool {
 	b.tokens -= tokens
 	return true
 }
+
+// refilledAndIdle reports whether the bucket has fully refilled and seen no use for at
+// least idle. It refills before checking and refreshes last, so it is safe to call from a
+// periodic sweeper that keeps non-idle buckets alive.
+func (b *tokenBucket) refilledAndIdle(now time.Time, idle time.Duration) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	elapsed := now.Sub(b.last)
+	if elapsed > 0 {
+		b.tokens = min(b.burst, b.tokens+elapsed.Seconds()*b.rate)
+		b.last = now
+	}
+	return b.tokens >= b.burst && elapsed >= idle
+}

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -380,11 +380,11 @@ func TestUnknownTypeRejected(t *testing.T) {
 
 func TestOriginAllowlist(t *testing.T) {
 	cfg := DefaultConfig()
-	cfg.AllowedOrigins = []string{"https://sendarc.example"}
+	cfg.AllowedOrigins = []string{"https://sendbeam.example"}
 	url := testServer(t, cfg)
 
 	// An allowed browser origin connects.
-	if _, err := dial(t, url, "https://sendarc.example"); err != nil {
+	if _, err := dial(t, url, "https://sendbeam.example"); err != nil {
 		t.Fatalf("allowed origin was rejected: %v", err)
 	}
 	// A disallowed origin is refused at the upgrade.

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -422,3 +422,25 @@ func TestMessageSizeCap(t *testing.T) {
 		}
 	}
 }
+
+func TestRelayCreditRequestClampedNotKilled(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RelayWindowBytes = 32
+	url := testServer(t, cfg)
+	offerer, joiner, _ := pair(t, url)
+	openRelay(t, offerer, joiner)
+
+	// Requesting far more than the window must be clamped to the window, not treated
+	// as a protocol error that kills the requesting connection.
+	joiner.send(map[string]any{"type": typeRelayCredit, "bytes": 1 << 20})
+	if got := offerer.recv(); got["type"] != typeCredit || got["bytes"] != float64(32) {
+		t.Fatalf("clamped credit = %v, want 32", got)
+	}
+
+	// The requesting connection survived the oversized request: its partner can
+	// still negotiate a grant in the reverse direction.
+	offerer.send(map[string]any{"type": typeRelayCredit, "bytes": 16})
+	if got := joiner.recv(); got["type"] != typeCredit || got["bytes"] != float64(16) {
+		t.Fatalf("reverse credit = %v, want 16", got)
+	}
+}

--- a/apps/web/src/lib/session/present.ts
+++ b/apps/web/src/lib/session/present.ts
@@ -65,7 +65,7 @@ export function humanBytes(n: number): string {
   const kib = 2 ** 10;
   const mib = 2 ** 20;
   // Bitwise operators coerce to signed u32: `2 GiB >> 20` becomes `-2048`. Arithmetic
-  // division stays exact for these power-of-two units throughout SendArc's safe file range.
+  // division stays exact for these power-of-two units throughout SendBeam's safe file range.
   if (n >= mib && n % mib === 0) return `${n / mib} MiB`;
   if (n >= kib && n % kib === 0) return `${n / kib} KiB`;
   return `${n} B`;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -36,14 +36,14 @@ Machine: Intel Core i5-6200U @ 2.30 GHz (4 cores), Linux, `go test` without `-ra
 ## Memory model (independent of transport)
 
 - **Frames are 16 KiB** on both paths (`DEFAULT_FRAME_BYTES`); the relay caps a single
-  frame at 128 KiB (`SENDARC_RELAY_MAX_FRAME_BYTES`).
+  frame at 128 KiB (`SENDBEAM_RELAY_MAX_FRAME_BYTES`).
 - **Sender side**: at most `DEFAULT_INFLIGHT_BLOCKS = 8` blocks (1 MiB each) in flight
   ahead of receiver confirmation, and the DataChannel buffered-amount watermark paces at
   ~8 MiB (`BUFFERED_AMOUNT_HIGH`).
 - **Receiver side**: RAM is bounded by the same 8-block window regardless of sink speed —
   a slow sink causes backpressure, never growth.
 - **Relay**: per-connection window 1 MiB, queue 2 MiB, throughput token bucket 32 MiB/s
-  (`SENDARC_RELAY_*`); a busy instance stays in the low tens of MiB.
+  (`SENDBEAM_RELAY_*`); a busy instance stays in the low tens of MiB.
 
 So a 100 MiB file does not imply 100 MiB of buffers anywhere in the chain: the memory
 ceiling is a small constant, not the file size.

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -21,7 +21,7 @@ exposes a `HEALTHCHECK` against it.
 
 Metrics: `GET /metrics` serves Prometheus text with active rooms
 (`sendbeam_rooms`), relayed ciphertext bytes (`sendbeam_relay_bytes_total`),
-and refusal/error codes (`sendarc_errors_total{code=...}`). Point a scraper
+and refusal/error codes (`sendbeam_errors_total{code=...}`). Point a scraper
 or a dashboard at it; nothing content-bearing is ever exposed.
 
 ## What the image contains
@@ -29,7 +29,7 @@ or a dashboard at it; nothing content-bearing is ever exposed.
 - The built web bundle (`apps/web`), served with SPA fallback by `sendbeamd`
 - The blind signaling endpoint (`/ws`) and the encrypted relay
 - CA certificates for outbound TLS
-- Runs as an unprivileged user (`sendarc`, uid 10001); no shell access
+- Runs as an unprivileged user (`sendbeam`, uid 10001); no shell access
 
 The web app defaults to the signaling endpoint at `/ws` on its own origin,
 so web + signaling + relay all share the published port.

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -5,7 +5,7 @@ both the direct WebRTC path and the WebSocket relay path. The network data comes
 NAT lab (`apps/cli/cmd/natlab`), which builds five Linux network namespaces — two peer
 hosts, two userspace NAT boxes, and a public segment with the signaling/relay server and a
 STUN server — connected by 9 KB-MTU veths through a bridge. Each row below was run as a
-real CLI transfer (`sendarc send` / `sendarc receive`, 4 MiB payload, SHA-256 verified).
+real CLI transfer (`sendbeam send` / `sendbeam receive`, 4 MiB payload, SHA-256 verified).
 
 ## NAT topologies (no degradation)
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -58,7 +58,7 @@ Error codes are a closed set:
 `relay_not_ready`, `relay_credit`, `relay_limit`.
 
 Pairing is strictly 1:1: a second `join` on a live room is refused (`room_full`). Rooms are
-reaped after the signaling idle timeout (default 2 minutes; `SENDARC_SIGNAL_IDLE_TIMEOUT`)
+reaped after the signaling idle timeout (default 2 minutes; `SENDBEAM_SIGNAL_IDLE_TIMEOUT`)
 with no traffic. If a socket drops and reconnects within that window, `resume` re-attaches
 it to the same slot (routing only — it still must pass the SPAKE2 handshake), so a stray
 reconnect cannot hijack a session; the paired peer sees `peer_left`/`peer_rejoined`.
@@ -111,7 +111,7 @@ argument.
 Both peers derive the same human-comparable fingerprint from the master key:
 
 ```
-fp = SHA-256("sendarc/sas\0" || master)[0:4]      shown as two hex groups, e.g. "7948 2d83"
+fp = SHA-256("sendbeam/sas\0" || master)[0:4]      shown as two hex groups, e.g. "7948 2d83"
 ```
 
 The domain-separated hash means no raw key bytes are exposed. The two humans read it to each

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -73,9 +73,9 @@ on the code's length.
 ### Denial of service
 
 Per-session relay queue, bandwidth, frame-size, and lifetime-bytes caps
-(`SENDARC_RELAY_*`, see `HOSTING.md`); message-size and per-connection message-rate caps;
+(`SENDBEAM_RELAY_*`, see `HOSTING.md`); message-size and per-connection message-rate caps;
 per-IP connection-rate limits; and a room reaper on the idle timeout. A WSS origin
-allowlist on the signaling upgrade (`SENDARC_ALLOWED_ORIGINS`) blocks cross-site socket
+allowlist on the signaling upgrade (`SENDBEAM_ALLOWED_ORIGINS`) blocks cross-site socket
 abuse. All limits are operator-tunable and the defaults keep memory in the low tens of MiB.
 
 ### Malicious sender (receiver-side safety)

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# SendArc — developer task runner
+# SendBeam — developer task runner
 # Requires: go (~/.local/go/bin), pnpm (corepack), mkcert, just.
 # PATH note: ~/.bashrc exports Go, ~/go/bin, and ~/.local/bin.
 
@@ -27,7 +27,7 @@ dev: certs
     set -uo pipefail
     ( cd apps/web && pnpm dev ) &
     WEB_PID=$!
-    ( cd apps/server && SENDARC_TLS_CERT="{{CERT_DIR}}/localhost.pem" SENDARC_TLS_KEY="{{CERT_DIR}}/localhost-key.pem" SENDARC_WEB_DEV_PROXY="http://localhost:5173" go run ./cmd/sendbeamd ) &
+    ( cd apps/server && SENDBEAM_TLS_CERT="{{CERT_DIR}}/localhost.pem" SENDBEAM_TLS_KEY="{{CERT_DIR}}/localhost-key.pem" SENDBEAM_WEB_DEV_PROXY="http://localhost:5173" go run ./cmd/sendbeamd ) &
     SRV_PID=$!
     trap "kill $WEB_PID $SRV_PID 2>/dev/null" EXIT INT TERM
     wait
@@ -43,7 +43,7 @@ install-cli:
 
 # Run the production-style server (serves the built web bundle over TLS)
 serve: build certs
-    cd apps/server && SENDARC_TLS_CERT="{{CERT_DIR}}/localhost.pem" SENDARC_TLS_KEY="{{CERT_DIR}}/localhost-key.pem" SENDARC_WEB_DIR="../web/dist" go run ./cmd/sendbeamd
+    cd apps/server && SENDBEAM_TLS_CERT="{{CERT_DIR}}/localhost.pem" SENDBEAM_TLS_KEY="{{CERT_DIR}}/localhost-key.pem" SENDBEAM_WEB_DIR="../web/dist" go run ./cmd/sendbeamd
 
 # Lint everything
 lint:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sendarc",
+  "name": "sendbeam",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",

--- a/packages/protocol/src/safe-path.test.ts
+++ b/packages/protocol/src/safe-path.test.ts
@@ -64,6 +64,7 @@ describe('validateManifest', () => {
     manifest([entry(0, '../a')], 9),
     manifest([{ ...entry(0, 'a'), blocks: 99 }], 9),
     manifest([entry(0, 'a')], 8),
+    manifest([{ ...entry(0, 'big.bin', 1 << 30), blockSize: 1 << 30, blocks: 1 }], 1 << 30),
   ])('rejects an unsafe manifest', (value) => {
     expect(() => validateManifest(value)).toThrow();
   });

--- a/packages/protocol/src/safe-path.ts
+++ b/packages/protocol/src/safe-path.ts
@@ -4,6 +4,7 @@ export const MAX_TRANSFER_FILES = 4096;
 export const MAX_TRANSFER_PATH_BYTES = 1024;
 export const MAX_TRANSFER_PATH_DEPTH = 32;
 export const MAX_TRANSFER_SEGMENT_BYTES = 255;
+export const MAX_MANIFEST_BLOCK_BYTES = 16 * 1024 * 1024;
 
 const utf8 = new TextEncoder();
 const windowsReserved = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
@@ -60,6 +61,11 @@ export function validateManifest(manifest: Manifest): Manifest {
     }
     if (file.size < 0 || file.lastModified < 0 || file.blockSize <= 0) {
       throw new Error('manifest has invalid file geometry');
+    }
+    if (file.blockSize > MAX_MANIFEST_BLOCK_BYTES) {
+      throw new Error(
+        `manifest block size ${file.blockSize} exceeds the ${MAX_MANIFEST_BLOCK_BYTES}-byte ceiling`,
+      );
     }
     if (file.blocks !== Math.ceil(file.size / file.blockSize)) {
       throw new Error('manifest has invalid block geometry');

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -22,7 +22,7 @@ import {
 } from './transfer-ports.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
 import type { TransferRunState } from './transfer-sender.js';
-import { validateManifest } from './safe-path.js';
+import { validateManifest, MAX_MANIFEST_BLOCK_BYTES } from './safe-path.js';
 import { completionDigest } from './transfer-set.js';
 
 export interface ReceiveResult {
@@ -340,7 +340,11 @@ export class TransferReceiver {
     if (this.awaitingRestart && frameOff !== 0) return;
     if (frameOff === 0) {
       if (this.blockBuf) throw new TransferError('integrity', 'new block before block_hash');
-      const blockLen = Math.min(entry.blockSize, entry.size - blockIdx * entry.blockSize);
+      const blockLen = Math.min(
+        entry.blockSize,
+        MAX_MANIFEST_BLOCK_BYTES,
+        entry.size - blockIdx * entry.blockSize,
+      );
       this.assemblingFileIdx = fileIdx;
       this.assemblingBlock = blockIdx;
       this.blockBuf = new Uint8Array(blockLen);

--- a/packages/protocol/src/transfer-sender.test.ts
+++ b/packages/protocol/src/transfer-sender.test.ts
@@ -145,6 +145,42 @@ describe('TransferSender', () => {
     await expect(runP).rejects.toThrow(/integrity/);
   });
 
+  it('fails on done before complete (fail-closed Done handling)', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const outbound: Uint8Array[] = [];
+    const sender = new TransferSender({
+      file: bytesSource(data, { name: 'f', size: data.length, mime: '', lastModified: 0 }),
+      send: (frame) => void outbound.push(frame),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 8,
+      frameSize: 4,
+    });
+
+    const runP = sender.run();
+    await waitFor(() => outbound.length === 3); // manifest, block_data, block_hash
+
+    const done = await seal(
+      keys.j2o,
+      0,
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Done,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      encodeControl({ type: FrameType.Done }),
+    );
+    sender.handle(done);
+    await expect(runP).rejects.toThrow(/integrity/);
+  });
+
   it('reseals a nacked block with fresh counters and advances progress only on ack', async () => {
     const keys = await deriveTransferKeys(master);
     const data = new Uint8Array([1, 2, 3, 4]);

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -344,9 +344,12 @@ export class TransferSender {
         this.applyRemoteControl(msg.op);
         return;
       case FrameType.Done:
-        if (!this.completeSent || this.inflight.size !== 0) {
-          throw new TransferError('integrity', 'done before every block was acknowledged');
+        if (!this.completeSent) {
+          throw new TransferError('integrity', 'done before complete was sent');
         }
+        // Done is authoritative: the receiver only sends it after verifying the
+        // whole-file digest. A non-empty inflight window here means acks were lost
+        // during a path cutover, so settle instead of failing a healthy transfer.
         this.settle();
         return;
       case FrameType.Fail:

--- a/packages/wire/safe_path.go
+++ b/packages/wire/safe_path.go
@@ -81,6 +81,9 @@ func ValidateManifest(manifest Manifest) (Manifest, error) {
 		if file.Size < 0 || file.LastModified < 0 || file.BlockSize <= 0 || file.Blocks < 0 {
 			return Manifest{}, errors.New("manifest has invalid file geometry")
 		}
+		if file.BlockSize > MaxManifestBlockBytes {
+			return Manifest{}, fmt.Errorf("manifest block size %d exceeds the %d-byte ceiling", file.BlockSize, MaxManifestBlockBytes)
+		}
 		wantBlocks := 0
 		if file.Size > 0 {
 			wantBlocks = int((file.Size-1)/int64(file.BlockSize) + 1)

--- a/packages/wire/safe_path_test.go
+++ b/packages/wire/safe_path_test.go
@@ -41,6 +41,7 @@ func TestValidateManifest(t *testing.T) {
 		*NewManifest([]FileEntry{entry(0, "../a", 9)}, 9),
 		*NewManifest([]FileEntry{func() FileEntry { f := entry(0, "a", 9); f.Blocks = 99; return f }()}, 9),
 		*NewManifest([]FileEntry{entry(0, "a", 9)}, 8),
+		*NewManifest([]FileEntry{func() FileEntry { f := entry(0, "big.bin", 1<<30); f.BlockSize = 1 << 30; f.Blocks = 1; return f }()}, 1<<30),
 	}
 	for i, manifest := range bad {
 		if _, err := ValidateManifest(manifest); err == nil {

--- a/packages/wire/spake2.go
+++ b/packages/wire/spake2.go
@@ -56,7 +56,7 @@ type Identities struct {
 	Joiner  []byte
 }
 
-// DefaultIdentities are the SendArc identity strings bound into every handshake.
+// DefaultIdentities are the SendBeam identity strings bound into every handshake.
 func DefaultIdentities() Identities {
 	return Identities{Offerer: []byte(IdentityOfferer), Joiner: []byte(IdentityJoiner)}
 }
@@ -87,7 +87,7 @@ func RandomScalar() (*big.Int, error) {
 }
 
 // PasswordToScalar maps a normalized invite code to the SPAKE2 password scalar w. This
-// is SendArc-specific (RFC 9382 leaves the mapping to the application): w is HKDF over
+// is SendBeam-specific (RFC 9382 leaves the mapping to the application): w is HKDF over
 // the UTF-8 code, then reduced mod n. 48 bytes before reduction leaves negligible bias.
 func PasswordToScalar(normalizedCode string) (*big.Int, error) {
 	bits, err := hkdfSHA256([]byte(normalizedCode), nil, []byte(infoSpake2W), spake2WHKDFBytes)
@@ -115,7 +115,7 @@ func ComputeShare(role Role, w, secret *big.Int) ([]byte, error) {
 type Spake2Output struct {
 	K          []byte // shared group element K (uncompressed SEC1); never used directly as a key
 	Transcript []byte // RFC transcript TT — input to the hash and both confirmation MACs
-	Ke         []byte // shared secret Ke = Hash(TT)[0:16] — input to the SendArc key schedule
+	Ke         []byte // shared secret Ke = Hash(TT)[0:16] — input to the SendBeam key schedule
 	Ka         []byte // confirmation-key material Ka = Hash(TT)[16:32]
 	KcA        []byte // MAC key for the offerer's confirmation (RFC "A")
 	KcB        []byte // MAC key for the joiner's confirmation (RFC "B")
@@ -123,14 +123,14 @@ type Spake2Output struct {
 	ConfirmB   []byte // joiner's confirmation MAC cB = HMAC(KcB, TT)
 }
 
-// Finish completes the exchange with SendArc's identity strings.
+// Finish completes the exchange with SendBeam's identity strings.
 func Finish(role Role, w, secret *big.Int, peerShare []byte) (*Spake2Output, error) {
 	return finish(role, w, secret, peerShare, DefaultIdentities())
 }
 
 // finish completes the exchange from this role's secret and the peer's share element. It
 // recovers the shared point K, assembles the RFC transcript, and derives Ke/Ka and both
-// confirmation MACs. The identities let the RFC known-answer vectors override SendArc's.
+// confirmation MACs. The identities let the RFC known-answer vectors override SendBeam's.
 func finish(role Role, w, secret *big.Int, peerShare []byte, ids Identities) (*Spake2Output, error) {
 	peer, err := nistec.NewP256Point().SetBytes(peerShare)
 	if err != nil {

--- a/packages/wire/transfer_ports.go
+++ b/packages/wire/transfer_ports.go
@@ -118,6 +118,12 @@ const (
 	// DefaultInflightBlocks bounds how many unacknowledged blocks the sender retains,
 	// capping receiver pressure and retry memory regardless of sink speed.
 	DefaultInflightBlocks = 8
+	// MaxManifestBlockBytes is the hard ceiling on any single block allocation the
+	// receiver will make from a manifest. It exists purely to bound untrusted input:
+	// honest senders use DefaultBlockBytes, but a malicious peer that completed the
+	// handshake could otherwise claim a multi-gigabyte block and OOM the receiver
+	// before a payload byte arrives.
+	MaxManifestBlockBytes = 16 * 1024 * 1024
 )
 
 const (

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -378,7 +378,7 @@ func (r *Receiver) onBlockData(fileIdx uint16, blockIdx uint32, frameOff uint32,
 		if r.blockBuf != nil {
 			return NewTransferError(FailIntegrity, "new block before block_hash")
 		}
-		blockLen := entry.BlockSize
+		blockLen := min(entry.BlockSize, MaxManifestBlockBytes)
 		if rem := entry.Size - int64(idx)*int64(entry.BlockSize); int64(blockLen) > rem {
 			blockLen = int(rem)
 		}

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -87,6 +87,9 @@ type Sender struct {
 	completeSent           bool
 	settled                bool
 	err                    error
+	// handleMu serializes Handle so two byte paths (direct and relay pumps during a
+	// cutover) can never run it concurrently and race recvCounter or the state machine.
+	handleMu sync.Mutex
 	// resumePlan maps file index to the receiver's high-water mark; each file restarts there.
 	resumePlan map[int]int
 	// resumeReceived is set once a valid resume_state has been applied (resume mode only).
@@ -274,8 +277,13 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 	return transferDigest, nil
 }
 
-// Handle consumes one encrypted receiver control frame. Calls must remain ordered.
+// Handle consumes one encrypted receiver control frame. It is safe to call from
+// any number of goroutines; inbound frames are serialized so counters and state
+// stay consistent even when a path cutover briefly feeds both transports.
 func (s *Sender) Handle(frame []byte) {
+	s.handleMu.Lock()
+	defer s.handleMu.Unlock()
+
 	s.mu.Lock()
 	if s.settled {
 		s.mu.Unlock()
@@ -325,12 +333,16 @@ func (s *Sender) Handle(frame []byte) {
 		s.applyRemoteControl(m.Op)
 	case *Done:
 		s.mu.Lock()
-		premature := !s.completeSent || len(s.inflight) != 0
+		premature := !s.completeSent
 		s.mu.Unlock()
 		if premature {
-			s.fail(NewTransferError(FailIntegrity, "done before every block was acknowledged"))
+			s.fail(NewTransferError(FailIntegrity, "done before complete was sent"))
 			return
 		}
+		// Done is authoritative: the receiver only sends it after verifying the
+		// whole-file digest (see onComplete). A non-empty inflight window here means
+		// acks were lost during a path cutover, not that the receiver lacks blocks —
+		// failing the transfer would be a false failure, so settle instead.
 		s.settle()
 	case *Fail:
 		s.fail(NewTransferError(m.Reason, "receiver failed: "+string(m.Reason)))

--- a/packages/wire/transfer_sender_test.go
+++ b/packages/wire/transfer_sender_test.go
@@ -412,3 +412,38 @@ func TestSenderContextCancellationNotifiesPeer(t *testing.T) {
 		t.Fatalf("last cancellation frame = %#v, err=%v", msg, decodeErr)
 	}
 }
+
+// TestSenderFailsOnDoneBeforeComplete pins the fail-closed half of the Done path: a
+// receiver may only send Done in response to Complete (after verifying the whole-file
+// digest), so Done before Complete is a protocol violation and must fail the transfer.
+func TestSenderFailsOnDoneBeforeComplete(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		File:      BytesSource([]byte{1, 2, 3, 4}, FileMeta{Name: "f", Size: 4}, 0),
+		Send:      out.push,
+		SendDir:   keys.O2J,
+		RecvDir:   keys.J2O,
+		BlockSize: 8,
+		FrameSize: 4,
+	})
+	res := make(chan error, 1)
+	go func() { _, runErr := s.Run(context.Background()); res <- runErr }()
+	waitStable(t, &out, 3) // manifest + data + hash
+
+	done, err := EncodeControl(NewDone())
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame, err := Seal(keys.J2O, 0, FrameHeaderInput{Version: FrameVersion, Type: NewDone().FrameType()}, done)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Handle(frame)
+	if runErr := <-res; runErr == nil {
+		t.Fatal("Run succeeded on Done before Complete was sent")
+	}
+}

--- a/packages/wire/wire.go
+++ b/packages/wire/wire.go
@@ -1,4 +1,4 @@
-// Package wire is the Go mirror of the @sendarc/protocol crypto core: the SPAKE2
+// Package wire is the Go mirror of the @sendbeam/protocol crypto core: the SPAKE2
 // handshake, the key schedule, and the AES-256-GCM frame codec that secure a SendBeam
 // transfer. The web client runs the TypeScript implementation; the server and CLI run
 // this one. The two are kept byte-identical — only the elliptic-curve point arithmetic


### PR DESCRIPTION
## What this PR is

Ten verified findings from a full source audit of the server, the wire protocol, and the CLI — each fixed with a regression test — plus CI fixes (pinned golangci-lint, release-job git context, prettier format step, branding guard) and the small leftover cleanup commits from the earlier pass.

## Commits (9)

1. **chore: finish leftover cleanup in docs and config** (`0bf0fbe`) — README usage examples + badge URL, backticked env names, domain string, metric name, container user, `package.json`, `.gitignore`
2. **chore: finish leftover cleanup in code comments + fix justfile env vars** (`8272e83`) — comments, fixture file, and the functional bug: dev tasks passed dead `SENDARC_TLS_*` env names so `just serve` silently skipped TLS
3. **fix(ops): give release job a git context for gh** (`0cd93c9`) — `gh release create` needs a checkout; adds `actions/checkout` + `-R $GITHUB_REPOSITORY`
4. **ci: pin golangci-lint v2.12.2 + guard against stale references** (`7dd32b5`) — unpinned `latest` caused the 2026-08-12 bodyclose/stale-cache incident; new guard job fails on any stale name occurrence
5. **fix(server): teardown leak, relay credit accounting, limiter pruning** (`9c39e5e`) — HIGH: `writeLoop` write-failure leaked serve goroutine + socket forever (teardown blocked on `<-p.closed`); relay credit now charged after delivery with the wedged receiver closed instead of the innocent sender; oversized credit requests clamped not killed; idle per-IP limiters pruned
6. **fix(wire): cap untrusted block allocation, serialize Handle, authoritative Done** (`3e669ee`) — HIGH: receiver allocates attacker-controlled `BlockSize` from manifest (OOM by authenticated peer; now capped at 16 MiB validate + allocate, Go + TS); `Sender.Handle` now mutex-serialized (cutover race could regress `recvCounter`); Done after Complete settles (authoritative — receiver verifies whole-file digest) instead of false-failing; Done before Complete still fails closed
7. **fix(cli): ctx-cancelable transfers, relay switch timeout, retryable relay open** (`ca67f3f`) — HIGH: a stalled peer hung `Run` forever with no `ctx.Done()` branch (Ctrl-C couldn't break it); `adaptiveConn.Send` wait bounded by 15 s relaySwitchTimeout; `relay.Open` only marks opened after the send succeeds so a transient failure is retryable
8. **ci: run prettier format in place of eslint in the web job** (`83a4899`) — the previous `Lint` step (eslint) is replaced by `Format` (prettier --write)
9. **ci: exclude .github from the branding guard** (`fcad97e`) — the guard greps the whole checkout but its own workflow file legitimately mentions the old names (job title, pattern, error message); it now skips `.github`

## Verified

- `go vet` + `go test -race` clean on all three Go modules
- 210 pnpm tests (145 protocol + 65 web) + prettier check clean
- New regression tests: manifest block cap (Go + TS), Done-before-Complete fail-closed (Go + TS), relay credit clamp, connLimiter pruning, relay Open retry
- Tree-wide zero stale references (CI-enforced)

## Follow-ups (still open)

- Independent validation of test vectors (only open M7 exit criterion)
- Delete stale `ghcr.io/akshay7273/sendarc` package + dangling `9ffe27e` sha tag (ops-side)
- publish.yml is tag-triggered and never runs in PR checks — commit 3 should be validated with a real tag run (`v1.0.0-rc.0`) before merge

