### PR TITLE
chore: complete SendArc→SendBeam rebrand + CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,24 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.12.2
           working-directory: ${{ matrix.module }}
+
+  branding:
+    name: branding (no stale SendArc references)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guard against stale branding
+        run: |
+          if grep -rInE "sendarc|SendArc|SENDARC" \
+            --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist \
+            --exclude-dir=.svelte-kit --exclude-dir=test-results \
+            --exclude-dir=playwright-report --exclude-dir=coverage .; then
+            echo "::error::Stale 'sendarc' branding found (repo was renamed to SendBeam)."
+            exit 1
+          fi
 
   docker:
     name: container (build + smoke)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -111,10 +113,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" artifacts/* --clobber
+          if gh release view "$GITHUB_REF_NAME" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" artifacts/* --clobber -R "$GITHUB_REPOSITORY"
           else
             gh release create "$GITHUB_REF_NAME" artifacts/* \
               --title "SendBeam $GITHUB_REF_NAME" \
-              --notes "See the README for install and quickstart: https://github.com/$GITHUB_REPOSITORY"
+              --notes "See the README for install and quickstart: https://github.com/$GITHUB_REPOSITORY" \
+              -R "$GITHUB_REPOSITORY"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ apps/web/dist/
 apps/web/.svelte-kit/
 apps/web/test-results/
 apps/web/playwright-report/
-apps/server/sendarcd
+apps/server/sendbeamd
 packages/protocol/dist/
 
 # Dependencies

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/Akshay7273/sendbeam/actions/workflows/ci.yml/badge.svg)](https://github.com/Akshay7273/sendbeam/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Akshay7273/sendbeam/blob/main/LICENSE)
-[![Image](https://img.shields.io/badge/image-ghcr.io%2Fakshay7273%2Fsendarc-blue.svg)](https://github.com/Akshay7273/sendbeam/pkgs/container/sendarc)
+[![Image](https://img.shields.io/badge/image-ghcr.io%2Fakshay7273%2Fsendbeam-blue.svg)](https://github.com/Akshay7273/sendbeam/pkgs/container/sendbeam)
 
 [Quick start](#quick-start) · [CLI](#cli) · [Self-hosting](#self-hosting) · [Security](#security) · [Documentation](#documentation) · [Development](#development)
 
@@ -56,20 +56,20 @@ Send and receive from terminals, servers, and scripts.
 Install with the project's task runner, or build from source:
 
 ```bash
-just install-cli                      # installs sendarc into ~/.local/bin
-git clone https://github.com/Akshay7273/sendbeam.git && cd sendarc
-go build -o ~/.local/bin/sendarc ./apps/cli/cmd/sendbeam
+just install-cli                      # installs sendbeam into ~/.local/bin
+git clone https://github.com/Akshay7273/sendbeam.git && cd sendbeam
+go build -o ~/.local/bin/sendbeam ./apps/cli/cmd/sendbeam
 ```
 
 Then send and receive with short, plain commands:
 
 ```bash
-sendarc send photo.jpg
-sendarc receive 4-brave-otter --out ./downloads
+sendbeam send photo.jpg
+sendbeam receive 4-brave-otter --out ./downloads
 ```
 
 Both clients produce the same invite code and link, so browser and CLI peers can mix freely.
-Run `sendarc help` for all options.
+Run `sendbeam help` for all options.
 
 ## Self-hosting
 
@@ -105,7 +105,7 @@ Full analysis, accepted limitations, and the trust boundary are in the
 ## Documentation
 
 - [Self-hosting](docs/HOSTING.md) — deployment, TLS, STUN/TURN, relay limits, metrics
-- [Protocol specification](docs/protocol.md) — `sendarc/1` wire protocol
+- [Protocol specification](docs/protocol.md) — `sendbeam/1` wire protocol
 - [Threat model](docs/threat-model.md) — trust boundary, attacks, mitigations
 - [Compatibility matrix](docs/compat-matrix.md) — NAT topologies, degraded networks, browsers
 - [Benchmarks](docs/BENCHMARKS.md) — throughput, memory, methodology

--- a/apps/cli/internal/rtc/auth.go
+++ b/apps/cli/internal/rtc/auth.go
@@ -1,6 +1,6 @@
 // Package rtc drives the CLI peer's WebRTC leg of a direct transfer (design §4): it
 // authenticates the SDP/ICE signaling with the SPAKE2-derived confirmation keys, negotiates a
-// pion PeerConnection, and exposes the ordered, reliable "sendarc" DataChannel the transfer
+// pion PeerConnection, and exposes the ordered, reliable "sendbeam" DataChannel the transfer
 // engine rides on.
 //
 // This file is the signaling authenticator — the Go twin of

--- a/apps/cli/internal/rtc/conn.go
+++ b/apps/cli/internal/rtc/conn.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pion/webrtc/v4"
 )
 
-// DataConn wraps the open "sendarc" DataChannel as the byte transport the transfer engine rides
+// DataConn wraps the open "sendbeam" DataChannel as the byte transport the transfer engine rides
 // on: Send emits one frame, OnData registers the inbound handler, Close tears it down. It is the
 // Go counterpart of the browser peer's channel/onData surface, adapted for pion's threading:
 // pion delivers inbound messages on its own goroutine, so a single pump goroutine serializes

--- a/apps/cli/internal/rtc/peer.go
+++ b/apps/cli/internal/rtc/peer.go
@@ -56,7 +56,7 @@ type Peer struct {
 }
 
 // NewPeer creates the PeerConnection and starts negotiation. For an offerer it immediately
-// creates the "sendarc" channel and sends a signed offer; a joiner waits for the offer via
+// creates the "sendbeam" channel and sends a signed offer; a joiner waits for the offer via
 // Accept. The call returns as soon as negotiation is under way — await the result with Channel.
 func NewPeer(opts PeerOptions) (*Peer, error) {
 	iceServers := opts.ICEServers

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -380,11 +380,11 @@ func TestUnknownTypeRejected(t *testing.T) {
 
 func TestOriginAllowlist(t *testing.T) {
 	cfg := DefaultConfig()
-	cfg.AllowedOrigins = []string{"https://sendarc.example"}
+	cfg.AllowedOrigins = []string{"https://sendbeam.example"}
 	url := testServer(t, cfg)
 
 	// An allowed browser origin connects.
-	if _, err := dial(t, url, "https://sendarc.example"); err != nil {
+	if _, err := dial(t, url, "https://sendbeam.example"); err != nil {
 		t.Fatalf("allowed origin was rejected: %v", err)
 	}
 	// A disallowed origin is refused at the upgrade.

--- a/apps/web/src/lib/session/present.ts
+++ b/apps/web/src/lib/session/present.ts
@@ -65,7 +65,7 @@ export function humanBytes(n: number): string {
   const kib = 2 ** 10;
   const mib = 2 ** 20;
   // Bitwise operators coerce to signed u32: `2 GiB >> 20` becomes `-2048`. Arithmetic
-  // division stays exact for these power-of-two units throughout SendArc's safe file range.
+  // division stays exact for these power-of-two units throughout SendBeam's safe file range.
   if (n >= mib && n % mib === 0) return `${n / mib} MiB`;
   if (n >= kib && n % kib === 0) return `${n / kib} KiB`;
   return `${n} B`;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -36,14 +36,14 @@ Machine: Intel Core i5-6200U @ 2.30 GHz (4 cores), Linux, `go test` without `-ra
 ## Memory model (independent of transport)
 
 - **Frames are 16 KiB** on both paths (`DEFAULT_FRAME_BYTES`); the relay caps a single
-  frame at 128 KiB (`SENDARC_RELAY_MAX_FRAME_BYTES`).
+  frame at 128 KiB (`SENDBEAM_RELAY_MAX_FRAME_BYTES`).
 - **Sender side**: at most `DEFAULT_INFLIGHT_BLOCKS = 8` blocks (1 MiB each) in flight
   ahead of receiver confirmation, and the DataChannel buffered-amount watermark paces at
   ~8 MiB (`BUFFERED_AMOUNT_HIGH`).
 - **Receiver side**: RAM is bounded by the same 8-block window regardless of sink speed —
   a slow sink causes backpressure, never growth.
 - **Relay**: per-connection window 1 MiB, queue 2 MiB, throughput token bucket 32 MiB/s
-  (`SENDARC_RELAY_*`); a busy instance stays in the low tens of MiB.
+  (`SENDBEAM_RELAY_*`); a busy instance stays in the low tens of MiB.
 
 So a 100 MiB file does not imply 100 MiB of buffers anywhere in the chain: the memory
 ceiling is a small constant, not the file size.

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -21,7 +21,7 @@ exposes a `HEALTHCHECK` against it.
 
 Metrics: `GET /metrics` serves Prometheus text with active rooms
 (`sendbeam_rooms`), relayed ciphertext bytes (`sendbeam_relay_bytes_total`),
-and refusal/error codes (`sendarc_errors_total{code=...}`). Point a scraper
+and refusal/error codes (`sendbeam_errors_total{code=...}`). Point a scraper
 or a dashboard at it; nothing content-bearing is ever exposed.
 
 ## What the image contains
@@ -29,7 +29,7 @@ or a dashboard at it; nothing content-bearing is ever exposed.
 - The built web bundle (`apps/web`), served with SPA fallback by `sendbeamd`
 - The blind signaling endpoint (`/ws`) and the encrypted relay
 - CA certificates for outbound TLS
-- Runs as an unprivileged user (`sendarc`, uid 10001); no shell access
+- Runs as an unprivileged user (`sendbeam`, uid 10001); no shell access
 
 The web app defaults to the signaling endpoint at `/ws` on its own origin,
 so web + signaling + relay all share the published port.

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -5,7 +5,7 @@ both the direct WebRTC path and the WebSocket relay path. The network data comes
 NAT lab (`apps/cli/cmd/natlab`), which builds five Linux network namespaces — two peer
 hosts, two userspace NAT boxes, and a public segment with the signaling/relay server and a
 STUN server — connected by 9 KB-MTU veths through a bridge. Each row below was run as a
-real CLI transfer (`sendarc send` / `sendarc receive`, 4 MiB payload, SHA-256 verified).
+real CLI transfer (`sendbeam send` / `sendbeam receive`, 4 MiB payload, SHA-256 verified).
 
 ## NAT topologies (no degradation)
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -58,7 +58,7 @@ Error codes are a closed set:
 `relay_not_ready`, `relay_credit`, `relay_limit`.
 
 Pairing is strictly 1:1: a second `join` on a live room is refused (`room_full`). Rooms are
-reaped after the signaling idle timeout (default 2 minutes; `SENDARC_SIGNAL_IDLE_TIMEOUT`)
+reaped after the signaling idle timeout (default 2 minutes; `SENDBEAM_SIGNAL_IDLE_TIMEOUT`)
 with no traffic. If a socket drops and reconnects within that window, `resume` re-attaches
 it to the same slot (routing only — it still must pass the SPAKE2 handshake), so a stray
 reconnect cannot hijack a session; the paired peer sees `peer_left`/`peer_rejoined`.
@@ -111,7 +111,7 @@ argument.
 Both peers derive the same human-comparable fingerprint from the master key:
 
 ```
-fp = SHA-256("sendarc/sas\0" || master)[0:4]      shown as two hex groups, e.g. "7948 2d83"
+fp = SHA-256("sendbeam/sas\0" || master)[0:4]      shown as two hex groups, e.g. "7948 2d83"
 ```
 
 The domain-separated hash means no raw key bytes are exposed. The two humans read it to each

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -73,9 +73,9 @@ on the code's length.
 ### Denial of service
 
 Per-session relay queue, bandwidth, frame-size, and lifetime-bytes caps
-(`SENDARC_RELAY_*`, see `HOSTING.md`); message-size and per-connection message-rate caps;
+(`SENDBEAM_RELAY_*`, see `HOSTING.md`); message-size and per-connection message-rate caps;
 per-IP connection-rate limits; and a room reaper on the idle timeout. A WSS origin
-allowlist on the signaling upgrade (`SENDARC_ALLOWED_ORIGINS`) blocks cross-site socket
+allowlist on the signaling upgrade (`SENDBEAM_ALLOWED_ORIGINS`) blocks cross-site socket
 abuse. All limits are operator-tunable and the defaults keep memory in the low tens of MiB.
 
 ### Malicious sender (receiver-side safety)

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# SendArc — developer task runner
+# SendBeam — developer task runner
 # Requires: go (~/.local/go/bin), pnpm (corepack), mkcert, just.
 # PATH note: ~/.bashrc exports Go, ~/go/bin, and ~/.local/bin.
 
@@ -27,7 +27,7 @@ dev: certs
     set -uo pipefail
     ( cd apps/web && pnpm dev ) &
     WEB_PID=$!
-    ( cd apps/server && SENDARC_TLS_CERT="{{CERT_DIR}}/localhost.pem" SENDARC_TLS_KEY="{{CERT_DIR}}/localhost-key.pem" SENDARC_WEB_DEV_PROXY="http://localhost:5173" go run ./cmd/sendbeamd ) &
+    ( cd apps/server && SENDBEAM_TLS_CERT="{{CERT_DIR}}/localhost.pem" SENDBEAM_TLS_KEY="{{CERT_DIR}}/localhost-key.pem" SENDBEAM_WEB_DEV_PROXY="http://localhost:5173" go run ./cmd/sendbeamd ) &
     SRV_PID=$!
     trap "kill $WEB_PID $SRV_PID 2>/dev/null" EXIT INT TERM
     wait
@@ -43,7 +43,7 @@ install-cli:
 
 # Run the production-style server (serves the built web bundle over TLS)
 serve: build certs
-    cd apps/server && SENDARC_TLS_CERT="{{CERT_DIR}}/localhost.pem" SENDARC_TLS_KEY="{{CERT_DIR}}/localhost-key.pem" SENDARC_WEB_DIR="../web/dist" go run ./cmd/sendbeamd
+    cd apps/server && SENDBEAM_TLS_CERT="{{CERT_DIR}}/localhost.pem" SENDBEAM_TLS_KEY="{{CERT_DIR}}/localhost-key.pem" SENDBEAM_WEB_DIR="../web/dist" go run ./cmd/sendbeamd
 
 # Lint everything
 lint:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sendarc",
+  "name": "sendbeam",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",

--- a/packages/wire/spake2.go
+++ b/packages/wire/spake2.go
@@ -56,7 +56,7 @@ type Identities struct {
 	Joiner  []byte
 }
 
-// DefaultIdentities are the SendArc identity strings bound into every handshake.
+// DefaultIdentities are the SendBeam identity strings bound into every handshake.
 func DefaultIdentities() Identities {
 	return Identities{Offerer: []byte(IdentityOfferer), Joiner: []byte(IdentityJoiner)}
 }
@@ -87,7 +87,7 @@ func RandomScalar() (*big.Int, error) {
 }
 
 // PasswordToScalar maps a normalized invite code to the SPAKE2 password scalar w. This
-// is SendArc-specific (RFC 9382 leaves the mapping to the application): w is HKDF over
+// is SendBeam-specific (RFC 9382 leaves the mapping to the application): w is HKDF over
 // the UTF-8 code, then reduced mod n. 48 bytes before reduction leaves negligible bias.
 func PasswordToScalar(normalizedCode string) (*big.Int, error) {
 	bits, err := hkdfSHA256([]byte(normalizedCode), nil, []byte(infoSpake2W), spake2WHKDFBytes)
@@ -115,7 +115,7 @@ func ComputeShare(role Role, w, secret *big.Int) ([]byte, error) {
 type Spake2Output struct {
 	K          []byte // shared group element K (uncompressed SEC1); never used directly as a key
 	Transcript []byte // RFC transcript TT — input to the hash and both confirmation MACs
-	Ke         []byte // shared secret Ke = Hash(TT)[0:16] — input to the SendArc key schedule
+	Ke         []byte // shared secret Ke = Hash(TT)[0:16] — input to the SendBeam key schedule
 	Ka         []byte // confirmation-key material Ka = Hash(TT)[16:32]
 	KcA        []byte // MAC key for the offerer's confirmation (RFC "A")
 	KcB        []byte // MAC key for the joiner's confirmation (RFC "B")
@@ -123,14 +123,14 @@ type Spake2Output struct {
 	ConfirmB   []byte // joiner's confirmation MAC cB = HMAC(KcB, TT)
 }
 
-// Finish completes the exchange with SendArc's identity strings.
+// Finish completes the exchange with SendBeam's identity strings.
 func Finish(role Role, w, secret *big.Int, peerShare []byte) (*Spake2Output, error) {
 	return finish(role, w, secret, peerShare, DefaultIdentities())
 }
 
 // finish completes the exchange from this role's secret and the peer's share element. It
 // recovers the shared point K, assembles the RFC transcript, and derives Ke/Ka and both
-// confirmation MACs. The identities let the RFC known-answer vectors override SendArc's.
+// confirmation MACs. The identities let the RFC known-answer vectors override SendBeam's.
 func finish(role Role, w, secret *big.Int, peerShare []byte, ids Identities) (*Spake2Output, error) {
 	peer, err := nistec.NewP256Point().SetBytes(peerShare)
 	if err != nil {

--- a/packages/wire/wire.go
+++ b/packages/wire/wire.go
@@ -1,4 +1,4 @@
-// Package wire is the Go mirror of the @sendarc/protocol crypto core: the SPAKE2
+// Package wire is the Go mirror of the @sendbeam/protocol crypto core: the SPAKE2
 // handshake, the key schedule, and the AES-256-GCM frame codec that secure a SendBeam
 // transfer. The web client runs the TypeScript implementation; the server and CLI run
 // this one. The two are kept byte-identical — only the elliptic-curve point arithmetic


### PR DESCRIPTION
## What this PR is

Not a cosmetic rename: it completes PR #86's rebrand (which shipped 28 stale `sendarc` references it claimed to remove) and hardens CI against the two failure classes this surfaced — unpinned tool drift and branding regression.

## Commits (4 logical steps)

1. **chore(rebase): finish rename in docs and config** (`0bf0fbe`)
   - README: usage examples (`sendarc send photo.jpg`, install copy, `cd sendarc`), URL-encoded image badge (`%2Fakshay7273%2Fsendarc`)
   - docs: backticked `SENDARC_*` env names (protocol.md, BENCHMARKS.md, threat-model.md, HOSTING.md), the `sendarc/sas` SAS domain string, `sendarc_errors_total` metric, container user name
   - root `package.json` name; dead `.gitignore` entry for the old `sendarcd` binary

2. **chore(rebase): finish rename in code comments + fix justfile env vars** (`8272e83`)
   - Comments describing the `"sendarc"` DataChannel, `@sendarc/protocol` mirror, `sendarc.example` test fixture
   - **Functional bug**: `justfile` dev tasks passed `SENDARC_TLS_CERT/KEY/WEB_DEV_PROXY/WEB_DIR` env names the server no longer reads — `just serve` silently skipped TLS. Now uses the `SENDBEAM_*` names the server actually consumes.

3. **fix(ops): give release job a git context for gh** (`0cd93c9`, cherry-picked from `wip/release-job-checkout`)
   - `gh release create` in publish.yml fails with `not a git repository` because the job never checks out. Adds `actions/checkout` + `-R $GITHUB_REPOSITORY` scoping.

4. **ci: pin golangci-lint to v2.12.2 + guard against stale branding** (`7dd32b5`)
   - `version: latest` → `v2.12.2` (matches local toolchain; unpinned `latest` drifted on 2026-08-12 — new bodyclose findings + poisoned lint caches)
   - New `branding` CI job fails on any `sendarc`/`SendArc`/`SENDARC` occurrence — a rename regression like #86's can never merge silently again

## Verified

- Tree-wide sweep: zero `sendarc`/`SENDARC`/`SendArc` outside build artifacts (now CI-enforced)
- Server builds; origin-allowlist test passes
- All documented names cross-checked against the implementation (`sendbeam/sas`, `SENDBEAM_*` env vars, `sendbeam` container user)

## Follow-ups (still open)

- Independent validation of test vectors (only open M7 exit criterion)
- Delete stale `ghcr.io/akshay7273/sendarc` package + dangling `9ffe27e` sha tag (cosmetic, ops-side)
- Rename local working directory `agy/SendArc` → `agy/SendBeam`
- Publish workflow changes are tag-triggered and never execute in PR checks — commit 3 should be validated with a real tag run (`v1.0.0-rc.0`) before merging

> Not merging — review first.
