### PR TITLE
chore: v1.1 housekeeping (SB-HYGIENE-001..006)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What this changes and why, in a few sentences. -->
+
+## Roadmap
+
+- [ ] Names the SB-* task ID(s) this satisfies (SB-SCOPE-001).
+
+## Checklist
+
+- [ ] Code, tests, and docs for the referenced task are complete (SB-SCOPE-008).
+- [ ] Docs match code defaults and actual behavior (README, HOSTING, protocol,
+      threat model, compat matrix).
+- [ ] Full test suite passes on the branch SHA: Go vet/test (all modules),
+      pnpm test/lint/typecheck.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
-      - name: Format
-        run: pnpm run format
+      - name: Lint
+        run: pnpm run lint
 
       - name: Typecheck
         run: pnpm run typecheck
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache-dependency-path: apps/server/go.sum
 
       - name: Install dependencies
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache-dependency-path: ${{ matrix.module }}/go.sum
 
       - name: Vet

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY apps/web ./apps/web
 RUN pnpm --filter @sendbeam/protocol build && pnpm --filter @sendbeam/web build
 
 # --- Stage 2: build the server binary --------------------------------------------
-FROM golang:1.24-alpine AS server
+FROM golang:1.25-alpine AS server
 WORKDIR /src
 COPY apps/server/go.mod apps/server/go.sum ./apps/server/
 RUN cd apps/server && go mod download

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Full analysis, accepted limitations, and the trust boundary are in the
 [docs/test-vectors/](docs/test-vectors/), and dependency audits run in CI.
 
 > [!NOTE]
-> SendBeam is pre-release software without a stable release or an independent security
-> audit. Do not use it for irreplaceable or highly sensitive data.
+> SendBeam is stable open-source software (v1.0). It has not had an independent
+> security audit; review the [threat model](docs/threat-model.md) before using it
+> for irreplaceable or highly sensitive data.
 
 ## Documentation
 

--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/sendbeam/server
 
-go 1.24
+go 1.25.0
 
 require github.com/go-chi/chi/v5 v5.3.1
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -58,7 +58,7 @@ Error codes are a closed set:
 `relay_not_ready`, `relay_credit`, `relay_limit`.
 
 Pairing is strictly 1:1: a second `join` on a live room is refused (`room_full`). Rooms are
-reaped after the signaling idle timeout (default 2 minutes; `SENDBEAM_SIGNAL_IDLE_TIMEOUT`)
+reaped after the signaling idle timeout (default 10 minutes; `SENDBEAM_SIGNAL_IDLE_TIMEOUT`)
 with no traffic. If a socket drops and reconnects within that window, `resume` re-attaches
 it to the same slot (routing only — it still must pass the SPAKE2 handshake), so a stray
 reconnect cannot hijack a session; the paired peer sees `peer_left`/`peer_rejoined`.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -63,7 +63,7 @@ SHA-256 escalates to abort (no blind retry). Resume state is integrity-checked: 
 
 Anyone who obtains the full invite code can join until the first peer pairs or the room is
 reaped. Mitigations: strictly 1:1 pairing (a second `join` on a live room is refused with
-`room_full`), rooms reaped after the signaling idle timeout (default 2 minutes), and — in
+`room_full`), rooms reaped after the signaling idle timeout (default 10 minutes), and — in
 the browser — a fragment-only code kept out of `Referer` and server logs via
 `Referrer-Policy: no-referrer` and fragment semantics. Because the code is a low-entropy
 human string, its security rests on the online, single-attempt nature of SPAKE2 (the server

--- a/packages/wire/go.mod
+++ b/packages/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/sendbeam/wire
 
-go 1.24.0
+go 1.25.0
 
 require filippo.io/nistec v0.0.4
 


### PR DESCRIPTION
Restores lint in the web CI job (the format step only mutated the checkout), fixes docs to the actual 10-minute signaling idle timeout, swaps the README pre-release note for stable v1.0 wording, normalizes the Go toolchain to 1.25.0 everywhere, and adds a release-PR template with the docs-consistency checklist.