### PR TITLE
refactor: error taxonomy, lifecycle ADRs, web generation guards (SB-1101..1110)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What this changes and why, in a few sentences. -->
+
+## Roadmap
+
+- [ ] Names the SB-* task ID(s) this satisfies (SB-SCOPE-001).
+
+## Checklist
+
+- [ ] Code, tests, and docs for the referenced task are complete (SB-SCOPE-008).
+- [ ] Docs match code defaults and actual behavior (README, HOSTING, protocol,
+      threat model, compat matrix).
+- [ ] Full test suite passes on the branch SHA: Go vet/test (all modules),
+      pnpm test/lint/typecheck.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
-      - name: Format
-        run: pnpm run format
+      - name: Lint
+        run: pnpm run lint
 
       - name: Typecheck
         run: pnpm run typecheck
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache-dependency-path: apps/server/go.sum
 
       - name: Install dependencies
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache-dependency-path: ${{ matrix.module }}/go.sum
 
       - name: Vet

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY apps/web ./apps/web
 RUN pnpm --filter @sendbeam/protocol build && pnpm --filter @sendbeam/web build
 
 # --- Stage 2: build the server binary --------------------------------------------
-FROM golang:1.24-alpine AS server
+FROM golang:1.25-alpine AS server
 WORKDIR /src
 COPY apps/server/go.mod apps/server/go.sum ./apps/server/
 RUN cd apps/server && go mod download

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Full analysis, accepted limitations, and the trust boundary are in the
 [docs/test-vectors/](docs/test-vectors/), and dependency audits run in CI.
 
 > [!NOTE]
-> SendBeam is pre-release software without a stable release or an independent security
-> audit. Do not use it for irreplaceable or highly sensitive data.
+> SendBeam is stable open-source software (v1.0). It has not had an independent
+> security audit; review the [threat model](docs/threat-model.md) before using it
+> for irreplaceable or highly sensitive data.
 
 ## Documentation
 

--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -331,9 +331,9 @@ func handshakeError(err error) string {
 		case rendezvous.CodeAborted:
 			return "cancelled"
 		}
-		return re.Msg
+		return "[" + string(wire.CodeOf(err)) + "] " + re.Msg
 	}
-	return err.Error()
+	return "[" + string(wire.CodeOf(err)) + "] " + err.Error()
 }
 
 func errorsAs(err error, target **rendezvous.Error) bool {

--- a/apps/cli/internal/transfer/adaptive_conn.go
+++ b/apps/cli/internal/transfer/adaptive_conn.go
@@ -1,12 +1,12 @@
 package transfer
 
 import (
-	"errors"
 	"sync"
 	"time"
 
 	relaytransport "github.com/sendbeam/cli/internal/relay"
 	"github.com/sendbeam/cli/internal/rtc"
+	"github.com/sendbeam/wire"
 )
 
 // relaySwitchTimeout bounds how long Send waits for the relay handshake to complete
@@ -63,7 +63,7 @@ func (c *adaptiveConn) Send(frame []byte) error {
 	path, closed := c.path, c.closed
 	c.mu.Unlock()
 	if closed {
-		return errors.New("transfer: connection closed")
+		return wire.Errorf(wire.CodeConnection, "transfer: connection closed")
 	}
 	if path == "relay" {
 		return c.relay.Send(frame)
@@ -75,7 +75,7 @@ func (c *adaptiveConn) Send(frame []byte) error {
 	select {
 	case <-c.switchDone:
 	case <-time.After(relaySwitchTimeout):
-		return errors.New("transfer: relay switch timed out")
+		return wire.Errorf(wire.CodeRelay, "transfer: relay switch timed out")
 	}
 	c.mu.Lock()
 	err := c.switchErr
@@ -85,7 +85,7 @@ func (c *adaptiveConn) Send(frame []byte) error {
 		return err
 	}
 	if path != "relay" {
-		return errors.New("transfer: relay switch did not complete")
+		return wire.Errorf(wire.CodeRelay, "transfer: relay switch did not complete")
 	}
 	return c.relay.Send(frame)
 }
@@ -114,7 +114,7 @@ func (c *adaptiveConn) Close() error {
 	c.mu.Lock()
 	c.closed = true
 	c.mu.Unlock()
-	c.finishSwitch(errors.New("transfer: connection closed"))
+	c.finishSwitch(wire.Errorf(wire.CodeConnection, "transfer: connection closed"))
 	_ = c.relay.Close()
 	return c.direct.Close()
 }

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -8,7 +8,6 @@ package transfer
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -162,7 +161,7 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 			return nil, herr
 		}
 		if err == nil {
-			err = errors.New("transfer: signaling closed before the channel opened")
+			err = wire.Errorf(wire.CodeConnection, "transfer: signaling closed before the channel opened")
 		}
 		return nil, err
 	case <-ctx.Done():
@@ -232,7 +231,7 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 		case sigErr := <-readCh:
 			readEnded = true
 			if sigErr == nil {
-				sigErr = errors.New("signaling closed")
+				sigErr = wire.Errorf(wire.CodeConnection, "signaling closed")
 			}
 			if adaptive != nil && !adaptive.IsRelay() {
 				adaptive.SignalingLost(sigErr)
@@ -245,7 +244,7 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 			if ctx.Err() != nil {
 				terr = ctx.Err()
 			} else {
-				terr = fmt.Errorf("transfer: relay connection lost: %w", sigErr)
+				terr = wire.Errorf(wire.CodeRelay, "transfer: relay connection lost: %v", sigErr)
 			}
 			goto transferSettled
 		}
@@ -285,7 +284,7 @@ type rtcResult struct {
 
 func (d *driver) selectTransport(ctx context.Context, peer *rtc.Peer, readErr <-chan error) (dataConn, string, error) {
 	if d.relay == nil {
-		return nil, "", errors.New("transfer: relay was not initialized")
+		return nil, "", wire.Errorf(wire.CodeRelay, "transfer: relay was not initialized")
 	}
 	direct := make(chan rtcResult, 1)
 	if peer != nil && !d.spec.ForceRelay {
@@ -311,12 +310,12 @@ func (d *driver) selectTransport(ctx context.Context, peer *rtc.Peer, readErr <-
 				return result.conn, "direct", nil
 			}
 			if err := d.relay.Open(); err != nil {
-				return nil, "", fmt.Errorf("transfer: direct failed (%v), relay open: %w", result.err, err)
+				return nil, "", wire.Errorf(wire.CodeRelay, "transfer: direct failed (%v), relay open: %v", result.err, err)
 			}
 			direct = nil
 		case <-timeoutCh:
 			if err := d.relay.Open(); err != nil {
-				return nil, "", fmt.Errorf("transfer: relay fallback: %w", err)
+				return nil, "", wire.Errorf(wire.CodeRelay, "transfer: relay fallback: %v", err)
 			}
 			timeoutCh = nil
 		case <-d.relay.Ready():
@@ -326,9 +325,9 @@ func (d *driver) selectTransport(ctx context.Context, peer *rtc.Peer, readErr <-
 			return d.relay, "relay", nil
 		case err := <-readErr:
 			if err == nil {
-				err = errors.New("signaling closed")
+				err = wire.Errorf(wire.CodeConnection, "signaling closed")
 			}
-			return nil, "", fmt.Errorf("transfer: signaling: %w", err)
+			return nil, "", wire.Errorf(wire.CodeConnection, "transfer: signaling: %v", err)
 		case <-ctx.Done():
 			return nil, "", ctx.Err()
 		}
@@ -415,7 +414,7 @@ func (d *driver) send(ctx context.Context, conn dataConn, res *rendezvous.Result
 		}
 	}
 	if needsFolders && !containsString(res.RemoteCaps.Features, "folders") {
-		return nil, errors.New("transfer: receiver does not support files or folders as a set")
+		return nil, wire.Errorf(wire.CodeCompat, "transfer: receiver does not support files or folders as a set")
 	}
 	sender := wire.NewSender(wire.SenderOptions{
 		Files:            sources,

--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/sendbeam/server
 
-go 1.24
+go 1.25.0
 
 require github.com/go-chi/chi/v5 v5.3.1
 

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -103,6 +103,9 @@ function run(
   const progress = new ProgressTracker(total);
   const wakeLock = new WakeLockManager();
   let settled = false;
+  // Monotonic generation: every async continuation captures it at creation and
+  // bails before mutating controller state once it is stale (ADR 0001 §5).
+  let generation = 0;
   let peer: Peer | undefined;
   let worker: Worker | undefined;
   let writer: ChannelWriter | undefined;
@@ -119,6 +122,7 @@ function run(
   });
 
   const cleanup = (): void => {
+    generation++;
     clearTimeout(cancelTimer);
     wakeLock.setActive(false);
     worker?.terminate();
@@ -151,16 +155,24 @@ function run(
       const relayPath = new RelayTransport(signaling);
       relay = relayPath;
       signaling.onClose((err) => {
+        const gen = generation;
+        if (gen !== generation) return;
         relayPath.fail(err);
         if (transport !== 'direct' || switchPromise) {
           fail(err);
         }
       });
       signaling.onMessage((msg) => {
+        const gen = generation;
+        if (gen !== generation) return;
         if (relayPath.handleMessage(msg)) return;
         if (msg.type === 'sdp' || msg.type === 'ice') p.accept(msg);
       });
-      signaling.onBinary((frame) => relayPath.handleBinary(frame));
+      signaling.onBinary((frame) => {
+        const gen = generation;
+        if (gen !== generation) return;
+        relayPath.handleBinary(frame);
+      });
 
       const w = new Worker(new URL('../transfer/transfer.worker.ts', import.meta.url), {
         type: 'module',
@@ -183,11 +195,14 @@ function run(
       const receive = (frame: ArrayBuffer): void =>
         w.postMessage({ kind: 'inbound-frame', frame } satisfies HostToWorker, [frame]);
       const switchToRelay = (): Promise<void> => {
+        const gen = generation;
+        if (gen !== generation) return Promise.resolve();
         if (transport === 'relay') return Promise.resolve();
         if (switchPromise) return switchPromise;
         switchPromise = (async () => {
           relayPath.open();
           await relayPath.ready;
+          if (gen !== generation) return;
           if (settled) return;
           transport = 'relay';
           w.postMessage({ kind: 'transport-changed' } satisfies HostToWorker);
@@ -201,6 +216,8 @@ function run(
         return switchPromise;
       };
       const sendOutbound = async (frame: ArrayBuffer): Promise<void> => {
+        const gen = generation;
+        if (gen !== generation) return;
         if (transport === 'relay') {
           await relayPath.write(frame);
           return;
@@ -220,21 +237,35 @@ function run(
 
       if (selected.kind === 'direct') {
         p.onData((frame) => {
+          const gen = generation;
+          if (gen !== generation) return;
           if (transport === 'direct' && !switchPromise) receive(frame);
         });
-        p.onDisconnect(() => void switchToRelay().catch(() => {}));
+        p.onDisconnect(() => {
+          const gen = generation;
+          if (gen !== generation) return;
+          void switchToRelay().catch(() => {});
+        });
         void relayPath.ready.then(switchToRelay).catch(() => {});
         relayPath.onData((frame) => {
+          const gen = generation;
+          if (gen !== generation) return;
           void switchToRelay()
             .then(() => receive(frame))
             .catch(() => {});
         });
       } else {
-        relayPath.onData(receive);
+        relayPath.onData((frame) => {
+          const gen = generation;
+          if (gen !== generation) return;
+          receive(frame);
+        });
       }
 
       // Worker → host events.
       w.addEventListener('message', (ev: MessageEvent) => {
+        const gen = generation;
+        if (gen !== generation) return;
         const msg = ev.data as WorkerToHost;
         switch (msg.kind) {
           case 'outbound-frame':
@@ -283,6 +314,8 @@ function run(
   })();
 
   async function completeTransfer(msg: Extract<WorkerToHost, { kind: 'done' }>): Promise<void> {
+    const gen = generation;
+    if (gen !== generation) return;
     const first = msg.files[0]!;
     if (spec.role === 'receive') {
       try {

--- a/docs/adr/0001-transfer-lifecycle.md
+++ b/docs/adr/0001-transfer-lifecycle.md
@@ -1,0 +1,121 @@
+# ADR 0001 — Transfer lifecycle, ownership, and generations
+
+Status: accepted
+Scope: v1.1 (SB-1101..SB-1105, SB-1107)
+Applies to: `packages/protocol`, `packages/wire`, `apps/web/src/lib/session/transfer.ts`, `apps/cli/internal/transfer`
+
+## Context
+
+The transfer pipeline spans a signaling socket, an authenticated direct path, an
+encrypted relay fallback, a worker/goroutine-owned crypto engine, a disk sink, and
+timers. Post-v1.0 hardening (PR #88) fixed concrete lifecycle defects, but the
+states, ownership, and cleanup rules were implicit. This ADR makes them explicit
+so web and Go can share one mental model and future generations of the code keep
+the guarantees.
+
+## 1. Lifecycle states (SB-1101)
+
+A transfer is always in exactly one of:
+
+| State | Meaning |
+| --- | --- |
+| `idle` | Controller created, nothing started. |
+| `pairing` | Invite/room exchange before the SPAKE2 handshake completes. |
+| `authenticating` | SPAKE2 / key confirmation in progress. |
+| `connecting` | Direct path negotiation or relay open in progress. |
+| `running` | Blocks flowing on an established path. |
+| `paused` | Sender stops producing new frames; buffered bytes may drain. |
+| `switching-path` | Cutover direct → relay (or recovery) in progress. |
+| `recovering` | Network change observed; ICE restart / path recovery attempt. |
+| `completing` | Final digest verified; `Complete`/`Done` exchange or output materialization. |
+| `completed` | Terminal: output verified and committed. |
+| `failed` | Terminal: explicit failure. |
+| `canceled` | Terminal: user cancellation or host teardown. |
+
+The web UI collapses `pairing`/`authenticating`/`connecting` into a single
+"connecting" presentation today; the states above are the engine contract, and
+presentation may merge them. `idle`, `recovering`, and `completing` may be
+transient (non-observable) where the host has no checkpoint to expose.
+
+## 2. Legal transitions (SB-1102)
+
+Allowed edges (any unlisted edge is illegal):
+
+```
+idle → pairing
+pairing → authenticating | failed | canceled
+authenticating → connecting | failed | canceled
+connecting → running | switching-path | recovering | failed | canceled
+running → paused | switching-path | recovering | completing | failed | canceled
+paused → running | canceling-equivalent (canceled) | failed
+switching-path → running | recovering | failed | canceled
+recovering → running | switching-path | failed | canceled
+completing → completed | failed | canceled
+```
+
+Terminal rules (SB-1102):
+
+- `completed`, `failed`, and `canceled` are absorbing. No event may move a
+  terminal transfer to any other state.
+- `failed` is preferred over `canceled` when both conditions are observed at the
+  same instant (failure wins).
+- A transfer that was canceled may still report a late `failed`-class cleanup
+  error only through logs; the public outcome remains `canceled`.
+
+## 3. Ownership (SB-1103)
+
+Every resource has exactly one owner; owners are the only code that closes or
+terminates them:
+
+| Resource | Owner |
+| --- | --- |
+| Signaling socket | Host controller (web `transfer.ts` `run`; CLI `driver.go`). |
+| Direct path (WebRTC / ICE) | Host controller while `connecting`; engine during `running`. |
+| Relay allocation | Host controller. |
+| Transfer worker / engine goroutine | Host controller; engine terminates on `Complete` or its `abort()`. |
+| Sink / destination | Engine; host owns the durable staging location. |
+| Temporary output (OPFS / `.part`) | Host controller during cleanup. |
+| Timers (relay fallback, cancel, switch timeout) | The scope that created them; canceled in `cleanup()`. |
+| Wake lock / progress renderer | Host controller (UI concern, not protocol). |
+
+## 4. Idempotent cleanup (SB-1104)
+
+`cleanup()` runs on every terminal path (`completed`, `failed`, `canceled`) and
+must be safe to call twice:
+
+- Every teardown primitive (`close()`, `abort()`, `terminate()`) is idempotent.
+- `cleanup()` never throws; each step's error is logged.
+- Late resource creation (e.g. a worker message arriving during teardown) must
+  not resurrect a closed resource: creation sites check the terminal flag.
+
+## 5. Generations (SB-1105..SB-1107)
+
+A **generation** is a monotonically increasing integer owned by the controller.
+Every asynchronous continuation (worker message handler, socket callback, timer,
+`switchToRelay`/path event) captures the generation at the moment it is created
+and checks it before any mutation of controller state or resource handles. A
+stale continuation is inert: it may return early, log, or drop the event, but
+must not:
+
+- resolve/reject the transfer outcome;
+- open, close, or write to a path or socket;
+- start a relay fallback;
+- mutate progress state.
+
+- Web (SB-1106): `transfer.ts` `run()` bumps the generation in `cleanup()`;
+  every closure compares its captured generation before acting. The existing
+  `settled` flag remains as the terminal-outcome guard; the generation is the
+  general staleness guard.
+- Go (SB-1107): engine objects (`Sender`/`Receiver`) serialize `Handle` with a
+  mutex and settle once; the host `driver` loop is the single goroutine that
+  owns the connection, so host-side race windows are closed by construction
+  plus bounded waits (relay switch timeout, PR #88).
+
+## Consequences
+
+- New transports (v1.2 supervisor) must present as path resources owned by the
+  controller, not transfer engines.
+- UI state machines must map onto the states above and never invent absorbing
+  behavior.
+- Code review gate: any new callback/goroutine/timer must name its owner and
+  generation capture.

--- a/docs/adr/0002-error-taxonomy.md
+++ b/docs/adr/0002-error-taxonomy.md
@@ -1,0 +1,65 @@
+# ADR 0002 — Error taxonomy and stable error codes
+
+Status: accepted
+Scope: v1.1 (SB-1108..SB-1110)
+Applies to: `packages/wire` (Go), `packages/protocol` (TS), `apps/cli`, `apps/web`
+
+## Context
+
+Errors today are bare strings (`"transfer: signaling closed"`, `errors.New(...)`)
+or wire `fail` reasons. Callers cannot classify failures, UI cannot show the
+right recovery action, and automation (v1.5 `--json`) has nothing stable to
+match on. This ADR defines one taxonomy shared by Go and TS.
+
+## 1. Error classes (SB-1108)
+
+| Class | Code | Meaning |
+| --- | --- | --- |
+| Authentication | `AUTH` | SPAKE2 / key confirmation / credential failure. |
+| Protocol / integrity | `PROTOCOL` | Malformed frame, replay, counter, manifest, digest mismatch. |
+| Connection | `CONNECTION` | Direct path or signaling connection failure. |
+| Relay | `RELAY` | Relay open / relay switch / relay transport failure. |
+| Retry exhausted | `RETRY_EXHAUSTED` | Bounded retry budget consumed. |
+| User canceled | `CANCELED` | User or host cancellation. |
+| Storage / quota | `STORAGE` | Quota exceeded, destination collision, storage unavailable. |
+| Source I/O | `SOURCE_IO` | Source read failure, source changed mid-transfer. |
+| Destination I/O | `DEST_IO` | Sink write / flush / close / rename failure. |
+| Compatibility | `COMPAT` | Peer or version incompatibility. |
+| Internal | `INTERNAL` | Invariant violation; bugs. |
+
+Every externally visible error has exactly one class. Wire `fail` reasons map
+into classes: `auth_failed`, `key_confirmation_failed` → `AUTH`; `integrity`,
+`protocol`, `unsupported` → `PROTOCOL`/`COMPAT`; `canceled` → `CANCELED`;
+everything else → `INTERNAL`.
+
+## 2. Machine codes and messages (SB-1109)
+
+- Every externally visible error carries a stable machine code (the class
+  constant above) and a human-facing message.
+- Go: `wire.Error` carries `Code ErrorCode`; `wire.CodeOf(err)` walks the
+  `Unwrap()` chain to classify wrapped errors. CLI prints
+  `sendbeam: <command> failed [CODE]: <message>`.
+- TS: `TransferError` carries `reason` (wire tag) plus `code` (class);
+  `RendezvousError` already carries a signal code and is mapped to a class at
+  the web boundary where needed.
+
+## 3. Message hygiene (SB-1110)
+
+Human-facing messages must not expose:
+
+- raw SDP / ICE candidates or full IPs,
+- invite words or invite codes,
+- master keys, nonces, or key material,
+- absolute filesystem paths unless they are the user's own local paths being
+  reported back to them (CLI send source errors may name the user's path).
+
+Sanitization is applied at the error construction site; logs may carry more
+detail than UI messages.
+
+## Consequences
+
+- New errors at external boundaries must use `wire.Errorf(code, ...)` /
+  `TransferError` with a code; bare `errors.New` is allowed only for internal
+  invariants.
+- Exit-code mapping (SB-1184) and structured output (SB-1186/v1.5) consume
+  `CodeOf`/`code`.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -58,7 +58,7 @@ Error codes are a closed set:
 `relay_not_ready`, `relay_credit`, `relay_limit`.
 
 Pairing is strictly 1:1: a second `join` on a live room is refused (`room_full`). Rooms are
-reaped after the signaling idle timeout (default 2 minutes; `SENDBEAM_SIGNAL_IDLE_TIMEOUT`)
+reaped after the signaling idle timeout (default 10 minutes; `SENDBEAM_SIGNAL_IDLE_TIMEOUT`)
 with no traffic. If a socket drops and reconnects within that window, `resume` re-attaches
 it to the same slot (routing only — it still must pass the SPAKE2 handshake), so a stray
 reconnect cannot hijack a session; the paired peer sees `peer_left`/`peer_rejoined`.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -63,7 +63,7 @@ SHA-256 escalates to abort (no blind retry). Resume state is integrity-checked: 
 
 Anyone who obtains the full invite code can join until the first peer pairs or the room is
 reaped. Mitigations: strictly 1:1 pairing (a second `join` on a live room is refused with
-`room_full`), rooms reaped after the signaling idle timeout (default 2 minutes), and — in
+`room_full`), rooms reaped after the signaling idle timeout (default 10 minutes), and — in
 the browser — a fragment-only code kept out of `Referer` and server logs via
 `Referrer-Policy: no-referrer` and fragment semantics. Because the code is a low-entropy
 human string, its security rests on the online, single-attempt nature of SPAKE2 (the server

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Stable machine-readable error classes shared with the Go wire package
+ * (ADR 0002 — error taxonomy). Externally visible errors carry exactly one
+ * class; UI and future automation key on it.
+ */
+export const ErrorCode = {
+  Auth: 'AUTH',
+  Protocol: 'PROTOCOL',
+  Connection: 'CONNECTION',
+  Relay: 'RELAY',
+  RetryExhausted: 'RETRY_EXHAUSTED',
+  Canceled: 'CANCELED',
+  Storage: 'STORAGE',
+  SourceIO: 'SOURCE_IO',
+  DestIO: 'DEST_IO',
+  Compat: 'COMPAT',
+  Internal: 'INTERNAL',
+} as const;
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -23,3 +23,4 @@ export * from './transfer-sender.js';
 export * from './transfer-receiver.js';
 export * from './safe-path.js';
 export * from './transfer-set.js';
+export * from './errors.js';

--- a/packages/protocol/src/transfer-ports.test.ts
+++ b/packages/protocol/src/transfer-ports.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { MemorySink, bytesSource } from './transfer-ports.js';
+import { MemorySink, TransferError, bytesSource } from './transfer-ports.js';
+import { ErrorCode } from "./errors.js";
 
 describe('MemorySink', () => {
   it('reassembles out-of-order offsets into one buffer', () => {
@@ -40,5 +41,24 @@ describe('bytesSource', () => {
     const chunks: Uint8Array[] = [];
     for await (const c of src.stream()) chunks.push(c);
     expect(chunks).toEqual([]);
+  });
+});
+
+
+describe('TransferError taxonomy', () => {
+  it('maps wire fail reasons onto classes', () => {
+    expect(new TransferError('digest_mismatch').code).toBe(ErrorCode.Protocol);
+    expect(new TransferError('integrity').code).toBe(ErrorCode.Protocol);
+    expect(new TransferError('sink_error').code).toBe(ErrorCode.DestIO);
+    expect(new TransferError('quota').code).toBe(ErrorCode.Storage);
+    expect(new TransferError('canceled').code).toBe(ErrorCode.Canceled);
+    expect(new TransferError('retry_exhausted').code).toBe(ErrorCode.RetryExhausted);
+  });
+
+  it('accepts an explicit code override', () => {
+    const err = new TransferError('canceled', 'msg', ErrorCode.Relay);
+    expect(err.code).toBe(ErrorCode.Relay);
+    expect(err.reason).toBe('canceled');
+    expect(err.message).toBe('canceled: msg');
   });
 });

--- a/packages/protocol/src/transfer-ports.ts
+++ b/packages/protocol/src/transfer-ports.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Fail, FileEntry, Manifest } from './transfer.js';
+import { ErrorCode, type ErrorCode as ErrorCodeType } from './errors.js';
 
 /** Minimal file metadata carried in the manifest. */
 export interface FileMeta {
@@ -68,18 +69,32 @@ export interface Digest {
   hexDigest(): string | Promise<string>;
 }
 
+/** Map a wire `fail` reason onto its taxonomy class (ADR 0002). */
+const codeForReason: Record<Fail['reason'], ErrorCodeType> = {
+  digest_mismatch: ErrorCode.Protocol,
+  integrity: ErrorCode.Protocol,
+  sink_error: ErrorCode.DestIO,
+  canceled: ErrorCode.Canceled,
+  quota: ErrorCode.Storage,
+  retry_exhausted: ErrorCode.RetryExhausted,
+};
+
 /**
- * A transfer failure carrying one of the protocol's `fail` reasons. The `reason` is the
- * machine-readable tag sent on the wire; it is always prefixed onto `message` so the reason
- * survives in `error.message` (logs, `toThrow` matchers) even when a detail string is given.
+ * A transfer failure carrying one of the protocol's `fail` reasons plus its taxonomy
+ * class. The `reason` is the machine-readable tag sent on the wire; it is always
+ * prefixed onto `message` so the reason survives in `error.message` (logs,
+ * `toThrow` matchers) even when a detail string is given.
  */
 export class TransferError extends Error {
+  readonly code: ErrorCodeType;
   constructor(
     readonly reason: Fail['reason'],
     message?: string,
+    code?: ErrorCodeType,
   ) {
     super(message ? `${reason}: ${message}` : reason);
     this.name = 'TransferError';
+    this.code = code ?? codeForReason[reason] ?? ErrorCode.Internal;
   }
 }
 

--- a/packages/wire/aead.go
+++ b/packages/wire/aead.go
@@ -4,7 +4,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/binary"
-	"errors"
 	"fmt"
 )
 
@@ -87,7 +86,7 @@ func Open(dir DirectionalKey, counter uint64, frame []byte) (*OpenedFrame, error
 
 // ErrFrameReplay identifies an already-consumed counter. Transfer engines ignore it while
 // keeping all forward counters authenticated, which makes transport replacement replay-safe.
-var ErrFrameReplay = errors.New("frame counter replay")
+var ErrFrameReplay = Errorf(CodeProtocol, "frame counter replay")
 
 // OpenSequenced opens a transfer frame using its authenticated wire counter. Forward gaps are
 // accepted after a transport loses a suffix; counters below minimum return ErrFrameReplay.

--- a/packages/wire/errors.go
+++ b/packages/wire/errors.go
@@ -1,0 +1,53 @@
+// Package wire errors: stable machine-readable error classes shared with the
+// TypeScript protocol (see ADR 0002). Every externally visible error carries a
+// class code plus a human message.
+package wire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrorCode is a stable machine-readable error class (ADR 0002).
+type ErrorCode string
+
+const (
+	CodeAuth          ErrorCode = "AUTH"
+	CodeProtocol      ErrorCode = "PROTOCOL"
+	CodeConnection    ErrorCode = "CONNECTION"
+	CodeRelay         ErrorCode = "RELAY"
+	CodeRetryExhausted ErrorCode = "RETRY_EXHAUSTED"
+	CodeCanceled      ErrorCode = "CANCELED"
+	CodeStorage       ErrorCode = "STORAGE"
+	CodeSourceIO      ErrorCode = "SOURCE_IO"
+	CodeDestIO        ErrorCode = "DEST_IO"
+	CodeCompat        ErrorCode = "COMPAT"
+	CodeInternal      ErrorCode = "INTERNAL"
+)
+
+// Error is an error carrying a stable machine-readable class.
+type Error struct {
+	Code ErrorCode
+	msg  string
+}
+
+func (e *Error) Error() string { return e.msg }
+
+// Errorf builds a classified error with a formatted message.
+func Errorf(code ErrorCode, format string, args ...any) error {
+	return &Error{Code: code, msg: fmt.Sprintf(format, args...)}
+}
+
+// CodeOf walks the error chain and returns the first classification found;
+// unclassified errors are INTERNAL, and context cancellation is CANCELED.
+func CodeOf(err error) ErrorCode {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Code
+	}
+	if errors.Is(err, context.Canceled) {
+		return CodeCanceled
+	}
+	return CodeInternal
+}

--- a/packages/wire/errors_test.go
+++ b/packages/wire/errors_test.go
@@ -1,0 +1,41 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrorfCarriesCode(t *testing.T) {
+	err := Errorf(CodeRelay, "relay switch timed out")
+	if err.Error() != "relay switch timed out" {
+		t.Fatalf("message = %q", err.Error())
+	}
+	if CodeOf(err) != CodeRelay {
+		t.Fatalf("code = %s, want RELAY", CodeOf(err))
+	}
+}
+
+func TestCodeOfWalksWrappedChain(t *testing.T) {
+	inner := Errorf(CodeConnection, "signaling closed")
+	wrapped := fmt.Errorf("transfer: %w", inner)
+	if CodeOf(wrapped) != CodeConnection {
+		t.Fatalf("code = %s, want CONNECTION", CodeOf(wrapped))
+	}
+}
+
+func TestCodeOfUnclassifiedIsInternal(t *testing.T) {
+	if CodeOf(errors.New("plain")) != CodeInternal {
+		t.Fatalf("plain error code = %s, want INTERNAL", CodeOf(errors.New("plain")))
+	}
+}
+
+func TestCodeOfContextCanceled(t *testing.T) {
+	if CodeOf(context.Canceled) != CodeCanceled {
+		t.Fatalf("context canceled code = %s, want CANCELED", CodeOf(context.Canceled))
+	}
+	if CodeOf(fmt.Errorf("wrapped: %w", context.Canceled)) != CodeCanceled {
+		t.Fatalf("wrapped context canceled code = %s, want CANCELED", CodeOf(fmt.Errorf("wrapped: %w", context.Canceled)))
+	}
+}

--- a/packages/wire/go.mod
+++ b/packages/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/sendbeam/wire
 
-go 1.24.0
+go 1.25.0
 
 require filippo.io/nistec v0.0.4
 

--- a/packages/wire/safe_path.go
+++ b/packages/wire/safe_path.go
@@ -28,40 +28,40 @@ var (
 // NormalizeTransferPath canonicalizes an untrusted manifest path without touching disk.
 func NormalizeTransferPath(input string) (string, error) {
 	if input == "" {
-		return "", errors.New("manifest path is empty")
+		return "", Errorf(CodeProtocol, "manifest path is empty")
 	}
 	if strings.HasPrefix(input, "/") || strings.HasPrefix(input, `\`) || drivePath.MatchString(input) {
-		return "", errors.New("manifest path must be relative")
+		return "", Errorf(CodeProtocol, "manifest path must be relative")
 	}
 	canonical := strings.ReplaceAll(input, `\`, "/")
 	segments := strings.Split(canonical, "/")
 	if len(segments) > MaxTransferPathDepth {
-		return "", errors.New("manifest path is too deep")
+		return "", Errorf(CodeProtocol, "manifest path is too deep")
 	}
 	for _, segment := range segments {
 		if segment == "" || segment == "." || segment == ".." {
-			return "", errors.New("manifest path contains an unsafe segment")
+			return "", Errorf(CodeProtocol, "manifest path contains an unsafe segment")
 		}
 		for _, r := range segment {
 			if r <= 0x1f || strings.ContainsRune(`<>:"|?*`, r) {
-				return "", errors.New("manifest path contains unsafe characters")
+				return "", Errorf(CodeProtocol, "manifest path contains unsafe characters")
 			}
 		}
 		if strings.HasSuffix(segment, ".") || strings.HasSuffix(segment, " ") {
-			return "", errors.New("manifest path has an unsafe suffix")
+			return "", Errorf(CodeProtocol, "manifest path has an unsafe suffix")
 		}
 		if windowsReserved.MatchString(segment) {
-			return "", errors.New("manifest path uses a reserved name")
+			return "", Errorf(CodeProtocol, "manifest path uses a reserved name")
 		}
 		if len(segment) > MaxTransferSegmentBytes {
-			return "", errors.New("manifest path segment is too long")
+			return "", Errorf(CodeProtocol, "manifest path segment is too long")
 		}
 	}
 	if len(canonical) > MaxTransferPathBytes {
-		return "", errors.New("manifest path is too long")
+		return "", Errorf(CodeProtocol, "manifest path is too long")
 	}
 	if !utf8.ValidString(canonical) {
-		return "", errors.New("manifest path is not valid UTF-8")
+		return "", Errorf(CodeProtocol, "manifest path is not valid UTF-8")
 	}
 	return canonical, nil
 }
@@ -69,17 +69,17 @@ func NormalizeTransferPath(input string) (string, error) {
 // ValidateManifest checks aggregate geometry and returns a copy with canonical relative paths.
 func ValidateManifest(manifest Manifest) (Manifest, error) {
 	if len(manifest.Files) == 0 || len(manifest.Files) > MaxTransferFiles {
-		return Manifest{}, errors.New("manifest has an invalid file count")
+		return Manifest{}, Errorf(CodeProtocol, "manifest has an invalid file count")
 	}
 	files := make([]FileEntry, len(manifest.Files))
 	paths := make(map[string]struct{}, len(manifest.Files))
 	var total int64
 	for idx, file := range manifest.Files {
 		if file.Idx != idx {
-			return Manifest{}, errors.New("manifest file indexes must be contiguous")
+			return Manifest{}, Errorf(CodeProtocol, "manifest file indexes must be contiguous")
 		}
 		if file.Size < 0 || file.LastModified < 0 || file.BlockSize <= 0 || file.Blocks < 0 {
-			return Manifest{}, errors.New("manifest has invalid file geometry")
+			return Manifest{}, Errorf(CodeProtocol, "manifest has invalid file geometry")
 		}
 		if file.BlockSize > MaxManifestBlockBytes {
 			return Manifest{}, fmt.Errorf("manifest block size %d exceeds the %d-byte ceiling", file.BlockSize, MaxManifestBlockBytes)
@@ -89,7 +89,7 @@ func ValidateManifest(manifest Manifest) (Manifest, error) {
 			wantBlocks = int((file.Size-1)/int64(file.BlockSize) + 1)
 		}
 		if file.Blocks != wantBlocks {
-			return Manifest{}, errors.New("manifest has invalid block geometry")
+			return Manifest{}, Errorf(CodeProtocol, "manifest has invalid block geometry")
 		}
 		name, err := NormalizeTransferPath(file.Name)
 		if err != nil {


### PR DESCRIPTION
Error handling was ad hoc across wire, CLI, and web, and web transfer continuations could touch controller state after teardown.

This adds transfer-lifecycle and error-taxonomy ADRs (SB-1101..1105, SB-1107), a shared code-class system in wire/protocol/CLI with [CODE] stderr prefixes (SB-1108..1110), and generation guards in the web transfer state machine (SB-1106).