### PR TITLE
test: deterministic fault-injection harness for wire, CLI, and protocol

### DIFF
--- a/apps/cli/internal/transfer/driver_faults_test.go
+++ b/apps/cli/internal/transfer/driver_faults_test.go
@@ -1,0 +1,314 @@
+package transfer
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/cli/internal/rendezvous"
+	"github.com/sendbeam/wire"
+)
+
+// faultPayload builds a deterministic payload crossing block boundaries.
+func faultPayload(size int) []byte {
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i*29 + 5)
+	}
+	return payload
+}
+
+// pathLog records every OnTransport report in order.
+type pathLog struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func appendPath(log *pathLog) func(string) {
+	return func(path string) {
+		log.mu.Lock()
+		log.paths = append(log.paths, path)
+		log.mu.Unlock()
+	}
+}
+
+// killBothSignaling simulates the signaling server going away: both sockets die
+// while the byte path lives or dies on its own.
+func killBothSignaling(hub *relay) {
+	hub.off.killSignaling()
+	hub.join.killSignaling()
+}
+
+// TestDriverSurvivesSignalingLossOnDirect pins SB-1122: signaling failure is
+// independent of the data path — a healthy direct channel finishes the transfer
+// with no relay fallback and no error when the signaling socket dies mid-file.
+func TestDriverSurvivesSignalingLossOnDirect(t *testing.T) {
+	hub := newRelay()
+	payload := faultPayload(2*1024*1024 + 77)
+	meta := wire.FileMeta{Name: "sig-loss.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *Outcome
+		err error
+	}
+	done := make(chan result, 2)
+	var once sync.Once
+	sendPaths, recvPaths := &pathLog{}, &pathLog{}
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:      wire.BytesSource(payload, meta, 64*1024),
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(sendPaths),
+			OnProgress: func(bytes int64) {
+				if bytes >= 1024*1024 {
+					once.Do(func() { killBothSignaling(hub) })
+				}
+			},
+		})
+		done <- result{out: out, err: err}
+	}()
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:     dir,
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(recvPaths),
+		})
+		done <- result{out: out, err: err}
+	}()
+
+	a, b := <-done, <-done
+	if a.err != nil || b.err != nil {
+		t.Fatalf("results after signaling loss: %v / %v", a.err, b.err)
+	}
+	var recv *Outcome
+	if a.out.Path != "" {
+		recv = a.out
+	} else {
+		recv = b.out
+	}
+	got, err := os.ReadFile(recv.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("output differs from source after signaling loss")
+	}
+	for name, log := range map[string]*pathLog{"sender": sendPaths, "receiver": recvPaths} {
+		log.mu.Lock()
+		paths := append([]string(nil), log.paths...)
+		log.mu.Unlock()
+		if len(paths) != 1 || paths[0] != "direct" {
+			t.Fatalf("%s paths = %v; want [direct] with signaling dead", name, paths)
+		}
+	}
+}
+
+// TestDriverSignalingLossOnRelayIsFatal pins the relay side of SB-1122: a relay
+// transfer needs signaling (credit accounting), so losing it mid-file fails both
+// sides with RELAY instead of silently stalling.
+func TestDriverSignalingLossOnRelayIsFatal(t *testing.T) {
+	hub := newRelay()
+	payload := faultPayload(2*1024*1024 + 13)
+	meta := wire.FileMeta{Name: "relay-sig-loss.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *Outcome
+		err error
+	}
+	done := make(chan result, 2)
+	var once sync.Once
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Session: rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:  wire.BytesSource(payload, meta, 64*1024),
+			// Explicit empty ICEServers: no direct path may even be attempted.
+			ICEServers: []webrtc.ICEServer{},
+			ForceRelay: true,
+			OnProgress: func(bytes int64) {
+				if bytes >= 512*1024 {
+					once.Do(func() { killBothSignaling(hub) })
+				}
+			},
+		})
+		done <- result{out: out, err: err}
+	}()
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:    dir,
+			ICEServers: []webrtc.ICEServer{},
+			ForceRelay: true,
+		})
+		done <- result{out: out, err: err}
+	}()
+
+	a, b := <-done, <-done
+	if a.err == nil || b.err == nil {
+		t.Fatalf("expected both sides to fail on relay signaling loss: %v / %v", a.err, b.err)
+	}
+	if code := wire.CodeOf(a.err); code != wire.CodeRelay {
+		t.Fatalf("sender error code = %s (%v); want RELAY", code, a.err)
+	}
+	if code := wire.CodeOf(b.err); code != wire.CodeRelay {
+		t.Fatalf("receiver error code = %s (%v); want RELAY", code, b.err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("destination contains %d files after a failed transfer; want none", len(entries))
+	}
+}
+
+// TestDriverCutoverBeforeDataStarts pins SB-1123 phase 1: the direct channel
+// dies before the first byte moves and the transfer still completes over the
+// relay with identical bytes.
+func TestDriverCutoverBeforeDataStarts(t *testing.T) {
+	hub := newRelay()
+	payload := faultPayload(512*1024 + 21)
+	meta := wire.FileMeta{Name: "cutover-early.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	trigger := make(chan struct{})
+	var triggerOnce sync.Once
+	sendPaths, recvPaths := &pathLog{}, &pathLog{}
+	type result struct {
+		out *Outcome
+		err error
+	}
+	done := make(chan result, 2)
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:      wire.BytesSource(payload, meta, 64*1024),
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(sendPaths),
+			breakDirect: trigger,
+			OnConnect: func() {
+				triggerOnce.Do(func() { close(trigger) })
+			},
+		})
+		done <- result{out: out, err: err}
+	}()
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:     dir,
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(recvPaths),
+		})
+		done <- result{out: out, err: err}
+	}()
+
+	a, b := <-done, <-done
+	if a.err != nil || b.err != nil {
+		t.Fatalf("cutover-before-data results: %v / %v", a.err, b.err)
+	}
+	var recv *Outcome
+	if a.out.Path != "" {
+		recv = a.out
+	} else {
+		recv = b.out
+	}
+	got, err := os.ReadFile(recv.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("output differs from source after early cutover")
+	}
+	for name, log := range map[string]*pathLog{"sender": sendPaths, "receiver": recvPaths} {
+		log.mu.Lock()
+		paths := append([]string(nil), log.paths...)
+		log.mu.Unlock()
+		if len(paths) != 2 || paths[0] != "direct" || paths[1] != "relay" {
+			t.Fatalf("%s paths = %v; want [direct relay]", name, paths)
+		}
+	}
+}
+
+// TestDriverCutoverAfterAllDataAcked pins SB-1123 phase 2: every byte has been
+// acknowledged before the direct path dies, so the cutover must not fail the
+// transfer over lost terminal control frames.
+func TestDriverCutoverAfterAllDataAcked(t *testing.T) {
+	hub := newRelay()
+	payload := faultPayload(1024*1024 + 29)
+	meta := wire.FileMeta{Name: "cutover-late.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	trigger := make(chan struct{})
+	var triggerOnce sync.Once
+	sendPaths, recvPaths := &pathLog{}, &pathLog{}
+	type result struct {
+		out *Outcome
+		err error
+	}
+	done := make(chan result, 2)
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:      wire.BytesSource(payload, meta, 64*1024),
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(sendPaths),
+			breakDirect: trigger,
+			OnProgress: func(bytes int64) {
+				if bytes >= meta.Size {
+					triggerOnce.Do(func() { close(trigger) })
+				}
+			},
+		})
+		done <- result{out: out, err: err}
+	}()
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:     dir,
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(recvPaths),
+		})
+		done <- result{out: out, err: err}
+	}()
+
+	a, b := <-done, <-done
+	if a.err != nil || b.err != nil {
+		t.Fatalf("cutover-after-data results: %v / %v", a.err, b.err)
+	}
+	var recv *Outcome
+	if a.out.Path != "" {
+		recv = a.out
+	} else {
+		recv = b.out
+	}
+	got, err := os.ReadFile(recv.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("output differs from source after late cutover")
+	}
+	for name, log := range map[string]*pathLog{"sender": sendPaths, "receiver": recvPaths} {
+		log.mu.Lock()
+		paths := append([]string(nil), log.paths...)
+		log.mu.Unlock()
+		if len(paths) < 1 || paths[0] != "direct" {
+			t.Fatalf("%s paths = %v; want direct first", name, paths)
+		}
+	}
+}

--- a/apps/cli/internal/transfer/driver_test.go
+++ b/apps/cli/internal/transfer/driver_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -88,10 +89,15 @@ type relayEnd struct {
 	relayOpen bool
 	once      sync.Once
 	done      chan struct{}
+	killOnce  sync.Once
+	killSig   chan struct{} // closed by killSignaling to simulate a dead signaling socket
 }
 
 func newRelayEnd(hub *relay, role string) *relayEnd {
-	return &relayEnd{hub: hub, role: role, in: make(chan rendezvous.Message, 256), bin: make(chan []byte, 256), done: make(chan struct{})}
+	return &relayEnd{
+		hub: hub, role: role, in: make(chan rendezvous.Message, 256),
+		bin: make(chan []byte, 256), done: make(chan struct{}), killSig: make(chan struct{}),
+	}
 }
 
 func (e *relayEnd) Send(m rendezvous.Message) error {
@@ -110,6 +116,8 @@ func (e *relayEnd) SendBinary(frame []byte) error {
 func (e *relayEnd) Run(ctx context.Context, onMessage func(rendezvous.Message), onBinary func([]byte)) error {
 	for {
 		select {
+		case <-e.killSig:
+			return errSignalingClosed
 		case m := <-e.in:
 			onMessage(m)
 		case frame := <-e.bin:
@@ -120,6 +128,15 @@ func (e *relayEnd) Run(ctx context.Context, onMessage func(rendezvous.Message), 
 			return ctx.Err()
 		}
 	}
+}
+
+// errSignalingClosed is what the driver sees when the signaling socket dies.
+var errSignalingClosed = errors.New("signaling socket closed")
+
+// killSignaling simulates the signaling socket dying while the byte path (direct
+// channel or relay) keeps or loses transport independently.
+func (e *relayEnd) killSignaling() {
+	e.killOnce.Do(func() { close(e.killSig) })
 }
 
 func (e *relayEnd) enqueueBinary(frame []byte) {

--- a/packages/protocol/src/transfer-receiver.test.ts
+++ b/packages/protocol/src/transfer-receiver.test.ts
@@ -108,6 +108,79 @@ describe('TransferReceiver', () => {
     expect(backTypes).toEqual([FrameType.Ack, FrameType.Ack, FrameType.Ack, FrameType.Done]);
   });
 
+  it('ignores pre-manifest data and identical duplicate manifests (cutover recovery)', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array(8).map((_, i) => i);
+    const fileDigest = createHash('sha256').update(data).digest('hex');
+    const b = await build(keys);
+    const manifest = {
+      type: FrameType.Manifest,
+      files: [
+        {
+          idx: 0,
+          name: 'f',
+          size: 8,
+          mime: '',
+          lastModified: 0,
+          blockSize: 8,
+          blocks: 1,
+          fileDigest,
+        },
+      ],
+      totalSize: 8,
+    };
+
+    // A path cutover can deliver block data before the manifest arrives; it must
+    // be ignored, not treated as a protocol violation.
+    await b.push(
+      {
+        version: FRAME_VERSION,
+        type: FrameType.BlockData,
+        flags: 1,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      data,
+    );
+    await b.ctrl(FrameType.Manifest, manifest);
+    // The sender may then retransmit the identical manifest on the new path.
+    await b.ctrl(FrameType.Manifest, manifest);
+    await b.push(
+      {
+        version: FRAME_VERSION,
+        type: FrameType.BlockData,
+        flags: 1,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      data,
+    );
+    await b.ctrl(FrameType.BlockHash, {
+      type: FrameType.BlockHash,
+      fileIdx: 0,
+      blockIdx: 0,
+      sha256: bytesToHex(await sha256(data)),
+    });
+    await b.ctrl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
+
+    const sink = new MemorySink();
+    const receiver = new TransferReceiver({
+      send: () => {},
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+    });
+    for (const f of b.frames) receiver.handle(f);
+    const result = await receiver.done;
+    expect(result.digest).toBe(fileDigest);
+    expect([...sink.bytes()]).toEqual([...data]);
+  });
+
   it('aborts with integrity on a corrupted frame (GCM failure)', async () => {
     const keys = await deriveTransferKeys(master);
     const data = new Uint8Array(8).map((_, i) => i);

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -250,6 +250,10 @@ export class TransferReceiver {
         : new TransferError('sink_error', e instanceof Error ? e.message : String(e));
     }
     this.manifest = manifest;
+    // The sender may already be retrying blocks on the old path while the
+    // cutover's manifest copy arrives; discard that stale tail (fragments
+    // before the next block boundary, plus its hash) instead of assembling it.
+    this.awaitingRestart = true;
     if (manifest.transferId !== undefined) {
       // The sender opted into resumption. Apply persisted offsets only when they belong to this
       // exact transfer, then report each file's high-water mark so the sender skips held blocks.

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -226,7 +226,6 @@ export class TransferReceiver {
   }
 
   private async applyManifest(payload: Uint8Array): Promise<void> {
-    if (this.manifest) throw new TransferError('integrity', 'duplicate manifest');
     const msg = decodeControl(payload);
     if (msg.type !== FrameType.Manifest) throw new TransferError('integrity', 'expected manifest');
     let manifest;
@@ -234,6 +233,13 @@ export class TransferReceiver {
       manifest = validateManifest(msg);
     } catch (e) {
       throw new TransferError('integrity', e instanceof Error ? e.message : String(e));
+    }
+    if (this.manifest) {
+      // A path cutover can retransmit the manifest while the original is still
+      // being processed. An identical copy is harmless; a different one is a
+      // protocol violation (mirrors the Go wire receiver).
+      if (manifestsEqual(manifest, this.manifest)) return;
+      throw new TransferError('integrity', 'duplicate manifest');
     }
     try {
       await this.destination.prepare(manifest);
@@ -332,7 +338,12 @@ export class TransferReceiver {
     payload: Uint8Array,
   ): void {
     const manifest = this.manifest;
-    if (!manifest) throw new TransferError('integrity', 'block_data before manifest');
+    if (!manifest) {
+      // A cutover may lose the manifest while block data is already streaming;
+      // the sender retransmits it, so stray data before the manifest is ignored
+      // rather than treated as a protocol violation (mirrors the Go wire receiver).
+      return;
+    }
     const entry = manifest.files[fileIdx];
     if (!entry || fileIdx > this.fileIdx || blockIdx < 0 || blockIdx >= entry.blocks) {
       throw new TransferError('integrity', `block_data outside manifest: ${blockIdx}`);
@@ -364,7 +375,8 @@ export class TransferReceiver {
   private async onBlockHash(payload: Uint8Array): Promise<void> {
     const block = this.blockBuf;
     if (!block && this.awaitingRestart) return;
-    if (!this.manifest || !block) {
+    if (!this.manifest) return; // pre-manifest; the manifest may be in flight after a cutover
+    if (!block) {
       throw new TransferError('integrity', 'block_hash without a block');
     }
     const msg = decodeControl(payload);
@@ -568,4 +580,30 @@ function asIntegrityError(e: unknown): TransferError {
   return e instanceof TransferError
     ? e
     : new TransferError('integrity', e instanceof Error ? e.message : String(e));
+}
+
+// manifestsEqual reports whether two validated manifests describe the same
+// transfer: same id, same total size, and identical file entries.
+function manifestsEqual(a: Manifest, b: Manifest): boolean {
+  if (
+    a.transferId !== b.transferId ||
+    a.totalSize !== b.totalSize ||
+    a.files.length !== b.files.length
+  ) {
+    return false;
+  }
+  return a.files.every((file, i) => {
+    const other = b.files[i];
+    if (!other) return false;
+    return (
+      file.idx === other.idx &&
+      file.name === other.name &&
+      file.size === other.size &&
+      file.mime === other.mime &&
+      file.lastModified === other.lastModified &&
+      file.blockSize === other.blockSize &&
+      file.blocks === other.blocks &&
+      file.fileDigest === other.fileDigest
+    );
+  });
 }

--- a/packages/protocol/src/transfer-sender.test.ts
+++ b/packages/protocol/src/transfer-sender.test.ts
@@ -46,7 +46,7 @@ describe('TransferSender', () => {
     const runP = sender.run();
 
     // Let the sender push manifest + block 0's frames + block 0 hash, then stall on window=1.
-    await new Promise((r) => setTimeout(r, 10));
+    await waitFor(() => outbound.length >= 4);
     let peek = 0;
     const types = await Promise.all(
       outbound.map(async (f) => (await open(keys.o2j, peek++, f)).header.type),

--- a/packages/protocol/src/transfer-sender.test.ts
+++ b/packages/protocol/src/transfer-sender.test.ts
@@ -291,17 +291,20 @@ describe('TransferSender', () => {
     const run = sender.run();
     await waitFor(() => outbound.length === 3);
     sender.transportChanged();
-    await waitFor(() => outbound.length === 5);
+    // Nothing is acknowledged yet, so the manifest is retransmitted alongside the
+    // unacknowledged block: 3 frames after the cutover.
+    await waitFor(() => outbound.length === 6);
     sender.cancel('test complete');
     await expect(run).rejects.toThrow(/test complete/);
 
     let counter = 0;
     const opened = [];
-    for (const frame of outbound.slice(0, 5)) opened.push(await open(keys.o2j, counter++, frame));
+    for (const frame of outbound.slice(0, 6)) opened.push(await open(keys.o2j, counter++, frame));
     expect(opened.map((frame) => frame.header.type)).toEqual([
       FrameType.Manifest,
       FrameType.BlockData,
       FrameType.BlockHash,
+      FrameType.Manifest,
       FrameType.BlockData,
       FrameType.BlockHash,
     ]);
@@ -369,5 +372,45 @@ describe('TransferSender', () => {
     sender.handle(done);
     await runP;
     expect(states).toEqual(['paused', 'running']);
+  });
+
+  it('times out on done after complete with retry_exhausted when the receiver never sends done', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const outbound: Uint8Array[] = [];
+    const sender = new TransferSender({
+      file: bytesSource(data, { name: 'f', size: data.length, mime: '', lastModified: 0 }),
+      send: (frame) => void outbound.push(frame),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 8,
+      frameSize: 4,
+      doneTimeoutMs: 60,
+    });
+
+    const runP = sender.run();
+    await waitFor(() => outbound.length === 3); // manifest, block_data, block_hash
+
+    const ack = await seal(
+      keys.j2o,
+      0,
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Ack,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      encodeControl({ type: FrameType.Ack, fileIdx: 0, blockIdx: 0 }),
+    );
+    sender.handle(ack);
+
+    // The receiver acknowledges everything but never sends done: the sender must
+    // fail with retry_exhausted instead of hanging.
+    await expect(runP).rejects.toThrow(/retry_exhausted/);
   });
 });

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -57,6 +57,11 @@ export interface TransferSenderOptions {
   ackTimeoutMs?: number;
   /** Retransmissions allowed per block after its initial send. */
   maxRetries?: number;
+  /**
+   * How long to wait for the receiver's Done after Complete before failing with
+   * retry exhaustion. A dead peer otherwise stalls `run` forever.
+   */
+  doneTimeoutMs?: number;
   /** Reports bytes acknowledged after verify-and-sink. */
   onProgress?(acknowledgedBytes: number): void;
   /** Reports verified progress for the active file plus aggregate acknowledged bytes. */
@@ -73,6 +78,7 @@ interface InflightBlock {
 
 const DEFAULT_ACK_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_DONE_TIMEOUT_MS = 30_000;
 
 export class TransferSender {
   private readonly o: TransferSenderOptions;
@@ -90,6 +96,8 @@ export class TransferSender {
   private completeSent = false;
   private activeFileIdx = -1;
   private activeFileAcknowledged = 0;
+  /** The validated manifest, kept so a path change before any acknowledgment can retransmit it. */
+  private manifest: Manifest | undefined;
 
   /** Set when a transfer id is advertised: the manifest carries it and a resume handshake runs. */
   private readonly transferId: string | undefined;
@@ -171,6 +179,14 @@ export class TransferSender {
       state.retries = 0;
       this.queueRetry(blockIdx);
     }
+    if (this.manifest !== undefined && this.acknowledged === 0) {
+      // The manifest may have been lost in the cutover; it is outside the block
+      // retransmit window. The receiver ignores identical duplicates and stray
+      // pre-manifest data, so resending it lets the transfer continue.
+      void this.sendControl(FrameType.Manifest, this.manifest).catch((e: unknown) =>
+        this.fail(e instanceof Error ? e : new Error(String(e))),
+      );
+    }
   }
 
   /** Pause locally and ask the peer to reflect the paused state. */
@@ -228,6 +244,7 @@ export class TransferSender {
     const transferDigest = await completionDigest(manifest.files);
     this.o.onManifest?.(manifest);
     await this.sendControl(FrameType.Manifest, manifest);
+    this.manifest = manifest;
 
     // A transfer id opts into resumption: the receiver answers the manifest with a resume_state
     // carrying each file's high-water mark (all zero on a first attempt). Wait for it before
@@ -269,8 +286,25 @@ export class TransferSender {
       type: FrameType.Complete,
       fileDigest: transferDigest,
     });
-    await this.done;
+    await this.waitForDone();
     return transferDigest;
+  }
+
+  private async waitForDone(): Promise<void> {
+    const timeoutMs = this.o.doneTimeoutMs ?? DEFAULT_DONE_TIMEOUT_MS;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        this.done,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(new TransferError('retry_exhausted', 'receiver did not send done in time'));
+          }, timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   private async processInbound(frame: Uint8Array): Promise<void> {

--- a/packages/wire/errors.go
+++ b/packages/wire/errors.go
@@ -14,17 +14,17 @@ type ErrorCode string
 
 // Stable machine-readable error class codes (ADR 0002).
 const (
-	CodeAuth          ErrorCode = "AUTH"
-	CodeProtocol      ErrorCode = "PROTOCOL"
-	CodeConnection    ErrorCode = "CONNECTION"
-	CodeRelay         ErrorCode = "RELAY"
+	CodeAuth           ErrorCode = "AUTH"
+	CodeProtocol       ErrorCode = "PROTOCOL"
+	CodeConnection     ErrorCode = "CONNECTION"
+	CodeRelay          ErrorCode = "RELAY"
 	CodeRetryExhausted ErrorCode = "RETRY_EXHAUSTED"
-	CodeCanceled      ErrorCode = "CANCELED"
-	CodeStorage       ErrorCode = "STORAGE"
-	CodeSourceIO      ErrorCode = "SOURCE_IO"
-	CodeDestIO        ErrorCode = "DEST_IO"
-	CodeCompat        ErrorCode = "COMPAT"
-	CodeInternal      ErrorCode = "INTERNAL"
+	CodeCanceled       ErrorCode = "CANCELED"
+	CodeStorage        ErrorCode = "STORAGE"
+	CodeSourceIO       ErrorCode = "SOURCE_IO"
+	CodeDestIO         ErrorCode = "DEST_IO"
+	CodeCompat         ErrorCode = "COMPAT"
+	CodeInternal       ErrorCode = "INTERNAL"
 )
 
 // Error is an error carrying a stable machine-readable class.

--- a/packages/wire/fault_io_test.go
+++ b/packages/wire/fault_io_test.go
@@ -1,0 +1,318 @@
+package wire
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// faultSink wraps a MemorySink and fails a chosen write (1-based) or Close with
+// a chosen error, mirroring disk failures on the receive side (SB-1125).
+type faultSink struct {
+	*MemorySink
+	failWriteAt int
+	writeErr    error
+	closeErr    error
+	writes      int
+}
+
+func (f *faultSink) Write(offset int64, bytes []byte) error {
+	f.writes++
+	if f.writes == f.failWriteAt && f.writeErr != nil {
+		return f.writeErr
+	}
+	return f.MemorySink.Write(offset, bytes)
+}
+
+func (f *faultSink) Close() error {
+	if f.closeErr != nil {
+		return f.closeErr
+	}
+	return f.MemorySink.Close()
+}
+
+// faultDestination fails on Open (destination collision) or Close (commit/flush
+// failure) exactly where the wire layer must surface FailSinkError (SB-1125).
+type faultDestination struct {
+	openErr  error
+	closeErr error
+	sinks    []*faultSink
+}
+
+func (d *faultDestination) Prepare(Manifest) error { return nil }
+
+func (d *faultDestination) Open(FileEntry) (Sink, error) {
+	if d.openErr != nil {
+		return nil, d.openErr
+	}
+	s := &faultSink{MemorySink: &MemorySink{}}
+	d.sinks = append(d.sinks, s)
+	return s, nil
+}
+
+func (d *faultDestination) Close() error { return d.closeErr }
+
+func (d *faultDestination) Abort(reason string) error {
+	for _, s := range d.sinks {
+		_ = s.Abort(reason)
+	}
+	return nil
+}
+
+// faultSource serves a different byte stream per pass so tests can inject file
+// disappearance, mid-read failure, and file mutation between the digest pass
+// and the transfer pass (SB-1126). Stream is called exactly twice by Sender.Run.
+type faultSource struct {
+	meta   FileMeta
+	passes [2][]byte
+	errs   [2]error
+	failAt [2]int // bytes emitted before failing on this pass; 0 fails immediately
+	calls  int
+}
+
+func (s *faultSource) Meta() FileMeta { return s.meta }
+
+func (s *faultSource) Stream(fn func(chunk []byte) error) error {
+	if s.calls > 1 {
+		return errors.New("faultSource: Stream called more than twice")
+	}
+	pass := s.calls
+	s.calls++
+	data := s.passes[pass]
+	limit := len(data)
+	if s.failAt[pass] > 0 && s.failAt[pass] < limit {
+		limit = s.failAt[pass]
+	}
+	for off := 0; off < limit; off += 512 {
+		end := off + 512
+		if end > limit {
+			end = limit
+		}
+		if err := fn(data[off:end]); err != nil {
+			return err
+		}
+	}
+	return s.errs[pass]
+}
+
+// failReasonOf extracts the transfer fail reason from an error, or reports no.
+func failReasonOf(err error) (FailReason, bool) {
+	var te *TransferError
+	if errors.As(err, &te) {
+		return te.Reason, true
+	}
+	return "", false
+}
+
+// TestFaultDroppedManifestFailsClosed pins that a manifest lost without a path
+// change still fails the transfer cleanly: pre-manifest data is ignored, the
+// sender exhausts its retries, and the peer learns of the failure.
+func TestFaultDroppedManifestFailsClosed(t *testing.T) {
+	data := testData(64_000, 79)
+	res := runFaultLoopback(t, data, 1024, 256, 4,
+		faultScript{}.at(dirS2R, FrameManifest, fDrop), nil,
+		faultRunOptions{ackTimeout: 120 * time.Millisecond, maxRetries: 3, deadline: 4 * time.Second})
+	if res.runErr == nil {
+		t.Fatal("sender must fail when the manifest is lost")
+	}
+	if res.recvSettled {
+		t.Fatal("receiver must not settle without a manifest")
+	}
+	if reason, ok := failReasonOf(res.runErr); !ok || reason != FailRetryExhausted {
+		t.Fatalf("sender reason = %q, %v; want retry exhaustion", reason, res.runErr)
+	}
+}
+
+// TestFaultManifestRetransmittedOnCutover pins that a path change after the
+// manifest was lost retransmits it, and the receiver's ignored pre-manifest
+// data plus the identical-duplicate tolerance let the transfer complete.
+func TestFaultManifestRetransmittedOnCutover(t *testing.T) {
+	data := testData(64_000, 83)
+	res := runFaultLoopback(t, data, 1024, 256, 4,
+		faultScript{}.at(dirS2R, FrameManifest, fDrop), nil,
+		faultRunOptions{
+			cutover: func(_ *faultLink, sender *Sender) { sender.TransportChanged() },
+		})
+	res.wantSuccess(t, data)
+}
+
+// TestFaultDuplicateManifestIsIgnored pins that a path change retransmitting an
+// identical manifest does not abort the transfer.
+func TestFaultDuplicateManifestIsIgnored(t *testing.T) {
+	data := testData(32_000, 97)
+	res := runFaultLoopback(t, data, 1024, 256, 4,
+		faultScript{}.at(dirS2R, FrameManifest, fDuplicate), nil,
+		faultRunOptions{
+			cutover: func(_ *faultLink, sender *Sender) { sender.TransportChanged() },
+		})
+	res.wantSuccess(t, data)
+}
+
+// TestFaultSinkQuotaAbortsTransfer pins that a typed FailQuota returned by the
+// sink survives as-is on both sides and the partial output is discarded.
+func TestFaultSinkQuotaAbortsTransfer(t *testing.T) {
+	data := testData(200_000, 41)
+	s := &faultSink{MemorySink: &MemorySink{},
+		failWriteAt: 5, writeErr: NewTransferError(FailQuota, "no space left on device")}
+	res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, nil,
+		faultRunOptions{sink: s})
+	if reason, ok := failReasonOf(res.recvErr); !ok || reason != FailQuota {
+		t.Fatalf("receiver reason = %q, %v; want FailQuota", reason, res.recvErr)
+	}
+	if reason, ok := failReasonOf(res.runErr); !ok || reason != FailQuota {
+		t.Fatalf("sender reason = %q, %v; want FailQuota", reason, res.runErr)
+	}
+	if s.AbortReason() == "" {
+		t.Fatal("sink was not aborted after a quota failure")
+	}
+	if s.IsClosed() {
+		t.Fatal("sink was closed despite the failure")
+	}
+}
+
+// TestFaultSinkWriteFailureAborts pins that a plain disk error surfaces as
+// FailSinkError on both sides and no bytes are ever committed.
+func TestFaultSinkWriteFailureAborts(t *testing.T) {
+	data := testData(120_000, 43)
+	s := &faultSink{MemorySink: &MemorySink{},
+		failWriteAt: 3, writeErr: errors.New("permission revoked: open /mnt/out/f: EACCES")}
+	res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, nil,
+		faultRunOptions{sink: s})
+	if reason, ok := failReasonOf(res.recvErr); !ok || reason != FailSinkError {
+		t.Fatalf("receiver reason = %q, %v; want FailSinkError", reason, res.recvErr)
+	}
+	if reason, ok := failReasonOf(res.runErr); !ok || reason != FailSinkError {
+		t.Fatalf("sender reason = %q, %v; want FailSinkError", reason, res.runErr)
+	}
+	if s.AbortReason() == "" {
+		t.Fatal("sink was not aborted after a write failure")
+	}
+}
+
+// TestFaultSinkCloseFailureAborts pins that a failing Close on the fully
+// received file still aborts the transfer instead of committing it.
+func TestFaultSinkCloseFailureAborts(t *testing.T) {
+	data := testData(64_000, 47)
+	s := &faultSink{MemorySink: &MemorySink{},
+		closeErr: errors.New("flush failed: EIO")}
+	res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, nil,
+		faultRunOptions{sink: s})
+	if reason, ok := failReasonOf(res.recvErr); !ok || reason != FailSinkError {
+		t.Fatalf("receiver reason = %q, %v; want FailSinkError", reason, res.recvErr)
+	}
+	if reason, ok := failReasonOf(res.runErr); !ok || reason != FailSinkError {
+		t.Fatalf("sender reason = %q, %v; want FailSinkError", reason, res.runErr)
+	}
+	if s.AbortReason() == "" {
+		t.Fatal("sink was not aborted when Close failed")
+	}
+	if s.IsClosed() {
+		t.Fatal("sink Close must not be considered successful")
+	}
+}
+
+// TestFaultDestinationCollisionAborts pins that a destination refusing to open
+// (file already exists, no overwrite) aborts before a single byte is written.
+func TestFaultDestinationCollisionAborts(t *testing.T) {
+	data := testData(80_000, 53)
+	dest := &faultDestination{openErr: errors.New("destination exists; refusing to overwrite")}
+	res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, nil,
+		faultRunOptions{destination: dest})
+	if reason, ok := failReasonOf(res.recvErr); !ok || reason != FailSinkError {
+		t.Fatalf("receiver reason = %q, %v; want FailSinkError", reason, res.recvErr)
+	}
+	if reason, ok := failReasonOf(res.runErr); !ok || reason != FailSinkError {
+		t.Fatalf("sender reason = %q, %v; want FailSinkError", reason, res.runErr)
+	}
+	if len(dest.sinks) != 0 {
+		t.Fatalf("destination opened %d sinks on a collision; want 0", len(dest.sinks))
+	}
+}
+
+// TestFaultDestinationFlushFailureAborts pins that a commit-time (flush)
+// failure after every block was verified still discards the output.
+func TestFaultDestinationFlushFailureAborts(t *testing.T) {
+	data := testData(64_000, 59)
+	dest := &faultDestination{closeErr: errors.New("flush failed: EIO")}
+	res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, nil,
+		faultRunOptions{destination: dest})
+	if reason, ok := failReasonOf(res.recvErr); !ok || reason != FailSinkError {
+		t.Fatalf("receiver reason = %q, %v; want FailSinkError", reason, res.recvErr)
+	}
+	if reason, ok := failReasonOf(res.runErr); !ok || reason != FailSinkError {
+		t.Fatalf("sender reason = %q, %v; want FailSinkError", reason, res.runErr)
+	}
+	if len(dest.sinks) != 1 {
+		t.Fatalf("destination opened %d sinks; want 1", len(dest.sinks))
+	}
+	if got := string(dest.sinks[0].Bytes()); got != string(data) {
+		t.Fatal("all bytes were verified and written before the flush failure")
+	}
+	if dest.sinks[0].AbortReason() == "" {
+		t.Fatal("written output was not aborted after the flush failure")
+	}
+}
+
+// TestFaultSourceDisappearsBeforeDigest pins that a source vanishing before the
+// digest pass fails the sender with SOURCE_IO and the receiver never settles.
+func TestFaultSourceDisappearsBeforeDigest(t *testing.T) {
+	data := testData(100_000, 61)
+	src := &faultSource{meta: FileMeta{Name: "gone", Size: int64(len(data))}}
+	src.passes[0] = data
+	src.errs[0] = os.ErrNotExist
+	res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, nil,
+		faultRunOptions{source: src, deadline: 2 * time.Second})
+	if res.runErr == nil || CodeOf(res.runErr) != CodeSourceIO {
+		t.Fatalf("sender error = %v; want SOURCE_IO", res.runErr)
+	}
+	if res.recvSettled {
+		t.Fatal("receiver settled although no manifest was ever sent")
+	}
+}
+
+// TestFaultSourceReadFailsMidTransfer pins that a read failure after the digest
+// pass fails the sender with SOURCE_IO and the partial transfer never commits.
+func TestFaultSourceReadFailsMidTransfer(t *testing.T) {
+	data := testData(200_000, 67)
+	src := &faultSource{meta: FileMeta{Name: "bad", Size: int64(len(data))}}
+	src.passes[0] = data
+	src.passes[1] = data
+	src.failAt[1] = 4096
+	src.errs[1] = errors.New("read /dev/sda1: EIO")
+	res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, nil,
+		faultRunOptions{source: src, ackTimeout: 120 * time.Millisecond, deadline: 2 * time.Second})
+	if res.runErr == nil || CodeOf(res.runErr) != CodeSourceIO {
+		t.Fatalf("sender error = %v; want SOURCE_IO", res.runErr)
+	}
+	if res.recvSettled {
+		t.Fatal("receiver settled on a partial transfer")
+	}
+	if res.recvErr == nil {
+		t.Fatal("receiver must report an error on an aborted source")
+	}
+}
+
+// TestFaultSourceMutatesBetweenPasses pins that a file changing between the
+// digest pass and the transfer pass fails closed on digest verification.
+func TestFaultSourceMutatesBetweenPasses(t *testing.T) {
+	data := testData(200_000, 71)
+	src := &faultSource{meta: FileMeta{Name: "mut", Size: int64(len(data))}}
+	src.passes[0] = data
+	src.passes[1] = testData(150_000, 73)
+	res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, nil,
+		faultRunOptions{source: src, ackTimeout: 120 * time.Millisecond})
+	if res.recvErr == nil {
+		t.Fatal("receiver accepted a file that changed mid-transfer")
+	}
+	reason, ok := failReasonOf(res.recvErr)
+	if !ok || (reason != FailDigestMismatch && reason != FailIntegrity) {
+		t.Fatalf("receiver reason = %q, %v; want digest mismatch or integrity", reason, res.recvErr)
+	}
+	if res.runErr == nil {
+		t.Fatal("sender must fail once the receiver rejects the mutation")
+	}
+	if res.sink.AbortReason() == "" {
+		t.Fatal("output was not discarded after the mutation was detected")
+	}
+}

--- a/packages/wire/fault_seeded_test.go
+++ b/packages/wire/fault_seeded_test.go
@@ -1,0 +1,109 @@
+package wire
+
+import (
+	"encoding/json"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// fixedSeeds are the seeds every CI run exercises; a failure at seed N is
+// reproduced locally with -run TestFaultRandomizedFailClosed (SB-1127).
+var fixedSeeds = []int64{11, 22, 33, 44, 55, 66, 77, 88}
+
+// TestFaultRandomizedFailClosed pins the fail-closed contract under every
+// randomized fault mix: a transfer either completes with the exact source
+// bytes, or fails on at least one side with the sink never committed. Silent
+// corruption is never acceptable.
+func TestFaultRandomizedFailClosed(t *testing.T) {
+	for _, seed := range fixedSeeds {
+		for _, destructive := range []bool{false, true} {
+			size := 16_000 + int(seed%97)*64
+			data := testData(size, byte(seed))
+			res := runFaultLoopback(t, data, 1024, 256, 4, faultScript{}, rand.New(rand.NewSource(seed)),
+				faultRunOptions{ackTimeout: 120 * time.Millisecond, maxRetries: 3, deadline: 3 * time.Second, benignOnly: !destructive})
+			if res.runErr == nil && res.recvErr == nil {
+				res.wantSuccess(t, data)
+			} else {
+				if res.recvSettled {
+					t.Fatalf("seed %d destructive=%v: receiver settled on a failed transfer", seed, destructive)
+				}
+				if res.sink.AbortReason() == "" {
+					t.Fatalf("seed %d destructive=%v: failed transfer left committed output", seed, destructive)
+				}
+			}
+		}
+	}
+}
+
+// faultFixture is one recorded regression scenario (SB-1128). Want is
+// "success" or "fail_closed".
+type faultFixture struct {
+	Seed        int64  `json:"seed"`
+	Size        int    `json:"size"`
+	BlockSize   int    `json:"blockSize"`
+	FrameSize   int    `json:"frameSize"`
+	Window      int    `json:"window"`
+	AckTimeout  int    `json:"ackTimeoutMs"`
+	MaxRetries  int    `json:"maxRetries"`
+	Destructive bool   `json:"destructive"`
+	Want        string `json:"want"`
+}
+
+// TestFaultSeededRegressionFixtures replays every stored seed so a seed that
+// once exposed a bug stays pinned to its recorded outcome.
+func TestFaultSeededRegressionFixtures(t *testing.T) {
+	path := filepath.Join("testdata", "fault-seeds", "regression.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixtures []faultFixture
+	if err := json.Unmarshal(raw, &fixtures); err != nil {
+		t.Fatal(err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatal("no regression fixtures recorded")
+	}
+	for _, fx := range fixtures {
+		fx := fx
+		t.Run(fx.name(), func(t *testing.T) {
+			data := testData(fx.Size, byte(fx.Seed))
+			res := runFaultLoopback(t, data, fx.BlockSize, fx.FrameSize, fx.Window, faultScript{}, rand.New(rand.NewSource(fx.Seed)),
+				faultRunOptions{
+					ackTimeout: time.Duration(fx.AckTimeout) * time.Millisecond,
+					maxRetries: fx.MaxRetries,
+					deadline:   3 * time.Second,
+					benignOnly: !fx.Destructive,
+				})
+			succeeded := res.runErr == nil && res.recvErr == nil
+			if fx.Want == "success" {
+				if !succeeded {
+					t.Fatalf("fixture %s regressed: expected success, got runErr=%v recvErr=%v", fx.name(), res.runErr, res.recvErr)
+				}
+				res.wantSuccess(t, data)
+			} else {
+				if succeeded {
+					t.Fatalf("fixture %s regressed: expected fail_closed, transfer succeeded", fx.name())
+				}
+				if res.recvSettled {
+					t.Fatalf("fixture %s: receiver settled on a failed transfer", fx.name())
+				}
+				if res.sink.AbortReason() == "" {
+					t.Fatalf("fixture %s: failed transfer left committed output", fx.name())
+				}
+			}
+		})
+	}
+}
+
+func (f faultFixture) name() string {
+	mode := "benign"
+	if f.Destructive {
+		mode = "destructive"
+	}
+	return "seed-" + strconv.FormatInt(f.Seed, 10) + "-" + mode
+}

--- a/packages/wire/faults_test.go
+++ b/packages/wire/faults_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"math/rand"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -61,6 +62,7 @@ type faultLink struct {
 	script   faultScript
 	rng      *rand.Rand
 
+	mu         sync.Mutex // guards counts and delayed
 	counts     [2]map[uint8]int
 	delayed    [2][]byte
 	closed     atomic.Bool
@@ -82,60 +84,74 @@ func (l *faultLink) send(dir int, frame []byte) error {
 	// Sealed frames are counter(8) || header(16) || ciphertext || tag, so the
 	// type byte lives at offset 9.
 	typ := frame[9]
+
+	l.mu.Lock()
 	occ := l.counts[dir][typ]
 	l.counts[dir][typ] = occ + 1
-
-	var act = fPass
+	act := fPass
 	if l.rng != nil {
 		act = l.randomAction(dir, typ)
 	} else if acts := l.script[dir][typ]; occ < len(acts) {
 		act = acts[occ]
 	}
+	// Decide and stage everything under the lock; channel sends happen outside
+	// it, since a send can block behind a full buffer while the drainer waits
+	// for the same lock on its next send (a deadlock).
+	var flush [2][][]byte
+	var plan [][]byte
 	switch act {
 	case fDrop:
-		return nil
 	case fClose:
-		l.close()
-		return nil
+		for d := 0; d < 2; d++ {
+			if l.delayed[d] != nil {
+				flush[d] = append([][]byte(nil), l.delayed[d])
+				l.delayed[d] = nil
+			}
+		}
 	case fDuplicate:
-		l.deliver(dir, frame)
-		l.deliver(dir, frame)
-		return nil
+		plan = append(plan, frame, frame)
 	case fReorder:
 		// Hold it until the next write so it lands after that frame.
 		if l.delayed[dir] == nil {
 			l.delayed[dir] = append([]byte(nil), frame...)
-			return nil
+		} else {
+			plan = append(plan, frame, l.delayed[dir])
+			l.delayed[dir] = nil
 		}
-		l.deliver(dir, frame)
-		return nil
 	case fLate:
 		g := append([]byte(nil), frame...)
-		time.AfterFunc(300*time.Millisecond, func() { l.deliver(dir, g) })
-		return nil
+		time.AfterFunc(300*time.Millisecond, func() { l.deliverOne(dir, g) })
 	case fTruncate:
-		l.deliver(dir, frame[:len(frame)/2])
-		return nil
+		plan = append(plan, frame[:len(frame)/2])
 	case fCorrupt:
 		g := append([]byte(nil), frame...)
 		g[len(g)-1] ^= 0x40
-		l.deliver(dir, g)
-		return nil
+		plan = append(plan, g)
 	default:
-		l.deliver(dir, frame)
+		plan = append(plan, frame)
+	}
+	l.mu.Unlock()
+
+	for d := 0; d < 2; d++ {
+		for _, f := range flush[d] {
+			l.deliverOne(d, f)
+		}
+	}
+	if act == fClose {
+		l.closed.Store(true)
 		return nil
 	}
+	for _, f := range plan {
+		l.deliverOne(dir, f)
+	}
+	return nil
 }
 
-func (l *faultLink) deliver(dir int, frame []byte) {
+func (l *faultLink) deliverOne(dir int, frame []byte) {
 	if l.closed.Load() {
 		return
 	}
 	l.sendToChannel(dir, frame)
-	if l.delayed[dir] != nil {
-		l.sendToChannel(dir, l.delayed[dir])
-		l.delayed[dir] = nil
-	}
 }
 
 func (l *faultLink) sendToChannel(dir int, frame []byte) {
@@ -149,16 +165,12 @@ func (l *faultLink) sendToChannel(dir int, frame []byte) {
 	ch <- append([]byte(nil), frame...)
 }
 
-// close kills both paths (a dead peer). Held frames are delivered first; the
-// flag is set afterwards so the drainers finish those frames then stop.
-func (l *faultLink) close() {
-	for dir := 0; dir < 2; dir++ {
-		if l.delayed[dir] != nil {
-			l.sendToChannel(dir, l.delayed[dir])
-			l.delayed[dir] = nil
-		}
-	}
-	l.closed.Store(true)
+// manifestSeen reports whether the sender has transmitted at least one
+// manifest on the s2r path.
+func (l *faultLink) manifestSeen() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.counts[dirS2R][FrameManifest] > 0
 }
 
 func (l *faultLink) isClosed() bool { return l.closed.Load() }
@@ -297,7 +309,7 @@ func runFaultLoopback(t *testing.T, data []byte, blockSize, frameSize, window in
 	}()
 	if opts.cutover != nil {
 		go func() {
-			for link.counts[dirS2R][FrameManifest] == 0 && !link.isClosed() {
+			for !link.manifestSeen() && !link.isClosed() {
 				time.Sleep(2 * time.Millisecond)
 			}
 			opts.cutover(link, sender)
@@ -583,25 +595,27 @@ func TestFaultDuplicateResumeStateIsIdempotent(t *testing.T) {
 
 // --- SB-1121: transport closure at every meaningful phase ---
 
-// TestFaultDroppedDataFailsClosed: the transport is reliable and ordered; a
-// dropped data frame is a protocol violation and must abort with integrity,
-// never commit the sink.
-func TestFaultDroppedDataFailsClosed(t *testing.T) {
+// TestFaultDroppedDataFrameRecoversViaRetry: a single dropped data frame is
+// masked by the sender's block retry — the receiver discards the partial cycle
+// tail after the manifest, reassembles the retransmitted block, and the final
+// digest must still match byte-for-byte.
+func TestFaultDroppedDataFrameRecoversViaRetry(t *testing.T) {
 	data := testData(50_000, 19)
 	script := faultScript{}.
 		at(dirS2R, FrameBlockData, fDrop)
 	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
-	res.wantCleanAbort(t)
+	res.wantSuccess(t, data)
 }
 
-// TestFaultReorderedFrameFailsClosed: reordering breaks the sequential counter
-// stream; the transfer must abort with integrity, never commit.
-func TestFaultReorderedFrameFailsClosed(t *testing.T) {
+// TestFaultReorderedDataFrameRecoversViaRetry: a held data frame that lands
+// after its siblings is stale-tail-discarded until the next block boundary, and
+// the retransmitted block completes the transfer with byte-exact data.
+func TestFaultReorderedDataFrameRecoversViaRetry(t *testing.T) {
 	data := testData(50_000, 13)
 	script := faultScript{}.
 		at(dirS2R, FrameBlockData, fReorder)
 	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
-	res.wantCleanAbort(t)
+	res.wantSuccess(t, data)
 }
 
 // TestFaultTruncatedDataFrameAbortsWithIntegrity: a half-delivered data frame

--- a/packages/wire/faults_test.go
+++ b/packages/wire/faults_test.go
@@ -1,0 +1,677 @@
+package wire
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"math/rand"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Deterministic fault-injection harness (plan §4.2, SB-1120..1128). A faultLink
+// sits between each side's Send and the peer's Handle and mutates frames
+// according to a per-direction, per-frame-type script keyed on occurrence, or —
+// with a seeded RNG — at random. The wire engine treats its transport as
+// reliable and ordered: any loss, reorder, or corruption of the sealed frame
+// stream is a protocol violation and must fail closed (integrity abort), never
+// corrupt or commit partial data. Every failure path must terminate both sides
+// cleanly; the harness enforces a deadline so a stall surfaces as a test
+// failure instead of a hang.
+
+type faultAction uint8
+
+const (
+	fPass      faultAction = iota // deliver untouched
+	fDrop                         // discard the frame
+	fDuplicate                    // deliver twice
+	fReorder                      // hold it, deliver after the next frame
+	fLate                         // deliver after 300 ms (slow but alive peer)
+	fTruncate                     // deliver the first half only (broken frame)
+	fCorrupt                      // flip one payload byte
+	fClose                        // drop this frame and kill both paths afterwards
+)
+
+// faultScript maps direction (0 = sender→receiver, 1 = receiver→sender) then
+// frame type to the actions applied to successive occurrences; occurrences past
+// the list pass through untouched.
+type faultScript map[int]map[uint8][]faultAction
+
+func (s faultScript) at(dir int, typ uint8, actions ...faultAction) faultScript {
+	if s[dir] == nil {
+		s[dir] = map[uint8][]faultAction{}
+	}
+	s[dir][typ] = actions
+	return s
+}
+
+const (
+	dirS2R = 0
+	dirR2S = 1
+)
+
+// faultLink wraps one bidirectional frame path. A nil script and nil rng pass
+// everything through untouched. Closing a path never closes the channels (a
+// send on a closed channel would panic); it sets a flag the drainers poll, and
+// frames sent after the flag are dropped — the same semantics as a dead peer.
+type faultLink struct {
+	s2r, r2s chan []byte
+	script   faultScript
+	rng      *rand.Rand
+
+	counts     [2]map[uint8]int
+	delayed    [2][]byte
+	closed     atomic.Bool
+	r2sSent    atomic.Uint64 // sealed receiver frames delivered (for NACK injection)
+	benignOnly bool          // randomAction keeps only recoverable faults (drop/dup/late)
+}
+
+func newFaultLink(script faultScript, rng *rand.Rand) *faultLink {
+	return &faultLink{
+		s2r:    make(chan []byte, 4096),
+		r2s:    make(chan []byte, 4096),
+		script: script,
+		rng:    rng,
+		counts: [2]map[uint8]int{{}, {}},
+	}
+}
+
+func (l *faultLink) send(dir int, frame []byte) error {
+	// Sealed frames are counter(8) || header(16) || ciphertext || tag, so the
+	// type byte lives at offset 9.
+	typ := frame[9]
+	occ := l.counts[dir][typ]
+	l.counts[dir][typ] = occ + 1
+
+	var act = fPass
+	if l.rng != nil {
+		act = l.randomAction(dir, typ)
+	} else if acts := l.script[dir][typ]; occ < len(acts) {
+		act = acts[occ]
+	}
+	switch act {
+	case fDrop:
+		return nil
+	case fClose:
+		l.close()
+		return nil
+	case fDuplicate:
+		l.deliver(dir, frame)
+		l.deliver(dir, frame)
+		return nil
+	case fReorder:
+		// Hold it until the next write so it lands after that frame.
+		if l.delayed[dir] == nil {
+			l.delayed[dir] = append([]byte(nil), frame...)
+			return nil
+		}
+		l.deliver(dir, frame)
+		return nil
+	case fLate:
+		g := append([]byte(nil), frame...)
+		time.AfterFunc(300*time.Millisecond, func() { l.deliver(dir, g) })
+		return nil
+	case fTruncate:
+		l.deliver(dir, frame[:len(frame)/2])
+		return nil
+	case fCorrupt:
+		g := append([]byte(nil), frame...)
+		g[len(g)-1] ^= 0x40
+		l.deliver(dir, g)
+		return nil
+	default:
+		l.deliver(dir, frame)
+		return nil
+	}
+}
+
+func (l *faultLink) deliver(dir int, frame []byte) {
+	if l.closed.Load() {
+		return
+	}
+	l.sendToChannel(dir, frame)
+	if l.delayed[dir] != nil {
+		l.sendToChannel(dir, l.delayed[dir])
+		l.delayed[dir] = nil
+	}
+}
+
+func (l *faultLink) sendToChannel(dir int, frame []byte) {
+	ch := l.s2r
+	if dir == dirR2S {
+		ch = l.r2s
+	}
+	if dir == dirR2S {
+		l.r2sSent.Add(1)
+	}
+	ch <- append([]byte(nil), frame...)
+}
+
+// close kills both paths (a dead peer). Held frames are delivered first; the
+// flag is set afterwards so the drainers finish those frames then stop.
+func (l *faultLink) close() {
+	for dir := 0; dir < 2; dir++ {
+		if l.delayed[dir] != nil {
+			l.sendToChannel(dir, l.delayed[dir])
+			l.delayed[dir] = nil
+		}
+	}
+	l.closed.Store(true)
+}
+
+func (l *faultLink) isClosed() bool { return l.closed.Load() }
+
+// randomAction draws a fault from a fixed probability table so seeds stay
+// comparable across runs.
+func (l *faultLink) randomAction(_ int, typ uint8) faultAction {
+	switch {
+	case l.rng.Float64() < 0.02:
+		return fDrop
+	case l.rng.Float64() < 0.01:
+		return fDuplicate
+	case !l.benignOnly && l.rng.Float64() < 0.015:
+		return fReorder
+	case l.rng.Float64() < 0.01:
+		return fLate
+	case !l.benignOnly && l.rng.Float64() < 0.008 && typ == FrameBlockData:
+		return fTruncate
+	case !l.benignOnly && l.rng.Float64() < 0.008 && typ == FrameBlockData:
+		return fCorrupt
+	case !l.benignOnly && l.rng.Float64() < 0.004:
+		return fClose
+	default:
+		return fPass
+	}
+}
+
+// faultResult mirrors loopbackResult and records whether the receiver settled
+// on its own (versus being cut off by the harness deadline).
+type faultResult struct {
+	runErr      error
+	recvErr     error
+	sink        *MemorySink
+	recvSettled bool
+	recvDigest  string
+}
+
+type faultRunOptions struct {
+	ackTimeout  time.Duration
+	doneTimeout time.Duration
+	maxRetries  int
+	deadline    time.Duration
+	source      FileSource
+	sink        Sink
+	destination Destination
+	benignOnly  bool
+	// cutover fires on the sender once the manifest frame has been attempted on
+	// the link (dropped or not), simulating a path change mid-transfer.
+	cutover func(link *faultLink, sender *Sender)
+}
+
+// runFaultLoopback runs one transfer through the fault link and enforces a
+// deadline so a stall fails the test instead of hanging it.
+func runFaultLoopback(t *testing.T, data []byte, blockSize, frameSize, window int,
+	script faultScript, rng *rand.Rand, opts faultRunOptions) faultResult {
+	t.Helper()
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := newFaultLink(script, rng)
+	link.benignOnly = opts.benignOnly
+	defaultSink := &MemorySink{}
+	userSink := opts.sink
+	if userSink == nil {
+		userSink = defaultSink
+	}
+	dest := opts.destination
+	if dest == nil {
+		dest = SingleSinkDestination(userSink)
+	}
+	source := opts.source
+	if source == nil {
+		source = BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0)
+	}
+
+	ackTimeout := opts.ackTimeout
+	if ackTimeout == 0 {
+		ackTimeout = 250 * time.Millisecond
+	}
+	doneTimeout := opts.doneTimeout
+	if doneTimeout == 0 {
+		doneTimeout = 1500 * time.Millisecond
+	}
+	maxRetries := opts.maxRetries
+	if maxRetries == 0 {
+		maxRetries = 5
+	}
+	deadline := opts.deadline
+	if deadline == 0 {
+		deadline = 15 * time.Second
+	}
+
+	sender := NewSender(SenderOptions{
+		File:        source,
+		Send:        func(f []byte) error { return link.send(dirS2R, f) },
+		SendDir:     keys.O2J,
+		RecvDir:     keys.J2O,
+		BlockSize:   blockSize,
+		FrameSize:   frameSize,
+		Window:      window,
+		AckTimeout:  ackTimeout,
+		MaxRetries:  maxRetries,
+		DoneTimeout: doneTimeout,
+	})
+	receiver := NewReceiver(ReceiverOptions{
+		Send:        func(f []byte) error { return link.send(dirR2S, f) },
+		SendDir:     keys.J2O,
+		RecvDir:     keys.O2J,
+		Destination: dest,
+	})
+
+	go func() {
+		for {
+			if link.isClosed() {
+				return
+			}
+			f, ok := <-link.s2r
+			if !ok {
+				return
+			}
+			receiver.Handle(f)
+		}
+	}()
+	go func() {
+		for {
+			if link.isClosed() {
+				return
+			}
+			f, ok := <-link.r2s
+			if !ok {
+				return
+			}
+			sender.Handle(f)
+		}
+	}()
+	if opts.cutover != nil {
+		go func() {
+			for link.counts[dirS2R][FrameManifest] == 0 && !link.isClosed() {
+				time.Sleep(2 * time.Millisecond)
+			}
+			opts.cutover(link, sender)
+		}()
+	}
+
+	recvCtx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+	runErrCh := make(chan error, 1)
+	go func() {
+		_, e := sender.Run(context.Background())
+		runErrCh <- e
+	}()
+
+	// The receiver aborts with FailCanceled (not a wrapped context error) when
+	// the harness deadline fires, so "settled" must mean the receiver actually
+	// completed on its own, not merely that the deadline fired.
+	recvRes, recvErr := receiver.Wait(recvCtx)
+	recvSettled := recvErr == nil
+	var runErr error
+	select {
+	case runErr = <-runErrCh:
+	case <-time.After(deadline):
+		t.Fatalf("sender.Run did not return within the deadline (recvErr=%v)", recvErr)
+	}
+	var recvDigest string
+	if recvErr == nil {
+		recvDigest = recvRes.Digest
+	}
+	return faultResult{runErr: runErr, recvErr: recvErr, sink: defaultSink, recvSettled: recvSettled, recvDigest: recvDigest}
+}
+
+func (r faultResult) wantSuccess(t *testing.T, data []byte) {
+	t.Helper()
+	if r.runErr != nil {
+		t.Fatalf("sender: %v", r.runErr)
+	}
+	if r.recvErr != nil {
+		t.Fatalf("receiver: %v", r.recvErr)
+	}
+	if string(r.sink.Bytes()) != string(data) {
+		t.Fatal("received bytes differ from source")
+	}
+	if !r.sink.IsClosed() {
+		t.Fatal("sink was not closed on success")
+	}
+	want := sha256.Sum256(data)
+	if got := r.recvDigest; got != hex.EncodeToString(want[:]) {
+		t.Fatalf("digest mismatch: got %s", got)
+	}
+}
+
+// wantCleanAbort asserts the transfer failed on at least one side and the sink
+// was never committed.
+func (r faultResult) wantCleanAbort(t *testing.T) {
+	t.Helper()
+	if r.runErr == nil && r.recvErr == nil {
+		t.Fatal("transfer settled cleanly; expected a failure on at least one side")
+	}
+	if r.sink.IsClosed() {
+		t.Error("sink was closed despite a failed transfer")
+	}
+}
+
+func testData(n int, mul byte) []byte {
+	data := make([]byte, n)
+	for i := range data {
+		data[i] = byte((i*int(mul) + 7) & 0xff)
+	}
+	return data
+}
+
+// --- SB-1120: the shim itself ---
+
+// TestFaultShimPassesEverything: an empty script must behave exactly like the
+// plain loopback.
+func TestFaultShimPassesEverything(t *testing.T) {
+	res := runFaultLoopback(t, testData(100_000, 131), 1024, 256, 4, faultScript{}, nil, faultRunOptions{})
+	res.wantSuccess(t, testData(100_000, 131))
+}
+
+// TestFaultDuplicateDataIsIgnored: a duplicated data frame is a replay; the
+// receiver drops it and the transfer completes.
+func TestFaultDuplicateDataIsIgnored(t *testing.T) {
+	data := testData(50_000, 53)
+	script := faultScript{}.
+		at(dirS2R, FrameBlockData, fPass, fDuplicate)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
+	res.wantSuccess(t, data)
+}
+
+// TestFaultDuplicateAckIsIgnored: a duplicated ACK must not corrupt sender
+// accounting.
+func TestFaultDuplicateAckIsIgnored(t *testing.T) {
+	data := testData(50_000, 11)
+	script := faultScript{}.
+		at(dirR2S, FrameAck, fDuplicate)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
+	res.wantSuccess(t, data)
+}
+
+// TestFaultRecoversFromLostAck: a lost ACK is recovered by the acknowledgement
+// timeout retransmitting the block.
+func TestFaultRecoversFromLostAck(t *testing.T) {
+	data := testData(100_000, 7)
+	script := faultScript{}.
+		at(dirR2S, FrameAck, fDrop)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil,
+		faultRunOptions{ackTimeout: 120 * time.Millisecond, maxRetries: 5})
+	res.wantSuccess(t, data)
+}
+
+// TestFaultLateDoneStillSucceeds: a Done that arrives 300 ms late (slow but
+// alive receiver) completes the transfer within the deadline.
+func TestFaultLateDoneStillSucceeds(t *testing.T) {
+	data := testData(50_000, 29)
+	script := faultScript{}.
+		at(dirR2S, FrameDone, fLate)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil,
+		faultRunOptions{doneTimeout: 5 * time.Second})
+	res.wantSuccess(t, data)
+}
+
+// TestFaultStaleNackIsHarmless (SB-1124): a NACK for an already-acknowledged
+// block is injected directly into the sender's inbound stream at the exact next
+// counter; the sender requeues and resends, the receiver ignores the replay,
+// and the transfer completes.
+func TestFaultStaleNackIsHarmless(t *testing.T) {
+	data := testData(100_000, 31)
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := newFaultLink(faultScript{}, nil)
+	sink := &MemorySink{}
+	sender := NewSender(SenderOptions{
+		File:        BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:        func(f []byte) error { return link.send(dirS2R, f) },
+		SendDir:     keys.O2J,
+		RecvDir:     keys.J2O,
+		BlockSize:   1024,
+		FrameSize:   256,
+		Window:      4,
+		AckTimeout:  120 * time.Millisecond,
+		MaxRetries:  5,
+		DoneTimeout: 5 * time.Second,
+	})
+	receiver := NewReceiver(ReceiverOptions{
+		Send:    func(f []byte) error { return link.send(dirR2S, f) },
+		SendDir: keys.J2O,
+		RecvDir: keys.O2J,
+		Sink:    sink,
+	})
+	go func() {
+		for !link.isClosed() {
+			f, ok := <-link.s2r
+			if !ok {
+				return
+			}
+			receiver.Handle(f)
+		}
+	}()
+	go func() {
+		for !link.isClosed() {
+			f, ok := <-link.r2s
+			if !ok {
+				return
+			}
+			sender.Handle(f)
+			// After the very first inbound control (an ACK for block 0), inject
+			// a stale NACK for block 0 sealed under the next expected counter.
+			if link.r2sSent.Load() == 1 {
+				payload, err := EncodeControl(NewNack(0, 0, NackMissing))
+				if err != nil {
+					t.Errorf("encode nack: %v", err)
+					return
+				}
+				frame, err := Seal(keys.J2O, 1, FrameHeaderInput{Version: FrameVersion, Type: FrameNack}, payload)
+				if err != nil {
+					t.Errorf("seal nack: %v", err)
+					return
+				}
+				sender.Handle(frame)
+			}
+		}
+	}()
+
+	recvCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	runErrCh := make(chan error, 1)
+	go func() { _, e := sender.Run(context.Background()); runErrCh <- e }()
+	_, recvErr := receiver.Wait(recvCtx)
+	var runErr error
+	select {
+	case runErr = <-runErrCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("sender did not return")
+	}
+	if runErr != nil || recvErr != nil {
+		t.Fatalf("send=%v receive=%v", runErr, recvErr)
+	}
+	if string(sink.Bytes()) != string(data) {
+		t.Fatal("bytes differ")
+	}
+}
+
+// TestFaultDuplicateResumeStateIsIdempotent (SB-1124): a duplicated
+// resume_state (receiver → sender) is applied once; the resumed transfer
+// completes.
+func TestFaultDuplicateResumeStateIsIdempotent(t *testing.T) {
+	data := testData(80_000, 17)
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := faultScript{}.
+		at(dirR2S, FrameResumeState, fDuplicate)
+	link := newFaultLink(script, nil)
+	sink := &MemorySink{}
+	prefix := 5 * 1024
+	_ = sink.Write(0, data[:prefix])
+	seed := NewSHA256Digest()
+	seed.Update(data[:prefix])
+	sender := NewSender(SenderOptions{
+		File:        BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:        func(f []byte) error { return link.send(dirS2R, f) },
+		SendDir:     keys.O2J,
+		RecvDir:     keys.J2O,
+		BlockSize:   1024,
+		FrameSize:   256,
+		Window:      4,
+		AckTimeout:  250 * time.Millisecond,
+		MaxRetries:  5,
+		DoneTimeout: 5 * time.Second,
+		TransferID:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	receiver := NewReceiver(ReceiverOptions{
+		Send:    func(f []byte) error { return link.send(dirR2S, f) },
+		SendDir: keys.J2O,
+		RecvDir: keys.O2J,
+		Sink:    sink,
+		Resume: &ReceiverResume{
+			TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Files:      map[int]ResumeFileProgress{0: {HaveBlocks: 5, SeedDigest: seed}},
+		},
+	})
+	go func() {
+		for !link.isClosed() {
+			f, ok := <-link.s2r
+			if !ok {
+				return
+			}
+			receiver.Handle(f)
+		}
+	}()
+	go func() {
+		for !link.isClosed() {
+			f, ok := <-link.r2s
+			if !ok {
+				return
+			}
+			sender.Handle(f)
+		}
+	}()
+	recvCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	runErrCh := make(chan error, 1)
+	go func() { _, e := sender.Run(context.Background()); runErrCh <- e }()
+	_, recvErr := receiver.Wait(recvCtx)
+	var runErr error
+	select {
+	case runErr = <-runErrCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("sender did not return")
+	}
+	if runErr != nil || recvErr != nil {
+		t.Fatalf("send=%v receive=%v", runErr, recvErr)
+	}
+	if string(sink.Bytes()) != string(data) {
+		t.Fatal("resumed transfer did not reassemble the full file")
+	}
+}
+
+// --- SB-1121: transport closure at every meaningful phase ---
+
+// TestFaultDroppedDataFailsClosed: the transport is reliable and ordered; a
+// dropped data frame is a protocol violation and must abort with integrity,
+// never commit the sink.
+func TestFaultDroppedDataFailsClosed(t *testing.T) {
+	data := testData(50_000, 19)
+	script := faultScript{}.
+		at(dirS2R, FrameBlockData, fDrop)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
+	res.wantCleanAbort(t)
+}
+
+// TestFaultReorderedFrameFailsClosed: reordering breaks the sequential counter
+// stream; the transfer must abort with integrity, never commit.
+func TestFaultReorderedFrameFailsClosed(t *testing.T) {
+	data := testData(50_000, 13)
+	script := faultScript{}.
+		at(dirS2R, FrameBlockData, fReorder)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
+	res.wantCleanAbort(t)
+}
+
+// TestFaultTruncatedDataFrameAbortsWithIntegrity: a half-delivered data frame
+// must abort with integrity, never commit the sink.
+func TestFaultTruncatedDataFrameAbortsWithIntegrity(t *testing.T) {
+	data := testData(50_000, 23)
+	script := faultScript{}.
+		at(dirS2R, FrameBlockData, fPass, fTruncate)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
+	res.wantCleanAbort(t)
+}
+
+// TestFaultCorruptedFrameAbortsWithIntegrity: a flipped payload byte must abort
+// with integrity, never commit the sink.
+func TestFaultCorruptedFrameAbortsWithIntegrity(t *testing.T) {
+	data := testData(50_000, 43)
+	script := faultScript{}.
+		at(dirS2R, FrameBlockData, fPass, fCorrupt)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
+	res.wantCleanAbort(t)
+}
+
+// TestFaultCloseMidTransferExhaustsRetries: the peer dies after the manifest;
+// the sender exhausts its retries with a classified failure, the receiver is
+// cut off by the harness deadline (peer-death detection is the transport's
+// job), and the sink is never committed. No hang.
+func TestFaultCloseMidTransferExhaustsRetries(t *testing.T) {
+	data := testData(200_000, 37)
+	script := faultScript{}.
+		at(dirS2R, FrameBlockHash, fPass, fPass, fPass, fPass, fClose)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil,
+		faultRunOptions{ackTimeout: 120 * time.Millisecond, maxRetries: 3, deadline: 3 * time.Second})
+	if res.runErr == nil {
+		t.Error("sender returned nil; want retry exhaustion")
+	}
+	if res.recvSettled {
+		t.Error("receiver settled on its own after the peer died; the wire layer cannot detect this")
+	}
+	res.wantCleanAbort(t)
+}
+
+// TestFaultCloseAfterCompleteTimesOutOnDone: the receiver verifies everything,
+// sends Done into a dead path, and settles; the sender must not stall waiting
+// for Done and instead fail with retry exhaustion (DoneTimeout).
+func TestFaultCloseAfterCompleteTimesOutOnDone(t *testing.T) {
+	data := testData(100_000, 41)
+	script := faultScript{}.
+		at(dirR2S, FrameDone, fClose)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil,
+		faultRunOptions{doneTimeout: 300 * time.Millisecond})
+	if res.runErr == nil {
+		t.Fatal("sender completed cleanly; want Done-timeout failure")
+	}
+	if !strings.Contains(res.runErr.Error(), "Done") {
+		t.Fatalf("sender error = %v; want a Done-related failure", res.runErr)
+	}
+	if res.recvErr != nil {
+		t.Fatalf("receiver should have settled after sending Done, got: %v", res.recvErr)
+	}
+	if !res.sink.IsClosed() {
+		t.Error("sink not closed though the receiver verified the file")
+	}
+}
+
+// TestFaultLateControlAfterSettlementIsIgnored (SB-1124): controls arriving
+// after the sender settled are dropped.
+func TestFaultLateControlAfterSettlementIsIgnored(t *testing.T) {
+	data := testData(40_000, 3)
+	script := faultScript{}.
+		at(dirR2S, FrameDone, fDuplicate)
+	res := runFaultLoopback(t, data, 1024, 256, 4, script, nil, faultRunOptions{})
+	res.wantSuccess(t, data)
+}

--- a/packages/wire/testdata/fault-seeds/regression.json
+++ b/packages/wire/testdata/fault-seeds/regression.json
@@ -1,0 +1,68 @@
+[
+  {
+    "seed": 66,
+    "size": 16000,
+    "blockSize": 1024,
+    "frameSize": 256,
+    "window": 4,
+    "ackTimeoutMs": 250,
+    "maxRetries": 5,
+    "destructive": false,
+    "want": "success"
+  },
+  {
+    "seed": 103,
+    "size": 16000,
+    "blockSize": 1024,
+    "frameSize": 256,
+    "window": 4,
+    "ackTimeoutMs": 250,
+    "maxRetries": 5,
+    "destructive": false,
+    "want": "success"
+  },
+  {
+    "seed": 11,
+    "size": 16000,
+    "blockSize": 1024,
+    "frameSize": 256,
+    "window": 4,
+    "ackTimeoutMs": 250,
+    "maxRetries": 5,
+    "destructive": false,
+    "want": "fail_closed"
+  },
+  {
+    "seed": 22,
+    "size": 16000,
+    "blockSize": 1024,
+    "frameSize": 256,
+    "window": 4,
+    "ackTimeoutMs": 250,
+    "maxRetries": 5,
+    "destructive": false,
+    "want": "fail_closed"
+  },
+  {
+    "seed": 11,
+    "size": 16000,
+    "blockSize": 1024,
+    "frameSize": 256,
+    "window": 4,
+    "ackTimeoutMs": 250,
+    "maxRetries": 5,
+    "destructive": true,
+    "want": "fail_closed"
+  },
+  {
+    "seed": 88,
+    "size": 16000,
+    "blockSize": 1024,
+    "frameSize": 256,
+    "window": 4,
+    "ackTimeoutMs": 250,
+    "maxRetries": 5,
+    "destructive": true,
+    "want": "fail_closed"
+  }
+]

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -225,9 +225,6 @@ func (r *Receiver) process(frame []byte) error {
 }
 
 func (r *Receiver) applyManifest(payload []byte) error {
-	if r.manifest != nil {
-		return NewTransferError(FailIntegrity, "duplicate manifest")
-	}
 	msg, err := DecodeControl(payload)
 	if err != nil {
 		return NewTransferError(FailIntegrity, err.Error())
@@ -239,6 +236,15 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	validated, err := ValidateManifest(*m)
 	if err != nil {
 		return NewTransferError(FailIntegrity, err.Error())
+	}
+	if r.manifest != nil {
+		// A path cutover can retransmit the manifest while the original is still
+		// being processed. An identical copy is harmless; a different one is a
+		// protocol violation.
+		if manifestsEqual(&validated, r.manifest) {
+			return nil
+		}
+		return NewTransferError(FailIntegrity, "duplicate manifest")
 	}
 	if r.destination == nil {
 		return NewTransferError(FailSinkError, "transfer destination is required")
@@ -360,7 +366,10 @@ func (r *Receiver) finishCurrentFile() error {
 
 func (r *Receiver) onBlockData(fileIdx uint16, blockIdx uint32, frameOff uint32, payload []byte) error {
 	if r.manifest == nil {
-		return NewTransferError(FailIntegrity, "block_data before manifest")
+		// A cutover may lose the manifest while block data is already streaming;
+		// the sender retransmits it, so stray data before the manifest is ignored
+		// rather than treated as a protocol violation.
+		return nil
 	}
 	fileNumber := int(fileIdx)
 	if fileNumber < 0 || fileNumber >= len(r.manifest.Files) || fileNumber > r.fileIdx {
@@ -404,7 +413,10 @@ func (r *Receiver) onBlockHash(payload []byte) error {
 	if r.blockBuf == nil && r.awaitingRestart {
 		return nil // hash for the abandoned partial block
 	}
-	if r.manifest == nil || r.blockBuf == nil {
+	if r.manifest == nil {
+		return nil // pre-manifest; the manifest may be in flight after a cutover
+	}
+	if r.blockBuf == nil {
 		return NewTransferError(FailIntegrity, "block_hash without a block")
 	}
 	msg, err := DecodeControl(payload)
@@ -646,4 +658,19 @@ func asTransferError(err error, fallback FailReason) *TransferError {
 		return transferErr
 	}
 	return NewTransferError(fallback, err.Error())
+}
+
+// manifestsEqual reports whether two validated manifests describe the same
+// transfer: same id, same total size, and identical file entries.
+func manifestsEqual(a, b *Manifest) bool {
+	if a == nil || b == nil || a.TransferID != b.TransferID || a.TotalSize != b.TotalSize ||
+		len(a.Files) != len(b.Files) {
+		return false
+	}
+	for i := range a.Files {
+		if a.Files[i] != b.Files[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -259,6 +259,10 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	}
 	r.manifest = &validated
 	r.digests = make([]string, len(validated.Files))
+	// The sender may already be retrying blocks on the old path while the
+	// cutover's manifest copy arrives; discard that stale tail (fragments
+	// before the next block boundary, plus its hash) instead of assembling it.
+	r.awaitingRestart = true
 	if validated.TransferID != "" {
 		// The sender opted into resumption. Apply persisted offsets only when they belong to this
 		// exact transfer, then report each file's high-water mark so the sender skips held blocks.

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -23,6 +23,10 @@ const (
 	DefaultAckTimeout = 15 * time.Second
 	// DefaultMaxBlockRetries bounds retransmissions after the initial block send.
 	DefaultMaxBlockRetries = 3
+	// DefaultDoneTimeout is how long the sender waits for the receiver's Done after
+	// sending Complete before failing with retry exhaustion (a dead peer otherwise
+	// stalls Run forever).
+	DefaultDoneTimeout = 30 * time.Second
 )
 
 // SenderOptions configures a Sender. Zero-valued sizing and retry fields select defaults.
@@ -47,6 +51,9 @@ type SenderOptions struct {
 	Window        int
 	AckTimeout    time.Duration
 	MaxRetries    int
+	// DoneTimeout bounds the wait for the receiver's Done after Complete; zero selects
+	// DefaultDoneTimeout.
+	DoneTimeout time.Duration
 	// OnProgress reports bytes acknowledged after verify-and-sink.
 	OnProgress     func(acknowledgedBytes int64)
 	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
@@ -73,6 +80,12 @@ type Sender struct {
 	sendCounter uint64
 
 	transferID string
+
+	// manifest is the validated manifest sent on the first path, kept so a
+	// TransportChanged before any acknowledgment can retransmit it (a cutover
+	// can lose it, and it is outside the block retransmit window).
+	manifest     *Manifest
+	manifestSent bool
 
 	mu                     sync.Mutex
 	cond                   *sync.Cond
@@ -114,6 +127,9 @@ func NewSender(opts SenderOptions) *Sender {
 	}
 	if opts.MaxRetries <= 0 {
 		opts.MaxRetries = DefaultMaxBlockRetries
+	}
+	if opts.DoneTimeout == 0 {
+		opts.DoneTimeout = DefaultDoneTimeout
 	}
 	if opts.CreateDigest == nil {
 		opts.CreateDigest = NewSHA256Digest
@@ -173,6 +189,7 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 			digest.Update(chunk)
 			return nil
 		}); err != nil {
+			err = Errorf(CodeSourceIO, "transfer: source read failed: %v", err)
 			s.fail(err)
 			return "", err
 		}
@@ -204,6 +221,10 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 		s.fail(err)
 		return "", err
 	}
+	s.mu.Lock()
+	s.manifest = &manifest
+	s.manifestSent = true
+	s.mu.Unlock()
 
 	// A transfer id opts into resumption: wait for the receiver's resume_state (all zero on a
 	// first attempt) before streaming so blocks it already holds are never sent. Fresh transfers
@@ -230,7 +251,18 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 		s.activeFileAcknowledged = committed
 		s.acknowledged += committed
 		s.mu.Unlock()
-		streamErr := ReChunk(StreamFunc(source.Stream), s.blockSize, s.blockSize, func(p FramePiece) error {
+		streamErr := ReChunk(StreamFunc(func(fn func(chunk []byte) error) error {
+			err := source.Stream(fn)
+			if err != nil && !errors.Is(err, errSenderSettled) {
+				// A peer failure or a local abort is not a source I/O problem; only
+				// genuine source read errors get classified as SOURCE_IO.
+				var te *TransferError
+				if !errors.As(err, &te) {
+					err = Errorf(CodeSourceIO, "transfer: source read failed: %v", err)
+				}
+			}
+			return err
+		}), s.blockSize, s.blockSize, func(p FramePiece) error {
 			// Held blocks are read past (the source is streamed for the digest regardless) but
 			// never sent.
 			if p.BlockIdx < haveBlocks {
@@ -356,8 +388,8 @@ func (s *Sender) Handle(frame []byte) {
 // Fresh counters are used, while replays arriving late from the old path remain harmless.
 func (s *Sender) TransportChanged() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.settled {
+		s.mu.Unlock()
 		return
 	}
 	for idx, state := range s.inflight {
@@ -371,7 +403,18 @@ func (s *Sender) TransportChanged() {
 			s.retryQueue = append(s.retryQueue, idx)
 		}
 	}
+	var resend *Manifest
+	if s.manifestSent && s.acknowledged == 0 {
+		resend = s.manifest
+	}
 	s.cond.Broadcast()
+	s.mu.Unlock()
+	if resend != nil {
+		// The manifest may have been lost in the cutover; the receiver ignores
+		// identical duplicates and stray pre-manifest data, so resending it is
+		// safe and lets the transfer continue on the new path.
+		_ = s.sendControl(resend)
+	}
 }
 
 // Pause stops new data frames locally and notifies the peer.
@@ -693,6 +736,13 @@ func (s *Sender) sendBlock(blockIdx int, block []byte) error {
 func (s *Sender) waitDone() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// A peer that dies after Complete never sends Done; without this deadline Run
+	// would stall forever, so time out and fail with retry exhaustion instead.
+	timer := time.AfterFunc(s.o.DoneTimeout, func() {
+		s.fail(NewTransferError(FailRetryExhausted,
+			"transfer: receiver did not send Done within the deadline"))
+	})
+	defer timer.Stop()
 	for !s.settled {
 		s.cond.Wait()
 	}


### PR DESCRIPTION
Deterministic fault-injection harness across the wire engine, CLI driver, and TypeScript protocol.

- Transport shim that deterministically drops, duplicates, delays, reorders, truncates, corrupts, and closes frames; randomized fail-closed property test over fixed seeds plus stored regression fixtures
- Sink faults (quota, write, close, flush, destination collision) and source faults (disappearance, mid-read failure, mutation between digest and transfer passes)
- CLI signaling loss on direct (survives) and relay (fails RELAY) paths; direct-to-relay cutover before data, mid-transfer, and after all bytes acknowledged
- Fix: a cutover could lose the manifest — the sender now retransmits it before any acknowledgment, the receiver ignores identical duplicates and pre-manifest data (Go + TypeScript parity)
- Sender Done-wait bounded by a configurable timeout on both senders