### PR TITLE
test: protocol fuzzing, property and cross-feed parity tests

### DIFF
--- a/apps/cli/internal/rendezvous/message_test.go
+++ b/apps/cli/internal/rendezvous/message_test.go
@@ -116,3 +116,37 @@ func keysOf(m map[string]any) []string {
 	}
 	return ks
 }
+
+// SB-1140: fuzz the signaling envelope decoder. Every JSON frame must decode or
+// fail without panicking, and a successfully decoded message must round-trip so
+// the session can act on it consistently.
+func FuzzUnmarshalMessage(f *testing.F) {
+	seeds := []string{
+		`{"type":"create"}`,
+		`{"type":"created","room":7}`,
+		`{"type":"join","room":1}`,
+		`{"type":"pake","msg":"AQID"}`,
+		`{"type":"confirm","mac":"AQID"}`,
+		`{"type":"caps","frame":"AQID"}`,
+		`{"type":"sdp","seq":0,"sdp":"v=0","mac":"AA"}`,
+		`{"type":"ice","seq":1,"cand":"c","mac":"AA"}`,
+		`{"type":"relay_credit","bytes":1024}`,
+		`{}`,
+		`not-json`,
+		`{"type":"unknown","room":999999999999999999999}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		msg, err := UnmarshalMessage(data)
+		if err != nil {
+			return
+		}
+		// A decoded message must be re-marshalable, providing a stable wire frame
+		// the session can round-trip through MarshalMessage.
+		if _, err := MarshalMessage(msg); err != nil {
+			t.Fatalf("round-trip marshal failed for %+v: %v", msg, err)
+		}
+	})
+}

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -444,3 +444,41 @@ func TestRelayCreditRequestClampedNotKilled(t *testing.T) {
 		t.Fatalf("reverse credit = %v, want 16", got)
 	}
 }
+
+// SB-1140: fuzz the server's inbound signaling envelope. The server only reads
+// type/room/role/bytes, so the invariant is a clean decode-or-reject with no
+// panic and no empty type slipping through (dispatch treats "" as invalid).
+func FuzzClientMsg(f *testing.F) {
+	seeds := []string{
+		`{"type":"create"}`,
+		`{"type":"join","room":3}`,
+		`{"type":"resume","room":3,"role":"offerer"}`,
+		`{"type":"sdp","sdp":"v=0"}`,
+		`{"type":"relay_credit","bytes":1024}`,
+		`{"type":"bye"}`,
+		`{}`,
+		`not-json`,
+		`{"type":"","room":1}`,
+		`{"type":42}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var m clientMsg
+		if err := json.Unmarshal(data, &m); err != nil {
+			return
+		}
+		if m.Type == "" {
+			// dispatch rejects an empty type as an invalid message; anything else
+			// is a server-side regression. Accept either a known type or the
+			// invalid-message rejection path (which is not exercised here directly).
+			return
+		}
+		// A non-empty type must decode into a marshalable envelope so the server
+		// can relay/reject it without corruption.
+		if _, err := json.Marshal(m); err != nil {
+			t.Fatalf("clientMsg round-trip marshal failed for %+v: %v", m, err)
+		}
+	})
+}

--- a/packages/protocol/src/property.test.ts
+++ b/packages/protocol/src/property.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import { encodeFrameHeader, decodeFrameHeader } from './frame.js';
+import { FRAME_HEADER_BYTES } from './constants.js';
+import { FrameType, type FrameHeader, type FileEntry, type Manifest } from './transfer.js';
+import { normalizeTransferPath, validateManifest } from './safe-path.js';
+import { deriveMaster, deriveTransferKeys } from './keyschedule.js';
+import { seal, open, type FrameHeaderInput } from './aead.js';
+
+// Deterministic seeded PRNG (mulberry32) so "property" checks are reproducible
+// in CI without pulling in a property-testing dependency.
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function intIn(rand: () => number, max: number): number {
+  return Math.floor(rand() * (max + 1));
+}
+
+function u8(rand: () => number): number {
+  return intIn(rand, 0xff);
+}
+function u16(rand: () => number): number {
+  return intIn(rand, 0xffff);
+}
+function u32(rand: () => number): number {
+  return intIn(rand, 0xffffffff);
+}
+
+const master = new Uint8Array(32).fill(9);
+
+// SB-1144: frame header encode/decode round-trip over many arbitrary but
+// in-range headers; decode(encode(h)) must equal h exactly and stay 16 bytes.
+describe('SB-1144 frame header property', () => {
+  it('round-trips arbitrary in-range headers', () => {
+    const rand = rng(0xbeef);
+    for (let i = 0; i < 2000; i++) {
+      const h: FrameHeader = {
+        version: u8(rand),
+        type: u8(rand),
+        flags: u8(rand),
+        fileIdx: u16(rand),
+        blockIdx: u32(rand),
+        frameOff: u32(rand),
+        len: u16(rand),
+      };
+      const buf = encodeFrameHeader(h);
+      expect(buf.byteLength).toBe(FRAME_HEADER_BYTES);
+      expect(decodeFrameHeader(buf)).toEqual(h);
+    }
+  });
+
+  it('rejects out-of-range fields for every width', () => {
+    const base: FrameHeader = {
+      version: 1,
+      type: FrameType.BlockData,
+      flags: 0,
+      fileIdx: 0,
+      blockIdx: 0,
+      frameOff: 0,
+      len: 0,
+    };
+    const cases: Array<Partial<FrameHeader>> = [
+      { version: 256 },
+      { type: 256 },
+      { flags: 256 },
+      { fileIdx: 65536 },
+      { blockIdx: 0x100000000 },
+      { frameOff: 0x100000000 },
+      { len: 65536 },
+      { version: -1 },
+      { blockIdx: 1.5 },
+    ];
+    for (const patch of cases) {
+      expect(() => encodeFrameHeader({ ...base, ...patch })).toThrow(RangeError);
+    }
+  });
+
+  it('rejects buffers shorter than the header', () => {
+    for (let n = 0; n < FRAME_HEADER_BYTES; n++) {
+      expect(() => decodeFrameHeader(new Uint8Array(n))).toThrow(RangeError);
+    }
+  });
+});
+
+// SB-1144: AEAD seal/open inverse over arbitrary plaintext lengths, plus the
+// guarantee that any single-byte mutation of a sealed frame fails to open.
+describe('SB-1144 AEAD frame property', () => {
+  it('seal then open recovers plaintext and header len', async () => {
+    const keys = await deriveTransferKeys(await deriveMaster(master, new Uint8Array(0)));
+    const rand = rng(0xdeadbeef);
+    for (let i = 0; i < 50; i++) {
+      const len = intIn(rand, 2048);
+      const plaintext = new Uint8Array(len);
+      for (let j = 0; j < len; j++) plaintext[j] = u8(rand);
+      const header: FrameHeaderInput = {
+        version: 1,
+        type: FrameType.BlockData,
+        flags: i % 2 === 0 ? 0 : 1,
+        fileIdx: u16(rand),
+        blockIdx: u32(rand),
+        frameOff: u32(rand),
+      };
+      const frame = await seal(keys.o2j, i, header, plaintext);
+      const opened = await open(keys.o2j, i, frame);
+      expect(opened.header.len).toBe(len);
+      expect(opened.header.type).toBe(FrameType.BlockData);
+      expect(opened.plaintext).toEqual(plaintext);
+    }
+  });
+
+  it('a single-byte mutation never opens', async () => {
+    const keys = await deriveTransferKeys(await deriveMaster(master, new Uint8Array(0)));
+    const plaintext = new Uint8Array(64).fill(7);
+    const frame = await seal(
+      keys.o2j,
+      0,
+      { version: 1, type: FrameType.BlockData, flags: 0, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      plaintext,
+    );
+    const mutated = frame.slice();
+    mutated[mutated.length - 1] ^= 0x01;
+    await expect(open(keys.o2j, 0, mutated)).rejects.toThrow();
+  });
+});
+
+// SB-1145: arbitrary safe relative segment strings must produce canonical,
+// absolute-free, dot-free output; structural invariants mirror the Go fuzzer.
+describe('SB-1145 normalizeTransferPath property', () => {
+  const alpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ .',
+    legal = 64;
+
+  it('accepts and canonicalizes arbitrary well-formed relative paths', () => {
+    const rand = rng(0x1111);
+    for (let i = 0; i < 2000; i++) {
+      const depth = 1 + intIn(rand, 10);
+      const segs: string[] = [];
+      for (let d = 0; d < depth; d++) {
+        const n = 1 + intIn(rand, 40);
+        // Every segment starts with 'z' so it can never collide with a Windows
+        // reserved name (con/prn/aux/nul/com[1-9]/lpt[1-9]) and thus always passes
+        // normalization.
+        let s = 'z';
+        for (let k = 1; k < n; k++) s += alpha[intIn(rand, legal - 1)];
+        if (d % 3 === 0 && d > 0) {
+          // Occasionally embed a backslash to exercise canonicalization without
+          // making the path absolute or creating empty segments.
+          segs.push(`${s}\\tail`);
+        } else {
+          segs.push(s);
+        }
+      }
+      const input = segs.join('/');
+      const out = normalizeTransferPath(input);
+      expect(out).not.toMatch(/^[/\\]/);
+      expect(out).not.toMatch(/\\/);
+      for (const part of out.split('/')) {
+        expect(part.length).toBeGreaterThan(0);
+        expect(part).not.toBe('.');
+        expect(part).not.toBe('..');
+      }
+    }
+  });
+
+  it('rejects unsafe inputs deterministically', () => {
+    const rand = rng(0x2222);
+    const unsafe = [
+      '/',
+      '\\',
+      '..',
+      '.',
+      'nul',
+      'CON',
+      'a:b',
+      'a*',
+      'a?',
+      'a"',
+      'a<',
+      'a>',
+      'a|',
+      'x ',
+      'a.',
+    ];
+    for (let i = 0; i < 2000; i++) {
+      const pick = unsafe[intIn(rand, unsafe.length - 1)];
+      // Prepend/append a legal segment so the input is a plausible path that
+      // must still be rejected (traversal, reserved names, bad chars, suffixes).
+      const input = `${alpha[intIn(rand, legal - 1)]}/${pick}`;
+      expect(() => normalizeTransferPath(input)).toThrow();
+    }
+    expect(() => normalizeTransferPath('')).toThrow();
+    expect(() => normalizeTransferPath('/etc/passwd')).toThrow();
+    expect(() => normalizeTransferPath('C:\\secret')).toThrow();
+  });
+});
+
+// SB-1145: validateManifest accepts geometrically consistent manifests and
+// rejects any whose block geometry, size sum, or paths are inconsistent.
+describe('SB-1145 validateManifest property', () => {
+  function file(idx: number, name: string, size: number, blockSize: number): FileEntry {
+    return {
+      idx,
+      name,
+      size,
+      mime: 'application/octet-stream',
+      lastModified: 1,
+      blockSize,
+      blocks: size === 0 ? 0 : Math.ceil(size / blockSize),
+      fileDigest: 'aa',
+    };
+  }
+
+  it('accepts consistent multi-file manifests and canonicalizes paths', () => {
+    const rand = rng(0x3333);
+    for (let i = 0; i < 200; i++) {
+      const n = 1 + intIn(rand, 8);
+      const files: FileEntry[] = [];
+      let total = 0;
+      for (let k = 0; k < n; k++) {
+        const size = intIn(rand, 1 << 20);
+        total += size;
+        files.push(file(k, `dir${k}/file-${k}.bin`, size, 1 + intIn(rand, 65536)));
+      }
+      const m: Manifest = { type: FrameType.Manifest, files, totalSize: total };
+      const out = validateManifest(m);
+      expect(out.files.length).toBe(n);
+      expect(out.totalSize).toBe(total);
+      for (let k = 0; k < n; k++) expect(out.files[k].idx).toBe(k);
+    }
+  });
+
+  it('rejects size/geometry inconsistencies', () => {
+    const good = file(0, 'a.bin', 100, 16);
+    const wrongTotal: Manifest = { type: FrameType.Manifest, files: [good], totalSize: 99 };
+    expect(() => validateManifest(wrongTotal)).toThrow();
+    const badBlocks: Manifest = {
+      type: FrameType.Manifest,
+      files: [{ ...good, blocks: good.blocks + 1 }],
+      totalSize: 100,
+    };
+    expect(() => validateManifest(badBlocks)).toThrow();
+    const badPath: Manifest = {
+      type: FrameType.Manifest,
+      files: [{ ...good, name: '../escape' }],
+      totalSize: 100,
+    };
+    expect(() => validateManifest(badPath)).toThrow();
+  });
+});

--- a/packages/protocol/src/transfer-messages.ts
+++ b/packages/protocol/src/transfer-messages.ts
@@ -21,6 +21,7 @@ import {
   type TransferMsg,
 } from './transfer.js';
 import { utf8 } from './bytes.js';
+import { MAX_TRANSFER_FILES } from './safe-path.js';
 
 const decoder = new TextDecoder();
 
@@ -93,6 +94,10 @@ function asFileEntry(v: unknown): FileEntry {
 function asManifest(m: Record<string, unknown>): Manifest {
   if (!Array.isArray(m.files) || m.files.length === 0)
     throw new Error('control frame: manifest.files');
+  if (m.files.length > MAX_TRANSFER_FILES)
+    throw new Error(
+      `control frame: manifest has ${m.files.length} files, maximum is ${MAX_TRANSFER_FILES}`,
+    );
   // transferId is optional; when present it must be a string and keeps its position right after
   // `type` so the re-encoded wire bytes match the original ordering.
   const transferId = m.transferId === undefined ? undefined : str(m, 'transferId');
@@ -147,6 +152,10 @@ function asResumeFileState(v: unknown): ResumeFileState {
 function asResumeState(m: Record<string, unknown>): ResumeState {
   if (!Array.isArray(m.files) || m.files.length === 0)
     throw new Error('control frame: resume_state.files');
+  if (m.files.length > MAX_TRANSFER_FILES)
+    throw new Error(
+      `control frame: resume_state has ${m.files.length} files, maximum is ${MAX_TRANSFER_FILES}`,
+    );
   return {
     type: FrameType.ResumeState,
     transferId: str(m, 'transferId'),

--- a/packages/protocol/src/transfer-vector.test.ts
+++ b/packages/protocol/src/transfer-vector.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { deriveTransferKeys } from './keyschedule.js';
+import { TransferReceiver } from './transfer-receiver.js';
+import { MemorySink, type Digest } from './transfer-ports.js';
+import { bytesToHex, hexToBytes } from './bytes.js';
+
+function nodeDigest(): Digest {
+  const h = createHash('sha256');
+  return { update: (b) => void h.update(b), hexDigest: () => h.digest('hex') };
+}
+
+interface Vector {
+  description: string;
+  master: string;
+  blockSize: number;
+  frameSize: number;
+  window: number;
+  keys: { o2j: { key: string; salt: string }; j2o: { key: string; salt: string } };
+  file: { name: string; size: number; mime: string; hex: string; sha256: string };
+  wireLog: Array<{ dir: 's2r' | 'r2s'; note: string; hex: string }>;
+}
+
+function loadVector(): Vector {
+  const url = new URL('../../../docs/test-vectors/transfer.json', import.meta.url);
+  return JSON.parse(readFileSync(fileURLToPath(url), 'utf8')) as Vector;
+}
+
+// SB-1146: cross-feed equivalence. The Go engine recorded a byte-exact wire log in
+// transfer.json; replaying the s2r frames into the TypeScript receiver must produce
+// byte-identical r2s replies, reconstruct the exact file bytes, and verify the same
+// canonical SHA-256 that the Go side asserts.
+describe('transfer vector cross-feed', () => {
+  it('replays transfer.json through the TypeScript receiver', async () => {
+    const v = loadVector();
+
+    const master = hexToBytes(v.master);
+    const keys = await deriveTransferKeys(master);
+    const o2j = {
+      key: hexToBytes(v.keys.o2j.key),
+      salt: hexToBytes(v.keys.o2j.salt),
+    };
+    const j2o = {
+      key: hexToBytes(v.keys.j2o.key),
+      salt: hexToBytes(v.keys.j2o.salt),
+    };
+
+    // The recorded directional keys must derive from the recorded master —
+    // evidence the Go and TS key schedules agree (parity check).
+    expect(bytesToHex(keys.o2j.key)).toBe(v.keys.o2j.key);
+    expect(bytesToHex(keys.o2j.salt)).toBe(v.keys.o2j.salt);
+    expect(bytesToHex(keys.j2o.key)).toBe(v.keys.j2o.key);
+    expect(bytesToHex(keys.j2o.salt)).toBe(v.keys.j2o.salt);
+
+    const wantBytes = hexToBytes(v.file.hex);
+    expect(wantBytes.length).toBe(v.file.size);
+    const h = createHash('sha256');
+    h.update(wantBytes);
+    expect(h.digest('hex')).toBe(v.file.sha256);
+
+    const sink = new MemorySink();
+    const replies: string[] = [];
+    const receiver = new TransferReceiver({
+      send: (f) => void replies.push(bytesToHex(f)),
+      sendDir: j2o,
+      recvDir: o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+    });
+
+    for (const fr of v.wireLog) {
+      if (fr.dir === 's2r') {
+        await receiver.handle(hexToBytes(fr.hex));
+      }
+    }
+
+    const wantReplies = v.wireLog.filter((f) => f.dir === 'r2s').map((f) => f.hex);
+    expect(replies.length).toBe(wantReplies.length);
+    for (let i = 0; i < replies.length; i++) {
+      expect(replies[i]).toBe(wantReplies[i]);
+    }
+
+    expect([...sink.bytes()]).toEqual([...wantBytes]);
+    const res = await receiver.done;
+    expect(res.digest).toBe(v.file.sha256);
+  });
+});

--- a/packages/wire/corpus_test.go
+++ b/packages/wire/corpus_test.go
@@ -1,0 +1,45 @@
+package wire
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ProtocolCorpus is a committed regression corpus (SB-1147). Each entry is a real
+// protocol shape that was hardened in or after v1.0 — oversized geometry, zero
+// block sizes, traversal paths, reserved names, unknown enums, missing fields —
+// plus the framing-level truncations they once triggered. Every payload must pass
+// through the decoders without panicking or allocating unboundedly.
+type ProtocolCorpus struct {
+	Name    string `json:"name"`
+	Payload string `json:"payload"`
+}
+
+// TestProtocolProtocolCorpus feeds every recorded adversarial payload through the
+// control-frame decoder. The invariant is "no panic, clean reject or bounded
+// accept" — a future regression that makes any of these crash fails loudly here.
+func TestProtocolCorpus(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "protocol-corpus.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []ProtocolCorpus
+	if err := json.Unmarshal(data, &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("empty regression corpus")
+	}
+	for _, e := range entries {
+		e := e
+		t.Run(e.Name, func(_ *testing.T) {
+			// decodeFrameHeader and DecodeControl are the two pure decode entry
+			// points that this corpus exercises without panicking; anything they
+			// don't accept must be a clean error, never a crash.
+			_, _ = decodeFrameHeader([]byte(e.Payload))
+			_, _ = DecodeControl([]byte(e.Payload))
+		})
+	}
+}

--- a/packages/wire/fuzz_test.go
+++ b/packages/wire/fuzz_test.go
@@ -1,0 +1,156 @@
+package wire
+
+import (
+	"math"
+	"testing"
+)
+
+// SB-1141 (wire): fuzz the transfer control-message decoders via DecodeControl.
+// Every per-type decoder is exercised by arbitrary payloads; the fragment sizes
+// and numeric ranges are validated later, so the invariant is "never panic, never
+// reject a structurally valid round-trip".
+func FuzzDecodeControl(f *testing.F) {
+	seeds := []string{
+		`{"type":2,"files":[{"idx":0,"name":"a.txt","size":0,"mime":"","lastModified":1,"blockSize":8,"blocks":0,"fileDigest":"aa"}],"totalSize":0}`,
+		`{"type":4,"fileIdx":0,"blockIdx":0,"sha256":"aa"}`,
+		`{"type":6,"fileIdx":0,"blockIdx":1}`,
+		`{"type":7,"fileIdx":0,"blockIdx":1,"reason":"integrity"}`,
+		`{"type":8,"op":"pause"}`,
+		`{"type":9,"fileDigest":"aa"}`,
+		`{"type":11,"reason":"integrity"}`,
+		`{"type":12,"transferId":"x","files":[{"idx":0,"haveBlocks":3}]}`,
+		`{"type":10}`,
+		`{}`,
+		`{"type":200}`,
+		`not json`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, payload []byte) {
+		msg, err := DecodeControl(payload)
+		if err != nil {
+			return
+		}
+		// Re-encoding a decoded message must not panic and must stay a valid
+		// JSON control frame (round-trip integrity for structurally valid input).
+		re, err := EncodeControl(msg)
+		if err != nil {
+			t.Fatalf("re-encode failed for %T: %v", msg, err)
+		}
+		msg2, err := DecodeControl(re)
+		if err != nil {
+			t.Fatalf("re-decode failed for %T: %v", msg, err)
+		}
+		if msg2.FrameType() != msg.FrameType() {
+			t.Fatalf("frame type changed on round-trip: %d -> %d", msg.FrameType(), msg2.FrameType())
+		}
+	})
+}
+
+// SB-1142 (wire): fuzz the frame-header decoder over arbitrary (often truncated)
+// buffers. It must never panic and must only accept exactly 16-byte inputs.
+func FuzzDecodeFrameHeader(f *testing.F) {
+	f.Add([]byte{0, 1, 2, 3, 0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 0, 16})
+	f.Add([]byte{1, 2, 3})
+	f.Add([]byte{})
+	f.Fuzz(func(t *testing.T, buf []byte) {
+		h, err := decodeFrameHeader(buf)
+		if err != nil {
+			return
+		}
+		// A successfully decoded header must be expressible in the wire layout.
+		enc := encodeFrameHeader(h)
+		h2, err := decodeFrameHeader(enc)
+		if err != nil {
+			t.Fatalf("round-trip decode failed: %v", err)
+		}
+		if h2 != h {
+			t.Fatalf("frame header round-trip mismatch: %+v vs %+v", h, h2)
+		}
+	})
+}
+
+// SB-1142 (wire): fuzz the sealed-frame open path with a fixed valid key.
+// Any tampered/truncated/short frame must return an error, never panic and never
+// yield a donated plaintext without GCM authentication.
+func FuzzOpenSequenced(f *testing.F) {
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		f.Fatal(err)
+	}
+	// Seed with a handful of adversarially shaped frames.
+	f.Add([]byte{})
+	f.Add([]byte("short"))
+	f.Add(make([]byte, 4096))
+	f.Add([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 10, 1, 2, 3, 4, 5, 6, 7})
+	f.Fuzz(func(t *testing.T, frame []byte) {
+		opened, err := OpenSequenced(keys.O2J, 0, frame)
+		if err != nil {
+			return
+		}
+		// A successfully authenticated frame must have a plausible header and
+		// a plaintext whose length matches the header's len field.
+		if len(opened.Plaintext) != int(opened.Header.Len) {
+			t.Fatalf("authenticated frame plaintext %d != header len %d", len(opened.Plaintext), opened.Header.Len)
+		}
+	})
+}
+
+// SB-1143 (wire): fuzz the decode+validate manifest path. The invariant is that
+// a validated manifest never carries out-of-range geometry that would drive the
+// receiver into an oversized allocation or a divide-by-zero.
+func FuzzValidateManifest(f *testing.F) {
+	f.Add([]byte(`{"type":2,"files":[{"idx":0,"name":"a.bin","size":9,"mime":"","lastModified":1,"blockSize":8,"blocks":2,"fileDigest":"aa"}],"totalSize":9}`))
+	f.Add([]byte(`{"type":2,"files":[{"idx":0,"name":"big","size":100,"mime":"","lastModified":1,"blockSize":1000,"blocks":1,"fileDigest":"aa"}],"totalSize":100}`))
+	f.Add([]byte(`{"type":2,"files":[{"idx":0,"name":"zero","size":0,"mime":"","lastModified":0,"blockSize":1,"blocks":0,"fileDigest":"aa"}],"totalSize":0}`))
+	f.Add([]byte(`{"type":2,"files":[{"idx":0,"name":"a","size":9,"mime":"","lastModified":1,"blockSize":8,"blocks":2,"fileDigest":"aa"}],"totalSize":99}`))
+	f.Fuzz(func(t *testing.T, payload []byte) {
+		msg, err := DecodeControl(payload)
+		if err != nil {
+			return
+		}
+		m, ok := msg.(*Manifest)
+		if !ok {
+			return
+		}
+		valid, err := ValidateManifest(*m)
+		if err != nil {
+			return
+		}
+		// The canonical manifest must preserve geometry and be re-encodeable.
+		if len(valid.Files) == 0 || len(valid.Files) > MaxTransferFiles {
+			t.Fatalf("validated manifest has %d files", len(valid.Files))
+		}
+		var total int64
+		for _, file := range valid.Files {
+			if file.Size < 0 || file.BlockSize <= 0 || file.Blocks < 0 {
+				t.Fatalf("validated manifest has negative geometry: %+v", file)
+			}
+			if file.Size > math.MaxInt64-total {
+				t.Fatalf("validated manifest size overflows")
+			}
+			total += file.Size
+		}
+		if valid.TotalSize != total {
+			t.Fatalf("validated manifest total size mismatch: %d != %d", valid.TotalSize, total)
+		}
+	})
+}
+
+// SB-1143 (wire): fuzz the JSON shape-checking of a manifest decoder alone. A
+// payload that decodes must never crash on unbounded slice lengths caused by a
+// huge literal array; the post-decode ValidateManifest caps at MaxTransferFiles.
+func FuzzDecodeManifestShape(f *testing.F) {
+	seeds := []string{
+		`{"type":2,"files":[],"totalSize":0}`,
+		`{"type":2,"files":[{"idx":0}],"totalSize":0}`,
+		`{"type":2}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(_ *testing.T, payload []byte) {
+		_, _ = DecodeControl(payload)
+	})
+}

--- a/packages/wire/testdata/protocol-corpus.json
+++ b/packages/wire/testdata/protocol-corpus.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "manifest: absurd block size",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0,\"name\":\"big\",\"size\":100,\"mime\":\"\",\"lastModified\":1,\"blockSize\":2147483647,\"blocks\":1,\"fileDigest\":\"aa\"}],\"totalSize\":100}"
+  },
+  {
+    "name": "manifest: negative size",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0,\"name\":\"a.bin\",\"size\":-1,\"mime\":\"\",\"lastModified\":1,\"blockSize\":8,\"blocks\":1,\"fileDigest\":\"aa\"}],\"totalSize\":-1}"
+  },
+  {
+    "name": "manifest: zero block size (divide-by-zero)",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0,\"name\":\"a.bin\",\"size\":100,\"mime\":\"\",\"lastModified\":1,\"blockSize\":0,\"blocks\":1,\"fileDigest\":\"aa\"}],\"totalSize\":100}"
+  },
+  {
+    "name": "manifest: overflow block count",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0,\"name\":\"a.bin\",\"size\":9223372036854775807,\"mime\":\"\",\"lastModified\":1,\"blockSize\":1,\"blocks\":9223372036854775807,\"fileDigest\":\"aa\"}],\"totalSize\":9223372036854775807}"
+  },
+  {
+    "name": "manifest: traversal path",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0,\"name\":\"../../etc/passwd\",\"size\":9,\"mime\":\"\",\"lastModified\":1,\"blockSize\":8,\"blocks\":2,\"fileDigest\":\"aa\"}],\"totalSize\":9}"
+  },
+  {
+    "name": "manifest: windows reserved name",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0,\"name\":\"CON\",\"size\":9,\"mime\":\"\",\"lastModified\":1,\"blockSize\":8,\"blocks\":2,\"fileDigest\":\"aa\"}],\"totalSize\":9}"
+  },
+  {
+    "name": "manifest: duplicate case-insensitive path",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0,\"name\":\"a.txt\",\"size\":9,\"mime\":\"\",\"lastModified\":1,\"blockSize\":8,\"blocks\":2,\"fileDigest\":\"aa\"},{\"idx\":1,\"name\":\"A.txt\",\"size\":9,\"mime\":\"\",\"lastModified\":1,\"blockSize\":8,\"blocks\":2,\"fileDigest\":\"aa\"}],\"totalSize\":18}"
+  },
+  {
+    "name": "manifest: non-contiguous indexes",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":5,\"name\":\"a.txt\",\"size\":9,\"mime\":\"\",\"lastModified\":1,\"blockSize\":8,\"blocks\":2,\"fileDigest\":\"aa\"}],\"totalSize\":9}"
+  },
+  {
+    "name": "manifest: total size sum mismatch",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0,\"name\":\"a.txt\",\"size\":9,\"mime\":\"\",\"lastModified\":1,\"blockSize\":8,\"blocks\":2,\"fileDigest\":\"aa\"}],\"totalSize\":999}"
+  },
+  {
+    "name": "manifest: empty files",
+    "payload": "{\"type\":2,\"files\":[],\"totalSize\":0}"
+  },
+  {
+    "name": "nack: unknown reason",
+    "payload": "{\"type\":7,\"fileIdx\":0,\"blockIdx\":1,\"reason\":\"bogus\"}"
+  },
+  {
+    "name": "control: unknown op",
+    "payload": "{\"type\":8,\"op\":\"explode\"}"
+  },
+  {
+    "name": "fail: unknown reason",
+    "payload": "{\"type\":11,\"reason\":\"self_destruct\"}"
+  },
+  {
+    "name": "manifest: missing required field",
+    "payload": "{\"type\":2,\"files\":[{\"idx\":0}],\"totalSize\":0}"
+  },
+  {
+    "name": "block_hash: missing sha256",
+    "payload": "{\"type\":4,\"fileIdx\":0,\"blockIdx\":0}"
+  },
+  {
+    "name": "resume_state: empty files",
+    "payload": "{\"type\":12,\"transferId\":\"t\",\"files\":[]}"
+  },
+  {
+    "name": "unexpected type",
+    "payload": "{\"type\":200}"
+  },
+  {
+    "name": "missing type",
+    "payload": "{}"
+  },
+  {
+    "name": "not json",
+    "payload": "{not json"
+  },
+  {
+    "name": "truncated frame header",
+    "payload": "AAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  }
+]

--- a/packages/wire/transfer_messages.go
+++ b/packages/wire/transfer_messages.go
@@ -301,6 +301,9 @@ func decodeManifest(payload []byte) (ControlMsg, error) {
 	if len(raw.Files) == 0 {
 		return nil, errors.New("control frame: manifest.files empty")
 	}
+	if len(raw.Files) > MaxTransferFiles {
+		return nil, fmt.Errorf("control frame: manifest has %d files, maximum is %d", len(raw.Files), MaxTransferFiles)
+	}
 	if raw.TotalSize == nil {
 		return nil, errors.New("control frame: manifest.totalSize missing")
 	}
@@ -445,6 +448,9 @@ func decodeResumeState(payload []byte) (ControlMsg, error) {
 	}
 	if len(raw.Files) == 0 {
 		return nil, errors.New("control frame: resume_state.files empty")
+	}
+	if len(raw.Files) > MaxTransferFiles {
+		return nil, fmt.Errorf("control frame: resume_state has %d files, maximum is %d", len(raw.Files), MaxTransferFiles)
 	}
 	files := make([]ResumeFileState, len(raw.Files))
 	for i, rf := range raw.Files {


### PR DESCRIPTION
Deterministic and generative coverage for the protocol decoders across Go and TypeScript.

- Go fuzz targets for the control-frame decoder, frame headers, AEAD open path, manifest decode+validate, and the rendezvous/server signaling envelopes
- Committed adversarial protocol corpus (oversized/negative geometry, zero block sizes, traversal paths, reserved names, unknown enums) replaying cleanly through the decoders, feeding the long-running fuzzers
- Cap decoded manifest/resume-state file arrays at the shared max-file bound in both Go and TypeScript decoders to bound allocation before validation
- Seeded TypeScript property tests for the frame/AEAD codecs and path/manifest validation
- TypeScript replay of the committed transfer wire-log vector asserting byte-identical replies, exact file bytes, and the canonical SHA-256 (Go/TS engine parity)