### PR TITLE
fix: cutover terminal-frame recovery, lifecycle guards, fuzzing cleanup

### DIFF
--- a/apps/cli/internal/rendezvous/message_test.go
+++ b/apps/cli/internal/rendezvous/message_test.go
@@ -117,7 +117,7 @@ func keysOf(m map[string]any) []string {
 	return ks
 }
 
-// SB-1140: fuzz the signaling envelope decoder. Every JSON frame must decode or
+// Fuzz the signaling envelope decoder. Every JSON frame must decode or
 // fail without panicking, and a successfully decoded message must round-trip so
 // the session can act on it consistently.
 func FuzzUnmarshalMessage(f *testing.F) {

--- a/apps/cli/internal/transfer/driver_faults_test.go
+++ b/apps/cli/internal/transfer/driver_faults_test.go
@@ -43,7 +43,7 @@ func killBothSignaling(hub *relay) {
 	hub.join.killSignaling()
 }
 
-// TestDriverSurvivesSignalingLossOnDirect pins SB-1122: signaling failure is
+// TestDriverSurvivesSignalingLossOnDirect pins signaling failure is
 // independent of the data path — a healthy direct channel finishes the transfer
 // with no relay fallback and no error when the signaling socket dies mid-file.
 func TestDriverSurvivesSignalingLossOnDirect(t *testing.T) {
@@ -112,7 +112,7 @@ func TestDriverSurvivesSignalingLossOnDirect(t *testing.T) {
 	}
 }
 
-// TestDriverSignalingLossOnRelayIsFatal pins the relay side of SB-1122: a relay
+// TestDriverSignalingLossOnRelayIsFatal pins the relay side: a relay
 // transfer needs signaling (credit accounting), so losing it mid-file fails both
 // sides with RELAY instead of silently stalling.
 func TestDriverSignalingLossOnRelayIsFatal(t *testing.T) {
@@ -173,7 +173,7 @@ func TestDriverSignalingLossOnRelayIsFatal(t *testing.T) {
 	}
 }
 
-// TestDriverCutoverBeforeDataStarts pins SB-1123 phase 1: the direct channel
+// TestDriverCutoverBeforeDataStarts pins cutover phase 1: the direct channel
 // dies before the first byte moves and the transfer still completes over the
 // relay with identical bytes.
 func TestDriverCutoverBeforeDataStarts(t *testing.T) {
@@ -242,7 +242,7 @@ func TestDriverCutoverBeforeDataStarts(t *testing.T) {
 	}
 }
 
-// TestDriverCutoverAfterAllDataAcked pins SB-1123 phase 2: every byte has been
+// TestDriverCutoverAfterAllDataAcked pins cutover phase 2: every byte has been
 // acknowledged before the direct path dies, so the cutover must not fail the
 // transfer over lost terminal control frames.
 func TestDriverCutoverAfterAllDataAcked(t *testing.T) {

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -445,7 +445,7 @@ func TestRelayCreditRequestClampedNotKilled(t *testing.T) {
 	}
 }
 
-// SB-1140: fuzz the server's inbound signaling envelope. The server only reads
+// Fuzz the server's inbound signaling envelope. The server only reads
 // type/room/role/bytes, so the invariant is a clean decode-or-reject with no
 // panic and no empty type slipping through (dispatch treats "" as invalid).
 func FuzzClientMsg(f *testing.F) {

--- a/apps/web/src/lib/session/generation.test.ts
+++ b/apps/web/src/lib/session/generation.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { GenerationGuard } from './generation.js';
+
+describe('GenerationGuard stale-continuation rejection', () => {
+  it('runs work while current and rejects it after a bump', () => {
+    const guard = new GenerationGuard();
+    const captured = guard.capture();
+    let ran = 0;
+
+    // Continuation fires before any teardown: expected to run.
+    expect(guard.isCurrent(captured)).toBe(true);
+    guard.guard(captured, () => ran++);
+    expect(ran).toBe(1);
+
+    // Tear down the session (cancel/finish/fail all bump), then fire the same
+    // captured continuation: it must be rejected before running.
+    guard.bump();
+    expect(guard.isCurrent(captured)).toBe(false);
+    guard.guard(captured, () => ran++);
+    expect(ran).toBe(1); // not incremented — the stale continuation was dropped
+  });
+
+  it('a late continuation cannot switch transports after cleanup', () => {
+    const guard = new GenerationGuard();
+    const captured = guard.capture();
+    let transport: 'direct' | 'relay' = 'direct';
+    const assumeItCanSwitch = () => (transport = 'relay');
+
+    // The continuation is registered while direct; cleanup then bumps.
+    guard.bump();
+    guard.guard(captured, assumeItCanSwitch);
+
+    // The transport must not have been switched by the late continuation.
+    expect(transport).toBe('direct');
+  });
+
+  it('a late continuation cannot send frames after cleanup', () => {
+    const guard = new GenerationGuard();
+    const captured = guard.capture();
+    const frames: number[] = [];
+    const sendOutbound = (frame: number, generation: number) =>
+      guard.guard(generation, () => frames.push(frame));
+
+    // Send while current.
+    sendOutbound(1, captured);
+    expect(frames).toEqual([1]);
+
+    // Cleanup, then a late outbound frame is dropped.
+    guard.bump();
+    sendOutbound(2, captured);
+    expect(frames).toEqual([1]);
+    // A continuation captured after the bump is still live.
+    const later = guard.capture();
+    sendOutbound(3, later);
+    expect(frames).toEqual([1, 3]);
+  });
+
+  it('a late continuation cannot resolve/reject the same promise twice', async () => {
+    const guard = new GenerationGuard();
+    let resolveFn!: (v: string) => void;
+    const promise = new Promise<string>((resolve) => {
+      resolveFn = resolve;
+    });
+    let resolveCount = 0;
+    const safeResolve = (value: string, generation: number) => {
+      if (guard.isCurrent(generation)) {
+        resolveCount++;
+        resolveFn(value);
+      }
+    };
+
+    const captured = guard.capture();
+    safeResolve('first', captured);
+    expect(resolveCount).toBe(1);
+    expect(await promise).toBe('first');
+
+    // A stale second resolution attempt (holding the OLD captured generation)
+    // is dropped: the promise was already settled, resolveCount stays at 1.
+    guard.bump();
+    safeResolve('stale', captured);
+    expect(resolveCount).toBe(1);
+    expect(await promise).toBe('first');
+  });
+
+  it('a stale continuation cannot touch terminated resources', () => {
+    const generation = new GenerationGuard();
+    const captured = generation.capture();
+    let terminated = false;
+    const peerCloseCalls: Array<number> = [];
+    let peerTouched = 0;
+    // The guard check runs before touching the resource, so a stale continuation
+    // can never reach the terminated-resource body.
+    const closePeer = (id: number, gen: number) => {
+      if (!generation.isCurrent(gen)) return;
+      if (terminated) throw new Error('resource already terminated');
+      peerCloseCalls.push(id);
+      peerTouched++;
+    };
+
+    closePeer(1, captured);
+    expect(peerCloseCalls).toEqual([1]);
+
+    // Terminate the resource and bump the generation: a stale close attempt is
+    // dropped before it can touch the terminated peer.
+    terminated = true;
+    generation.bump();
+    closePeer(2, captured);
+    expect(peerCloseCalls).toEqual([1]);
+    expect(peerTouched).toBe(1);
+  });
+
+  it('capture points taken after a bump are distinct and live', () => {
+    const guard = new GenerationGuard();
+    const a = guard.capture();
+    guard.bump();
+    const b = guard.capture();
+    expect(guard.isCurrent(a)).toBe(false);
+    expect(guard.isCurrent(b)).toBe(true);
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/web/src/lib/session/generation.ts
+++ b/apps/web/src/lib/session/generation.ts
@@ -1,0 +1,42 @@
+/**
+ * A generation guard for async orchestration continuations.
+ *
+ * Browser transfer orchestration registers many callbacks (signaling, peer, relay,
+ * worker, transport switching) that each close over captured state. If a callback
+ * fires after the session was torn down (cancel/finish/fail), it must not mutate
+ * state, switch transports, send frames, resolve/reject a promise twice, or touch
+ * terminated resources.
+ *
+ * The guard is captured once when a continuation is created, then checked when the
+ * continuation actually runs. A naive guard that reads the generation at runtime
+ * inside the callback (instead of at capture time) can never detect staleness,
+ * because cleanup can advance the generation only between capture and run.
+ */
+export class GenerationGuard {
+  private current = 0;
+
+  /** Capture the current generation for a new continuation (called at creation time). */
+  capture(): number {
+    return this.current;
+  }
+
+  /** True while `captured` is still the current session generation. */
+  isCurrent(captured: number): boolean {
+    return captured === this.current;
+  }
+
+  /** Advance the generation so every previously captured continuation becomes stale. */
+  bump(): void {
+    this.current++;
+  }
+
+  /**
+   * Run `fn` only if `captured` is still the current generation (i.e. the session
+   * has not been torn down since the continuation was created). Returns its result,
+   * or `undefined` if the continuation is stale.
+   */
+  guard<T>(captured: number, fn: () => T): T | undefined {
+    if (captured !== this.current) return undefined;
+    return fn();
+  }
+}

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -25,6 +25,7 @@ import type {
   SessionCrypto,
   WorkerToHost,
 } from '../transfer/wire.js';
+import { GenerationGuard } from './generation.js';
 
 /** Terminal outcome of a transfer. `file` is present on the receive side (the downloadable result). */
 export interface TransferOutcome {
@@ -103,9 +104,9 @@ function run(
   const progress = new ProgressTracker(total);
   const wakeLock = new WakeLockManager();
   let settled = false;
-  // Monotonic generation: every async continuation captures it at creation and
-  // bails before mutating controller state once it is stale (ADR 0001 §5).
-  let generation = 0;
+  // Monotonic generation guard: every async continuation captures the generation at
+  // creation and bails before mutating controller state once it is stale (ADR 0001 §5).
+  const generation = new GenerationGuard();
   let peer: Peer | undefined;
   let worker: Worker | undefined;
   let writer: ChannelWriter | undefined;
@@ -122,7 +123,7 @@ function run(
   });
 
   const cleanup = (): void => {
-    generation++;
+    generation.bump();
     clearTimeout(cancelTimer);
     wakeLock.setActive(false);
     worker?.terminate();
@@ -143,6 +144,10 @@ function run(
     rejectDone(err);
   };
 
+  // Capture the generation at session start. cleanup() bumps it only on
+  // cancel/finish/fail, so a callback that fires after teardown sees a mismatch
+  // and bails before mutating state (a stale continuation).
+  const gen = generation.capture();
   void (async () => {
     try {
       const auth = SignalAuthenticator.fromSession(
@@ -155,22 +160,19 @@ function run(
       const relayPath = new RelayTransport(signaling);
       relay = relayPath;
       signaling.onClose((err) => {
-        const gen = generation;
-        if (gen !== generation) return;
+        if (!generation.isCurrent(gen)) return;
         relayPath.fail(err);
         if (transport !== 'direct' || switchPromise) {
           fail(err);
         }
       });
       signaling.onMessage((msg) => {
-        const gen = generation;
-        if (gen !== generation) return;
+        if (!generation.isCurrent(gen)) return;
         if (relayPath.handleMessage(msg)) return;
         if (msg.type === 'sdp' || msg.type === 'ice') p.accept(msg);
       });
       signaling.onBinary((frame) => {
-        const gen = generation;
-        if (gen !== generation) return;
+        if (!generation.isCurrent(gen)) return;
         relayPath.handleBinary(frame);
       });
 
@@ -195,14 +197,13 @@ function run(
       const receive = (frame: ArrayBuffer): void =>
         w.postMessage({ kind: 'inbound-frame', frame } satisfies HostToWorker, [frame]);
       const switchToRelay = (): Promise<void> => {
-        const gen = generation;
-        if (gen !== generation) return Promise.resolve();
+        if (!generation.isCurrent(gen)) return Promise.resolve();
         if (transport === 'relay') return Promise.resolve();
         if (switchPromise) return switchPromise;
         switchPromise = (async () => {
           relayPath.open();
           await relayPath.ready;
-          if (gen !== generation) return;
+          if (!generation.isCurrent(gen)) return;
           if (settled) return;
           transport = 'relay';
           w.postMessage({ kind: 'transport-changed' } satisfies HostToWorker);
@@ -216,8 +217,7 @@ function run(
         return switchPromise;
       };
       const sendOutbound = async (frame: ArrayBuffer): Promise<void> => {
-        const gen = generation;
-        if (gen !== generation) return;
+        if (!generation.isCurrent(gen)) return;
         if (transport === 'relay') {
           await relayPath.write(frame);
           return;
@@ -237,35 +237,30 @@ function run(
 
       if (selected.kind === 'direct') {
         p.onData((frame) => {
-          const gen = generation;
-          if (gen !== generation) return;
+          if (!generation.isCurrent(gen)) return;
           if (transport === 'direct' && !switchPromise) receive(frame);
         });
         p.onDisconnect(() => {
-          const gen = generation;
-          if (gen !== generation) return;
+          if (!generation.isCurrent(gen)) return;
           void switchToRelay().catch(() => {});
         });
         void relayPath.ready.then(switchToRelay).catch(() => {});
         relayPath.onData((frame) => {
-          const gen = generation;
-          if (gen !== generation) return;
+          if (!generation.isCurrent(gen)) return;
           void switchToRelay()
             .then(() => receive(frame))
             .catch(() => {});
         });
       } else {
         relayPath.onData((frame) => {
-          const gen = generation;
-          if (gen !== generation) return;
+          if (!generation.isCurrent(gen)) return;
           receive(frame);
         });
       }
 
       // Worker → host events.
       w.addEventListener('message', (ev: MessageEvent) => {
-        const gen = generation;
-        if (gen !== generation) return;
+        if (!generation.isCurrent(gen)) return;
         const msg = ev.data as WorkerToHost;
         switch (msg.kind) {
           case 'outbound-frame':
@@ -314,8 +309,7 @@ function run(
   })();
 
   async function completeTransfer(msg: Extract<WorkerToHost, { kind: 'done' }>): Promise<void> {
-    const gen = generation;
-    if (gen !== generation) return;
+    if (!generation.isCurrent(gen)) return;
     const first = msg.files[0]!;
     if (spec.role === 'receive') {
       try {

--- a/packages/protocol/src/property.test.ts
+++ b/packages/protocol/src/property.test.ts
@@ -35,9 +35,9 @@ function u32(rand: () => number): number {
 
 const master = new Uint8Array(32).fill(9);
 
-// SB-1144: frame header encode/decode round-trip over many arbitrary but
+// Frame header encode/decode round-trip over many arbitrary but
 // in-range headers; decode(encode(h)) must equal h exactly and stay 16 bytes.
-describe('SB-1144 frame header property', () => {
+describe('frame header property', () => {
   it('round-trips arbitrary in-range headers', () => {
     const rand = rng(0xbeef);
     for (let i = 0; i < 2000; i++) {
@@ -89,9 +89,9 @@ describe('SB-1144 frame header property', () => {
   });
 });
 
-// SB-1144: AEAD seal/open inverse over arbitrary plaintext lengths, plus the
+// AEAD seal/open inverse over arbitrary plaintext lengths, plus the
 // guarantee that any single-byte mutation of a sealed frame fails to open.
-describe('SB-1144 AEAD frame property', () => {
+describe('AEAD frame property', () => {
   it('seal then open recovers plaintext and header len', async () => {
     const keys = await deriveTransferKeys(await deriveMaster(master, new Uint8Array(0)));
     const rand = rng(0xdeadbeef);
@@ -130,9 +130,9 @@ describe('SB-1144 AEAD frame property', () => {
   });
 });
 
-// SB-1145: arbitrary safe relative segment strings must produce canonical,
+// Arbitrary safe relative segment strings must produce canonical,
 // absolute-free, dot-free output; structural invariants mirror the Go fuzzer.
-describe('SB-1145 normalizeTransferPath property', () => {
+describe('normalizeTransferPath property', () => {
   const alpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ .',
     legal = 64;
 
@@ -200,9 +200,9 @@ describe('SB-1145 normalizeTransferPath property', () => {
   });
 });
 
-// SB-1145: validateManifest accepts geometrically consistent manifests and
+// validateManifest accepts geometrically consistent manifests and
 // rejects any whose block geometry, size sum, or paths are inconsistent.
-describe('SB-1145 validateManifest property', () => {
+describe('validateManifest property', () => {
   function file(idx: number, name: string, size: number, blockSize: number): FileEntry {
     return {
       idx,

--- a/packages/protocol/src/transfer-vector.test.ts
+++ b/packages/protocol/src/transfer-vector.test.ts
@@ -28,7 +28,7 @@ function loadVector(): Vector {
   return JSON.parse(readFileSync(fileURLToPath(url), 'utf8')) as Vector;
 }
 
-// SB-1146: cross-feed equivalence. The Go engine recorded a byte-exact wire log in
+// Cross-feed equivalence. The Go engine recorded a byte-exact wire log in
 // transfer.json; replaying the s2r frames into the TypeScript receiver must produce
 // byte-identical r2s replies, reconstruct the exact file bytes, and verify the same
 // canonical SHA-256 that the Go side asserts.

--- a/packages/wire/corpus_test.go
+++ b/packages/wire/corpus_test.go
@@ -7,19 +7,21 @@ import (
 	"testing"
 )
 
-// ProtocolCorpus is a committed regression corpus (SB-1147). Each entry is a real
+// ProtocolCorpus is a committed regression corpus. Each entry is a real
 // protocol shape that was hardened in or after v1.0 — oversized geometry, zero
 // block sizes, traversal paths, reserved names, unknown enums, missing fields —
-// plus the framing-level truncations they once triggered. Every payload must pass
-// through the decoders without panicking or allocating unboundedly.
+// plus framing-level truncations. Every payload is run through the decoders and
+// must be rejected (or accepted) without panicking.
 type ProtocolCorpus struct {
 	Name    string `json:"name"`
 	Payload string `json:"payload"`
 }
 
-// TestProtocolProtocolCorpus feeds every recorded adversarial payload through the
-// control-frame decoder. The invariant is "no panic, clean reject or bounded
-// accept" — a future regression that makes any of these crash fails loudly here.
+// TestProtocolCorpus feeds every recorded adversarial payload through the pure
+// control-frame and frame-header decoders. The invariant under test is exactly
+// "never panic on malformed input": each entry must decode or reject with a
+// clean error (nothing is asserted about the specific error reason). A future
+// regression that makes any of these crash fails loudly here.
 func TestProtocolCorpus(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("testdata", "protocol-corpus.json"))
 	if err != nil {
@@ -35,11 +37,11 @@ func TestProtocolCorpus(t *testing.T) {
 	for _, e := range entries {
 		e := e
 		t.Run(e.Name, func(_ *testing.T) {
-			// decodeFrameHeader and DecodeControl are the two pure decode entry
-			// points that this corpus exercises without panicking; anything they
-			// don't accept must be a clean error, never a crash.
-			_, _ = decodeFrameHeader([]byte(e.Payload))
+			// DecodeControl is the entry point exercised by the JSON payloads;
+			// decodeFrameHeader is included so truncation-type corpus entries are
+			// run through a binary framing decoder too. Neither may panic.
 			_, _ = DecodeControl([]byte(e.Payload))
+			_, _ = decodeFrameHeader([]byte(e.Payload))
 		})
 	}
 }

--- a/packages/wire/fault_io_test.go
+++ b/packages/wire/fault_io_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // faultSink wraps a MemorySink and fails a chosen write (1-based) or Close with
-// a chosen error, mirroring disk failures on the receive side (SB-1125).
+// a chosen error, mirroring disk failures on the receive side.
 type faultSink struct {
 	*MemorySink
 	failWriteAt int
@@ -33,7 +33,7 @@ func (f *faultSink) Close() error {
 }
 
 // faultDestination fails on Open (destination collision) or Close (commit/flush
-// failure) exactly where the wire layer must surface FailSinkError (SB-1125).
+// failure) exactly where the wire layer must surface FailSinkError.
 type faultDestination struct {
 	openErr  error
 	closeErr error
@@ -62,7 +62,7 @@ func (d *faultDestination) Abort(reason string) error {
 
 // faultSource serves a different byte stream per pass so tests can inject file
 // disappearance, mid-read failure, and file mutation between the digest pass
-// and the transfer pass (SB-1126). Stream is called exactly twice by Sender.Run.
+// and the transfer pass. Stream is called exactly twice by Sender.Run.
 type faultSource struct {
 	meta   FileMeta
 	passes [2][]byte

--- a/packages/wire/fault_seeded_test.go
+++ b/packages/wire/fault_seeded_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // fixedSeeds are the seeds every CI run exercises; a failure at seed N is
-// reproduced locally with -run TestFaultRandomizedFailClosed (SB-1127).
+// reproduced locally with -run TestFaultRandomizedFailClosed.
 var fixedSeeds = []int64{11, 22, 33, 44, 55, 66, 77, 88}
 
 // TestFaultRandomizedFailClosed pins the fail-closed contract under every
@@ -39,7 +39,7 @@ func TestFaultRandomizedFailClosed(t *testing.T) {
 	}
 }
 
-// faultFixture is one recorded regression scenario (SB-1128). Want is
+// faultFixture is one recorded regression scenario. Want is
 // "success" or "fail_closed".
 type faultFixture struct {
 	Seed        int64  `json:"seed"`

--- a/packages/wire/faults_test.go
+++ b/packages/wire/faults_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// Deterministic fault-injection harness (plan §4.2, SB-1120..1128). A faultLink
+// Deterministic fault-injection harness . A faultLink
 // sits between each side's Send and the peer's Handle and mutates frames
 // according to a per-direction, per-frame-type script keyed on occurrence, or —
 // with a seeded RNG — at random. The wire engine treats its transport as
@@ -174,6 +174,14 @@ func (l *faultLink) manifestSeen() bool {
 }
 
 func (l *faultLink) isClosed() bool { return l.closed.Load() }
+
+// completeSeen reports whether the sender has transmitted at least one
+// FrameComplete on the s2r path (dropped or not).
+func (l *faultLink) completeSeen() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.counts[dirS2R][FrameComplete] > 0
+}
 
 // randomAction draws a fault from a fixed probability table so seeds stay
 // comparable across runs.
@@ -382,7 +390,7 @@ func testData(n int, mul byte) []byte {
 	return data
 }
 
-// --- SB-1120: the shim itself ---
+// --- the shim itself ---
 
 // TestFaultShimPassesEverything: an empty script must behave exactly like the
 // plain loopback.
@@ -433,7 +441,7 @@ func TestFaultLateDoneStillSucceeds(t *testing.T) {
 	res.wantSuccess(t, data)
 }
 
-// TestFaultStaleNackIsHarmless (SB-1124): a NACK for an already-acknowledged
+// TestFaultStaleNackIsHarmless: a NACK for an already-acknowledged
 // block is injected directly into the sender's inbound stream at the exact next
 // counter; the sender requeues and resends, the receiver ignores the replay,
 // and the transfer completes.
@@ -516,7 +524,7 @@ func TestFaultStaleNackIsHarmless(t *testing.T) {
 	}
 }
 
-// TestFaultDuplicateResumeStateIsIdempotent (SB-1124): a duplicated
+// TestFaultDuplicateResumeStateIsIdempotent: a duplicated
 // resume_state (receiver → sender) is applied once; the resumed transfer
 // completes.
 func TestFaultDuplicateResumeStateIsIdempotent(t *testing.T) {
@@ -593,7 +601,7 @@ func TestFaultDuplicateResumeStateIsIdempotent(t *testing.T) {
 	}
 }
 
-// --- SB-1121: transport closure at every meaningful phase ---
+// --- transport closure at every meaningful phase ---
 
 // TestFaultDroppedDataFrameRecoversViaRetry: a single dropped data frame is
 // masked by the sender's block retry — the receiver discards the partial cycle
@@ -680,7 +688,7 @@ func TestFaultCloseAfterCompleteTimesOutOnDone(t *testing.T) {
 	}
 }
 
-// TestFaultLateControlAfterSettlementIsIgnored (SB-1124): controls arriving
+// TestFaultLateControlAfterSettlementIsIgnored: controls arriving
 // after the sender settled are dropped.
 func TestFaultLateControlAfterSettlementIsIgnored(t *testing.T) {
 	data := testData(40_000, 3)

--- a/packages/wire/fuzz_test.go
+++ b/packages/wire/fuzz_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// SB-1141 (wire): fuzz the transfer control-message decoders via DecodeControl.
+// fuzz the transfer control-message decoders via DecodeControl.
 // Every per-type decoder is exercised by arbitrary payloads; the fragment sizes
 // and numeric ranges are validated later, so the invariant is "never panic, never
 // reject a structurally valid round-trip".
@@ -48,8 +48,11 @@ func FuzzDecodeControl(f *testing.F) {
 	})
 }
 
-// SB-1142 (wire): fuzz the frame-header decoder over arbitrary (often truncated)
-// buffers. It must never panic and must only accept exactly 16-byte inputs.
+// (wire): fuzz the frame-header decoder over arbitrary (often truncated)
+// buffers. The wire contract is that the decoder reads the first 16 bytes of any
+// buffer that is at least 16 bytes long and rejects shorter buffers, so it must
+// never panic; the round-trip invariant below is that any successfully decoded
+// header re-encodes to the same header.
 func FuzzDecodeFrameHeader(f *testing.F) {
 	f.Add([]byte{0, 1, 2, 3, 0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 0, 16})
 	f.Add([]byte{1, 2, 3})
@@ -71,7 +74,7 @@ func FuzzDecodeFrameHeader(f *testing.F) {
 	})
 }
 
-// SB-1142 (wire): fuzz the sealed-frame open path with a fixed valid key.
+// (wire): fuzz the sealed-frame open path with a fixed valid key.
 // Any tampered/truncated/short frame must return an error, never panic and never
 // yield a donated plaintext without GCM authentication.
 func FuzzOpenSequenced(f *testing.F) {
@@ -79,6 +82,19 @@ func FuzzOpenSequenced(f *testing.F) {
 	if err != nil {
 		f.Fatal(err)
 	}
+	// Seed with a genuinely valid, authenticated frame generated via Seal so the
+	// fuzzer starts from an accepted input and explores the successful
+	// OpenSequenced path and its neighborhoods (single-bit flips, body edits,
+	// truncations) around a frame the decoder verifies.
+	valid, err := Seal(keys.O2J, 0, FrameHeaderInput{
+		Version: FrameVersion, Type: FrameBlockData, Flags: 0,
+		FileIdx: 0, BlockIdx: 7, FrameOff: 0,
+	}, []byte("authenticated payload"))
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(valid)
+	f.Add(valid[:len(valid)-1])
 	// Seed with a handful of adversarially shaped frames.
 	f.Add([]byte{})
 	f.Add([]byte("short"))
@@ -97,7 +113,7 @@ func FuzzOpenSequenced(f *testing.F) {
 	})
 }
 
-// SB-1143 (wire): fuzz the decode+validate manifest path. The invariant is that
+// (wire): fuzz the decode+validate manifest path. The invariant is that
 // a validated manifest never carries out-of-range geometry that would drive the
 // receiver into an oversized allocation or a divide-by-zero.
 func FuzzValidateManifest(f *testing.F) {
@@ -138,7 +154,7 @@ func FuzzValidateManifest(f *testing.F) {
 	})
 }
 
-// SB-1143 (wire): fuzz the JSON shape-checking of a manifest decoder alone. A
+// (wire): fuzz the JSON shape-checking of a manifest decoder alone. A
 // payload that decodes must never crash on unbounded slice lengths caused by a
 // huge literal array; the post-decode ValidateManifest caps at MaxTransferFiles.
 func FuzzDecodeManifestShape(f *testing.F) {

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -98,6 +98,7 @@ type Sender struct {
 	activeFileAcknowledged int64
 	paused                 bool
 	completeSent           bool
+	complete               *Complete
 	settled                bool
 	err                    error
 	// handleMu serializes Handle so two byte paths (direct and relay pumps during a
@@ -298,8 +299,10 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 	}
 	s.mu.Lock()
 	s.completeSent = true
+	s.complete = NewComplete(transferDigest)
+	complete := s.complete
 	s.mu.Unlock()
-	if err := s.sendControl(NewComplete(transferDigest)); err != nil {
+	if err := s.sendControl(complete); err != nil {
 		s.fail(err)
 		return "", err
 	}
@@ -407,6 +410,10 @@ func (s *Sender) TransportChanged() {
 	if s.manifestSent && s.acknowledged == 0 {
 		resend = s.manifest
 	}
+	var resendComplete *Complete
+	if s.completeSent && s.complete != nil && !s.settled {
+		resendComplete = s.complete
+	}
 	s.cond.Broadcast()
 	s.mu.Unlock()
 	if resend != nil {
@@ -414,6 +421,15 @@ func (s *Sender) TransportChanged() {
 		// identical duplicates and stray pre-manifest data, so resending it is
 		// safe and lets the transfer continue on the new path.
 		_ = s.sendControl(resend)
+	}
+	if resendComplete != nil {
+		// The one-shot Complete can be starved by the Direct channel teardown after
+		// every block is acknowledged but before the recipient sees it. The receiver
+		// sends Done once it has settled, and a settled receiver ignores a duplicate
+		// Complete, so retransmitting it on a path change is safe. It is sent on a
+		// background goroutine: a relay connection may not have granted send credit
+		// yet, so this must not block TransportChanged (or the sender's Run) on it.
+		go func(complete *Complete) { _ = s.sendControl(complete) }(resendComplete)
 	}
 }
 

--- a/packages/wire/transfer_sender_cutover_test.go
+++ b/packages/wire/transfer_sender_cutover_test.go
@@ -1,0 +1,111 @@
+package wire
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestSenderRetransmitsCompleteOnCutover pins the terminal-frame recovery that a
+// direct→relay cutover depends on. The sender's Complete is a one-shot frame: it
+// is not acknowledged and, before this fix, had no retransmission on a path
+// change. If Complete is lost (queued into a data channel that is torn down at
+// the moment every block is acknowledged), the receiver never settles, never
+// sends Done, and the sender pins in waitDone until its DoneTimeout.
+//
+// The harness drops the first FrameComplete, then simulates the cutover by
+// calling TransportChanged once the sender has attempted Complete — exactly the
+// sequence the CLI driver performs when it switches a live transfer to the
+// relay. The sender must retransmit Complete on the new path so the receiver
+// settles and Done resolves.
+func TestSenderRetransmitsCompleteOnCutover(t *testing.T) {
+	data := testData(64_000, 41)
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := newFaultLink(faultScript{}.at(dirS2R, FrameComplete, fDrop), nil)
+	doneTimeout := 2 * time.Second // keep the no-fix failure fast
+	sink := &MemorySink{}
+
+	sender := NewSender(SenderOptions{
+		File:        BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:        func(f []byte) error { return link.send(dirS2R, f) },
+		SendDir:     keys.O2J,
+		RecvDir:     keys.J2O,
+		BlockSize:   1024,
+		FrameSize:   256,
+		Window:      4,
+		AckTimeout:  250 * time.Millisecond,
+		MaxRetries:  5,
+		DoneTimeout: doneTimeout,
+	})
+	receiver := NewReceiver(ReceiverOptions{
+		Send:    func(f []byte) error { return link.send(dirR2S, f) },
+		SendDir: keys.J2O,
+		RecvDir: keys.O2J,
+		Sink:    sink,
+	})
+
+	go func() {
+		for {
+			if link.isClosed() {
+				return
+			}
+			f, ok := <-link.s2r
+			if !ok {
+				return
+			}
+			receiver.Handle(f)
+		}
+	}()
+	go func() {
+		for {
+			if link.isClosed() {
+				return
+			}
+			f, ok := <-link.r2s
+			if !ok {
+				return
+			}
+			sender.Handle(f)
+		}
+	}()
+
+	// Once the sender has attempted Complete (its only terminal frame), simulate
+	// the cutover by telling it the path changed. With the fix it retransmits
+	// Complete; without it the receiver never settles and waitDone times out.
+	go func() {
+		for !link.completeSeen() && !link.isClosed() {
+			time.Sleep(2 * time.Millisecond)
+		}
+		sender.TransportChanged()
+	}()
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	runErrCh := make(chan error, 1)
+	go func() {
+		_, e := sender.Run(runCtx)
+		runErrCh <- e
+	}()
+	recvRes, recvErr := receiver.Wait(runCtx)
+	var runErr error
+	select {
+	case runErr = <-runErrCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sender.Run did not return; Complete retransmission missing")
+	}
+	if runErr != nil {
+		t.Fatalf("sender: %v", runErr)
+	}
+	if recvErr != nil {
+		t.Fatalf("receiver: %v", recvErr)
+	}
+	if string(sink.Bytes()) != string(data) {
+		t.Fatal("received bytes differ from source after Complete retransmission")
+	}
+	if recvRes.Digest == "" {
+		t.Fatal("receiver did not produce a digest")
+	}
+}


### PR DESCRIPTION
Post-v1.1 stabilization and cleanup found during final review of the fuzzing and fault-injection PRs.

- Sender retransmits the one-shot Complete on a transport change (asynchronously, so it never blocks the sender's Run on relay credit), fixing a cutover where the terminal frame is starved by the Direct channel teardown after every block is acknowledged. Includes a deterministic regression test that drops FrameComplete and verifies recovery.
- Seeded FuzzOpenSequenced with a genuinely valid Seal-generated frame so mutations explore the successful open path; aligned the frame-header fuzz and protocol-corpus test comments/assertions with the actual decoder contract.
- Removed roadmap item IDs from source and test comments where they carry no technical value.
- Fixed the browser orchestrator's generation guards: the generation is now captured at session start instead of inside each callback, so stale callbacks after cancel/finish/fail are actually rejected. Added regression tests covering state mutation, transport switching, frame sending, double promise settling, and terminated-resource access.