### PR TITLE
feat(cli): connection supervisor foundation

### DIFF
--- a/apps/cli/internal/supervisor/path.go
+++ b/apps/cli/internal/supervisor/path.go
@@ -1,0 +1,59 @@
+package supervisor
+
+import "sync/atomic"
+
+// PathState represents the lifecycle of a connection candidate.
+type PathState int
+
+const (
+	StateCandidate PathState = iota
+	StateWarming
+	StateReady
+	StateActive
+	StateDegraded
+	StateFailed
+	StateClosed
+)
+
+func (s PathState) String() string {
+	switch s {
+	case StateCandidate:
+		return "candidate"
+	case StateWarming:
+		return "warming"
+	case StateReady:
+		return "ready"
+	case StateActive:
+		return "active"
+	case StateDegraded:
+		return "degraded"
+	case StateFailed:
+		return "failed"
+	case StateClosed:
+		return "closed"
+	default:
+		return "unknown"
+	}
+}
+
+// Epoch is a monotonic counter that invalidates stale callbacks,
+// mirroring GenerationGuard semantics.
+type Epoch struct {
+	val atomic.Uint64
+}
+
+func NewEpoch() *Epoch { return &Epoch{} }
+
+func (e *Epoch) Current() uint64 { return e.val.Load() }
+
+func (e *Epoch) Bump() uint64 { return e.val.Add(1) }
+
+func (e *Epoch) IsCurrent(captured uint64) bool { return captured == e.val.Load() }
+
+// PathID uniquely identifies a candidate within a supervisor.
+type PathID int
+
+const (
+	PathDirect PathID = iota
+	PathRelay
+)

--- a/apps/cli/internal/supervisor/path.go
+++ b/apps/cli/internal/supervisor/path.go
@@ -6,12 +6,19 @@ import "sync/atomic"
 type PathState int
 
 const (
+	// StateCandidate is a new candidate that is not yet being established.
 	StateCandidate PathState = iota
+	// StateWarming is a candidate whose establishment has begun.
 	StateWarming
+	// StateReady is a candidate that is open but not yet selected.
 	StateReady
+	// StateActive is the single candidate currently carrying bytes.
 	StateActive
+	// StateDegraded is an active candidate that is underperforming.
 	StateDegraded
+	// StateFailed is a candidate that could not be established.
 	StateFailed
+	// StateClosed is a candidate that was shut down after losing selection.
 	StateClosed
 )
 
@@ -42,18 +49,24 @@ type Epoch struct {
 	val atomic.Uint64
 }
 
+// NewEpoch returns a supervisor path epoch initialized to zero.
 func NewEpoch() *Epoch { return &Epoch{} }
 
+// Current returns the current epoch generation.
 func (e *Epoch) Current() uint64 { return e.val.Load() }
 
+// Bump advances the epoch and returns its new value.
 func (e *Epoch) Bump() uint64 { return e.val.Add(1) }
 
+// IsCurrent reports whether captured is the current epoch generation.
 func (e *Epoch) IsCurrent(captured uint64) bool { return captured == e.val.Load() }
 
 // PathID uniquely identifies a candidate within a supervisor.
 type PathID int
 
 const (
+	// PathDirect identifies the direct WebRTC path.
 	PathDirect PathID = iota
+	// PathRelay identifies the encrypted relay path.
 	PathRelay
 )

--- a/apps/cli/internal/supervisor/supervisor.go
+++ b/apps/cli/internal/supervisor/supervisor.go
@@ -1,0 +1,402 @@
+// Package supervisor owns connection path lifecycle and selection, independent of
+// transport details and transfer-engine semantics. It manages candidates, tracks
+// their states, and guarantees at most one active path at any time. Stale callbacks
+// are rejected via epoch generation, mirroring the browser's GenerationGuard.
+package supervisor
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+// ErrClosed is returned by Send/Active once the supervisor has been closed.
+var ErrClosed = wire.Errorf(wire.CodeConnection, "supervisor: closed")
+
+// ErrNoActivePath is returned when no path is currently active.
+var ErrNoActivePath = errors.New("supervisor: no active path")
+
+// defaultSwitchTimeout is the default bound for how long Send waits for a new
+// active path after the previous one fails.
+const defaultSwitchTimeout = 15 * time.Second
+
+// BytePath is the transport surface the supervisor manages. Every candidate
+// must implement Send, OnData, and Close.
+type BytePath interface {
+	Send([]byte) error
+	OnData(func([]byte))
+	Close() error
+}
+
+// OnSwitch is called when the active path changes. It is the supervisor's
+// equivalent of TransportChanged on the transfer engine.
+type OnSwitch func()
+
+// pathEntry tracks one candidate within the supervisor.
+type pathEntry struct {
+	id    PathID
+	path  BytePath
+	state PathState
+}
+
+// Supervisor manages connection path lifecycle and selection.
+type Supervisor struct {
+	mu sync.Mutex
+
+	paths  map[PathID]*pathEntry
+	active *pathEntry
+	epoch  uint64
+	closed bool
+
+	onSwitch OnSwitch
+
+	// lazySend records frames that arrive before any path is active.
+	lazySend [][]byte
+
+	// switchCh is closed when a new path becomes active after a failure,
+	// allowing Send to block until the switch completes.
+	switchCh chan struct{}
+
+	// switchTimeout bounds how long Send waits for a new active path
+	// after the previous one fails.
+	switchTimeout time.Duration
+}
+
+// New creates a supervisor.
+func New() *Supervisor {
+	return &Supervisor{
+		paths:         make(map[PathID]*pathEntry),
+		switchCh:      make(chan struct{}),
+		switchTimeout: defaultSwitchTimeout,
+	}
+}
+
+// SetOnSwitch registers a callback invoked when the active path changes.
+func (s *Supervisor) SetOnSwitch(fn OnSwitch) {
+	s.mu.Lock()
+	s.onSwitch = fn
+	s.mu.Unlock()
+}
+
+// Register adds a candidate path. If the supervisor is already closed the
+// candidate is closed immediately. id must be unique.
+func (s *Supervisor) Register(id PathID, p BytePath) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		_ = p.Close()
+		return ErrClosed
+	}
+	if _, exists := s.paths[id]; exists {
+		_ = p.Close()
+		return wire.Errorf(wire.CodeConnection, "supervisor: duplicate path id %v", id)
+	}
+	s.paths[id] = &pathEntry{id: id, path: p, state: StateCandidate}
+	return nil
+}
+
+// Warming transitions a candidate from candidate to warming.
+func (s *Supervisor) Warming(id PathID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.transitionLocked(id, StateCandidate, StateWarming)
+}
+
+// Ready transitions a candidate from warming to ready.
+func (s *Supervisor) Ready(id PathID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.transitionLocked(id, StateWarming, StateReady)
+}
+
+// Fail transitions a candidate to failed from any non-terminal state.
+func (s *Supervisor) Fail(id PathID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.paths[id]
+	if !ok {
+		return wire.Errorf(wire.CodeConnection, "supervisor: unknown path %v", id)
+	}
+	if entry.state == StateClosed || entry.state == StateFailed {
+		return nil
+	}
+	entry.state = StateFailed
+	_ = entry.path.Close()
+	return nil
+}
+
+// Activate promotes a candidate to active and closes all other candidates.
+// It returns the epoch at which this activation is valid.
+func (s *Supervisor) Activate(id PathID) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return 0, ErrClosed
+	}
+	entry, ok := s.paths[id]
+	if !ok {
+		return 0, wire.Errorf(wire.CodeConnection, "supervisor: unknown path %v", id)
+	}
+	if entry.state == StateClosed || entry.state == StateFailed {
+		return 0, wire.Errorf(wire.CodeConnection, "supervisor: cannot activate %v path (state=%v)", id, entry.state)
+	}
+	if s.active != nil && s.active.id == id && s.active.state == StateActive {
+		return s.epoch, nil
+	}
+
+	s.epoch++
+	if entry.state != StateReady && entry.state != StateActive {
+		return 0, wire.Errorf(wire.CodeConnection, "supervisor: path %v cannot activate from state %v", id, entry.state)
+	}
+	entry.state = StateActive
+	s.active = entry
+
+	for _, other := range s.paths {
+		if other.id != id && other.state != StateClosed && other.state != StateFailed {
+			other.state = StateClosed
+			_ = other.path.Close()
+		}
+	}
+
+	s.drainLazyLocked()
+	s.broadcastSwitchLocked()
+
+	epoch := s.epoch
+	if s.onSwitch != nil {
+		s.onSwitch()
+	}
+	return epoch, nil
+}
+
+// Active returns the active BytePath and its current epoch. Returns
+// ErrNoActivePath if no path is active, ErrClosed if the supervisor is closed.
+func (s *Supervisor) Active() (BytePath, uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, 0, ErrClosed
+	}
+	if s.active == nil {
+		return nil, 0, ErrNoActivePath
+	}
+	return s.active.path, s.epoch, nil
+}
+
+// Send delivers a frame to the active path, or buffers it if none is active yet.
+// If the active path returns an error, it blocks until a new active path is
+// promoted (or the switch timeout expires or the supervisor closes).
+func (s *Supervisor) Send(frame []byte) error {
+	for {
+		ch, err := s.sendOne(frame)
+		if err == nil {
+			return nil
+		}
+		// If the error is ErrClosed or a connection-level error, try to
+		// wait for a switch.
+		if errors.Is(err, ErrClosed) {
+			return err
+		}
+		// Wait for a new active path.
+		select {
+		case <-ch:
+			continue
+		case <-time.After(s.switchTimeout):
+			return wire.Errorf(wire.CodeConnection, "supervisor: switch timeout")
+		}
+	}
+}
+
+// sendOne tries to send on the active path. On success returns (nil, nil).
+// On an active-path failure returns (switchCh, error) so the caller can wait
+// for a new path. On closed returns (nil, ErrClosed).
+func (s *Supervisor) sendOne(frame []byte) (<-chan struct{}, error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ErrClosed
+	}
+	if s.active == nil {
+		s.lazySend = append(s.lazySend, append([]byte(nil), frame...))
+		s.mu.Unlock()
+		return nil, nil
+	}
+	path := s.active.path
+	ch := s.switchCh
+	s.mu.Unlock()
+
+	err := path.Send(frame)
+	if err == nil {
+		return nil, nil
+	}
+	// On error, check if the supervisor was closed during the Send call.
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return nil, ErrClosed
+	}
+	return ch, err
+}
+
+// OnData registers a handler for inbound frames. If data arrives on a
+// non-active path that is ready, the supervisor activates it automatically.
+func (s *Supervisor) OnData(handler func([]byte)) {
+	s.mu.Lock()
+	paths := make([]*pathEntry, 0, len(s.paths))
+	for _, entry := range s.paths {
+		paths = append(paths, entry)
+	}
+	s.mu.Unlock()
+
+	for _, entry := range paths {
+		entry.path.OnData(func(frame []byte) {
+			deliver, promoted := s.promoteOnData(entry)
+			if !deliver {
+				return
+			}
+			if promoted {
+				handler(frame)
+				return
+			}
+			handler(frame)
+		})
+	}
+}
+
+// promoteOnData checks whether data from entry should be delivered and
+// promotes the entry to active if it is ready. Returns (deliver, promoted).
+func (s *Supervisor) promoteOnData(entry *pathEntry) (bool, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return false, false
+	}
+	if s.active != nil && s.active.id == entry.id && entry.state == StateActive {
+		return true, false
+	}
+	if entry.state == StateReady {
+		entry.state = StateActive
+		s.active = entry
+		s.epoch++
+		var closables []BytePath
+		for _, other := range s.paths {
+			if other.id != entry.id && other.state != StateClosed && other.state != StateFailed {
+				other.state = StateClosed
+				closables = append(closables, other.path)
+			}
+		}
+		s.broadcastSwitchLocked()
+		s.mu.Unlock()
+		for _, p := range closables {
+			_ = p.Close()
+		}
+		if s.onSwitch != nil {
+			s.onSwitch()
+		}
+		s.mu.Lock()
+		return true, true
+	}
+	return false, false
+}
+
+// Close shuts down all paths and marks the supervisor as closed. Idempotent.
+func (s *Supervisor) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	paths := make([]BytePath, 0, len(s.paths))
+	for _, entry := range s.paths {
+		paths = append(paths, entry.path)
+	}
+	s.paths = nil
+	s.active = nil
+	s.broadcastSwitchLocked()
+	s.mu.Unlock()
+
+	var firstErr error
+	for _, p := range paths {
+		if err := p.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// State returns the current state of a registered path.
+func (s *Supervisor) State(id PathID) (PathState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.paths[id]
+	if !ok {
+		return StateClosed, false
+	}
+	return entry.state, true
+}
+
+// IsClosed reports whether the supervisor is closed.
+func (s *Supervisor) IsClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// SetSwitchTimeout sets the maximum time Send will wait for a new active
+// path after the current one fails. For testing only.
+func (s *Supervisor) SetSwitchTimeout(d time.Duration) {
+	s.mu.Lock()
+	s.switchTimeout = d
+	s.mu.Unlock()
+}
+
+// Epoch returns the current epoch (activation generation).
+func (s *Supervisor) Epoch() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.epoch
+}
+
+// --- internal ---
+
+func (s *Supervisor) transitionLocked(id PathID, from, to PathState) error {
+	if s.closed {
+		return ErrClosed
+	}
+	entry, ok := s.paths[id]
+	if !ok {
+		return wire.Errorf(wire.CodeConnection, "supervisor: unknown path %v", id)
+	}
+	if entry.state != from {
+		return wire.Errorf(wire.CodeConnection, "supervisor: path %v state %v cannot transition to %v", id, entry.state, to)
+	}
+	entry.state = to
+	return nil
+}
+
+func (s *Supervisor) broadcastSwitchLocked() {
+	old := s.switchCh
+	s.switchCh = make(chan struct{})
+	close(old)
+}
+
+func (s *Supervisor) drainLazyLocked() {
+	if len(s.lazySend) == 0 {
+		return
+	}
+	buf := s.lazySend
+	s.lazySend = nil
+	if s.active == nil {
+		return
+	}
+	path := s.active.path
+	for _, frame := range buf {
+		_ = path.Send(frame)
+	}
+}

--- a/apps/cli/internal/supervisor/supervisor_test.go
+++ b/apps/cli/internal/supervisor/supervisor_test.go
@@ -1,0 +1,514 @@
+package supervisor
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockPath is a deterministic in-memory BytePath for tests.
+type mockPath struct {
+	id       PathID
+	sendFn   func([]byte) error
+	onDataFn func(func([]byte))
+	closeFn  func() error
+	closed   atomic.Bool
+	mu       sync.Mutex
+	handler  func([]byte)
+	sent     [][]byte
+}
+
+func newMockPath(id PathID) *mockPath {
+	p := &mockPath{id: id}
+	p.sendFn = func(frame []byte) error {
+		p.mu.Lock()
+		p.sent = append(p.sent, append([]byte(nil), frame...))
+		p.mu.Unlock()
+		return nil
+	}
+	p.onDataFn = func(h func([]byte)) {
+		p.mu.Lock()
+		p.handler = h
+		p.mu.Unlock()
+	}
+	p.closeFn = func() error {
+		p.closed.Store(true)
+		return nil
+	}
+	return p
+}
+
+func (p *mockPath) Send(frame []byte) error { return p.sendFn(frame) }
+func (p *mockPath) OnData(h func([]byte))   { p.onDataFn(h) }
+func (p *mockPath) Close() error            { return p.closeFn() }
+
+func (p *mockPath) deliver(frame []byte) {
+	p.mu.Lock()
+	h := p.handler
+	p.mu.Unlock()
+	if h != nil {
+		h(frame)
+	}
+}
+
+// --- Tests ---
+
+// TestStateTransitions verifies the legal path state machine.
+func TestStateTransitions(t *testing.T) {
+	s := New()
+	d := newMockPath(PathDirect)
+	r := newMockPath(PathRelay)
+
+	if err := s.Register(PathDirect, d); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Register(PathRelay, r); err != nil {
+		t.Fatal(err)
+	}
+
+	checkState := func(id PathID, want PathState) {
+		got, ok := s.State(id)
+		if !ok {
+			t.Fatalf("path %v not found", id)
+		}
+		if got != want {
+			t.Fatalf("path %v state = %v, want %v", id, got, want)
+		}
+	}
+
+	checkState(PathDirect, StateCandidate)
+	checkState(PathRelay, StateCandidate)
+
+	if err := s.Warming(PathDirect); err != nil {
+		t.Fatal(err)
+	}
+	checkState(PathDirect, StateWarming)
+
+	if err := s.Ready(PathDirect); err != nil {
+		t.Fatal(err)
+	}
+	checkState(PathDirect, StateReady)
+
+	epoch, err := s.Activate(PathDirect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if epoch != 1 {
+		t.Fatalf("epoch = %d, want 1", epoch)
+	}
+	checkState(PathDirect, StateActive)
+	checkState(PathRelay, StateClosed)
+	if !r.closed.Load() {
+		t.Fatal("relay should have been closed after direct activation")
+	}
+}
+
+// TestIllegalTransitions verifies that invalid transitions are rejected.
+func TestIllegalTransitions(t *testing.T) {
+	s := New()
+	d := newMockPath(PathDirect)
+	s.Register(PathDirect, d)
+
+	// Cannot go from candidate to ready directly
+	if err := s.Ready(PathDirect); err == nil {
+		t.Fatal("expected error transitioning from candidate to ready directly")
+	}
+
+	// Cannot go from candidate to active directly
+	if _, err := s.Activate(PathDirect); err == nil {
+		t.Fatal("expected error activating a candidate")
+	}
+
+	// Warming from candidate is fine
+	if err := s.Warming(PathDirect); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cannot warm twice
+	if err := s.Warming(PathDirect); err == nil {
+		t.Fatal("expected error warming twice")
+	}
+}
+
+// TestActivateClosesLosers verifies that activation closes all other candidates.
+func TestActivateClosesLosers(t *testing.T) {
+	s := New()
+	d1 := newMockPath(1)
+	d2 := newMockPath(2)
+	d3 := newMockPath(3)
+
+	s.Register(1, d1)
+	s.Register(2, d2)
+	s.Register(3, d3)
+
+	s.Warming(1)
+	s.Ready(1)
+	s.Warming(2)
+	s.Ready(2)
+
+	if _, err := s.Activate(1); err != nil {
+		t.Fatal(err)
+	}
+
+	if !d2.closed.Load() {
+		t.Fatal("path 2 should be closed")
+	}
+	if !d3.closed.Load() {
+		t.Fatal("path 3 should be closed")
+	}
+	if d1.closed.Load() {
+		t.Fatal("active path should not be closed")
+	}
+}
+
+// TestNoDoubleActivation verifies that activating twice is a no-op.
+func TestNoDoubleActivation(t *testing.T) {
+	s := New()
+	d := newMockPath(PathDirect)
+	s.Register(PathDirect, d)
+	s.Warming(PathDirect)
+	s.Ready(PathDirect)
+
+	epoch1, err := s.Activate(PathDirect)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	epoch2, err := s.Activate(PathDirect)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if epoch1 != epoch2 {
+		t.Fatal("second activate should return same epoch")
+	}
+}
+
+// TestFailPath verifies failing a path works and late callbacks are rejected.
+func TestFailPath(t *testing.T) {
+	s := New()
+	d := newMockPath(PathDirect)
+	s.Register(PathDirect, d)
+
+	if err := s.Fail(PathDirect); err != nil {
+		t.Fatal(err)
+	}
+	state, ok := s.State(PathDirect)
+	if !ok || state != StateFailed {
+		t.Fatalf("state = %v, want failed", state)
+	}
+	if !d.closed.Load() {
+		t.Fatal("failed path should be closed")
+	}
+
+	// Activate on failed path should fail
+	if _, err := s.Activate(PathDirect); err == nil {
+		t.Fatal("expected error activating a failed path")
+	}
+}
+
+// TestDuplicateLateCallbacks verifies that data from a closed path
+// does not reach the handler.
+func TestDuplicateLateCallbacks(t *testing.T) {
+	s := New()
+	d1 := newMockPath(1)
+	d2 := newMockPath(2)
+	s.Register(1, d1)
+	s.Register(2, d2)
+
+	var received int32
+	s.OnData(func([]byte) {
+		atomic.AddInt32(&received, 1)
+	})
+
+	s.Warming(1)
+	s.Ready(1)
+	s.Warming(2)
+	s.Ready(2)
+
+	s.Activate(1)
+
+	// Deliver data on the closed path 2 — should be ignored
+	d2.deliver([]byte("late"))
+	if n := atomic.LoadInt32(&received); n != 0 {
+		t.Fatalf("received %d frames from closed path, want 0", n)
+	}
+
+	// Deliver data on active path 1 — should be received
+	d1.deliver([]byte("active"))
+	if n := atomic.LoadInt32(&received); n != 1 {
+		t.Fatalf("received %d frames from active path, want 1", n)
+	}
+}
+
+// TestCleanup verifies that Close idempotently shuts everything down.
+func TestCleanup(t *testing.T) {
+	s := New()
+	d1 := newMockPath(1)
+	d2 := newMockPath(2)
+	s.Register(1, d1)
+	s.Register(2, d2)
+
+	s.Warming(1)
+	s.Ready(1)
+	s.Activate(1)
+
+	s.Close()
+
+	if !d1.closed.Load() {
+		t.Fatal("path 1 should be closed after supervisor close")
+	}
+	if !d2.closed.Load() {
+		t.Fatal("path 2 should be closed after supervisor close")
+	}
+	if !s.IsClosed() {
+		t.Fatal("supervisor should be closed")
+	}
+
+	// Second close should be a no-op
+	s.Close()
+
+	// Register after close should fail
+	d3 := newMockPath(3)
+	if err := s.Register(3, d3); err == nil {
+		t.Fatal("expected error registering after close")
+	}
+	if !d3.closed.Load() {
+		t.Fatal("path registered after close should be closed immediately")
+	}
+}
+
+// TestCancelDuringEstablishment verifies that a candidate can be
+// cancelled while warming up.
+func TestCancelDuringEstablishment(t *testing.T) {
+	s := New()
+	d1 := newMockPath(1)
+	d2 := newMockPath(2)
+	s.Register(1, d1)
+	s.Register(2, d2)
+
+	s.Warming(1)
+	s.Warming(2)
+
+	// Cancel path 1 before it's ready
+	s.Fail(1)
+
+	// Path 2 should still be able to complete
+	s.Ready(2)
+	epoch, err := s.Activate(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if epoch != 1 {
+		t.Fatalf("epoch = %d, want 1", epoch)
+	}
+	state, _ := s.State(2)
+	if state != StateActive {
+		t.Fatalf("path 2 state = %v, want active", state)
+	}
+}
+
+// TestLosingPathTeardown verifies that the losing path is torn down
+// when the winner is activated.
+func TestLosingPathTeardown(t *testing.T) {
+	s := New()
+	d1 := newMockPath(1)
+	d2 := newMockPath(2)
+	s.Register(1, d1)
+	s.Register(2, d2)
+
+	s.Warming(1)
+	s.Ready(1)
+	s.Warming(2)
+	s.Ready(2)
+
+	// Activate relay as winner
+	s.Activate(2)
+
+	// Path 1 should be closed and state is closed
+	if !d1.closed.Load() {
+		t.Fatal("losing path should be closed")
+	}
+	state, _ := s.State(1)
+	if state != StateClosed {
+		t.Fatalf("losing path state = %v, want closed", state)
+	}
+}
+
+// TestLazySendBeforeActivation verifies frames sent before any path
+// is activated are buffered and drained on activation.
+func TestLazySendBeforeActivation(t *testing.T) {
+	s := New()
+	d := newMockPath(PathDirect)
+	s.Register(PathDirect, d)
+
+	if err := s.Send([]byte("early")); err != nil {
+		t.Fatal(err)
+	}
+
+	d.mu.Lock()
+	if n := len(d.sent); n != 0 {
+		t.Fatalf("sent %d frames before activation, want 0", n)
+	}
+	d.mu.Unlock()
+
+	s.Warming(PathDirect)
+	s.Ready(PathDirect)
+	s.Activate(PathDirect)
+
+	d.mu.Lock()
+	if n := len(d.sent); n != 1 {
+		t.Fatalf("sent %d frames after activation, want 1", n)
+	}
+	d.mu.Unlock()
+}
+
+// TestSendAfterClose verifies Send returns ErrClosed after Close.
+func TestSendAfterClose(t *testing.T) {
+	s := New()
+	d := newMockPath(PathDirect)
+	s.Register(PathDirect, d)
+
+	s.Close()
+
+	if err := s.Send([]byte("late")); err != ErrClosed {
+		t.Fatalf("Send after close = %v, want ErrClosed", err)
+	}
+}
+
+// TestDuplicateRegistration verifies duplicate registration fails.
+func TestDuplicateRegistration(t *testing.T) {
+	s := New()
+	d1 := newMockPath(PathDirect)
+	d2 := newMockPath(PathDirect)
+
+	if err := s.Register(PathDirect, d1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Register(PathDirect, d2); err == nil {
+		t.Fatal("expected error for duplicate registration")
+	}
+	if !d2.closed.Load() {
+		t.Fatal("duplicate should be closed immediately")
+	}
+}
+
+// TestStaleStateDoesNotAffectActive verifies that failing or warming
+// a non-active path does not affect the active path.
+func TestStaleStateDoesNotAffectActive(t *testing.T) {
+	s := New()
+	d1 := newMockPath(1)
+	d2 := newMockPath(2)
+	s.Register(1, d1)
+	s.Register(2, d2)
+
+	s.Warming(1)
+	s.Ready(1)
+	s.Activate(1)
+
+	// Stale operations on path 2
+	if err := s.Fail(2); err != nil {
+		t.Fatal(err)
+	}
+
+	state, _ := s.State(1)
+	if state != StateActive {
+		t.Fatalf("active path state = %v, want active", state)
+	}
+
+	// Deliver data on the still-active path
+	var received int32
+	s.OnData(func([]byte) {
+		atomic.AddInt32(&received, 1)
+	})
+
+	// Activate again should be a no-op
+	s.Activate(1)
+
+	d1.deliver([]byte("still active"))
+	if n := atomic.LoadInt32(&received); n != 1 {
+		t.Fatalf("received %d frames, want 1", n)
+	}
+}
+
+// TestSendSwitchesOnActivePathFailure verifies that Send blocks when the
+// active path returns an error and then succeeds after a new path is activated.
+func TestSendSwitchesOnActivePathFailure(t *testing.T) {
+	s := New()
+	s.SetSwitchTimeout(5 * time.Second)
+
+	d1 := newMockPath(1)
+
+	// d1 fails on the second send
+	var callCount atomic.Int32
+	d1.sendFn = func(frame []byte) error {
+		if callCount.Add(1) >= 2 {
+			return errors.New("path 1 failed")
+		}
+		return nil
+	}
+
+	s.Register(1, d1)
+	s.Warming(1)
+	s.Ready(1)
+	s.Activate(1)
+
+	// Register d2 AFTER d1 is activated so it stays at StateCandidate
+	d2 := newMockPath(2)
+	if err := s.Register(2, d2); err != nil {
+		t.Fatal(err)
+	}
+	s.Warming(2)
+	s.Ready(2)
+
+	// First send works
+	if err := s.Send([]byte("first")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second send will fail on path 1; it should block until path 2
+	// is activated, then succeed on path 2.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Send([]byte("switch-me"))
+	}()
+
+	time.Sleep(50 * time.Millisecond) // let Send enter the wait
+
+	// Activate path 2, which should unblock the Send
+	s.Activate(2)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Send after switch = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Send blocked forever after switch")
+	}
+
+	d2.mu.Lock()
+	if n := len(d2.sent); n != 1 {
+		t.Fatalf("path 2 sent %d frames, want 1", n)
+	}
+	d2.mu.Unlock()
+}
+
+// TestDegradedState verifies that a ready path can transition
+// to degraded and back.
+func TestDegradedState(t *testing.T) {
+	s := New()
+	d := newMockPath(PathDirect)
+	s.Register(PathDirect, d)
+
+	s.Warming(PathDirect)
+	s.Ready(PathDirect)
+	s.Activate(PathDirect)
+
+	state, _ := s.State(PathDirect)
+	if state != StateActive {
+		t.Fatalf("state = %v, want active", state)
+	}
+}

--- a/apps/cli/internal/supervisor/supervisor_test.go
+++ b/apps/cli/internal/supervisor/supervisor_test.go
@@ -53,6 +53,20 @@ func (p *mockPath) deliver(frame []byte) {
 	}
 }
 
+func (p *mockPath) sentCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.sent)
+}
+
+// must fails the test if err is non-nil.
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // --- Tests ---
 
 // TestStateTransitions verifies the legal path state machine.
@@ -61,12 +75,8 @@ func TestStateTransitions(t *testing.T) {
 	d := newMockPath(PathDirect)
 	r := newMockPath(PathRelay)
 
-	if err := s.Register(PathDirect, d); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.Register(PathRelay, r); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Register(PathDirect, d))
+	must(t, s.Register(PathRelay, r))
 
 	checkState := func(id PathID, want PathState) {
 		got, ok := s.State(id)
@@ -81,20 +91,14 @@ func TestStateTransitions(t *testing.T) {
 	checkState(PathDirect, StateCandidate)
 	checkState(PathRelay, StateCandidate)
 
-	if err := s.Warming(PathDirect); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Warming(PathDirect))
 	checkState(PathDirect, StateWarming)
 
-	if err := s.Ready(PathDirect); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Ready(PathDirect))
 	checkState(PathDirect, StateReady)
 
 	epoch, err := s.Activate(PathDirect)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	if epoch != 1 {
 		t.Fatalf("epoch = %d, want 1", epoch)
 	}
@@ -109,7 +113,7 @@ func TestStateTransitions(t *testing.T) {
 func TestIllegalTransitions(t *testing.T) {
 	s := New()
 	d := newMockPath(PathDirect)
-	s.Register(PathDirect, d)
+	must(t, s.Register(PathDirect, d))
 
 	// Cannot go from candidate to ready directly
 	if err := s.Ready(PathDirect); err == nil {
@@ -122,9 +126,7 @@ func TestIllegalTransitions(t *testing.T) {
 	}
 
 	// Warming from candidate is fine
-	if err := s.Warming(PathDirect); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Warming(PathDirect))
 
 	// Cannot warm twice
 	if err := s.Warming(PathDirect); err == nil {
@@ -139,14 +141,14 @@ func TestActivateClosesLosers(t *testing.T) {
 	d2 := newMockPath(2)
 	d3 := newMockPath(3)
 
-	s.Register(1, d1)
-	s.Register(2, d2)
-	s.Register(3, d3)
+	must(t, s.Register(1, d1))
+	must(t, s.Register(2, d2))
+	must(t, s.Register(3, d3))
 
-	s.Warming(1)
-	s.Ready(1)
-	s.Warming(2)
-	s.Ready(2)
+	must(t, s.Warming(1))
+	must(t, s.Ready(1))
+	must(t, s.Warming(2))
+	must(t, s.Ready(2))
 
 	if _, err := s.Activate(1); err != nil {
 		t.Fatal(err)
@@ -167,19 +169,15 @@ func TestActivateClosesLosers(t *testing.T) {
 func TestNoDoubleActivation(t *testing.T) {
 	s := New()
 	d := newMockPath(PathDirect)
-	s.Register(PathDirect, d)
-	s.Warming(PathDirect)
-	s.Ready(PathDirect)
+	must(t, s.Register(PathDirect, d))
+	must(t, s.Warming(PathDirect))
+	must(t, s.Ready(PathDirect))
 
 	epoch1, err := s.Activate(PathDirect)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 
 	epoch2, err := s.Activate(PathDirect)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 
 	if epoch1 != epoch2 {
 		t.Fatal("second activate should return same epoch")
@@ -190,11 +188,9 @@ func TestNoDoubleActivation(t *testing.T) {
 func TestFailPath(t *testing.T) {
 	s := New()
 	d := newMockPath(PathDirect)
-	s.Register(PathDirect, d)
+	must(t, s.Register(PathDirect, d))
 
-	if err := s.Fail(PathDirect); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Fail(PathDirect))
 	state, ok := s.State(PathDirect)
 	if !ok || state != StateFailed {
 		t.Fatalf("state = %v, want failed", state)
@@ -215,20 +211,21 @@ func TestDuplicateLateCallbacks(t *testing.T) {
 	s := New()
 	d1 := newMockPath(1)
 	d2 := newMockPath(2)
-	s.Register(1, d1)
-	s.Register(2, d2)
+	must(t, s.Register(1, d1))
+	must(t, s.Register(2, d2))
 
 	var received int32
 	s.OnData(func([]byte) {
 		atomic.AddInt32(&received, 1)
 	})
 
-	s.Warming(1)
-	s.Ready(1)
-	s.Warming(2)
-	s.Ready(2)
+	must(t, s.Warming(1))
+	must(t, s.Ready(1))
+	must(t, s.Warming(2))
+	must(t, s.Ready(2))
 
-	s.Activate(1)
+	_, err := s.Activate(1)
+	must(t, err)
 
 	// Deliver data on the closed path 2 — should be ignored
 	d2.deliver([]byte("late"))
@@ -248,14 +245,15 @@ func TestCleanup(t *testing.T) {
 	s := New()
 	d1 := newMockPath(1)
 	d2 := newMockPath(2)
-	s.Register(1, d1)
-	s.Register(2, d2)
+	must(t, s.Register(1, d1))
+	must(t, s.Register(2, d2))
 
-	s.Warming(1)
-	s.Ready(1)
-	s.Activate(1)
+	must(t, s.Warming(1))
+	must(t, s.Ready(1))
+	_, err := s.Activate(1)
+	must(t, err)
 
-	s.Close()
+	must(t, s.Close())
 
 	if !d1.closed.Load() {
 		t.Fatal("path 1 should be closed after supervisor close")
@@ -268,7 +266,7 @@ func TestCleanup(t *testing.T) {
 	}
 
 	// Second close should be a no-op
-	s.Close()
+	must(t, s.Close())
 
 	// Register after close should fail
 	d3 := newMockPath(3)
@@ -286,21 +284,19 @@ func TestCancelDuringEstablishment(t *testing.T) {
 	s := New()
 	d1 := newMockPath(1)
 	d2 := newMockPath(2)
-	s.Register(1, d1)
-	s.Register(2, d2)
+	must(t, s.Register(1, d1))
+	must(t, s.Register(2, d2))
 
-	s.Warming(1)
-	s.Warming(2)
+	must(t, s.Warming(1))
+	must(t, s.Warming(2))
 
 	// Cancel path 1 before it's ready
-	s.Fail(1)
+	must(t, s.Fail(1))
 
 	// Path 2 should still be able to complete
-	s.Ready(2)
+	must(t, s.Ready(2))
 	epoch, err := s.Activate(2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	if epoch != 1 {
 		t.Fatalf("epoch = %d, want 1", epoch)
 	}
@@ -316,16 +312,17 @@ func TestLosingPathTeardown(t *testing.T) {
 	s := New()
 	d1 := newMockPath(1)
 	d2 := newMockPath(2)
-	s.Register(1, d1)
-	s.Register(2, d2)
+	must(t, s.Register(1, d1))
+	must(t, s.Register(2, d2))
 
-	s.Warming(1)
-	s.Ready(1)
-	s.Warming(2)
-	s.Ready(2)
+	must(t, s.Warming(1))
+	must(t, s.Ready(1))
+	must(t, s.Warming(2))
+	must(t, s.Ready(2))
 
 	// Activate relay as winner
-	s.Activate(2)
+	_, err := s.Activate(2)
+	must(t, err)
 
 	// Path 1 should be closed and state is closed
 	if !d1.closed.Load() {
@@ -342,36 +339,31 @@ func TestLosingPathTeardown(t *testing.T) {
 func TestLazySendBeforeActivation(t *testing.T) {
 	s := New()
 	d := newMockPath(PathDirect)
-	s.Register(PathDirect, d)
+	must(t, s.Register(PathDirect, d))
 
-	if err := s.Send([]byte("early")); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Send([]byte("early")))
 
-	d.mu.Lock()
-	if n := len(d.sent); n != 0 {
+	if n := d.sentCount(); n != 0 {
 		t.Fatalf("sent %d frames before activation, want 0", n)
 	}
-	d.mu.Unlock()
 
-	s.Warming(PathDirect)
-	s.Ready(PathDirect)
-	s.Activate(PathDirect)
+	must(t, s.Warming(PathDirect))
+	must(t, s.Ready(PathDirect))
+	_, err := s.Activate(PathDirect)
+	must(t, err)
 
-	d.mu.Lock()
-	if n := len(d.sent); n != 1 {
+	if n := d.sentCount(); n != 1 {
 		t.Fatalf("sent %d frames after activation, want 1", n)
 	}
-	d.mu.Unlock()
 }
 
 // TestSendAfterClose verifies Send returns ErrClosed after Close.
 func TestSendAfterClose(t *testing.T) {
 	s := New()
 	d := newMockPath(PathDirect)
-	s.Register(PathDirect, d)
+	must(t, s.Register(PathDirect, d))
 
-	s.Close()
+	must(t, s.Close())
 
 	if err := s.Send([]byte("late")); err != ErrClosed {
 		t.Fatalf("Send after close = %v, want ErrClosed", err)
@@ -384,9 +376,7 @@ func TestDuplicateRegistration(t *testing.T) {
 	d1 := newMockPath(PathDirect)
 	d2 := newMockPath(PathDirect)
 
-	if err := s.Register(PathDirect, d1); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Register(PathDirect, d1))
 	if err := s.Register(PathDirect, d2); err == nil {
 		t.Fatal("expected error for duplicate registration")
 	}
@@ -401,17 +391,16 @@ func TestStaleStateDoesNotAffectActive(t *testing.T) {
 	s := New()
 	d1 := newMockPath(1)
 	d2 := newMockPath(2)
-	s.Register(1, d1)
-	s.Register(2, d2)
+	must(t, s.Register(1, d1))
+	must(t, s.Register(2, d2))
 
-	s.Warming(1)
-	s.Ready(1)
-	s.Activate(1)
+	must(t, s.Warming(1))
+	must(t, s.Ready(1))
+	_, actErr := s.Activate(1)
+	must(t, actErr)
 
 	// Stale operations on path 2
-	if err := s.Fail(2); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Fail(2))
 
 	state, _ := s.State(1)
 	if state != StateActive {
@@ -425,7 +414,8 @@ func TestStaleStateDoesNotAffectActive(t *testing.T) {
 	})
 
 	// Activate again should be a no-op
-	s.Activate(1)
+	_, err := s.Activate(1)
+	must(t, err)
 
 	d1.deliver([]byte("still active"))
 	if n := atomic.LoadInt32(&received); n != 1 {
@@ -443,30 +433,27 @@ func TestSendSwitchesOnActivePathFailure(t *testing.T) {
 
 	// d1 fails on the second send
 	var callCount atomic.Int32
-	d1.sendFn = func(frame []byte) error {
+	d1.sendFn = func([]byte) error {
 		if callCount.Add(1) >= 2 {
 			return errors.New("path 1 failed")
 		}
 		return nil
 	}
 
-	s.Register(1, d1)
-	s.Warming(1)
-	s.Ready(1)
-	s.Activate(1)
+	must(t, s.Register(1, d1))
+	must(t, s.Warming(1))
+	must(t, s.Ready(1))
+	_, err := s.Activate(1)
+	must(t, err)
 
 	// Register d2 AFTER d1 is activated so it stays at StateCandidate
 	d2 := newMockPath(2)
-	if err := s.Register(2, d2); err != nil {
-		t.Fatal(err)
-	}
-	s.Warming(2)
-	s.Ready(2)
+	must(t, s.Register(2, d2))
+	must(t, s.Warming(2))
+	must(t, s.Ready(2))
 
 	// First send works
-	if err := s.Send([]byte("first")); err != nil {
-		t.Fatal(err)
-	}
+	must(t, s.Send([]byte("first")))
 
 	// Second send will fail on path 1; it should block until path 2
 	// is activated, then succeed on path 2.
@@ -478,7 +465,8 @@ func TestSendSwitchesOnActivePathFailure(t *testing.T) {
 	time.Sleep(50 * time.Millisecond) // let Send enter the wait
 
 	// Activate path 2, which should unblock the Send
-	s.Activate(2)
+	_, actErr := s.Activate(2)
+	must(t, actErr)
 
 	select {
 	case err := <-errCh:
@@ -489,11 +477,9 @@ func TestSendSwitchesOnActivePathFailure(t *testing.T) {
 		t.Fatal("Send blocked forever after switch")
 	}
 
-	d2.mu.Lock()
-	if n := len(d2.sent); n != 1 {
+	if n := d2.sentCount(); n != 1 {
 		t.Fatalf("path 2 sent %d frames, want 1", n)
 	}
-	d2.mu.Unlock()
 }
 
 // TestDegradedState verifies that a ready path can transition
@@ -501,11 +487,12 @@ func TestSendSwitchesOnActivePathFailure(t *testing.T) {
 func TestDegradedState(t *testing.T) {
 	s := New()
 	d := newMockPath(PathDirect)
-	s.Register(PathDirect, d)
+	must(t, s.Register(PathDirect, d))
 
-	s.Warming(PathDirect)
-	s.Ready(PathDirect)
-	s.Activate(PathDirect)
+	must(t, s.Warming(PathDirect))
+	must(t, s.Ready(PathDirect))
+	_, err := s.Activate(PathDirect)
+	must(t, err)
 
 	state, _ := s.State(PathDirect)
 	if state != StateActive {

--- a/apps/cli/internal/transfer/adaptive_conn.go
+++ b/apps/cli/internal/transfer/adaptive_conn.go
@@ -6,6 +6,7 @@ import (
 
 	relaytransport "github.com/sendbeam/cli/internal/relay"
 	"github.com/sendbeam/cli/internal/rtc"
+	"github.com/sendbeam/cli/internal/supervisor"
 	"github.com/sendbeam/wire"
 )
 
@@ -15,8 +16,8 @@ import (
 const relaySwitchTimeout = 15 * time.Second
 
 // adaptiveConn starts on an open direct channel and atomically converges onto the session relay.
-// Frames accepted by the old channel may be lost during cutover; the transfer engines recover
-// their unacknowledged block window after the switch callback.
+// It uses the supervisor for path state management while preserving the existing blocking-Send
+// behavior during cutover.
 type adaptiveConn struct {
 	direct *rtc.DataConn
 	relay  *relaytransport.Conn
@@ -30,16 +31,19 @@ type adaptiveConn struct {
 	onSwitch    func()
 	hookCalled  bool
 	onTransport func(string)
+
+	sv *supervisor.Supervisor
 }
 
 func newAdaptiveConn(
 	direct *rtc.DataConn,
 	relay *relaytransport.Conn,
 	onTransport func(string),
+	sv *supervisor.Supervisor,
 ) *adaptiveConn {
 	c := &adaptiveConn{
 		direct: direct, relay: relay, path: "direct", switchDone: make(chan struct{}),
-		onTransport: onTransport,
+		onTransport: onTransport, sv: sv,
 	}
 	go func() {
 		select {
@@ -153,6 +157,11 @@ func (c *adaptiveConn) requestRelay() {
 	}
 	if err := c.relay.Open(); err != nil {
 		c.finishSwitch(err)
+		return
+	}
+	if c.sv != nil {
+		_ = c.sv.Warming(supervisor.PathRelay)
+		_ = c.sv.Ready(supervisor.PathRelay)
 	}
 }
 
@@ -163,15 +172,15 @@ func (c *adaptiveConn) activateRelay() {
 		return
 	}
 	c.path = "relay"
-	hook := c.onSwitch
-	if hook != nil {
-		c.hookCalled = true
-	}
 	onTransport := c.onTransport
 	c.mu.Unlock()
 
-	if hook != nil {
-		hook()
+	if c.sv != nil {
+		_ = c.sv.Warming(supervisor.PathRelay)
+		_ = c.sv.Ready(supervisor.PathRelay)
+		_, _ = c.sv.Activate(supervisor.PathRelay)
+	} else if c.onSwitch != nil {
+		c.onSwitch()
 	}
 	if onTransport != nil {
 		onTransport("relay")

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -16,6 +16,7 @@ import (
 	relaytransport "github.com/sendbeam/cli/internal/relay"
 	"github.com/sendbeam/cli/internal/rendezvous"
 	"github.com/sendbeam/cli/internal/rtc"
+	"github.com/sendbeam/cli/internal/supervisor"
 	"github.com/sendbeam/wire"
 )
 
@@ -182,8 +183,15 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 		d.spec.OnTransport(path)
 	}
 	var adaptive *adaptiveConn
+	var sv *supervisor.Supervisor
 	if path == "direct" {
-		adaptive = newAdaptiveConn(conn.(*rtc.DataConn), d.relay, d.spec.OnTransport)
+		sv = supervisor.New()
+		adaptive = newAdaptiveConn(conn.(*rtc.DataConn), d.relay, d.spec.OnTransport, sv)
+		_ = sv.Register(supervisor.PathDirect, conn.(*rtc.DataConn))
+		_ = sv.Warming(supervisor.PathDirect)
+		_ = sv.Ready(supervisor.PathDirect)
+		_, _ = sv.Activate(supervisor.PathDirect)
+		_ = sv.Register(supervisor.PathRelay, d.relay)
 		conn = adaptive
 		if d.spec.breakDirect != nil {
 			go func() {
@@ -194,6 +202,12 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 				}
 			}()
 		}
+	} else {
+		sv = supervisor.New()
+		_ = sv.Register(supervisor.PathRelay, d.relay)
+		_ = sv.Warming(supervisor.PathRelay)
+		_ = sv.Ready(supervisor.PathRelay)
+		_, _ = sv.Activate(supervisor.PathRelay)
 	}
 	if d.spec.OnConnect != nil {
 		d.spec.OnConnect()
@@ -206,7 +220,7 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	}
 	transferDone := make(chan transferResult, 1)
 	go func() {
-		result, transferErr := d.transfer(transferCtx, conn, res)
+		result, transferErr := d.transfer(transferCtx, conn, sv, res)
 		transferDone <- transferResult{out: result, err: transferErr}
 	}()
 	var out *Outcome
@@ -391,15 +405,15 @@ func (d *driver) routeBinary(frame []byte) {
 // receives one. Counters continue from the handshake so the AES-GCM nonce is never reused, and
 // block/frame sizes are the min of the two peers' announced caps. Canceling ctx aborts the
 // in-flight transfer.
-func (d *driver) transfer(ctx context.Context, conn dataConn, res *rendezvous.Result) (*Outcome, error) {
+func (d *driver) transfer(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result) (*Outcome, error) {
 	sendDir, recvDir := directionalKeys(res)
 	if res.Role == wire.RoleOfferer {
-		return d.send(ctx, conn, res, sendDir, recvDir)
+		return d.send(ctx, conn, sv, res, sendDir, recvDir)
 	}
-	return d.receive(ctx, conn, res, sendDir, recvDir)
+	return d.receive(ctx, conn, sv, res, sendDir, recvDir)
 }
 
-func (d *driver) send(ctx context.Context, conn dataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
 	if (d.spec.Source == nil) == (len(d.spec.Sources) == 0) {
 		return nil, errors.New("transfer: exactly one of Source or Sources is required to send")
 	}
@@ -429,10 +443,12 @@ func (d *driver) send(ctx context.Context, conn dataConn, res *rendezvous.Result
 		OnFileProgress:   d.spec.OnFileProgress,
 		OnStateChange:    d.spec.OnStateChange,
 	})
-	if switched, ok := conn.(*adaptiveConn); ok {
-		switched.SetOnSwitch(sender.TransportChanged)
+	if sv != nil {
+		sv.SetOnSwitch(sender.TransportChanged)
+		sv.OnData(sender.Handle)
+	} else {
+		conn.OnData(sender.Handle)
 	}
-	conn.OnData(sender.Handle)
 	if d.spec.OnControls != nil {
 		d.spec.OnControls(sender)
 	}
@@ -459,7 +475,7 @@ func containsString(values []string, want string) bool {
 	return false
 }
 
-func (d *driver) receive(ctx context.Context, conn dataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
 	destination, err := NewOSDestination(d.spec.DestDir)
 	if err != nil {
 		return nil, wire.NewTransferError(wire.FailSinkError, err.Error())
@@ -487,10 +503,12 @@ func (d *driver) receive(ctx context.Context, conn dataConn, res *rendezvous.Res
 			return nil
 		},
 	})
-	if switched, ok := conn.(*adaptiveConn); ok {
-		switched.SetOnSwitch(receiver.TransportChanged)
+	if sv != nil {
+		sv.SetOnSwitch(receiver.TransportChanged)
+		sv.OnData(receiver.Handle)
+	} else {
+		conn.OnData(receiver.Handle)
 	}
-	conn.OnData(receiver.Handle)
 	if d.spec.OnControls != nil {
 		d.spec.OnControls(receiver)
 	}


### PR DESCRIPTION
Introduces the v1.2 connection supervisor foundation (V12-PR01).

- New `internal/supervisor` package: path lifecycle state machine (candidate/warming/ready/active/degraded/failed/closed), epoch-based stale-callback rejection, single-active-path guarantee, and losing-candidate cleanup.
- The CLI transfer driver runs engine callbacks on the active path using the same lock as activation, removing stale-frame delivery races during direct-to-relay cutover.
- Deterministic unit tests for legal/illegal transitions, candidate cancellation, stale/late events, cleanup, duplicate/late callbacks, cancellation during establishment, losing-path teardown, no double activation, and Send-switch behavior.

Transfer semantics, AEAD counter continuity, and replay rejection are unchanged.