### PR TITLE
feat: ICE telemetry and runtime ICE configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ RUN pnpm --filter @sendbeam/protocol build && pnpm --filter @sendbeam/web build
 FROM golang:1.25-alpine AS server
 WORKDIR /src
 COPY apps/server/go.mod apps/server/go.sum ./apps/server/
+COPY packages/wire/go.mod packages/wire/go.sum ./packages/wire/
 RUN cd apps/server && go mod download
 COPY apps/server ./apps/server
+COPY packages/wire ./packages/wire
 RUN cd apps/server && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /sendbeamd ./cmd/sendbeamd
 
 # --- Stage 3: runtime --------------------------------------------------------------

--- a/apps/cli/cmd/sendbeam/ice.go
+++ b/apps/cli/cmd/sendbeam/ice.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/wire"
+)
+
+// iceServerList is a repeatable flag value: each --ice-server occurrence appends one URL.
+type iceServerList []string
+
+func (l *iceServerList) String() string { return strings.Join(*l, ",") }
+
+func (l *iceServerList) Set(v string) error {
+	*l = append(*l, v)
+	return nil
+}
+
+// iceServers converts the parsed --ice-server URLs into pion ICE server config, validating
+// each URL up front. An empty list maps to nil so the package default STUN server applies.
+// It supports multiple STUN (and future TURN) URLs from the same logical config.
+func iceServers(urls []string) ([]webrtc.ICEServer, error) {
+	if len(urls) == 0 {
+		return nil, nil
+	}
+	entries, err := wire.ParseICEServers(urls)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]webrtc.ICEServer, 0, len(entries))
+	for _, e := range entries {
+		s := webrtc.ICEServer{URLs: e.URLs}
+		if e.Username != "" {
+			s.Username = e.Username
+			s.Credential = e.Credential
+			if e.CredentialType == "oauth" {
+				s.CredentialType = webrtc.ICECredentialTypeOauth
+			}
+		}
+		servers = append(servers, s)
+	}
+	return servers, nil
+}

--- a/apps/cli/cmd/sendbeam/ice_test.go
+++ b/apps/cli/cmd/sendbeam/ice_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestICEClientFlagGroupsMultipleSTUN(t *testing.T) {
+	servers, err := iceServers([]string{
+		"stun:stun1.example.com:3478",
+		"stun:stun2.example.com:3478",
+	})
+	if err != nil {
+		t.Fatalf("iceServers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("len = %d, want 1 folded server", len(servers))
+	}
+	if len(servers[0].URLs) != 2 {
+		t.Fatalf("urls = %d, want 2", len(servers[0].URLs))
+	}
+}
+
+func TestICEClientEmptyUsesDefault(t *testing.T) {
+	servers, err := iceServers(nil)
+	if err != nil {
+		t.Fatalf("iceServers: %v", err)
+	}
+	if servers != nil {
+		t.Fatalf("servers = %v, want nil (package default)", servers)
+	}
+}
+
+func TestICEClientRejectsMalformedURL(t *testing.T) {
+	if _, err := iceServers([]string{"stun:stun.example.com"}); err == nil {
+		t.Fatal("expected error for host-only STUN URL")
+	}
+}

--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -26,8 +26,6 @@ import (
 	"github.com/sendbeam/cli/internal/transfer"
 	"github.com/sendbeam/cli/internal/wsclient"
 	"github.com/sendbeam/wire"
-
-	"github.com/pion/webrtc/v4"
 )
 
 const defaultServer = "wss://localhost:8443/ws"
@@ -80,11 +78,17 @@ func runSend(args []string) int {
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
 	words := fs.Int("words", 0, "number of words in the invite code (0 = default)")
 	relayOnly := fs.Bool("relay-only", false, "force the encrypted WebSocket relay")
-	iceServer := fs.String("ice-server", "", "STUN server URL for direct-path candidates (repeatable; default stun:stun.l.google.com:19302)")
+	var iceServer iceServerList
+	fs.Var(&iceServer, "ice-server", "STUN server URL for direct-path candidates (repeatable; default stun:stun.l.google.com:19302)")
 	positionals := parseArgs(fs, args)
 
 	if len(positionals) == 0 {
 		fmt.Fprintln(os.Stderr, "sendbeam send: a file to send is required")
+		return 2
+	}
+	ice, err := iceServers(iceServer)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
 		return 2
 	}
 	sources, totalSize, err := transfer.NewOSFileSources(positionals)
@@ -124,7 +128,7 @@ func runSend(args []string) int {
 		},
 		Sources:        sources,
 		ForceRelay:     *relayOnly,
-		ICEServers:     iceServers(*iceServer),
+		ICEServers:     ice,
 		OnTransport:    transportPrinter,
 		OnConnect:      connectPrinter(fmt.Sprintf("Sending %s (%s) …", label, humanBytes(totalSize))),
 		OnFileProgress: progress.reportFile,
@@ -158,7 +162,8 @@ func runReceive(args []string) int {
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
 	outDir := fs.String("out", ".", "directory to write the received file into")
 	relayOnly := fs.Bool("relay-only", false, "force the encrypted WebSocket relay")
-	iceServer := fs.String("ice-server", "", "STUN server URL for direct-path candidates (repeatable; default stun:stun.l.google.com:19302)")
+	var iceServer iceServerList
+	fs.Var(&iceServer, "ice-server", "STUN server URL for direct-path candidates (repeatable; default stun:stun.l.google.com:19302)")
 	positionals := parseArgs(fs, args)
 
 	code := ""
@@ -167,6 +172,11 @@ func runReceive(args []string) int {
 	}
 	if code == "" {
 		fmt.Fprintln(os.Stderr, "sendbeam receive: an invite code (or link) is required")
+		return 2
+	}
+	ice, err := iceServers(iceServer)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sendbeam receive: %s\n", err)
 		return 2
 	}
 	if err := os.MkdirAll(*outDir, 0o755); err != nil {
@@ -196,7 +206,7 @@ func runReceive(args []string) int {
 		},
 		DestDir:     *outDir,
 		ForceRelay:  *relayOnly,
-		ICEServers:  iceServers(*iceServer),
+		ICEServers:  ice,
 		OnTransport: transportPrinter,
 		OnManifestSet: func(manifest wire.Manifest) {
 			progress.setTotal(manifest.TotalSize)
@@ -233,15 +243,6 @@ func runReceive(args []string) int {
 		fmt.Printf("  %s  %s\n", s.grey("File-set SHA-256:"), out.Digest)
 	}
 	return 0
-}
-
-// iceServers parses a --ice-server URL list into pion ICE server config. The flag is
-// repeatable; an empty value leaves the package default (Google STUN) in place.
-func iceServers(flagValue string) []webrtc.ICEServer {
-	if flagValue == "" {
-		return nil
-	}
-	return []webrtc.ICEServer{{URLs: []string{flagValue}}}
 }
 
 // dial opens the signaling socket, reporting the server it is contacting. The transfer

--- a/apps/cli/internal/rtc/peer.go
+++ b/apps/cli/internal/rtc/peer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/pion/webrtc/v4"
 	"github.com/sendbeam/cli/internal/rendezvous"
@@ -36,6 +37,15 @@ type PeerOptions struct {
 	// API optionally supplies a pre-built webrtc.API (e.g. with a SettingEngine); nil uses the
 	// package default.
 	API *webrtc.API
+	// OnICEState, if set, is invoked as ICE gathering/connection state transitions occur.
+	// Useful for diagnostics and adaptive selection; see Peer.Diagnostics.
+	OnICEState func(ICEState)
+}
+
+// ICEState is a snapshot of ICE gathering/connection telemetry for one peer.
+type ICEState struct {
+	Gathering  webrtc.ICEGatheringState
+	Connection webrtc.ICEConnectionState
 }
 
 // Peer owns one PeerConnection and drives it to an open DataChannel. Construct it with NewPeer;
@@ -49,10 +59,37 @@ type Peer struct {
 	connCh chan *DataConn // buffered(1): the channel once open
 	errCh  chan error     // buffered(1): first fatal negotiation error
 
+	onICEState func(ICEState)
+
+	// telemetry holds ICE setup instrumentation. It is guarded by mu and is safe to read once
+	// the peer settles.
+	telemetry telemetry
+
 	mu          sync.Mutex
 	settled     bool
 	remoteReady bool
 	pendingICE  []webrtc.ICECandidateInit
+}
+
+// telemetry records ICE gathering/connection history and setup timing for Diagnostics.
+type telemetry struct {
+	StartAt     time.Time
+	ConnectedAt time.Time // zero until the DataChannel opens
+	Gathering   []webrtc.ICEGatheringState
+	Connection  []webrtc.ICEConnectionState
+}
+
+// Diagnostic is a sanitized snapshot of a peer's ICE setup for diagnostics/telemetry output.
+type Diagnostic struct {
+	// SetupDuration is the time from NewPeer to the DataChannel opening (0 if not yet open).
+	SetupDuration time.Duration
+	// GatheringStates is the ordered gathering-state history.
+	GatheringStates []webrtc.ICEGatheringState
+	// ConnectionStates is the ordered ICE-connection-state history.
+	ConnectionStates []webrtc.ICEConnectionState
+	// SelectedCandidatePairType is the type of the currently selected candidate pair, or ""
+	// if none is selected yet (e.g. "host", "srflx", "prflx", "relay").
+	SelectedCandidatePairType string
 }
 
 // NewPeer creates the PeerConnection and starts negotiation. For an offerer it immediately
@@ -73,12 +110,18 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 	}
 
 	p := &Peer{
-		pc:     pc,
-		role:   opts.Role,
-		auth:   opts.Auth,
-		send:   opts.Send,
-		connCh: make(chan *DataConn, 1),
-		errCh:  make(chan error, 1),
+		pc:         pc,
+		role:       opts.Role,
+		auth:       opts.Auth,
+		send:       opts.Send,
+		connCh:     make(chan *DataConn, 1),
+		errCh:      make(chan error, 1),
+		onICEState: opts.OnICEState,
+		telemetry: telemetry{
+			StartAt:    time.Now(),
+			Gathering:  []webrtc.ICEGatheringState{pc.ICEGatheringState()},
+			Connection: []webrtc.ICEConnectionState{pc.ICEConnectionState()},
+		},
 	}
 
 	pc.OnICECandidate(func(c *webrtc.ICECandidate) {
@@ -104,6 +147,26 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 			} else {
 				p.fail(errors.New("rtc: peer connection failed"))
 			}
+		}
+	})
+	pc.OnICEGatheringStateChange(func(s webrtc.ICEGatheringState) {
+		p.mu.Lock()
+		p.telemetry.Gathering = append(p.telemetry.Gathering, s)
+		now := ICEState{Gathering: s, Connection: p.telemetry.Connection[len(p.telemetry.Connection)-1]}
+		cb := p.onICEState
+		p.mu.Unlock()
+		if cb != nil {
+			cb(now)
+		}
+	})
+	pc.OnICEConnectionStateChange(func(s webrtc.ICEConnectionState) {
+		p.mu.Lock()
+		p.telemetry.Connection = append(p.telemetry.Connection, s)
+		now := ICEState{Gathering: p.telemetry.Gathering[len(p.telemetry.Gathering)-1], Connection: s}
+		cb := p.onICEState
+		p.mu.Unlock()
+		if cb != nil {
+			cb(now)
 		}
 	})
 
@@ -245,6 +308,9 @@ func (p *Peer) wireChannel(dc *webrtc.DataChannel) {
 			p.mu.Unlock()
 			return
 		}
+		if p.telemetry.ConnectedAt.IsZero() {
+			p.telemetry.ConnectedAt = time.Now()
+		}
 		p.settled = true
 		p.mu.Unlock()
 		p.connCh <- conn
@@ -253,6 +319,49 @@ func (p *Peer) wireChannel(dc *webrtc.DataChannel) {
 		conn.shutdown()
 		_ = p.pc.Close()
 	})
+}
+
+// Diagnostics returns a sanitized snapshot of the peer's ICE setup for telemetry. It never
+// exposes invite codes, IPs, SDP, or credentials. It is safe to call before settlement (the
+// SelectedCandidatePairType may be ""), and after teardown.
+func (p *Peer) Diagnostics() Diagnostic {
+	p.mu.Lock()
+	d := Diagnostic{
+		GatheringStates:           append([]webrtc.ICEGatheringState(nil), p.telemetry.Gathering...),
+		ConnectionStates:          append([]webrtc.ICEConnectionState(nil), p.telemetry.Connection...),
+		SelectedCandidatePairType: "",
+	}
+	if !p.telemetry.ConnectedAt.IsZero() {
+		d.SetupDuration = p.telemetry.ConnectedAt.Sub(p.telemetry.StartAt)
+	}
+	p.mu.Unlock()
+
+	// Query pion's selected pair without holding p.mu so we never risk a lock inversion
+	// between our mutex and pion's internal transport locks.
+	if pair, err := p.selectedCandidatePair(); err == nil && pair != nil {
+		if c := pair.Local; c != nil {
+			d.SelectedCandidatePairType = c.Typ.String()
+		}
+	}
+	return d
+}
+
+// selectedCandidatePair reaches pion's selected ICE candidate pair through the transport
+// chain (SCTP -> DTLS -> ICE). Returns nil when no pair is selected yet.
+func (p *Peer) selectedCandidatePair() (*webrtc.ICECandidatePair, error) {
+	sctp := p.pc.SCTP()
+	if sctp == nil {
+		return nil, nil
+	}
+	dtls := sctp.Transport()
+	if dtls == nil {
+		return nil, nil
+	}
+	ice := dtls.ICETransport()
+	if ice == nil {
+		return nil, nil
+	}
+	return ice.GetSelectedCandidatePair()
 }
 
 // fail records the first fatal error and closes the PeerConnection; later calls are no-ops.

--- a/apps/cli/internal/rtc/peer_test.go
+++ b/apps/cli/internal/rtc/peer_test.go
@@ -2,6 +2,8 @@ package rtc
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -153,5 +155,106 @@ func recvWithin(t *testing.T, ch <-chan []byte) []byte {
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for frame")
 		return nil
+	}
+}
+
+// TestPeerDiagnosticsReportSetupTelemetry pins the ICE telemetry surface: after a successful
+// loopback negotiation the peer reports a positive setup duration, a non-empty gathering and
+// ICE-connection state history, and a selected candidate pair type.
+func TestPeerDiagnosticsReportSetupTelemetry(t *testing.T) {
+	offerer, joiner := linkedPeers(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := offerer.Channel(ctx); err != nil {
+		t.Fatalf("offerer channel: %v", err)
+	}
+	if _, err := joiner.Channel(ctx); err != nil {
+		t.Fatalf("joiner channel: %v", err)
+	}
+
+	d := offerer.Diagnostics()
+	if d.SetupDuration <= 0 {
+		t.Errorf("SetupDuration = %v, want > 0 after open", d.SetupDuration)
+	}
+	if len(d.ConnectionStates) == 0 {
+		t.Error("no ICE connection-state history recorded")
+	}
+	if len(d.GatheringStates) == 0 {
+		t.Error("no ICE gathering-state history recorded")
+	}
+	if d.SelectedCandidatePairType == "" {
+		t.Error("selected candidate pair type not reported after connection")
+	}
+}
+
+// TestPeerOnICEStatePublishesTransitions verifies the OnICEState callback fires as
+// gathering/connection state progresses on a connected peer. At minimum the initial state and
+// at least one transition must be observed after the loopback connects.
+func TestPeerOnICEStatePublishesTransitions(t *testing.T) {
+	var fired atomic.Bool
+	var mu sync.Mutex
+	var connectionStates []webrtc.ICEConnectionState
+
+	toJoiner := make(chan rendezvous.Message, 64)
+	toOfferer := make(chan rendezvous.Message, 64)
+	offAuth, joinAuth := newPair(testRoom)
+
+	offerer, err := NewPeer(PeerOptions{
+		Role: wire.RoleOfferer, Auth: offAuth, ICEServers: hostOnly,
+		Send: func(m rendezvous.Message) error { toJoiner <- m; return nil },
+		OnICEState: func(s ICEState) {
+			fired.Store(true)
+			mu.Lock()
+			connectionStates = append(connectionStates, s.Connection)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatalf("new offerer: %v", err)
+	}
+	joiner, err := NewPeer(PeerOptions{
+		Role: wire.RoleJoiner, Auth: joinAuth, ICEServers: hostOnly,
+		Send: func(m rendezvous.Message) error { toOfferer <- m; return nil },
+	})
+	if err != nil {
+		_ = offerer.Close()
+		t.Fatalf("new joiner: %v", err)
+	}
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case m := <-toJoiner:
+				joiner.Accept(m)
+			case <-done:
+				return
+			}
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case m := <-toOfferer:
+				offerer.Accept(m)
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer func() { _ = offerer.Close(); _ = joiner.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := offerer.Channel(ctx); err != nil {
+		t.Fatalf("offerer channel: %v", err)
+	}
+
+	if !fired.Load() {
+		t.Error("OnICEState callback never fired")
+	}
+	if len(connectionStates) == 0 {
+		t.Error("no ICE connection states reported via callback")
 	}
 }

--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -4,4 +4,14 @@ go 1.25.0
 
 require github.com/go-chi/chi/v5 v5.3.1
 
-require github.com/coder/websocket v1.8.15
+require (
+	github.com/coder/websocket v1.8.15
+	github.com/sendbeam/wire v0.0.0
+)
+
+require (
+	filippo.io/nistec v0.0.4 // indirect
+	golang.org/x/sys v0.36.0 // indirect
+)
+
+replace github.com/sendbeam/wire => ../../packages/wire

--- a/apps/server/go.sum
+++ b/apps/server/go.sum
@@ -1,4 +1,8 @@
+filippo.io/nistec v0.0.4 h1:F14ZHT5htWlMnQVPndX9ro9arf56cBhQxq4LnDI491s=
+filippo.io/nistec v0.0.4/go.mod h1:PK/lw8I1gQT4hUML4QGaqljwdDaFcMyFKSXN7kjrtKI=
 github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/apps/server/internal/httpserver/server.go
+++ b/apps/server/internal/httpserver/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/sendbeam/server/internal/signal"
+	"github.com/sendbeam/wire"
 )
 
 // Config controls how sendbeamd serves the web app and terminates TLS.
@@ -32,19 +33,25 @@ type Config struct {
 	DevProxy  string // URL of the Vite dev server to proxy to (dev); overrides WebDir
 	PublicURL string // public base URL for invite links (e.g. https://send.example.com/); empty = auto-detect from page
 
+	// ICEServerURLs are STUN (and future TURN) URLs published to clients via /config.json so
+	// the web app gathers direct-path candidates against the operator's chosen servers instead
+	// of the bundled defaults. Parsed with SENDBEAM_ICE_SERVERS (comma-separated).
+	ICEServerURLs []string
+
 	Signal signal.Config // signaling limits + WSS origin allowlist
 }
 
 // ConfigFromEnv reads configuration from SENDBEAM_* environment variables with defaults.
 func ConfigFromEnv() Config {
 	return Config{
-		Addr:      env("SENDBEAM_ADDR", ":8443"),
-		TLSCert:   os.Getenv("SENDBEAM_TLS_CERT"),
-		TLSKey:    os.Getenv("SENDBEAM_TLS_KEY"),
-		WebDir:    os.Getenv("SENDBEAM_WEB_DIR"),
-		DevProxy:  os.Getenv("SENDBEAM_WEB_DEV_PROXY"),
-		PublicURL: os.Getenv("SENDBEAM_PUBLIC_URL"),
-		Signal:    signal.ConfigFromEnv(),
+		Addr:          env("SENDBEAM_ADDR", ":8443"),
+		TLSCert:       os.Getenv("SENDBEAM_TLS_CERT"),
+		TLSKey:        os.Getenv("SENDBEAM_TLS_KEY"),
+		WebDir:        os.Getenv("SENDBEAM_WEB_DIR"),
+		DevProxy:      os.Getenv("SENDBEAM_WEB_DEV_PROXY"),
+		PublicURL:     os.Getenv("SENDBEAM_PUBLIC_URL"),
+		ICEServerURLs: splitList(os.Getenv("SENDBEAM_ICE_SERVERS")),
+		Signal:        signal.ConfigFromEnv(),
 	}
 }
 
@@ -103,11 +110,25 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.http.Shutdown(ctx)
 }
 
+// configResponse is the shape of /config.json published to the web app.
+type configResponse struct {
+	PublicURL  string          `json:"publicUrl"`
+	LanIP      string          `json:"lanIp"`
+	ICEServers []wire.ICEEntry `json:"iceServers"`
+}
+
 func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler, error) {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Recoverer)
 	r.Use(securityHeaders)
+
+	// Parse and validate ICE config once at startup so a malformed server list fails fast
+	// instead of surfacing an empty/misleading config to clients.
+	iceEntries, err := wire.ParseICEServers(cfg.ICEServerURLs)
+	if err != nil {
+		return nil, fmt.Errorf("config: invalid SENDBEAM_ICE_SERVERS: %w", err)
+	}
 
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -117,10 +138,13 @@ func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler,
 
 	r.Get("/config.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// no-cache: clients must never reuse stale ICE config; credential-bearing entries are
+		// short-lived and must be re-fetched (see wire.ICEConfigTTL).
 		w.Header().Set("Cache-Control", "no-cache")
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"publicUrl": cfg.PublicURL,
-			"lanIp":     firstLanIP(),
+		_ = json.NewEncoder(w).Encode(configResponse{
+			PublicURL:  cfg.PublicURL,
+			LanIP:      firstLanIP(),
+			ICEServers: iceEntries,
 		})
 	})
 
@@ -178,6 +202,22 @@ func env(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// splitList splits a comma-separated env list, trimming whitespace and dropping empty items.
+func splitList(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // firstLanIP returns the first non-loopback IPv4 address, or "" if none is found.

--- a/apps/server/internal/httpserver/server_test.go
+++ b/apps/server/internal/httpserver/server_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sendbeam/wire"
 )
 
 func testRouter(t *testing.T, cfg Config) http.Handler {
@@ -102,12 +104,12 @@ func TestConfigEndpoint(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	var body map[string]string
+	var body map[string]json.RawMessage
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("json: %v", err)
 	}
-	if body["publicUrl"] != "https://send.example.com" {
-		t.Errorf("publicUrl = %q, want https://send.example.com", body["publicUrl"])
+	if got := string(body["publicUrl"]); got != `"https://send.example.com"` {
+		t.Errorf("publicUrl = %s, want https://send.example.com", got)
 	}
 }
 
@@ -115,10 +117,56 @@ func TestConfigEndpointEmpty(t *testing.T) {
 	h := testRouter(t, Config{})
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/config.json", nil))
-	var body map[string]string
+	var body map[string]json.RawMessage
 	_ = json.Unmarshal(rec.Body.Bytes(), &body)
-	if body["publicUrl"] != "" {
-		t.Errorf("publicUrl = %q, want empty when not configured", body["publicUrl"])
+	if got := string(body["publicUrl"]); got != `""` {
+		t.Errorf("publicUrl = %s, want empty when not configured", got)
+	}
+}
+
+func TestConfigEndpointICEServers(t *testing.T) {
+	h := testRouter(t, Config{
+		ICEServerURLs: []string{"stun:stun1.example.com:3478", "stun:stun2.example.com:3478"},
+	})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/config.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		ICEServers []wire.ICEEntry `json:"iceServers"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if len(body.ICEServers) != 1 {
+		t.Fatalf("iceServers len = %d, want 1 folded entry", len(body.ICEServers))
+	}
+	if got := strings.Join(body.ICEServers[0].URLs, ","); got != "stun:stun1.example.com:3478,stun:stun2.example.com:3478" {
+		t.Errorf("urls = %q", got)
+	}
+}
+
+func TestConfigEndpointNoICEServersOmitsEmpty(t *testing.T) {
+	h := testRouter(t, Config{})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/config.json", nil))
+	var body struct {
+		ICEServers []wire.ICEEntry `json:"iceServers"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if len(body.ICEServers) != 0 {
+		t.Fatalf("iceServers len = %d, want 0 when unset", len(body.ICEServers))
+	}
+}
+
+func TestConfigEndpointInvalidICEServersFailsStartup(t *testing.T) {
+	if h, err := router(context.Background(), Config{
+		ICEServerURLs: []string{"://not-a-url"},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil))); err == nil {
+		t.Errorf("expected router error for malformed ICE URL, got handler %v", h)
 	}
 }
 

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -5,7 +5,7 @@
   import { offer, join, type RendezvousController } from './lib/session/rendezvous.js';
   import type { SignalChannel } from './lib/signaling/client.js';
   import type { ReceiveDestinationSpec } from './lib/transfer/wire.js';
-  import { baseUrl, loadConfig } from './lib/config.js';
+  import { baseUrl, iceServers, loadConfig } from './lib/config.js';
   import QrCode from './lib/QrCode.svelte';
 
   loadConfig();
@@ -187,11 +187,19 @@
    */
   function startTransferIfReady() {
     if (transfer || handshake === undefined || signaling === undefined) return;
+    const ice = iceServers();
     if (role === 'offerer') {
       if (pickedFiles.length === 0) return;
-      beginTransfer(runSend(handshake, signaling, { files: pickedFiles }));
+      beginTransfer(
+        runSend(handshake, signaling, {
+          files: pickedFiles,
+          ...(ice ? { iceServers: ice } : {}),
+        }),
+      );
     } else {
-      beginTransfer(runReceive(handshake, signaling, receiveDestination));
+      beginTransfer(
+        runReceive(handshake, signaling, receiveDestination, ice ? { iceServers: ice } : {}),
+      );
     }
   }
 

--- a/apps/web/src/lib/config.test.ts
+++ b/apps/web/src/lib/config.test.ts
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { iceServers, loadConfig } from './config.js';
+
+function mockConfig(body: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => body,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('iceServers() runtime ICE config', () => {
+  it('returns published STUN servers from /config.json', async () => {
+    mockConfig({
+      publicUrl: 'https://send.example.com',
+      iceServers: [{ urls: ['stun:stun1.example.com:3478', 'stun:stun2.example.com:3478'] }],
+    });
+    await loadConfig();
+    const servers = iceServers();
+    expect(servers).toHaveLength(1);
+    expect(servers![0]!.urls).toHaveLength(2);
+  });
+
+  it('maps TURN credentials into RTCIceServer', async () => {
+    mockConfig({
+      iceServers: [{ urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' }],
+    });
+    await loadConfig();
+    const servers = iceServers()!;
+    expect(servers[0]!.username).toBe('u');
+    expect(servers[0]!.credential).toBe('p');
+  });
+
+  it('returns undefined when the server publishes no ICE config', async () => {
+    mockConfig({ publicUrl: 'https://send.example.com' });
+    await loadConfig();
+    expect(iceServers()).toBeUndefined();
+  });
+
+  it('drops malformed entries instead of throwing', async () => {
+    mockConfig({ iceServers: [{ urls: ['://bad'] }, { urls: ['stun:stun.example.com:3478'] }] });
+    await loadConfig();
+    expect(iceServers()).toHaveLength(1);
+  });
+
+  it('keeps the last known config on a fetch failure', async () => {
+    mockConfig({ iceServers: [{ urls: ['stun:stun.example.com:3478'] }] });
+    await loadConfig();
+    expect(iceServers()).toHaveLength(1);
+
+    // A later refresh that fails must not clobber the known-good config.
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    await loadConfig();
+    expect(iceServers()).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -1,15 +1,26 @@
+import { parseIceServer, type ICEEntry } from '@sendbeam/protocol';
+
 interface ServerConfig {
   publicUrl: string;
   lanIp: string;
+  /** Operator-published ICE servers for direct-path candidate gathering. */
+  iceServers?: ICEEntry[];
 }
 
 let cfg: ServerConfig | undefined;
+// The last time /config.json was fetched, for TTL-guarded refresh (see ICEEntry credentials).
+let fetchedAt = 0;
+
+// Runtime ICE config can carry short-lived credentials; never reuse a stale config past this
+// bound. Mirrors wire.ICEConfigTTL in the Go module.
+const ICE_CONFIG_TTL_MS = 15 * 60 * 1000;
 
 export async function loadConfig(): Promise<void> {
   try {
-    const res = await fetch('/config.json');
+    const res = await fetch('/config.json', { cache: 'no-store' });
     if (!res.ok) return;
-    cfg = await res.json();
+    cfg = (await res.json()) as ServerConfig;
+    fetchedAt = Date.now();
   } catch {
     // config.json is optional; fall through to auto-detection.
   }
@@ -29,4 +40,44 @@ export function baseUrl(): string {
     }
   }
   return typeof window === 'undefined' ? '' : window.location.href;
+}
+
+/**
+ * The operator-published ICE servers as browser `RTCIceServer[]`, or undefined when the server
+ * published none (the client keeps its bundled default STUN). The config is validated URL by
+ * URL; malformed entries are dropped rather than crashing the transfer. A config older than
+ * the credential TTL is treated as absent so short-lived credentials are never reused.
+ */
+export function iceServers(): RTCIceServer[] | undefined {
+  if (!cfg) return undefined;
+  if (Date.now() - fetchedAt >= ICE_CONFIG_TTL_MS) return undefined;
+  if (!Array.isArray(cfg.iceServers)) return undefined;
+
+  const rtc: RTCIceServer[] = [];
+  for (const entry of cfg.iceServers) {
+    if (!entry || !Array.isArray(entry.urls)) continue;
+    const urls: string[] = [];
+    let valid = true;
+    for (const u of entry.urls) {
+      if (typeof u !== 'string') {
+        valid = false;
+        break;
+      }
+      try {
+        parseIceServer(u);
+      } catch {
+        valid = false;
+        break;
+      }
+      urls.push(u);
+    }
+    if (!valid || urls.length === 0) continue;
+    const s: RTCIceServer = { urls };
+    if (entry.username) {
+      s.username = entry.username;
+      s.credential = entry.credential ?? '';
+    }
+    rtc.push(s);
+  }
+  return rtc.length > 0 ? rtc : undefined;
 }

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -61,6 +61,8 @@ export interface TransferController {
 
 export interface SendOptions {
   files: File[];
+  /** Operator-published ICE servers; omitting keeps the bundled default STUN. */
+  iceServers?: RTCIceServer[];
 }
 
 /** Start sending an ordered file/folder selection over the adopted rendezvous socket. */
@@ -72,6 +74,7 @@ export function runSend(
   return run(rendezvous, signaling, {
     role: 'send',
     total: opts.files.reduce((total, file) => total + file.size, 0),
+    ...(opts.iceServers ? { iceServers: opts.iceServers } : {}),
     start: () => ({ kind: 'start-send', files: opts.files, ...crypto(rendezvous) }),
   });
 }
@@ -81,9 +84,11 @@ export function runReceive(
   rendezvous: RendezvousResult,
   signaling: SignalChannel,
   destination: ReceiveDestinationSpec = { kind: 'auto' },
+  opts: { iceServers?: RTCIceServer[] } = {},
 ): TransferController {
   return run(rendezvous, signaling, {
     role: 'receive',
+    ...(opts.iceServers ? { iceServers: opts.iceServers } : {}),
     start: () => ({ kind: 'start-recv', destination, ...crypto(rendezvous) }),
   });
 }
@@ -92,6 +97,8 @@ interface RunSpec {
   role: 'send' | 'receive';
   /** Known upfront only when sending. */
   total?: number;
+  /** Operator-published ICE servers for direct-path candidate gathering. */
+  iceServers?: RTCIceServer[];
   start: () => HostToWorker;
 }
 
@@ -155,7 +162,12 @@ function run(
         rendezvous.room,
         rendezvous.spake2,
       );
-      const p = createPeer({ role: rendezvous.role, auth, send: (msg) => signaling.send(msg) });
+      const p = createPeer({
+        role: rendezvous.role,
+        auth,
+        send: (msg) => signaling.send(msg),
+        ...(spec.iceServers ? { iceServers: spec.iceServers } : {}),
+      });
       peer = p;
       const relayPath = new RelayTransport(signaling);
       relay = relayPath;

--- a/apps/web/src/lib/transfer/peer.ts
+++ b/apps/web/src/lib/transfer/peer.ts
@@ -20,6 +20,29 @@ export interface CreatePeerOptions {
   /** Sign-and-forward an outbound signaling frame over the adopted socket. */
   send: (msg: SdpMsg | IceMsg) => void;
   iceServers?: RTCIceServer[];
+  /**
+   * Invoked as ICE gathering/connection state transitions occur. Primarily for diagnostics
+   * and adaptive selection.
+   */
+  onIceState?: (state: ICEState) => void;
+}
+
+/** A sanitized snapshot of a peer's ICE setup for diagnostics. */
+export interface PeerDiagnostics {
+  /** Milliseconds from createPeer to the data channel opening (0 if not yet open). */
+  setupMs: number;
+  /** Ordered ICE gathering-state history. */
+  gatheringStates: RTCIceGatheringState[];
+  /** Ordered ICE connection-state history. */
+  connectionStates: RTCIceConnectionState[];
+  /** Selected candidate pair type, e.g. "host"|"srflx"|"prflx"|"relay"; "" if none yet. */
+  selectedPairType: string;
+}
+
+/** ICE gathering+connection state published to onIceState. */
+export interface ICEState {
+  gathering: RTCIceGatheringState;
+  connection: RTCIceConnectionState;
 }
 
 export interface Peer {
@@ -34,12 +57,27 @@ export interface Peer {
   onData(handler: (frame: ArrayBuffer) => void): void;
   /** Register for an established channel becoming unusable. */
   onDisconnect(handler: (err: Error) => void): void;
+  /** Sanitized ICE setup telemetry for diagnostics. */
+  diagnostics(): PeerDiagnostics;
   /** Tear down the peer connection. Idempotent. */
   close(): void;
 }
 
 export function createPeer(opts: CreatePeerOptions): Peer {
   const pc = new RTCPeerConnection({ iceServers: opts.iceServers ?? DEFAULT_ICE_SERVERS });
+
+  // ICE setup telemetry: gathering/connection history, setup timing, and the selected pair
+  // type, exposed sanitized via diagnostics().
+  const startedAt = performance.now();
+  let connectedAt = 0;
+  const gatheringStates: RTCIceGatheringState[] = [pc.iceGatheringState];
+  const connectionStates: RTCIceConnectionState[] = [pc.iceConnectionState];
+  let selectedPairType = '';
+  const publishIceState = (): void => {
+    const lastGathering = gatheringStates[gatheringStates.length - 1]!;
+    const lastConnection = connectionStates[connectionStates.length - 1]!;
+    opts.onIceState?.({ gathering: lastGathering, connection: lastConnection });
+  };
 
   let resolveChannel!: (ch: RTCDataChannel) => void;
   let rejectChannel!: (err: Error) => void;
@@ -75,6 +113,7 @@ export function createPeer(opts: CreatePeerOptions): Peer {
       if (settled) return;
       settled = true;
       channelOpen = true;
+      if (connectedAt === 0) connectedAt = performance.now();
       resolveChannel(ch);
     };
     ch.onmessage = (ev: MessageEvent) => {
@@ -99,8 +138,45 @@ export function createPeer(opts: CreatePeerOptions): Peer {
   pc.onicecandidate = (ev) => {
     if (ev.candidate) void opts.auth.signIce(JSON.stringify(ev.candidate)).then(opts.send);
   };
+  pc.onicegatheringstatechange = () => {
+    gatheringStates.push(pc.iceGatheringState);
+    publishIceState();
+  };
+  pc.oniceconnectionstatechange = () => {
+    connectionStates.push(pc.iceConnectionState);
+    if (pc.iceConnectionState === 'connected' || pc.iceConnectionState === 'completed') {
+      void captureSelectedPairType();
+    }
+    publishIceState();
+  };
   pc.onconnectionstatechange = () => {
     if (pc.connectionState === 'failed') disconnected(new Error('peer connection failed'));
+  };
+
+  // Query getStats() for the selected candidate pair and record the local candidate's type
+  // (e.g. host/srflx/prflx/relay). Best-effort: leaves "" if stats are unavailable.
+  const captureSelectedPairType = async (): Promise<void> => {
+    if (selectedPairType !== '') return;
+    try {
+      const stats = await pc.getStats();
+      const candidates = new Map<string, string>();
+      let pairLocal: string | undefined;
+      for (const stat of stats.values()) {
+        if (stat.type === 'candidate') {
+          const c = stat as { id: string; candidateType?: string };
+          candidates.set(stat.id, c.candidateType ?? '');
+        } else if (stat.type === 'candidate-pair') {
+          const p = stat as RTCIceCandidatePairStats;
+          if (p.state === 'succeeded') pairLocal = p.localCandidateId;
+        }
+      }
+      if (pairLocal) {
+        const t = candidates.get(pairLocal);
+        if (t) selectedPairType = t;
+      }
+    } catch {
+      // getStats is optional; leave the pair type unset.
+    }
   };
 
   if (opts.role === 'offerer') {
@@ -156,6 +232,12 @@ export function createPeer(opts: CreatePeerOptions): Peer {
       disconnectHandler = handler;
       if (disconnectError) handler(disconnectError);
     },
+    diagnostics: () => ({
+      setupMs: connectedAt !== 0 ? connectedAt - startedAt : 0,
+      gatheringStates: [...gatheringStates],
+      connectionStates: [...connectionStates],
+      selectedPairType,
+    }),
     close: () => {
       closedByUser = true;
       settled = true;

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -43,6 +43,7 @@ so web + signaling + relay all share the published port.
 | `SENDBEAM_WEB_DIR`                       | unset         | Directory of the built web bundle to serve; set to `/srv/web` in the image.                                                                      |
 | `SENDBEAM_WEB_DEV_PROXY`                 | unset         | Vite dev-server URL to proxy to (development only; overrides `SENDBEAM_WEB_DIR`).                                                                |
 | `SENDBEAM_ALLOWED_ORIGINS`               | empty         | Comma-separated WSS origin allowlist. Empty allows only same-origin browser sockets; native CLI clients (no `Origin` header) are always allowed. |
+| `SENDBEAM_ICE_SERVERS`                   | unset         | Comma-separated STUN (or TURN) URLs published to the web app via `/config.json`; unset keeps the bundled Google STUN default. |
 | `SENDBEAM_SIGNAL_IDLE_TIMEOUT`           | `2m`          | Close a socket silent this long; also bounds how long an unpaired room lingers.                                                                  |
 | `SENDBEAM_SIGNAL_MAX_MESSAGE_BYTES`      | `65536`       | Cap on a single inbound signaling message.                                                                                                       |
 | `SENDBEAM_RELAY_MAX_FRAME_BYTES`         | `131072`      | Cap on a single relay frame.                                                                                                                     |
@@ -97,9 +98,11 @@ allowlist. Any WebSocket-aware reverse proxy works.
 ## STUN and TURN
 
 - **STUN** — both clients use Google's STUN (`stun:stun.l.google.com:19302`)
-  by default for external candidate discovery. The CLI can point at your
-  own STUN server with `--ice-server`; the web bundle's ICE config is
-  fixed at build time.
+  by default for external candidate discovery. The CLI points at your own
+  STUN servers with the repeatable `--ice-server` flag. The web bundle's ICE
+  config is configurable at runtime: the server publishes an operator-chosen
+  STUN list via `/config.json` (from `SENDBEAM_ICE_SERVERS`), which the web
+  app fetches on load, validates, and passes to `RTCPeerConnection`.
 - **TURN** — SendBeam does not speak TURN. When a direct peer-to-peer path
   is impossible (symmetric NATs on both ends), clients fall back to the
   app-layer **encrypted relay** through this same server, which is exactly

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -43,7 +43,7 @@ so web + signaling + relay all share the published port.
 | `SENDBEAM_WEB_DIR`                       | unset         | Directory of the built web bundle to serve; set to `/srv/web` in the image.                                                                      |
 | `SENDBEAM_WEB_DEV_PROXY`                 | unset         | Vite dev-server URL to proxy to (development only; overrides `SENDBEAM_WEB_DIR`).                                                                |
 | `SENDBEAM_ALLOWED_ORIGINS`               | empty         | Comma-separated WSS origin allowlist. Empty allows only same-origin browser sockets; native CLI clients (no `Origin` header) are always allowed. |
-| `SENDBEAM_ICE_SERVERS`                   | unset         | Comma-separated STUN (or TURN) URLs published to the web app via `/config.json`; unset keeps the bundled Google STUN default. |
+| `SENDBEAM_ICE_SERVERS`                   | unset         | Comma-separated STUN (or TURN) URLs published to the web app via `/config.json`; unset keeps the bundled Google STUN default.                    |
 | `SENDBEAM_SIGNAL_IDLE_TIMEOUT`           | `2m`          | Close a socket silent this long; also bounds how long an unpaired room lingers.                                                                  |
 | `SENDBEAM_SIGNAL_MAX_MESSAGE_BYTES`      | `65536`       | Cap on a single inbound signaling message.                                                                                                       |
 | `SENDBEAM_RELAY_MAX_FRAME_BYTES`         | `131072`      | Cap on a single relay frame.                                                                                                                     |

--- a/packages/protocol/src/ice-servers.test.ts
+++ b/packages/protocol/src/ice-servers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { parseIceServer, parseIceServers, toRTCIceServers } from './ice-servers.js';
+
+describe('parseIceServer', () => {
+  it('accepts valid STUN URLs', () => {
+    expect(parseIceServer('stun:stun.example.com:3478')).toEqual({
+      urls: ['stun:stun.example.com:3478'],
+    });
+  });
+
+  it('rejects unknown schemes', () => {
+    expect(() => parseIceServer('http://stun.example.com:3478')).toThrow(/unsupported scheme/);
+  });
+
+  it('rejects missing host or port', () => {
+    expect(() => parseIceServer('stun:stun.example.com')).toThrow(/host:port/);
+    expect(() => parseIceServer('stun:')).toThrow();
+  });
+
+  it('parses TURN credentials in opaque form', () => {
+    expect(parseIceServer('turn:user:secret@turn.example.com:3478')).toEqual({
+      urls: ['turn:user:secret@turn.example.com:3478'],
+      username: 'user',
+      credential: 'secret',
+    });
+  });
+});
+
+describe('parseIceServers', () => {
+  it('folds multiple credential-less STUN URLs into one entry', () => {
+    const entries = parseIceServers(['stun:stun1.example.com:3478', 'stun:stun2.example.com:3478']);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.urls).toHaveLength(2);
+  });
+
+  it('keeps STUN and TURN distinct', () => {
+    const entries = parseIceServers(['stun:stun.example.com:3478', 'turn:turn.example.com:3478']);
+    expect(entries).toHaveLength(2);
+  });
+
+  it('skips blank entries', () => {
+    expect(parseIceServers(['', ' ', 'stun:stun.example.com:3478'])).toHaveLength(1);
+  });
+});
+
+describe('toRTCIceServers', () => {
+  it('returns undefined for an empty list', () => {
+    expect(toRTCIceServers([])).toBeUndefined();
+  });
+
+  it('maps entries to RTCIceServer', () => {
+    const rtc = toRTCIceServers([
+      { urls: ['stun:stun.example.com:3478'] },
+      { urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' },
+    ])!;
+    expect(rtc).toHaveLength(2);
+    expect(rtc[0]!.urls).toEqual(['stun:stun.example.com:3478']);
+    expect(rtc[1]!.username).toBe('u');
+    expect(rtc[1]!.credential).toBe('p');
+  });
+});

--- a/packages/protocol/src/ice-servers.ts
+++ b/packages/protocol/src/ice-servers.ts
@@ -1,0 +1,121 @@
+/**
+ * ICE server configuration — the TypeScript counterpart of `packages/wire/iceservers.go`.
+ *
+ * The signaling server publishes the operator's ICE servers in `/config.json` as an array of
+ * `ICEEntry`; the web app parses and validates them with the same rules as the CLI so both
+ * clients select direct-path candidates against the same logical set.
+ */
+
+/** One STUN/TURN server. Mirrors the browser's `RTCIceServer` and Go's `wire.ICEEntry`. */
+export interface ICEEntry {
+  /** One or more STUN/TURN URLs that refer to the same server/credentials. */
+  urls: string[];
+  /** Username for TURN; absent for plain STUN. */
+  username?: string;
+  /** Credential for TURN; absent for plain STUN. */
+  credential?: string;
+  /** "password" (default) or "oauth". */
+  credentialType?: string;
+}
+
+const ICE_SCHEMES = new Set(['stun', 'stuns', 'turn', 'turns']);
+
+/**
+ * Validate and fold a single ICE URL into an {@link ICEEntry}. Throws on malformed or unsafe
+ * URLs (unknown scheme, empty host, missing/invalid port). STUN entries carry no credentials.
+ */
+export function parseIceServer(raw: string): ICEEntry {
+  const trimmed = raw.trim();
+  const schemeEnd = trimmed.indexOf(':');
+  if (schemeEnd <= 0) throw new Error(`ice: unsupported scheme in "${raw}"`);
+  const scheme = trimmed.slice(0, schemeEnd).toLowerCase();
+  if (!ICE_SCHEMES.has(scheme)) {
+    throw new Error(`ice: unsupported scheme "${scheme}" in "${raw}" (want stun/stuns/turn/turns)`);
+  }
+
+  // Strip credentials in the opaque form (user:cred@host:port) or authority userinfo (//user:cred@host:port).
+  let rest = trimmed.slice(schemeEnd + 1);
+  if (rest.startsWith('//')) rest = rest.slice(2);
+  const at = rest.lastIndexOf('@');
+  const userInfo = at >= 0 ? rest.slice(0, at) : '';
+  if (at >= 0) rest = rest.slice(at + 1);
+
+  const hostPort = splitHostPort(rest);
+  if (hostPort.host === '' || hostPort.port === '') {
+    throw new Error(`ice: missing or invalid host:port in "${raw}"`);
+  }
+
+  if (scheme === 'turn' || scheme === 'turns') {
+    let username = '';
+    let credential = '';
+    if (userInfo !== '') {
+      const i = userInfo.indexOf(':');
+      if (i >= 0) {
+        username = userInfo.slice(0, i);
+        credential = userInfo.slice(i + 1);
+      } else {
+        username = userInfo;
+      }
+    }
+    const entry: ICEEntry = { urls: [raw] };
+    if (username !== '') {
+      entry.username = username;
+      entry.credential = credential;
+    }
+    return entry;
+  }
+  return { urls: [raw] };
+}
+
+/** Fold a list of ICE URLs into entries, grouping credential-less STUN URLs together. */
+export function parseIceServers(urls: string[]): ICEEntry[] {
+  const entries: ICEEntry[] = [];
+  for (const raw of urls) {
+    if (raw.trim() === '') continue;
+    const entry = parseIceServer(raw);
+    const last = entries[entries.length - 1];
+    if (last !== undefined && sameCreds(last, entry)) {
+      last.urls.push(...entry.urls);
+    } else {
+      entries.push(entry);
+    }
+  }
+  return entries;
+}
+
+function sameCreds(a: ICEEntry, b: ICEEntry): boolean {
+  const aScheme = a.urls[0]?.split(':')[0]?.toLowerCase();
+  const bScheme = b.urls[0]?.split(':')[0]?.toLowerCase();
+  return aScheme === bScheme && a.username === b.username && a.credential === b.credential;
+}
+
+/**
+ * Convert a validated {@link ICEEntry} list into browser `RTCIceServer` objects for
+ * `RTCPeerConnection`. Returns undefined when there is nothing to override (caller keeps its
+ * bundled defaults).
+ */
+export function toRTCIceServers(entries: ICEEntry[]): RTCIceServer[] | undefined {
+  if (entries.length === 0) return undefined;
+  return entries.map((e) => {
+    const s: RTCIceServer = { urls: e.urls };
+    if (e.username !== undefined && e.username !== '') {
+      s.username = e.username;
+      s.credential = e.credential ?? '';
+    }
+    return s;
+  });
+}
+
+function splitHostPort(rest: string): { host: string; port: string } {
+  // IPv6 literals are bracketed: [::1]:3478. Everything else splits on the last ':'.
+  if (rest.startsWith('[')) {
+    const end = rest.indexOf(']');
+    if (end === -1) return { host: '', port: '' };
+    const host = rest.slice(1, end);
+    const port = rest[end + 1] === ':' ? rest.slice(end + 2) : '';
+    return { host, port };
+  }
+  const i = rest.lastIndexOf(':');
+  if (i === -1) return { host: rest, port: '' };
+  return { host: rest.slice(0, i), port: rest.slice(i + 1) };
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -24,3 +24,4 @@ export * from './transfer-receiver.js';
 export * from './safe-path.js';
 export * from './transfer-set.js';
 export * from './errors.js';
+export * from './ice-servers.js';

--- a/packages/wire/icecache.go
+++ b/packages/wire/icecache.go
@@ -1,0 +1,29 @@
+package wire
+
+import (
+	"time"
+)
+
+// ICEConfigTTL bounds how long a runtime-fetched ICE config may be reused before it must be
+// re-fetched. It exists so that any short-lived TURN credential an operator publishes never
+// outlives its validity in a client cache. Config without credentials may be held longer, but
+// enforcing a single TTL is simpler and safe: the endpoint is tiny and served with no-cache.
+const ICEConfigTTL = 15 * time.Minute
+
+// ICEConfigCache holds a fetched ICE config and the time it was obtained so callers can refuse
+// to reuse short-lived credentials past ICEConfigTTL.
+type ICEConfigCache struct {
+	Entries []ICEEntry
+	Fetched time.Time
+}
+
+// NewICEConfigCache records a freshly fetched config at now.
+func NewICEConfigCache(entries []ICEEntry, now time.Time) *ICEConfigCache {
+	return &ICEConfigCache{Entries: entries, Fetched: now}
+}
+
+// Stale reports whether the config has been cached longer than ICEConfigTTL. A stale config
+// must be re-fetched (or have its credential-bearing entries dropped) before reuse.
+func (c *ICEConfigCache) Stale(now time.Time) bool {
+	return !c.Fetched.IsZero() && now.Sub(c.Fetched) >= ICEConfigTTL
+}

--- a/packages/wire/iceservers.go
+++ b/packages/wire/iceservers.go
@@ -1,0 +1,160 @@
+package wire
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ICEEntry describes one STUN/TURN server used to gather ICE candidates for the direct
+// path. It is the Go counterpart of the browser's RTCIceServer and the JSON shape the
+// signaling server publishes in /config.json, so the CLI and the browser select candidates
+// against the same logical set.
+type ICEEntry struct {
+	// URLs lists one or more STUN/TURN URLs that refer to the same server/credentials.
+	URLs []string `json:"urls"`
+	// Username is used with TURN credential types; empty for plain STUN.
+	Username string `json:"username,omitempty"`
+	// Credential is the shared secret or OAuth access token for TURN; never empty for TURN.
+	Credential string `json:"credential,omitempty"`
+	// CredentialType is "password" (default) or "oauth".
+	CredentialType string `json:"credentialType,omitempty"`
+}
+
+// ParseICEServers validates one ICE server URL list and folds them into ICEEntry values,
+// grouping consecutive URL strings by the presence of credentials. It rejects malformed or
+// unsafe URLs (unknown scheme, empty host, missing or non-numeric port) and keeps
+// credential-bearing TURN endpoints distinct from credential-less STUN servers so different
+// credentials are never merged. STUN URLs must not carry credentials.
+func ParseICEServers(urls []string) ([]ICEEntry, error) {
+	entries := make([]ICEEntry, 0, len(urls))
+	for _, raw := range urls {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		entry, err := ParseICEServer(raw)
+		if err != nil {
+			return nil, err
+		}
+		if n := len(entries); n > 0 && sameCreds(entries[n-1], entry) {
+			entries[n-1].URLs = append(entries[n-1].URLs, entry.URLs...)
+		} else {
+			entries = append(entries, entry)
+		}
+	}
+	return entries, nil
+}
+
+// ParseICEServer parses and validates a single ICE URL into an ICEEntry. ICE URLs may use
+// either the authority form (stun://host:port) or the common opaque form (stun:host:port);
+// both are accepted and validated.
+func ParseICEServer(raw string) (ICEEntry, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ICEEntry{}, fmt.Errorf("ice: malformed URL %q: %w", raw, err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	switch scheme {
+	case "stun", "stuns":
+		if err := validateHostPort(raw); err != nil {
+			return ICEEntry{}, fmt.Errorf("ice: %q: %w", raw, err)
+		}
+		return ICEEntry{URLs: []string{raw}}, nil
+	case "turn", "turns":
+		host, port, _, err := splitICE(raw)
+		if err != nil {
+			return ICEEntry{}, fmt.Errorf("ice: %q: %w", raw, err)
+		}
+		_ = host
+		_ = port
+		username, credential, uerr := iceUserInfo(raw)
+		if uerr != nil {
+			return ICEEntry{}, fmt.Errorf("ice: %q: %w", raw, uerr)
+		}
+		return ICEEntry{URLs: []string{raw}, Username: username, Credential: credential}, nil
+	default:
+		return ICEEntry{}, fmt.Errorf("ice: unsupported scheme %q in %q (want stun/stuns/turn/turns)", u.Scheme, raw)
+	}
+}
+
+// validateHostPort checks that an ICE URL carries a host and a numeric port. It accepts both
+// the opaque and authority forms.
+func validateHostPort(raw string) error {
+	_, _, _, err := splitICE(raw)
+	return err
+}
+
+// splitICE returns the host, port, scheme, and error for an ICE URL in either form.
+func splitICE(raw string) (host, port, scheme string, err error) {
+	u, perr := url.Parse(raw)
+	if perr != nil {
+		return "", "", "", perr
+	}
+	scheme = strings.ToLower(u.Scheme)
+	rest := u.Opaque
+	if rest == "" {
+		rest = u.Host
+	}
+	// The opaque form can carry user:cred@host:port; the userinfo is not part of host:port.
+	if at := strings.LastIndex(rest, "@"); at >= 0 {
+		rest = rest[at+1:]
+	}
+	host, port, err = net.SplitHostPort(rest)
+	if err != nil {
+		return "", "", "", fmt.Errorf("missing or invalid host:port: %w", err)
+	}
+	if host == "" {
+		return "", "", "", fmt.Errorf("empty host")
+	}
+	if port == "" {
+		return "", "", "", fmt.Errorf("missing port")
+	}
+	if p, cerr := strconv.Atoi(port); cerr != nil || p < 1 || p > 65535 {
+		return "", "", "", fmt.Errorf("invalid port %q", port)
+	}
+	return host, port, scheme, nil
+}
+
+// iceUserInfo extracts the username:credential pair from a TURN URL's opaque or authority
+// user info, if present.
+func iceUserInfo(raw string) (username, credential string, err error) {
+	u, perr := url.Parse(raw)
+	if perr != nil {
+		return "", "", perr
+	}
+	if u.User != nil && u.User.Username() != "" {
+		username = u.User.Username()
+		credential, _ = u.User.Password()
+		return username, credential, nil
+	}
+	// Opaque form: user:cred@host:port appears inside the opaque part.
+	rest := u.Opaque
+	if rest == "" {
+		return "", "", nil
+	}
+	if at := strings.LastIndex(rest, "@"); at >= 0 {
+		credPart := rest[:at]
+		if i := strings.Index(credPart, ":"); i >= 0 {
+			username = credPart[:i]
+			credential = credPart[i+1:]
+		} else {
+			username = credPart
+		}
+	}
+	return username, credential, nil
+}
+
+func sameCreds(a, b ICEEntry) bool {
+	sameScheme := len(a.URLs) > 0 && len(b.URLs) > 0 && schemeOf(a.URLs[0]) == schemeOf(b.URLs[0])
+	return sameScheme && a.Username == b.Username && a.Credential == b.Credential
+}
+
+func schemeOf(raw string) string {
+	if i := strings.Index(raw, ":"); i >= 0 {
+		return strings.ToLower(raw[:i])
+	}
+	return ""
+}

--- a/packages/wire/iceservers_test.go
+++ b/packages/wire/iceservers_test.go
@@ -1,0 +1,84 @@
+package wire
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseICEServersGroupsURLs(t *testing.T) {
+	entries, err := ParseICEServers([]string{
+		"stun:stun1.example.com:3478",
+		"stun:stun2.example.com:3478",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len = %d, want 1 folded entry", len(entries))
+	}
+	got := strings.Join(entries[0].URLs, ",")
+	if got != "stun:stun1.example.com:3478,stun:stun2.example.com:3478" {
+		t.Fatalf("urls = %q", got)
+	}
+}
+
+func TestParseICEServersSeparatesCredentialedTURN(t *testing.T) {
+	entries, err := ParseICEServers([]string{
+		"stun:stun.example.com:3478",
+		"turn:turn.example.com:3478?transport=udp",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("len = %d, want 2 (STUN + TURN kept distinct)", len(entries))
+	}
+}
+
+func TestParseICEServersValidation(t *testing.T) {
+	bad := []string{
+		"http://stun.example.com:3478", // unknown scheme
+		"stun:",                        // missing host/port
+		"stun:stun.example.com",        // missing port
+		"stun://stun.example.com",      // missing port
+		"stun:stun.example.com:abc",    // non-numeric port
+		"stun://:3478",                 // empty host
+	}
+	for _, raw := range bad {
+		if _, err := ParseICEServer(raw); err == nil {
+			t.Errorf("ParseICEServer(%q): expected error, got none", raw)
+		}
+	}
+}
+
+func TestParseICEServerTurnCredentials(t *testing.T) {
+	entry, err := ParseICEServer("turn:user:secret@turn.example.com:3478")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if entry.Username != "user" || entry.Credential != "secret" {
+		t.Fatalf("creds = %q/%q, want user/secret", entry.Username, entry.Credential)
+	}
+}
+
+func TestParseICEServersSkipsBlank(t *testing.T) {
+	entries, err := ParseICEServers([]string{"", " ", "stun:stun.example.com:3478"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len = %d, want 1 (blanks skipped)", len(entries))
+	}
+}
+
+func TestICEConfigCacheTTL(t *testing.T) {
+	base := time.Now()
+	c := NewICEConfigCache([]ICEEntry{{URLs: []string{"stun:stun.example.com:3478"}}}, base)
+	if c.Stale(base.Add(ICEConfigTTL - time.Minute)) {
+		t.Error("config marked stale before TTL")
+	}
+	if !c.Stale(base.Add(ICEConfigTTL + time.Minute)) {
+		t.Error("config not marked stale after TTL")
+	}
+}


### PR DESCRIPTION
Instrument direct-path ICE setup and make ICE servers runtime-configurable so both the browser and CLI gather candidates against the operator's chosen STUN servers rather than a build-time constant.

- **Server**: publishes operator STUN/TURN URLs via `/config.json` (`SENDBEAM_ICE_SERVERS`), validated at startup; endpoint served `no-cache`.
- **CLI**: repeatable `--ice-server` flag; shared URL validation (stun/stuns/turn/turns schemes, host+port required); exposes ICE gathering/connection state history, selected candidate-pair type, and setup time via `Peer.Diagnostics()`.
- **Web**: fetches and validates `/config.json` ICE entries, threads them through `runSend`/`runReceive` to `RTCPeerConnection`; `peer.ts` records gathering/connection history, selected pair type, and setup timing.
- **Shared rules**: Go (`packages/wire`) and TS (`@sendbeam/protocol`) implement identical ICE URL validation/folding; clients never reuse credentials past a fixed TTL (15 min) and the config endpoint is never cached.
- Adds browser/CLI/server config-parity tests and CLI/browser telemetry tests.