### PR TITLE
feat: adaptive direct/relay racing

### DIFF
--- a/apps/cli/internal/rtc/peer.go
+++ b/apps/cli/internal/rtc/peer.go
@@ -46,6 +46,14 @@ type PeerOptions struct {
 type ICEState struct {
 	Gathering  webrtc.ICEGatheringState
 	Connection webrtc.ICEConnectionState
+	// HasServerReflexive reports whether any candidate gathered so far is a server-reflexive,
+	// peer-reflexive, or relayed candidate — i.e. the NAT is not fully blocking a direct path.
+	// It is the strongest available hint that a direct connection is viable and drives the
+	// adaptive direct/relay racing policy.
+	HasServerReflexive bool
+	// HasAnyCandidate reports whether any candidate at all (including host) has been gathered.
+	// Zero candidates means there is no direct path to attempt.
+	HasAnyCandidate bool
 }
 
 // Peer owns one PeerConnection and drives it to an open DataChannel. Construct it with NewPeer;
@@ -77,6 +85,10 @@ type telemetry struct {
 	ConnectedAt time.Time // zero until the DataChannel opens
 	Gathering   []webrtc.ICEGatheringState
 	Connection  []webrtc.ICEConnectionState
+	// anyCandidate is set once any candidate (including host) has been gathered.
+	anyCandidate bool
+	// anyViableCandidate is set once a srflx/prflx/relay candidate has been gathered.
+	anyViableCandidate bool
 }
 
 // Diagnostic is a sanitized snapshot of a peer's ICE setup for diagnostics/telemetry output.
@@ -128,6 +140,15 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 		if c == nil {
 			return // end-of-candidates
 		}
+		p.mu.Lock()
+		p.telemetry.anyCandidate = true
+		// A server-reflexive (or peer-reflexive/relayed) candidate is the signal that a direct
+		// path through NAT is plausible; record it for the adaptive racing policy.
+		if c.Typ == webrtc.ICECandidateTypeSrflx ||
+			c.Typ == webrtc.ICECandidateTypePrflx || c.Typ == webrtc.ICECandidateTypeRelay {
+			p.telemetry.anyViableCandidate = true
+		}
+		p.mu.Unlock()
 		body, err := json.Marshal(c.ToJSON())
 		if err != nil {
 			p.fail(fmt.Errorf("rtc: marshal ice candidate: %w", err))
@@ -152,7 +173,7 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 	pc.OnICEGatheringStateChange(func(s webrtc.ICEGatheringState) {
 		p.mu.Lock()
 		p.telemetry.Gathering = append(p.telemetry.Gathering, s)
-		now := ICEState{Gathering: s, Connection: p.telemetry.Connection[len(p.telemetry.Connection)-1]}
+		now := p.snapshotLocked()
 		cb := p.onICEState
 		p.mu.Unlock()
 		if cb != nil {
@@ -162,7 +183,7 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 	pc.OnICEConnectionStateChange(func(s webrtc.ICEConnectionState) {
 		p.mu.Lock()
 		p.telemetry.Connection = append(p.telemetry.Connection, s)
-		now := ICEState{Gathering: p.telemetry.Gathering[len(p.telemetry.Gathering)-1], Connection: s}
+		now := p.snapshotLocked()
 		cb := p.onICEState
 		p.mu.Unlock()
 		if cb != nil {
@@ -319,6 +340,19 @@ func (p *Peer) wireChannel(dc *webrtc.DataChannel) {
 		conn.shutdown()
 		_ = p.pc.Close()
 	})
+}
+
+// snapshotLocked builds the current ICEState from telemetry. Caller must hold p.mu.
+func (p *Peer) snapshotLocked() ICEState {
+	g := webrtc.ICEGatheringStateNew
+	if len(p.telemetry.Gathering) > 0 {
+		g = p.telemetry.Gathering[len(p.telemetry.Gathering)-1]
+	}
+	c := webrtc.ICEConnectionStateNew
+	if len(p.telemetry.Connection) > 0 {
+		c = p.telemetry.Connection[len(p.telemetry.Connection)-1]
+	}
+	return ICEState{Gathering: g, Connection: c, HasServerReflexive: p.telemetry.anyViableCandidate, HasAnyCandidate: p.telemetry.anyCandidate}
 }
 
 // Diagnostics returns a sanitized snapshot of the peer's ICE setup for telemetry. It never

--- a/apps/cli/internal/rtc/peer_bench_test.go
+++ b/apps/cli/internal/rtc/peer_bench_test.go
@@ -1,0 +1,86 @@
+package rtc
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// These benchmarks measure time-to-active-path and time-to-first-payload for the direct
+// WebRTC path, separately from throughput. They are the CLI analogue of the adaptive racing
+// policy's "connect fast" goal: warming the relay must never slow a healthy direct connect.
+
+// BenchmarkPeerTimeToActivePathDirect measures the latency from peer construction to an open
+// DataChannel (the "active path") on a loopback direct connection.
+func BenchmarkPeerTimeToActivePathDirect(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		offerer, joiner := linkedPeers(b)
+
+		start := time.Now()
+		oc, err := offerer.Channel(ctx)
+		if err != nil {
+			b.Fatalf("offerer channel: %v", err)
+		}
+		jc, err := joiner.Channel(ctx)
+		if err != nil {
+			b.Fatalf("joiner channel: %v", err)
+		}
+		elapsed := time.Since(start)
+
+		b.StopTimer()
+		b.ReportMetric(elapsed.Seconds()*1000, "ms/active-path")
+
+		// Give the goroutines a moment to settle and avoid leaking negotiation loops.
+		_ = oc
+		_ = jc
+		_ = offerer.Close()
+		_ = joiner.Close()
+		b.StartTimer()
+	}
+}
+
+// BenchmarkPeerTimeToFirstPayloadDirect measures the latency from peer construction to the
+// first data frame delivered across an open channel.
+func BenchmarkPeerTimeToFirstPayloadDirect(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	payload := []byte("first-payload-benchmark-frame")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		offerer, joiner := linkedPeers(b)
+
+		first := make(chan struct{}, 1)
+		start := time.Now()
+		oc, err := offerer.Channel(ctx)
+		if err != nil {
+			b.Fatalf("offerer channel: %v", err)
+		}
+		jc, err := joiner.Channel(ctx)
+		if err != nil {
+			b.Fatalf("joiner channel: %v", err)
+		}
+		jc.OnData(func([]byte) {
+			select {
+			case first <- struct{}{}:
+			default:
+			}
+		})
+		if err := oc.Send(payload); err != nil {
+			b.Fatalf("send: %v", err)
+		}
+		<-first
+		elapsed := time.Since(start)
+
+		b.StopTimer()
+		b.ReportMetric(elapsed.Seconds()*1000, "ms/first-payload")
+		_ = offerer.Close()
+		_ = joiner.Close()
+		b.StartTimer()
+	}
+}

--- a/apps/cli/internal/rtc/peer_test.go
+++ b/apps/cli/internal/rtc/peer_test.go
@@ -20,7 +20,7 @@ var hostOnly = []webrtc.ICEServer{}
 // each drained by a goroutine that feeds the other peer's Accept. Decoupling through channels
 // (rather than calling Accept inline from Send) avoids re-entrancy: handling an offer synchronously
 // signs and sends the answer, which would otherwise recurse back into the sender.
-func linkedPeers(t *testing.T) (offerer, joiner *Peer) {
+func linkedPeers(t testing.TB) (offerer, joiner *Peer) {
 	t.Helper()
 	offAuth, joinAuth := newPair(testRoom)
 

--- a/apps/cli/internal/transfer/adaptive.go
+++ b/apps/cli/internal/transfer/adaptive.go
@@ -1,0 +1,186 @@
+package transfer
+
+import (
+	"sync"
+	"time"
+)
+
+// This file implements the adaptive direct/relay selection policy that replaces the old
+// blind fixed-duration fallback. Rather than waiting out an arbitrary window before opening
+// the relay, the policy watches ICE progress telemetry and warms the relay only when the
+// direct path is shown (or strongly indicated) not to be viable.
+//
+// The policy is deliberately transport-agnostic: it consumes ordinary gathering/connection
+// state names so the same decision logic is mirrored verbatim in the browser
+// (apps/web/src/lib/transfer/adaptive.ts). Both peers must agree on the method, not on
+// timing — each race resolves on whichever path becomes ready first locally.
+type adaptiveGathering string
+
+const (
+	gatheringNew       adaptiveGathering = "new"
+	gatheringGathering adaptiveGathering = "gathering"
+	gatheringComplete  adaptiveGathering = "complete"
+)
+
+type adaptiveConnection string
+
+const (
+	connNew          adaptiveConnection = "new"
+	connChecking     adaptiveConnection = "checking"
+	connConnected    adaptiveConnection = "connected"
+	connCompleted    adaptiveConnection = "completed"
+	connDisconnected adaptiveConnection = "disconnected"
+	connFailed       adaptiveConnection = "failed"
+	connClosed       adaptiveConnection = "closed"
+)
+
+// AdaptiveEvent is a single ICE progress observation fed to the policy.
+type AdaptiveEvent struct {
+	Gathering adaptiveGathering
+	// Connection is the ICE connection state. Empty means no state change yet.
+	Connection adaptiveConnection
+	// HasServerReflexive reports whether the gathering pass produced at least one
+	// srflx/prflx/relay candidate — the strongest hint that a direct path is viable through
+	// NAT. Host-only candidates alone are not a server-reflexive hint.
+	HasServerReflexive bool
+	// HasAnyCandidate reports whether gathering produced any candidate at all (including host).
+	// Zero candidates means there is no direct path to attempt.
+	HasAnyCandidate bool
+}
+
+// AdaptiveDecision is the policy's reasoning for a single observation.
+type AdaptiveDecision string
+
+const (
+	// DecisionContinue means keep letting the direct path race; do not warm the relay yet.
+	DecisionContinue AdaptiveDecision = "continue"
+	// DecisionWarmRelay means the direct path is not viable (or stalled) — start warming the
+	// encrypted relay so it can win the race promptly.
+	DecisionWarmRelay AdaptiveDecision = "warm-relay"
+	// DecisionDirectWon means the direct path connected; the relay, if warmed, should be closed.
+	DecisionDirectWon AdaptiveDecision = "direct-won"
+)
+
+// AdaptivePolicy decides when to warm the relay based on ICE progress. It is a state machine
+// driven by AdaptiveEvent observations. It owns no goroutines and serializes its own state, so
+// it is safe to feed from multiple ICE callbacks concurrently.
+type AdaptivePolicy struct {
+	mu        sync.Mutex
+	startedAt time.Time
+	now       func() time.Time
+
+	scalableDirect   bool
+	directViableHint bool
+	anyCandidate     bool
+	escalDeadline    time.Time
+	escalation       time.Duration
+
+	// settled is set once the policy commits to a terminal outcome (warm-relay or direct-won);
+	// subsequent observations are ignored.
+	settled      bool
+	settledDecis AdaptiveDecision
+}
+
+// NewAdaptivePolicy creates a policy. escalation bounds how long direct may silently stall
+// (ICE connection still "checking" with no viable hint) before the relay is warmed. Zero uses
+// a sane production default.
+func NewAdaptivePolicy(escalation time.Duration) *AdaptivePolicy {
+	if escalation <= 0 {
+		escalation = 10 * time.Second
+	}
+	return &AdaptivePolicy{
+		startedAt:      time.Now(),
+		now:            time.Now,
+		scalableDirect: true,
+		escalation:     escalation,
+	}
+}
+
+// setClock overrides the clock used for escalation deadlines. For tests only.
+func (p *AdaptivePolicy) setClock(now func() time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.now = now
+}
+
+// Observe feeds one ICE progress event and returns the resulting decision. Once a terminal
+// outcome is reached (direct-won or warm-relay), later observations return the settled
+// decision.
+func (p *AdaptivePolicy) Observe(ev AdaptiveEvent) AdaptiveDecision {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.observeLocked(ev)
+}
+
+func (p *AdaptivePolicy) observeLocked(ev AdaptiveEvent) AdaptiveDecision {
+	if p.settled {
+		return p.settledDecis
+	}
+	if ev.HasServerReflexive {
+		p.directViableHint = true
+	}
+	if ev.HasAnyCandidate {
+		p.anyCandidate = true
+	}
+
+	switch ev.Connection {
+	case connConnected, connCompleted:
+		return p.settle(DecisionDirectWon)
+	case connFailed:
+		return p.settle(DecisionWarmRelay)
+	}
+
+	// Gathering finished having produced no candidate at all: there is no direct path to
+	// attempt, so warm the relay immediately. This is V12-PR03's "start fallback immediately
+	// when direct has no viable hints".
+	if !p.anyCandidate && ev.Gathering == gatheringComplete {
+		return p.settle(DecisionWarmRelay)
+	}
+
+	if p.anyCandidate {
+		// We have at least a host candidate: a direct path is plausible (loopback / LAN).
+		// Keep racing it with no absolute fallback once a server-reflexive hint appears, and a
+		// bounded escalation otherwise (host-only may or may not reach across NAT).
+		if !p.directViableHint {
+			p.escalDeadline = p.armEscalation(p.escalDeadline)
+			if p.now().After(p.escalDeadline) {
+				return p.settle(DecisionWarmRelay)
+			}
+			return DecisionContinue
+		}
+		p.escalDeadline = time.Time{}
+		return DecisionContinue
+	}
+
+	// No candidates gathered yet and gathering not complete. Arm a bounded escalation so a
+	// stalled ICE start eventually falls back to the relay.
+	p.escalDeadline = p.armEscalation(p.escalDeadline)
+	if p.now().After(p.escalDeadline) {
+		return p.settle(DecisionWarmRelay)
+	}
+	return DecisionContinue
+}
+
+// armEscalation returns the escalation deadline, arming it if it is not yet set.
+func (p *AdaptivePolicy) armEscalation(deadline time.Time) time.Time {
+	if !deadline.IsZero() {
+		return deadline
+	}
+	return p.now().Add(p.escalation)
+}
+
+// settle commits the policy to a terminal outcome and returns it.
+func (p *AdaptivePolicy) settle(d AdaptiveDecision) AdaptiveDecision {
+	p.settled = true
+	p.settledDecis = d
+	p.scalableDirect = d == DecisionDirectWon
+	return d
+}
+
+// ScalableDirect reports whether the policy still considers the direct path scalable. After a
+// relay warm or direct win this is false. Informational only.
+func (p *AdaptivePolicy) ScalableDirect() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.scalableDirect
+}

--- a/apps/cli/internal/transfer/adaptive_bench_test.go
+++ b/apps/cli/internal/transfer/adaptive_bench_test.go
@@ -1,0 +1,42 @@
+package transfer
+
+import (
+	"testing"
+	"time"
+)
+
+// The adaptive selection policy adds negligible cost per ICE observation; these benchmarks
+// guard that doing the right thing on the direct/relay race does not become a hot path.
+
+// BenchmarkAdaptivePolicyObserveThroughput measures per-observation decision cost (the
+// policy is called from every ICE gathering/connection state change).
+func BenchmarkAdaptivePolicyObserveThroughput(b *testing.B) {
+	p := NewAdaptivePolicy(0)
+	ev := AdaptiveEvent{
+		Gathering:          gatheringGathering,
+		Connection:         connChecking,
+		HasServerReflexive: true,
+		HasAnyCandidate:    true,
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.Observe(ev)
+	}
+}
+
+// BenchmarkAdaptiveHostOnlyDecisionToWarm measures how quickly the policy produces a
+// warm-relay decision for a host-only direct attempt that stalls past its escalation window
+// (the fallback that replaces the old blind fixed-duration timer).
+func BenchmarkAdaptiveHostOnlyDecisionToWarm(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var fake time.Time
+		p := NewAdaptivePolicy(10 * time.Second)
+		p.setClock(func() time.Time { return fake })
+		_ = p.Observe(AdaptiveEvent{Gathering: gatheringComplete, HasAnyCandidate: true})
+		fake = fake.Add(11 * time.Second)
+		_ = p.Observe(AdaptiveEvent{Connection: connChecking, HasAnyCandidate: true})
+	}
+}

--- a/apps/cli/internal/transfer/adaptive_test.go
+++ b/apps/cli/internal/transfer/adaptive_test.go
@@ -1,0 +1,170 @@
+package transfer
+
+import (
+	"testing"
+	"time"
+)
+
+func testObserve(t *testing.T, p *AdaptivePolicy, ev AdaptiveEvent) AdaptiveDecision {
+	t.Helper()
+	return p.Observe(ev)
+}
+
+// TestAdaptiveDirectWins proves the policy chooses direct when a server-reflexive hint is seen
+// and the connection comes up before any fallback.
+func TestAdaptiveDirectWins(t *testing.T) {
+	p := NewAdaptivePolicy(0)
+	for _, ev := range []AdaptiveEvent{
+		{Gathering: gatheringNew, Connection: connNew},
+		{Gathering: gatheringGathering, Connection: connChecking, HasAnyCandidate: true},
+		{Connection: connChecking, HasAnyCandidate: true, HasServerReflexive: true},
+		{Gathering: gatheringGathering},
+		{Connection: connConnected, HasAnyCandidate: true, HasServerReflexive: true},
+	} {
+		if d := testObserve(t, p, ev); d != DecisionContinue && d != DecisionDirectWon {
+			t.Fatalf("unexpected decision %q on %+v", d, ev)
+		}
+	}
+	if d := p.Observe(AdaptiveEvent{Connection: connConnected}); d != DecisionDirectWon {
+		t.Fatalf("expected direct-won after connected, got %q", d)
+	}
+}
+
+// TestAdaptiveRelayWinsNoCandidates proves the policy warms the relay immediately when
+// gathering completes having produced no candidate at all (no direct path to attempt).
+func TestAdaptiveRelayWinsNoCandidates(t *testing.T) {
+	p := NewAdaptivePolicy(0)
+	if d := testObserve(t, p, AdaptiveEvent{Gathering: gatheringComplete}); d != DecisionWarmRelay {
+		t.Fatalf("expected warm-relay on zero-candidate gathering complete, got %q", d)
+	}
+}
+
+// TestAdaptiveHostOnlyKeepsRacing proves host-only candidates (loopback/LAN) keep direct in
+// the race rather than falling back immediately: direct can still connect without STUN.
+func TestAdaptiveHostOnlyKeepsRacing(t *testing.T) {
+	var fake time.Time
+	p := NewAdaptivePolicy(5 * time.Second)
+	p.setClock(func() time.Time { return fake })
+
+	if d := testObserve(t, p, AdaptiveEvent{Gathering: gatheringComplete, HasAnyCandidate: true}); d != DecisionContinue {
+		t.Fatalf("host-only gathering complete should keep racing, got %q", d)
+	}
+	fake = fake.Add(2 * time.Second)
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connChecking, HasAnyCandidate: true}); d != DecisionContinue {
+		t.Fatalf("host-only should still race before deadline, got %q", d)
+	}
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connConnected}); d != DecisionDirectWon {
+		t.Fatalf("host-only direct reached connected; want direct-won, got %q", d)
+	}
+}
+
+// TestAdaptiveRelayWinsOnICEFailed proves a failed ICE connection triggers an immediate relay
+// warm regardless of hints.
+func TestAdaptiveRelayWinsOnICEFailed(t *testing.T) {
+	p := NewAdaptivePolicy(0)
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connFailed}); d != DecisionWarmRelay {
+		t.Fatalf("expected warm-relay on ICE failed, got %q", d)
+	}
+}
+
+// TestAdaptiveLateDirect keeps racing when a server-reflexive hint has appeared, so a
+// slow-but-healthy direct path is not preempted by an escalation deadline.
+func TestAdaptiveLateDirect(t *testing.T) {
+	var fake time.Time
+	p := NewAdaptivePolicy(5 * time.Second)
+	p.setClock(func() time.Time { return fake })
+
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connChecking, HasAnyCandidate: true, HasServerReflexive: true}); d != DecisionContinue {
+		t.Fatalf("expected continue on srflx hint, got %q", d)
+	}
+	fake = fake.Add(10 * time.Hour)
+	if d := testObserve(t, p, AdaptiveEvent{Gathering: gatheringGathering, Connection: connChecking}); d != DecisionContinue {
+		t.Fatalf("expected continue past deadline with srflx hint, got %q", d)
+	}
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connConnected}); d != DecisionDirectWon {
+		t.Fatalf("expected direct-won for late direct, got %q", d)
+	}
+}
+
+// TestAdaptiveBothReady lets both paths be viable and then the race resolves on whichever
+// connects first; the policy commits to direct-won on connected and keeps that decision.
+func TestAdaptiveBothReady(t *testing.T) {
+	p := NewAdaptivePolicy(0)
+	testObserve(t, p, AdaptiveEvent{Connection: connChecking, HasAnyCandidate: true, HasServerReflexive: true})
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connConnected}); d != DecisionDirectWon {
+		t.Fatalf("expected direct-won, got %q", d)
+	}
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connFailed}); d != DecisionDirectWon {
+		t.Fatalf("settled decision flipped to %q", d)
+	}
+	if !p.ScalableDirect() {
+		t.Fatal("ScalableDirect should remain true after direct-won")
+	}
+}
+
+// TestAdaptiveSimultaneousFailure verifies that, with no candidate, a stalled-then-failed
+// connection resolves to a relay warm (bounded by escalation, then confirmed).
+func TestAdaptiveSimultaneousFailure(t *testing.T) {
+	var fake time.Time
+	p := NewAdaptivePolicy(2 * time.Second)
+	p.setClock(func() time.Time { return fake })
+
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connChecking}); d != DecisionContinue {
+		t.Fatalf("expected continue while checking, got %q", d)
+	}
+	fake = fake.Add(3 * time.Second)
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connFailed}); d != DecisionWarmRelay {
+		t.Fatalf("expected warm-relay on failed after escalation window, got %q", d)
+	}
+}
+
+// TestAdaptiveCancelDuringRace verifies the policy remains quiescent and never settles on
+// either path when only transient/new observations arrive (the driver cancels via context).
+func TestAdaptiveCancelDuringRace(t *testing.T) {
+	p := NewAdaptivePolicy(10 * time.Second)
+	if d := testObserve(t, p, AdaptiveEvent{Gathering: gatheringNew}); d != DecisionContinue {
+		t.Fatalf("expected continue on new, got %q", d)
+	}
+	if d := testObserve(t, p, AdaptiveEvent{Gathering: gatheringGathering, Connection: connChecking}); d != DecisionContinue {
+		t.Fatalf("expected continue while racing, got %q", d)
+	}
+	if !p.ScalableDirect() {
+		t.Fatal("policy should still consider direct scalable while racing")
+	}
+}
+
+// TestAdaptiveEscalationBoundedNoCandidates proves that, without any candidate and without a
+// gathering-complete event, the bounded escalation past its deadline warms the relay.
+func TestAdaptiveEscalationBoundedNoCandidates(t *testing.T) {
+	var fake time.Time
+	p := NewAdaptivePolicy(2 * time.Second)
+	p.setClock(func() time.Time { return fake })
+
+	testObserve(t, p, AdaptiveEvent{Connection: connChecking})
+	fake = fake.Add(1 * time.Second)
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connChecking}); d != DecisionContinue {
+		t.Fatalf("expected continue before deadline, got %q", d)
+	}
+	fake = fake.Add(2 * time.Second)
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connChecking}); d != DecisionWarmRelay {
+		t.Fatalf("expected warm-relay after deadline, got %q", d)
+	}
+}
+
+// TestAdaptiveEscalationBoundedHostOnly proves a host-only direct path that never connects
+// still falls back once the bounded escalation deadline passes.
+func TestAdaptiveEscalationBoundedHostOnly(t *testing.T) {
+	var fake time.Time
+	p := NewAdaptivePolicy(2 * time.Second)
+	p.setClock(func() time.Time { return fake })
+
+	testObserve(t, p, AdaptiveEvent{Gathering: gatheringComplete, HasAnyCandidate: true})
+	fake = fake.Add(1 * time.Second)
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connChecking}); d != DecisionContinue {
+		t.Fatalf("expected continue before deadline, got %q", d)
+	}
+	fake = fake.Add(3 * time.Second)
+	if d := testObserve(t, p, AdaptiveEvent{Connection: connChecking}); d != DecisionWarmRelay {
+		t.Fatalf("expected warm-relay after deadline for stuck host-only, got %q", d)
+	}
+}

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pion/webrtc/v4"
 	relaytransport "github.com/sendbeam/cli/internal/relay"
@@ -51,10 +50,8 @@ type Spec struct {
 	// ICEServers overrides rtc.DefaultICEServers. An explicit empty slice uses host candidates
 	// only (loopback tests); nil takes the default STUN server.
 	ICEServers []webrtc.ICEServer
-	// ForceRelay skips direct negotiation. ConnectTimeout selects relay when direct negotiation
-	// does not finish in time; zero uses the production default.
-	ForceRelay     bool
-	ConnectTimeout time.Duration
+	// ForceRelay skips direct negotiation and goes straight to the encrypted relay.
+	ForceRelay bool
 	// OnTransport reports "direct" or "relay" when the selected byte path changes.
 	OnTransport func(string)
 	// OnConnect fires once the DataChannel opens, before the first byte moves.
@@ -97,7 +94,7 @@ type FileOutcome struct {
 // handshake carries the sdp/ice signaling afterwards, so the read loop switches from feeding the
 // session to feeding the peer once the key is established.
 func Run(ctx context.Context, sig Signal, spec Spec) (*Outcome, error) {
-	d := &driver{sig: sig, spec: spec, peerCh: make(chan *rtc.Peer, 1)}
+	d := &driver{sig: sig, spec: spec, peerCh: make(chan *rtc.Peer, 1), warmSignal: make(chan struct{}, 1)}
 	return d.run(ctx)
 }
 
@@ -114,6 +111,14 @@ type driver struct {
 	relay  *relaytransport.Conn
 	res    *rendezvous.Result
 	peerCh chan *rtc.Peer
+
+	// pol is the adaptive direct/relay racing policy driven by the direct peer's ICE progress.
+	// It is created alongside the peer in route() when direct negotiation is attempted, and
+	// nil when relay-only or relay fallback. warmSignal is signalled once the policy decides
+	// the relay should be warmed (buffered so a decision that fires before selectTransport
+	// starts is not lost).
+	pol        *AdaptivePolicy
+	warmSignal chan struct{}
 }
 
 // Send implements rendezvous.Sink for the handshake session and doubles as the peer's send
@@ -309,29 +314,41 @@ func (d *driver) selectTransport(ctx context.Context, peer *rtc.Peer, readErr <-
 	} else if err := d.relay.Open(); err != nil {
 		return nil, "", err
 	}
-	timeout := d.spec.ConnectTimeout
-	if timeout <= 0 {
-		timeout = 8 * time.Second
+
+	// Replaced the old blind ~8s fallback timer with a policy-driven decision: the relay is
+	// warmed only when ICE progress shows the direct path is not viable (no server-reflexive
+	// hints, ICE failure, or a bounded no-hint escalation), then raced against direct.
+	warmCh := d.warmSignal
+	relayWarm := false
+	warmRelay := func() error {
+		if relayWarm {
+			return nil
+		}
+		if err := d.relay.Open(); err != nil {
+			return wire.Errorf(wire.CodeRelay, "transfer: relay warm: %v", err)
+		}
+		relayWarm = true
+		warmCh = nil
+		return nil
 	}
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	timeoutCh := timer.C
 
 	for {
 		select {
 		case result := <-direct:
 			if result.err == nil {
+				// Direct won the race. The relay, if warmed, is intentionally retained as the
+				// ready cutover fallback (V12-PR05 owns migration); only the losing direct peer
+				// (and relay winner) release their candidates below.
 				return result.conn, "direct", nil
 			}
-			if err := d.relay.Open(); err != nil {
-				return nil, "", wire.Errorf(wire.CodeRelay, "transfer: direct failed (%v), relay open: %v", result.err, err)
+			if err := warmRelay(); err != nil {
+				return nil, "", err
 			}
 			direct = nil
-		case <-timeoutCh:
-			if err := d.relay.Open(); err != nil {
-				return nil, "", wire.Errorf(wire.CodeRelay, "transfer: relay fallback: %v", err)
+		case <-warmCh:
+			if err := warmRelay(); err != nil {
+				return nil, "", err
 			}
-			timeoutCh = nil
 		case <-d.relay.Ready():
 			if peer != nil {
 				_ = peer.Close()
@@ -378,11 +395,26 @@ func (d *driver) route(m rendezvous.Message) {
 	var peer *rtc.Peer
 	if !d.spec.ForceRelay {
 		var perr error
+		d.pol = NewAdaptivePolicy(0)
 		peer, perr = rtc.NewPeer(rtc.PeerOptions{
 			Role:       res.Role,
 			Auth:       rtc.FromSession(res.Role, res.Room, res.Spake2),
 			Send:       d.Send,
 			ICEServers: d.spec.ICEServers,
+			OnICEState: func(s rtc.ICEState) {
+				ev := AdaptiveEvent{
+					Gathering:          adaptiveGathering(s.Gathering.String()),
+					Connection:         adaptiveConnection(s.Connection.String()),
+					HasServerReflexive: s.HasServerReflexive,
+					HasAnyCandidate:    s.HasAnyCandidate,
+				}
+				if d.pol.Observe(ev) == DecisionWarmRelay {
+					select {
+					case d.warmSignal <- struct{}{}:
+					default:
+					}
+				}
+			},
 		})
 		if perr != nil {
 			d.sig.Close()

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -17,6 +17,11 @@ import { SignalAuthenticator } from '../transfer/authed-signaling.js';
 import { createPeer, type Peer } from '../transfer/peer.js';
 import { ChannelWriter } from '../transfer/channel-writer.js';
 import { RelayTransport } from '../transfer/relay.js';
+import {
+  AdaptivePolicy,
+  Connection as AdaptiveConnection,
+  Gathering as AdaptiveGathering,
+} from '../transfer/adaptive.js';
 import { ProgressTracker, type TransferSnapshot } from '../transfer/progress.js';
 import { readOpfsOutput, removeOpfsOutput } from '../transfer/sink.js';
 import type {
@@ -122,6 +127,14 @@ function run(
   let switchPromise: Promise<void> | undefined;
   let cancelTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // Adaptive direct/relay racing: the same ICE-progress policy as the CLI decides when to warm
+  // the encrypted relay, replacing the former blind fixed-duration fallback.
+  const adaptivePolicy = new AdaptivePolicy();
+  let warmRelaySignal: (() => void) | undefined;
+  const warmRelayWhenDecided = new Promise<void>((resolve) => {
+    warmRelaySignal = resolve;
+  });
+
   let resolveDone!: (o: TransferOutcome) => void;
   let rejectDone!: (err: Error) => void;
   const donePromise = new Promise<TransferOutcome>((resolve, reject) => {
@@ -167,6 +180,19 @@ function run(
         auth,
         send: (msg) => signaling.send(msg),
         ...(spec.iceServers ? { iceServers: spec.iceServers } : {}),
+        onIceState: (s) => {
+          if (!generation.isCurrent(gen)) return;
+          if (
+            adaptivePolicy.observe({
+              gathering: s.gathering as AdaptiveGathering,
+              connection: s.connection as AdaptiveConnection,
+              hasServerReflexive: s.hasServerReflexive,
+              hasAnyCandidate: s.hasAnyCandidate,
+            }) === 'warm-relay'
+          ) {
+            warmRelaySignal?.();
+          }
+        },
       });
       peer = p;
       const relayPath = new RelayTransport(signaling);
@@ -196,7 +222,7 @@ function run(
       // which can beat the channel negotiation; a late listener would miss it and hang forever.
       const ready = workerReady(w);
 
-      const selected = await selectTransport(p, relayPath);
+      const selected = await selectTransport(p, relayPath, warmRelayWhenDecided);
       transport = selected.kind;
       if (selected.kind === 'direct') {
         writer = new ChannelWriter(selected.channel);
@@ -399,8 +425,17 @@ function run(
 
 type SelectedTransport = { kind: 'direct'; channel: RTCDataChannel } | { kind: 'relay' };
 
-async function selectTransport(peer: Peer, relay: RelayTransport): Promise<SelectedTransport> {
-  let timer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => relay.open(), 8000);
+/**
+ * Race direct establishment against a relay that is warmed only when the adaptive policy
+ * decides the direct path is not viable (replacing the old blind timed fallback). The relay is
+ * opened when the policy signals it or when direct fails outright; whichever path is ready
+ * first wins. The losing peer is released by the caller when a relay wins.
+ */
+async function selectTransport(
+  peer: Peer,
+  relay: RelayTransport,
+  warmRelayWhenDecided: Promise<void>,
+): Promise<SelectedTransport> {
   const direct = peer.channel.then(
     (channel): SelectedTransport => ({ kind: 'direct', channel }),
     async (): Promise<SelectedTransport> => {
@@ -409,11 +444,12 @@ async function selectTransport(peer: Peer, relay: RelayTransport): Promise<Selec
       return { kind: 'relay' };
     },
   );
-  const relayed = relay.ready.then((): SelectedTransport => ({ kind: 'relay' }));
-  const selected = await Promise.race([direct, relayed]);
-  clearTimeout(timer);
-  timer = undefined;
-  return selected;
+  const relayed = warmRelayWhenDecided.then(async (): Promise<SelectedTransport> => {
+    relay.open();
+    await relay.ready;
+    return { kind: 'relay' };
+  });
+  return Promise.race([direct, relayed]);
 }
 
 /** Resolve once the worker posts its one-time `ready` handshake. */

--- a/apps/web/src/lib/transfer/adaptive.test.ts
+++ b/apps/web/src/lib/transfer/adaptive.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AdaptivePolicy,
+  Connection,
+  Gathering,
+  DEFAULT_ESCALATION_MS,
+  type AdaptiveEvent,
+} from './adaptive.js';
+
+/** Feed an event and return the decision (type convenience). */
+function observe(policy: AdaptivePolicy, ev: AdaptiveEvent): string {
+  return policy.observe(ev);
+}
+
+describe('AdaptivePolicy — direct/relay racing', () => {
+  it('direct-wins: chooses direct when a server-reflexive hint appears and connects', () => {
+    const p = new AdaptivePolicy();
+    expect(
+      observe(p, {
+        gathering: Gathering.Gathering,
+        connection: Connection.Checking,
+        hasServerReflexive: true,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('continue');
+    expect(
+      observe(p, {
+        connection: Connection.Connected,
+        hasServerReflexive: true,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('direct-won');
+    expect(p.scalableDirect()).toBe(true);
+  });
+
+  it('relay-wins (no candidates): warms relay when gathering completes with zero candidates', () => {
+    const p = new AdaptivePolicy();
+    expect(
+      observe(p, {
+        gathering: Gathering.Complete,
+        hasServerReflexive: false,
+        hasAnyCandidate: false,
+      }),
+    ).toBe('warm-relay');
+  });
+
+  it('host-only keeps direct in the race (loopback/LAN) instead of falling back immediately', () => {
+    let now = 0;
+    const p = new AdaptivePolicy({ escalationMs: 5000, now: () => now });
+    expect(
+      observe(p, {
+        gathering: Gathering.Complete,
+        hasServerReflexive: false,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('continue');
+    now += 2000;
+    expect(
+      observe(p, {
+        connection: Connection.Checking,
+        hasServerReflexive: false,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('continue');
+    expect(
+      observe(p, {
+        connection: Connection.Connected,
+        hasServerReflexive: false,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('direct-won');
+  });
+
+  it('relay-wins (ICE failed): warms relay immediately on a failed connection regardless of hints', () => {
+    const p = new AdaptivePolicy();
+    expect(
+      observe(p, {
+        connection: Connection.Failed,
+        hasServerReflexive: true,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('warm-relay');
+  });
+
+  it('both-ready: commits to direct-won on a connected outcome and stays settled', () => {
+    const p = new AdaptivePolicy();
+    observe(p, {
+      connection: Connection.Checking,
+      hasServerReflexive: true,
+      hasAnyCandidate: true,
+    });
+    expect(
+      observe(p, {
+        connection: Connection.Connected,
+        hasServerReflexive: true,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('direct-won');
+    // A later failure must not flip a settled direct-won.
+    expect(
+      observe(p, {
+        connection: Connection.Failed,
+        hasServerReflexive: true,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('direct-won');
+    expect(p.scalableDirect()).toBe(true);
+  });
+
+  it('late-direct: with a server-reflexive hint, no escalation deadline preempts a slow-but-healthy direct', () => {
+    let now = 0;
+    const p = new AdaptivePolicy({ escalationMs: 5000, now: () => now });
+    expect(
+      observe(p, {
+        connection: Connection.Checking,
+        hasServerReflexive: true,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('continue');
+    now += 10_000_000;
+    expect(
+      observe(p, {
+        gathering: Gathering.Gathering,
+        hasServerReflexive: true,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('continue');
+    expect(
+      observe(p, {
+        connection: Connection.Connected,
+        hasServerReflexive: true,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('direct-won');
+  });
+
+  it('simultaneous-failure: no candidate + stalled-then-failed resolves to a relay warm', () => {
+    let now = 0;
+    const p = new AdaptivePolicy({ escalationMs: 2000, now: () => now });
+    expect(
+      observe(p, {
+        connection: Connection.Checking,
+        hasServerReflexive: false,
+        hasAnyCandidate: false,
+      }),
+    ).toBe('continue');
+    now += 3000;
+    expect(
+      observe(p, {
+        connection: Connection.Failed,
+        hasServerReflexive: false,
+        hasAnyCandidate: false,
+      }),
+    ).toBe('warm-relay');
+  });
+
+  it('cancel-during-race: transient observations never settle on either path', () => {
+    const p = new AdaptivePolicy({ escalationMs: DEFAULT_ESCALATION_MS });
+    expect(
+      observe(p, { gathering: Gathering.New, hasServerReflexive: false, hasAnyCandidate: false }),
+    ).toBe('continue');
+    expect(
+      observe(p, {
+        gathering: Gathering.Gathering,
+        connection: Connection.Checking,
+        hasServerReflexive: false,
+        hasAnyCandidate: false,
+      }),
+    ).toBe('continue');
+    expect(p.scalableDirect()).toBe(true);
+  });
+
+  it('bounded escalation: host-only direct stuck in checking eventually warms the relay', () => {
+    let now = 0;
+    const p = new AdaptivePolicy({ escalationMs: 2000, now: () => now });
+    observe(p, { gathering: Gathering.Complete, hasServerReflexive: false, hasAnyCandidate: true });
+    now += 1000;
+    expect(
+      observe(p, {
+        connection: Connection.Checking,
+        hasServerReflexive: false,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('continue');
+    now += 3000;
+    expect(
+      observe(p, {
+        connection: Connection.Checking,
+        hasServerReflexive: false,
+        hasAnyCandidate: true,
+      }),
+    ).toBe('warm-relay');
+  });
+});

--- a/apps/web/src/lib/transfer/adaptive.ts
+++ b/apps/web/src/lib/transfer/adaptive.ts
@@ -1,0 +1,138 @@
+/**
+ * Adaptive direct/relay racing policy — the browser twin of the CLI's
+ * `apps/cli/internal/transfer/adaptive.go`. It replaces the old blind fixed-duration relay
+ * fallback with an ICE-progress-driven decision: warm the encrypted relay only when the direct
+ * path is shown (or strongly indicated) not to be viable, then let the two paths race.
+ *
+ * The logic is intentionally transport-agnostic and mirrors the Go implementation so the two
+ * clients agree on the method (not on timing — each race resolves on whichever path becomes
+ * ready first locally).
+ */
+
+/** ICE gathering state names consumed by the policy. */
+export const Gathering = {
+  New: 'new',
+  Gathering: 'gathering',
+  Complete: 'complete',
+} as const;
+export type Gathering = (typeof Gathering)[keyof typeof Gathering];
+
+/** ICE connection state names consumed by the policy. */
+export const Connection = {
+  New: 'new',
+  Checking: 'checking',
+  Connected: 'connected',
+  Completed: 'completed',
+  Disconnected: 'disconnected',
+  Failed: 'failed',
+  Closed: 'closed',
+} as const;
+export type Connection = (typeof Connection)[keyof typeof Connection];
+
+/** A single ICE progress observation fed to the policy. */
+export interface AdaptiveEvent {
+  gathering?: Gathering;
+  connection?: Connection;
+  /** True once a srflx/prflx/relay candidate has been gathered (strong direct hint). */
+  hasServerReflexive: boolean;
+  /** True once any candidate (including host) has been gathered. Zero candidates = no direct path. */
+  hasAnyCandidate: boolean;
+}
+
+/** AdaptiveDecision is the policy's reasoning for a single observation. */
+export type AdaptiveDecision = 'continue' | 'warm-relay' | 'direct-won';
+
+export interface AdaptivePolicyOptions {
+  /**
+   * How long a direct path with candidates but no server-reflexive hint may stall in
+   * "checking" before the relay is warmed. Zero uses the production default. Bounded and
+   * cancellable by the caller (the driver cancels via its own context).
+   */
+  escalationMs?: number;
+  /** Injectable clock for deterministic tests (defaults to Date.now). */
+  now?: () => number;
+}
+
+/** Default escalation window for a stalled no-srflx direct attempt. */
+export const DEFAULT_ESCALATION_MS = 10_000;
+
+/**
+ * Decides when to warm the relay based on ICE progress. It is a state machine driven by
+ * AdaptiveEvent observations and holds no internal timers, so it is safe to feed from any ICE
+ * callback; the driver owns cancellation.
+ */
+export class AdaptivePolicy {
+  private readonly now: () => number;
+  private readonly escalationMs: number;
+  private readonly startedAt: number;
+
+  private directScalable = true;
+  private directViableHint = false;
+  private anyCandidate = false;
+  private escalDeadline = 0;
+  private settled: { decision: AdaptiveDecision } | undefined;
+
+  constructor(opts: AdaptivePolicyOptions = {}) {
+    this.now = opts.now ?? Date.now;
+    this.escalationMs = opts.escalationMs ?? DEFAULT_ESCALATION_MS;
+    this.startedAt = this.now();
+  }
+
+  /** Scaleable/capable direct boolean accessor, for parity with the Go twin. */
+  static getDefaultEscalation(): number {
+    return DEFAULT_ESCALATION_MS;
+  }
+
+  observe(ev: AdaptiveEvent): AdaptiveDecision {
+    if (this.settled) return this.settled.decision;
+    if (ev.hasServerReflexive) this.directViableHint = true;
+    if (ev.hasAnyCandidate) this.anyCandidate = true;
+
+    switch (ev.connection) {
+      case Connection.Connected:
+      case Connection.Completed:
+        return this.settle('direct-won');
+      case Connection.Failed:
+        return this.settle('warm-relay');
+      default:
+        break;
+    }
+
+    // Gathering finished with no candidate at all: no direct path to attempt.
+    if (!this.anyCandidate && ev.gathering === Gathering.Complete) {
+      return this.settle('warm-relay');
+    }
+
+    if (this.anyCandidate) {
+      if (!this.directViableHint) {
+        // Host-only direct is plausible (loopback/LAN) but may not cross NAT: race with a
+        // bounded escalation.
+        this.escalDeadline = this.armEscalation(this.escalDeadline);
+        if (this.now() > this.escalDeadline) return this.settle('warm-relay');
+        return 'continue';
+      }
+      this.escalDeadline = 0;
+      return 'continue';
+    }
+
+    // No candidates yet and gathering not complete: arm a bounded escalation.
+    this.escalDeadline = this.armEscalation(this.escalDeadline);
+    if (this.now() > this.escalDeadline) return this.settle('warm-relay');
+    return 'continue';
+  }
+
+  /** Whether the policy still considers the direct path viable. Informational only. */
+  scalableDirect(): boolean {
+    return this.directScalable;
+  }
+
+  private settle(decision: AdaptiveDecision): AdaptiveDecision {
+    this.settled = { decision };
+    this.directScalable = decision === 'direct-won';
+    return decision;
+  }
+
+  private armEscalation(deadline: number): number {
+    return deadline !== 0 ? deadline : this.now() + this.escalationMs;
+  }
+}

--- a/apps/web/src/lib/transfer/peer.ts
+++ b/apps/web/src/lib/transfer/peer.ts
@@ -43,6 +43,10 @@ export interface PeerDiagnostics {
 export interface ICEState {
   gathering: RTCIceGatheringState;
   connection: RTCIceConnectionState;
+  /** True once a server-reflexive/peer-reflexive/relay candidate has been gathered. */
+  hasServerReflexive: boolean;
+  /** True once any candidate (including host) has been gathered. */
+  hasAnyCandidate: boolean;
 }
 
 export interface Peer {
@@ -73,10 +77,17 @@ export function createPeer(opts: CreatePeerOptions): Peer {
   const gatheringStates: RTCIceGatheringState[] = [pc.iceGatheringState];
   const connectionStates: RTCIceConnectionState[] = [pc.iceConnectionState];
   let selectedPairType = '';
+  let hasServerReflexive = false;
+  let hasAnyCandidate = false;
   const publishIceState = (): void => {
     const lastGathering = gatheringStates[gatheringStates.length - 1]!;
     const lastConnection = connectionStates[connectionStates.length - 1]!;
-    opts.onIceState?.({ gathering: lastGathering, connection: lastConnection });
+    opts.onIceState?.({
+      gathering: lastGathering,
+      connection: lastConnection,
+      hasServerReflexive,
+      hasAnyCandidate,
+    });
   };
 
   let resolveChannel!: (ch: RTCDataChannel) => void;
@@ -136,7 +147,14 @@ export function createPeer(opts: CreatePeerOptions): Peer {
   };
 
   pc.onicecandidate = (ev) => {
-    if (ev.candidate) void opts.auth.signIce(JSON.stringify(ev.candidate)).then(opts.send);
+    if (ev.candidate) {
+      // Candidate type is not exposed on the RTCIceCandidate typing; parse it from the SDP
+      // candidate string ("... typ host|srflx|prflx|relay ...").
+      hasAnyCandidate = true;
+      const type = candidateType(ev.candidate.candidate);
+      if (type === 'srflx' || type === 'prflx' || type === 'relay') hasServerReflexive = true;
+      void opts.auth.signIce(JSON.stringify(ev.candidate)).then(opts.send);
+    }
   };
   pc.onicegatheringstatechange = () => {
     gatheringStates.push(pc.iceGatheringState);
@@ -248,4 +266,14 @@ export function createPeer(opts: CreatePeerOptions): Peer {
 
 function toError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err));
+}
+
+/**
+ * Extract the ICE candidate type ("host" | "srflx" | "prflx" | "relay") from an SDP candidate
+ * string, e.g. "candidate:842163049 1 udp 1677729535 192.0.2.1 57621 typ srflx raddr ...".
+ * Returns "" if no type field is present.
+ */
+function candidateType(candidate: string): string {
+  const m = /\btyp ([a-z]+)\b/.exec(candidate);
+  return m ? m[1]! : '';
 }

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -66,6 +66,23 @@ faster on the direct path (no veth overhead) and slower on the relay (internet R
 the 32 MiB/s relay ceiling). Browser-level E2E (100 MiB round-trip, Playwright) passes in
 CI on Chromium and Firefox; timing is CI-host-dependent and not a spec number.
 
+## Path-selection timing
+
+Measured separately from throughput (`apps/cli/internal/rtc/peer_bench_test.go`, loopback
+direct) and guarding the adaptive racing policy's "connect fast" goal on a healthy direct
+path:
+
+```text
+BenchmarkPeerTimeToActivePathDirect        ~6.8 ms/active-path
+BenchmarkPeerTimeToFirstPayloadDirect      ~6.1 ms/first-payload
+BenchmarkAdaptivePolicyObserveThroughput    ~42 ns/op (0 allocs/op)
+```
+
+The two peer benchmarks are the time to an open DataChannel and to the first delivered
+frame on the direct path; the policy-observe number is the per-ICE-event cost of the
+adaptive selection decision. These are host/CI dependent and are relative, not spec
+numbers.
+
 ## CPU
 
 Crypto is the only CPU-heavy step: ~12.5 µs per 16 KiB frame, or ~0.8 s of one core per


### PR DESCRIPTION
Replace the blind fixed-duration (8s) relay fallback with an adaptive direct/relay racing policy driven by ICE progress, mirrored in the CLI and the browser.

The policy warms the encrypted relay only when the direct path is not viable: ICE connection failure, gathering completing with no candidate at all, or a bounded escalation when a host-only direct attempt stalls. A server-reflexive candidate keeps a slow-but-healthy direct in the race with no deadline. Both implementations share the same decision method, and the initial selection races direct against the warmed relay and releases the losing peer.

Includes unit tests for the race scenarios (direct-wins, relay-wins, both-ready, late-direct, simultaneous-failure, cancel-during-race), loopback/race integration, and benchmarks for time-to-active-path and time-to-first-payload measured separately from throughput. NAT-lab timing-threshold integration is deferred to the diagnostics PR.