### PR TITLE
feat: ICE restart and network/signaling recovery

### DIFF
--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -245,12 +245,13 @@ func runReceive(args []string) int {
 	return 0
 }
 
-// dial opens the signaling socket, reporting the server it is contacting. The transfer
-// driver adopts the returned client for the whole exchange and closes it when done.
-func dial(ctx context.Context, server string, insecure bool) (*wsclient.Client, error) {
+// dial opens the signaling socket, reporting the server it is contacting. It returns a
+// reconnecting signal so a post-establishment socket drop can re-attach to the room when the
+// transfer is healthy; the driver adopts it for the whole exchange and closes it when done.
+func dial(ctx context.Context, server string, insecure bool) (*wsclient.ReconnectingSignal, error) {
 	s := newStyle(os.Stderr)
 	fmt.Fprintln(os.Stderr, s.dim("Connecting to "+server+" …"))
-	return wsclient.Dial(ctx, server, wsclient.DialOptions{InsecureSkipVerify: insecure})
+	return wsclient.NewReconnectingSignal(ctx, server, wsclient.DialOptions{InsecureSkipVerify: insecure})
 }
 
 // parseArgs parses flags that may appear before or after positional arguments. Go's flag
@@ -311,9 +312,12 @@ func connectPrinter(line string) func() {
 
 func transportPrinter(path string) {
 	s := newStyle(os.Stderr)
-	if path == "relay" {
+	switch path {
+	case "relay":
 		fmt.Fprintln(os.Stderr, s.dim("Transport: encrypted WebSocket relay"))
-	} else {
+	case "recovering":
+		fmt.Fprintln(os.Stderr, s.cyan("Transport: recovering connection…"))
+	default:
 		fmt.Fprintln(os.Stderr, s.dim("Transport: direct WebRTC"))
 	}
 }

--- a/apps/cli/internal/rtc/peer.go
+++ b/apps/cli/internal/rtc/peer.go
@@ -40,7 +40,22 @@ type PeerOptions struct {
 	// OnICEState, if set, is invoked as ICE gathering/connection state transitions occur.
 	// Useful for diagnostics and adaptive selection; see Peer.Diagnostics.
 	OnICEState func(ICEState)
+	// OnRecovering, if set, is invoked with true when an established direct path enters the
+	// transient-disconnected recovery window (an ICE restart is under way) and false when it
+	// recovers back to connected. Used to expose a distinct "recovering connection" state.
+	OnRecovering func(recovering bool)
+	// OnRecoverFailed, if set, is invoked when the recovery window elapses (or the ICE restart
+	// fails) without returning to connected, meaning the direct path is gone and the caller
+	// should fall back to the relay without resetting transfer progress.
+	OnRecoverFailed func()
+	// RecoverWindow bounds how long the peer observes a transient disconnect before giving up
+	// and failing recovery. Zero uses the production default.
+	RecoverWindow time.Duration
 }
+
+// DefaultRecoverWindow is the default bound for observing a transient ICE disconnect before the
+// direct path is declared unrecoverable and the caller falls back to the relay.
+const DefaultRecoverWindow = 6 * time.Second
 
 // ICEState is a snapshot of ICE gathering/connection telemetry for one peer.
 type ICEState struct {
@@ -67,7 +82,10 @@ type Peer struct {
 	connCh chan *DataConn // buffered(1): the channel once open
 	errCh  chan error     // buffered(1): first fatal negotiation error
 
-	onICEState func(ICEState)
+	onICEState     func(ICEState)
+	onRecovering   func(recovering bool)
+	onRecoverFailed func()
+	recoverWindow  time.Duration
 
 	// telemetry holds ICE setup instrumentation. It is guarded by mu and is safe to read once
 	// the peer settles.
@@ -75,8 +93,14 @@ type Peer struct {
 
 	mu          sync.Mutex
 	settled     bool
+	closed      bool
 	remoteReady bool
 	pendingICE  []webrtc.ICECandidateInit
+
+	// recovering is true while an established direct path is in the transient-disconnect
+	// recovery window. recoverTimer bounds that window. Both are guarded by mu.
+	recovering   bool
+	recoverTimer *time.Timer
 }
 
 // telemetry records ICE gathering/connection history and setup timing for Diagnostics.
@@ -112,9 +136,20 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 	if iceServers == nil {
 		iceServers = DefaultICEServers
 	}
-	newPC := webrtc.NewPeerConnection
+	recoverWindow := opts.RecoverWindow
+	if recoverWindow <= 0 {
+		recoverWindow = DefaultRecoverWindow
+	}
+	var newPC func(webrtc.Configuration) (*webrtc.PeerConnection, error)
 	if opts.API != nil {
 		newPC = opts.API.NewPeerConnection
+	} else {
+		// Observe a transient disconnect promptly and bound the failed state so recovery (or
+		// fallback) is decided within a controlled window rather than Pion's long defaults.
+		s := webrtc.SettingEngine{}
+		s.SetICETimeouts(3*time.Second, 8*time.Second, 2*time.Second)
+		api := webrtc.NewAPI(webrtc.WithSettingEngine(s))
+		newPC = api.NewPeerConnection
 	}
 	pc, err := newPC(webrtc.Configuration{ICEServers: iceServers})
 	if err != nil {
@@ -122,13 +157,16 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 	}
 
 	p := &Peer{
-		pc:         pc,
-		role:       opts.Role,
-		auth:       opts.Auth,
-		send:       opts.Send,
-		connCh:     make(chan *DataConn, 1),
-		errCh:      make(chan error, 1),
-		onICEState: opts.OnICEState,
+		pc:             pc,
+		role:           opts.Role,
+		auth:           opts.Auth,
+		send:           opts.Send,
+		connCh:         make(chan *DataConn, 1),
+		errCh:          make(chan error, 1),
+		onICEState:     opts.OnICEState,
+		onRecovering:   opts.OnRecovering,
+		onRecoverFailed: opts.OnRecoverFailed,
+		recoverWindow:  recoverWindow,
 		telemetry: telemetry{
 			StartAt:    time.Now(),
 			Gathering:  []webrtc.ICEGatheringState{pc.ICEGatheringState()},
@@ -184,10 +222,23 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 		p.mu.Lock()
 		p.telemetry.Connection = append(p.telemetry.Connection, s)
 		now := p.snapshotLocked()
-		cb := p.onICEState
+		settled := p.settled
 		p.mu.Unlock()
-		if cb != nil {
-			cb(now)
+		if p.onICEState != nil {
+			p.onICEState(now)
+		}
+		// Recovery applies only to an established direct path (the channel already opened).
+		// Before settlement, disconnected/failed continue to fail the peer outright.
+		if !settled {
+			return
+		}
+		switch s {
+		case webrtc.ICEConnectionStateDisconnected:
+			p.enterRecover()
+		case webrtc.ICEConnectionStateConnected, webrtc.ICEConnectionStateCompleted:
+			p.exitRecover()
+		case webrtc.ICEConnectionStateFailed:
+			p.failRecover()
 		}
 	})
 
@@ -234,6 +285,11 @@ func (p *Peer) Accept(msg rendezvous.Message) {
 func (p *Peer) Close() error {
 	p.mu.Lock()
 	p.settled = true
+	p.closed = true
+	if p.recoverTimer != nil {
+		p.recoverTimer.Stop()
+		p.recoverTimer = nil
+	}
 	p.mu.Unlock()
 	return p.pc.Close()
 }
@@ -353,6 +409,103 @@ func (p *Peer) snapshotLocked() ICEState {
 		c = p.telemetry.Connection[len(p.telemetry.Connection)-1]
 	}
 	return ICEState{Gathering: g, Connection: c, HasServerReflexive: p.telemetry.anyViableCandidate, HasAnyCandidate: p.telemetry.anyCandidate}
+}
+
+// Recovering reports whether the established direct path is currently in the
+// transient-disconnect recovery window.
+func (p *Peer) Recovering() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.recovering
+}
+
+// enterRecover starts recovery for an established direct path that has gone transiently
+// disconnected: it reports the recovering state, has the offerer issue an ICE restart over
+// signaling, and bounds the observation window so a path that cannot return to connected fails
+// over to the relay rather than stalling forever.
+func (p *Peer) enterRecover() {
+	p.mu.Lock()
+	if p.closed || p.recovering {
+		p.mu.Unlock()
+		return
+	}
+	p.recovering = true
+	restart := p.role == wire.RoleOfferer
+	onRecovering := p.onRecovering
+	p.mu.Unlock()
+
+	if onRecovering != nil {
+		onRecovering(true)
+	}
+	if restart {
+		if err := p.restartOffer(); err != nil {
+			p.failRecover()
+			return
+		}
+	}
+	p.mu.Lock()
+	if p.closed || p.recoverTimer != nil {
+		p.mu.Unlock()
+		return
+	}
+	p.recoverTimer = time.AfterFunc(p.recoverWindow, func() { p.failRecover() })
+	p.mu.Unlock()
+}
+
+// restartOffer performs an ICE restart as the offerer: a new offer with ICERestart set, sent
+// over signaling so the partner answers and both sides re-establish the ICE transport while the
+// existing data channel (and therefore the transfer progress) stays alive.
+func (p *Peer) restartOffer() error {
+	offer, err := p.pc.CreateOffer(&webrtc.OfferOptions{ICERestart: true})
+	if err != nil {
+		return fmt.Errorf("rtc: create restart offer: %w", err)
+	}
+	if err := p.pc.SetLocalDescription(offer); err != nil {
+		return fmt.Errorf("rtc: set restart offer: %w", err)
+	}
+	return p.send(p.auth.SignSDP(offer.SDP))
+}
+
+// exitRecover clears the recovery state once the path returns to connected. Idempotent.
+func (p *Peer) exitRecover() {
+	p.mu.Lock()
+	if !p.recovering {
+		p.mu.Unlock()
+		return
+	}
+	p.recovering = false
+	if p.recoverTimer != nil {
+		p.recoverTimer.Stop()
+		p.recoverTimer = nil
+	}
+	onRecovering := p.onRecovering
+	p.mu.Unlock()
+	if onRecovering != nil {
+		onRecovering(false)
+	}
+}
+
+// failRecover gives up on the direct path after the observation window elapsed (or the ICE
+// restart failed) without returning to connected: it reports recovery failure and closes the
+// PeerConnection so the DataConn teardown notifies the active-path failure and the caller falls
+// back to the relay. Idempotent and safe to call from the timer and ICE callbacks.
+func (p *Peer) failRecover() {
+	p.mu.Lock()
+	if p.closed || !p.recovering {
+		p.mu.Unlock()
+		return
+	}
+	p.recovering = false
+	if p.recoverTimer != nil {
+		p.recoverTimer.Stop()
+		p.recoverTimer = nil
+	}
+	onRecoverFailed := p.onRecoverFailed
+	p.mu.Unlock()
+	if onRecoverFailed != nil {
+		onRecoverFailed()
+	}
+	_ = p.pc.Close()
 }
 
 // Diagnostics returns a sanitized snapshot of the peer's ICE setup for telemetry. It never

--- a/apps/cli/internal/rtc/peer_test.go
+++ b/apps/cli/internal/rtc/peer_test.go
@@ -1,6 +1,7 @@
 package rtc
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"sync/atomic"
@@ -155,6 +156,289 @@ func recvWithin(t *testing.T, ch <-chan []byte) []byte {
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for frame")
 		return nil
+	}
+}
+
+// TestPeerRestartICEKeepsChannelAlive pins the ICE-restart renegotiation path that V12-PR04
+// recovery relies on: after a connected pair restarts ICE as the offerer, the existing data
+// channel survives (progress is not reset) and bytes still flow in both directions.
+func TestPeerRestartICEKeepsChannelAlive(t *testing.T) {
+	offerer, joiner := linkedPeers(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	offConn, err := offerer.Channel(ctx)
+	if err != nil {
+		t.Fatalf("offerer channel: %v", err)
+	}
+	joinConn, err := joiner.Channel(ctx)
+	if err != nil {
+		t.Fatalf("joiner channel: %v", err)
+	}
+
+	fromOfferer := make(chan []byte, 8)
+	fromJoiner := make(chan []byte, 8)
+	joinConn.OnData(func(f []byte) { fromOfferer <- f })
+	offConn.OnData(func(f []byte) { fromJoiner <- f })
+
+	if err := offConn.Send([]byte("before")); err != nil {
+		t.Fatalf("offerer send: %v", err)
+	}
+	if got := recvWithin(t, fromOfferer); string(got) != "before" {
+		t.Fatalf("before restart: got %q, want before", got)
+	}
+
+	// ICE restart: the offerer renegotiates with a fresh offer over the same channel.
+	if err := offerer.restartOffer(); err != nil {
+		t.Fatalf("restart offer: %v", err)
+	}
+
+	// The existing channel must still carry bytes after renegotiation completes.
+	sendAndExpect := func(send func([]byte) error, recv chan []byte, want string) {
+		t.Helper()
+		if err := send([]byte(want)); err != nil {
+			t.Fatalf("send after restart %q: %v", want, err)
+		}
+		var got []byte
+		select {
+		case got = <-recv:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timed out waiting for %q after restart", want)
+		}
+		if string(got) != want {
+			t.Fatalf("after restart: got %q, want %q", got, want)
+		}
+	}
+	sendAndExpect(offConn.Send, fromOfferer, "after-offer")
+	sendAndExpect(joinConn.Send, fromJoiner, "after-answer")
+}
+
+// TestPeerRecoveryCallbacks pins the recovery state machine on the Pion peer: entering the
+// transient-disconnect window reports recovering, a return to connected clears it, and an
+// unrecovered window fails over (with a bounded timer), all reflected by the Recovering getter.
+func TestPeerRecoveryCallbacks(t *testing.T) {
+	var ( // offerer reports recovering; use a short window so the timer fires deterministically.
+		becomes       []bool
+		recoverFailed atomic.Bool
+		mu            sync.Mutex
+	)
+	record := func(b bool) {
+		mu.Lock()
+		becomes = append(becomes, b)
+		mu.Unlock()
+	}
+
+	toJoiner := make(chan rendezvous.Message, 64)
+	toOfferer := make(chan rendezvous.Message, 64)
+	offAuth, joinAuth := newPair(testRoom)
+
+	offerer, err := NewPeer(PeerOptions{
+		Role: wire.RoleOfferer, Auth: offAuth, ICEServers: hostOnly,
+		Send:            func(m rendezvous.Message) error { toJoiner <- m; return nil },
+		RecoverWindow:   30 * time.Millisecond,
+		OnRecovering:    record,
+		OnRecoverFailed: func() { recoverFailed.Store(true) },
+	})
+	if err != nil {
+		t.Fatalf("new offerer: %v", err)
+	}
+	joiner, err := NewPeer(PeerOptions{
+		Role: wire.RoleJoiner, Auth: joinAuth, ICEServers: hostOnly,
+		Send: func(m rendezvous.Message) error { toOfferer <- m; return nil },
+	})
+	if err != nil {
+		_ = offerer.Close()
+		t.Fatalf("new joiner: %v", err)
+	}
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case m := <-toJoiner:
+				joiner.Accept(m)
+			case <-done:
+				return
+			}
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case m := <-toOfferer:
+				offerer.Accept(m)
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer func() { _ = offerer.Close(); _ = joiner.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := offerer.Channel(ctx); err != nil {
+		t.Fatalf("offerer channel: %v", err)
+	}
+
+	// Entering recovery reports recovering=true and arms the bounded timer.
+	offerer.enterRecover()
+	if !offerer.Recovering() {
+		t.Fatal("expected Recovering() true after enterRecover")
+	}
+	mu.Lock()
+	got := append([]bool(nil), becomes...)
+	mu.Unlock()
+	if len(got) != 1 || got[0] != true {
+		t.Fatalf("onRecovering calls = %v, want [true]", got)
+	}
+
+	// A return to connected clears it and reports recovering=false.
+	offerer.exitRecover()
+	if offerer.Recovering() {
+		t.Fatal("expected Recovering() false after exitRecover")
+	}
+	mu.Lock()
+	got = append([]bool(nil), becomes...)
+	mu.Unlock()
+	if len(got) != 2 || got[1] != false {
+		t.Fatalf("onRecovering calls = %v, want [true false]", got)
+	}
+
+	// A bounded, unrecovered window fails over within the window, without leaking the timer.
+	recoverFailed.Store(false)
+	offerer.enterRecover()
+	deadline := time.Now().Add(5 * time.Second)
+	for !recoverFailed.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !recoverFailed.Load() {
+		t.Fatal("expected onRecoverFailed after the recovery window elapsed")
+	}
+	if offerer.Recovering() {
+		t.Fatal("expected Recovering() false after failed recovery")
+	}
+}
+
+// TestPeerRepeatedRecoveryCyclesKeepChannelAlive pins the V12-PR04 guarantee that repeated
+// network-change cycles (disconnect → recover → reconnect) never reset transfer progress: the
+// existing channel survives each cycle and bytes flow in both directions with no loss.
+func TestPeerRepeatedRecoveryCyclesKeepChannelAlive(t *testing.T) {
+	offerer, joiner := linkedPeers(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	offConn, err := offerer.Channel(ctx)
+	if err != nil {
+		t.Fatalf("offerer channel: %v", err)
+	}
+	joinConn, err := joiner.Channel(ctx)
+	if err != nil {
+		t.Fatalf("joiner channel: %v", err)
+	}
+
+	fromOfferer := make(chan []byte, 8)
+	fromJoiner := make(chan []byte, 8)
+	joinConn.OnData(func(f []byte) { fromOfferer <- f })
+	offConn.OnData(func(f []byte) { fromJoiner <- f })
+
+	for i := 0; i < 3; i++ {
+		payload := []byte{byte('a' + i), byte(i)}
+		if err := offConn.Send(payload); err != nil {
+			t.Fatalf("cycle %d offerer send: %v", i, err)
+		}
+		if got := recvWithin(t, fromOfferer); !bytes.Equal(got, payload) {
+			t.Fatalf("cycle %d offerer-side: got %v, want %v", i, got, payload)
+		}
+		// Enter and clear the recovery window (the transient disconnect it models).
+		offerer.enterRecover()
+		offerer.exitRecover()
+		// The channel must still carry bytes after the cycle.
+		if err := joinConn.Send(payload); err != nil {
+			t.Fatalf("cycle %d joiner send: %v", i, err)
+		}
+		if got := recvWithin(t, fromJoiner); !bytes.Equal(got, payload) {
+			t.Fatalf("cycle %d joiner-side: got %v, want %v", i, got, payload)
+		}
+	}
+
+	// The last enter must be clearable/recoverable — no stale recovery state piling up.
+	if offerer.Recovering() {
+		t.Fatal("recovery state left set after a successful cycle")
+	}
+}
+
+// TestPeerTeardownDuringRecoveryIsClean pins that closing the peer while it is inside a recovery
+// window tears down cleanly: the bounded observation timer is cancelled (never fires after Close)
+// and no goroutine/timer survives (verified by the race detector). A peer closed mid-recovery
+// never reports a recovery failure to a caller that has already moved on.
+func TestPeerTeardownDuringRecoveryIsClean(t *testing.T) {
+	offAuth, joinAuth := newPair(testRoom)
+	toJoiner := make(chan rendezvous.Message, 64)
+	toOfferer := make(chan rendezvous.Message, 64)
+	var recoverFailed atomic.Bool
+
+	offerer, err := NewPeer(PeerOptions{
+		Role: wire.RoleOfferer, Auth: offAuth, ICEServers: hostOnly,
+		Send:            func(m rendezvous.Message) error { toJoiner <- m; return nil },
+		RecoverWindow:   50 * time.Millisecond,
+		OnRecoverFailed: func() { recoverFailed.Store(true) },
+	})
+	if err != nil {
+		t.Fatalf("new offerer: %v", err)
+	}
+	joiner, err := NewPeer(PeerOptions{
+		Role: wire.RoleJoiner, Auth: joinAuth, ICEServers: hostOnly,
+		Send: func(m rendezvous.Message) error { toOfferer <- m; return nil },
+	})
+	if err != nil {
+		_ = offerer.Close()
+		t.Fatalf("new joiner: %v", err)
+	}
+	done := make(chan struct{})
+	defer func() { close(done); _ = joiner.Close(); _ = offerer.Close() }()
+	go func() {
+		for {
+			select {
+			case m := <-toJoiner:
+				joiner.Accept(m)
+			case <-done:
+				return
+			}
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case m := <-toOfferer:
+				offerer.Accept(m)
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := offerer.Channel(ctx); err != nil {
+		t.Fatalf("offerer channel: %v", err)
+	}
+
+	offerer.enterRecover()
+	if !offerer.Recovering() {
+		t.Fatal("expected Recovering() true after enterRecover")
+	}
+
+	// Close while recovering: the bounded observation timer is cancelled, so the recover-failed
+	// callback must never fire for a peer we have already torn down (no stale timer/goroutine —
+	// verified by the race detector).
+	if err := offerer.Close(); err != nil {
+		t.Fatalf("close during recovery: %v", err)
+	}
+	// Let the (cancelled) observation window elapse and confirm no stale failure callback fires.
+	time.Sleep(120 * time.Millisecond)
+	if recoverFailed.Load() {
+		t.Fatal("OnRecoverFailed fired after close during recovery")
 	}
 }
 

--- a/apps/cli/internal/transfer/adaptive_conn.go
+++ b/apps/cli/internal/transfer/adaptive_conn.go
@@ -165,6 +165,11 @@ func (c *adaptiveConn) requestRelay() {
 	}
 }
 
+// FallbackToRelay starts the encrypted-relay fallback in response to a failed direct recovery.
+// It is idempotent: a path already on the relay (or already switching) is a no-op. Called from
+// the peer's recovery-failure hook without resetting transfer progress.
+func (c *adaptiveConn) FallbackToRelay() { c.requestRelay() }
+
 func (c *adaptiveConn) activateRelay() {
 	c.mu.Lock()
 	if c.closed || c.path == "relay" || c.switchErr != nil {

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -29,6 +29,13 @@ type Signal interface {
 	Close()
 }
 
+// ReconnectSetter is implemented by signals that can re-attach to the signaling room after a
+// post-establishment drop (e.g. wsclient.ReconnectingSignal), so the driver can arm them with
+// the room and role once the handshake settles.
+type ReconnectSetter interface {
+	SetResume(room int, role string)
+}
+
 // Controls is the live transfer surface exposed to terminal frontends.
 type Controls interface {
 	Pause() error
@@ -69,6 +76,9 @@ type Spec struct {
 	OnStateChange func(wire.TransferState)
 	// breakDirect is a deterministic in-package integration hook.
 	breakDirect <-chan struct{}
+	// breakDirectRecovery simulates the peer's recovery-failure hook firing (direct recovery
+	// failed) so the driver falls back to the relay. Test-only.
+	breakDirectRecovery <-chan struct{}
 }
 
 // Outcome is the result of a completed transfer.
@@ -119,6 +129,12 @@ type driver struct {
 	// starts is not lost).
 	pol        *AdaptivePolicy
 	warmSignal chan struct{}
+
+	// adaptive is the direct→relay cutover connection once selected (set in run()); the peer's
+	// recovery-failure hook uses it to fall back to the relay. recovering reports the transient
+	// ICE-disconnect recovery window for the terminal's OnTransport status. Both are guarded by mu.
+	adaptive   *adaptiveConn
+	recovering bool
 }
 
 // Send implements rendezvous.Sink for the handshake session and doubles as the peer's send
@@ -192,6 +208,9 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	if path == "direct" {
 		sv = supervisor.New()
 		adaptive = newAdaptiveConn(conn.(*rtc.DataConn), d.relay, d.spec.OnTransport, sv)
+		d.mu.Lock()
+		d.adaptive = adaptive
+		d.mu.Unlock()
 		_ = sv.Register(supervisor.PathDirect, conn.(*rtc.DataConn))
 		_ = sv.Warming(supervisor.PathDirect)
 		_ = sv.Ready(supervisor.PathDirect)
@@ -203,6 +222,20 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 				select {
 				case <-d.spec.breakDirect:
 					_ = peer.Close()
+				case <-ctx.Done():
+				}
+			}()
+		}
+		if d.spec.breakDirectRecovery != nil {
+			go func() {
+				select {
+				case <-d.spec.breakDirectRecovery:
+					d.mu.Lock()
+					ad := d.adaptive
+					d.mu.Unlock()
+					if ad != nil {
+						ad.FallbackToRelay()
+					}
 				case <-ctx.Done():
 				}
 			}()
@@ -415,6 +448,15 @@ func (d *driver) route(m rendezvous.Message) {
 					}
 				}
 			},
+			OnRecovering: func(rec bool) { d.reportRecovering(rec) },
+			OnRecoverFailed: func() {
+				d.mu.Lock()
+				ad := d.adaptive
+				d.mu.Unlock()
+				if ad != nil {
+					ad.FallbackToRelay()
+				}
+			},
 		})
 		if perr != nil {
 			d.sig.Close()
@@ -422,6 +464,11 @@ func (d *driver) route(m rendezvous.Message) {
 		}
 	}
 	d.res = res
+	// Arm a reconnect-capable signal with the room/role once the handshake settles, so a later
+	// signaling drop can re-attach to the room (V12-PR04 signaling recovery).
+	if rs, ok := d.sig.(ReconnectSetter); ok {
+		rs.SetResume(res.Room, string(res.Role))
+	}
 	d.relay = relaytransport.New(d)
 	d.peer = peer
 	d.peerCh <- peer
@@ -430,6 +477,32 @@ func (d *driver) route(m rendezvous.Message) {
 func (d *driver) routeBinary(frame []byte) {
 	if d.relay != nil {
 		d.relay.HandleBinary(frame)
+	}
+}
+
+// reportRecovering exposes the direct path's transient ICE-disconnect recovery window as a
+// distinct transport status ("recovering"), and returns to "direct" once the path recovers.
+// A recovery that never returns to connected transfers to the relay via the fallback hook, so
+// reporting "direct" here only fires while the byte path is still direct.
+func (d *driver) reportRecovering(rec bool) {
+	if rec {
+		d.mu.Lock()
+		d.recovering = true
+		d.mu.Unlock()
+		if d.spec.OnTransport != nil {
+			d.spec.OnTransport("recovering")
+		}
+		return
+	}
+	d.mu.Lock()
+	d.recovering = false
+	ad := d.adaptive
+	d.mu.Unlock()
+	if ad == nil || ad.IsRelay() {
+		return
+	}
+	if d.spec.OnTransport != nil {
+		d.spec.OnTransport("direct")
 	}
 }
 

--- a/apps/cli/internal/transfer/driver_faults_test.go
+++ b/apps/cli/internal/transfer/driver_faults_test.go
@@ -43,6 +43,21 @@ func killBothSignaling(hub *relay) {
 	hub.join.killSignaling()
 }
 
+// expectCutover asserts a direct→relay cutover path sequence. V12-PR04 may transiently emit a
+// "recovering" transport state between direct and relay while the direct peer's ICE observes the
+// drop; the meaningful invariant is that the path begins on direct and settles on relay.
+func expectCutover(t *testing.T, name string, paths []string) {
+	t.Helper()
+	if len(paths) < 2 || paths[0] != "direct" || paths[len(paths)-1] != "relay" {
+		t.Fatalf("%s paths = %v; want direct first and relay last", name, paths)
+	}
+	for _, p := range paths[1 : len(paths)-1] {
+		if p != "recovering" {
+			t.Fatalf("%s paths = %v; unexpected intermediate path %q", name, paths, p)
+		}
+	}
+}
+
 // TestDriverSurvivesSignalingLossOnDirect pins signaling failure is
 // independent of the data path — a healthy direct channel finishes the transfer
 // with no relay fallback and no error when the signaling socket dies mid-file.
@@ -236,9 +251,7 @@ func TestDriverCutoverBeforeDataStarts(t *testing.T) {
 		log.mu.Lock()
 		paths := append([]string(nil), log.paths...)
 		log.mu.Unlock()
-		if len(paths) != 2 || paths[0] != "direct" || paths[1] != "relay" {
-			t.Fatalf("%s paths = %v; want [direct relay]", name, paths)
-		}
+		expectCutover(t, name, paths)
 	}
 }
 
@@ -310,5 +323,75 @@ func TestDriverCutoverAfterAllDataAcked(t *testing.T) {
 		if len(paths) < 1 || paths[0] != "direct" {
 			t.Fatalf("%s paths = %v; want direct first", name, paths)
 		}
+	}
+}
+
+// TestDriverFallsBackOnFailedDirectRecovery pins the V12-PR04 recovery wiring: when the direct
+// path's recovery window fails over (the peer's OnRecoverFailed hook firing), the driver falls
+// back to the relay without restarting transfer progress — the transfer still completes with a
+// byte-identical file, reporting [direct relay] on both peers.
+func TestDriverFallsBackOnFailedDirectRecovery(t *testing.T) {
+	hub := newRelay()
+	payload := faultPayload(3*1024*1024 + 41)
+	meta := wire.FileMeta{Name: "recover-fail.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	trigger := make(chan struct{})
+	var triggerOnce sync.Once
+	sendPaths, recvPaths := &pathLog{}, &pathLog{}
+	type result struct {
+		out *Outcome
+		err error
+	}
+	done := make(chan result, 2)
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:      wire.BytesSource(payload, meta, 64*1024),
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(sendPaths),
+			breakDirectRecovery: trigger,
+			OnProgress: func(bytes int64) {
+				if bytes >= 1024*1024 {
+					triggerOnce.Do(func() { close(trigger) })
+				}
+			},
+		})
+		done <- result{out: out, err: err}
+	}()
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:     dir,
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(recvPaths),
+		})
+		done <- result{out: out, err: err}
+	}()
+
+	a, b := <-done, <-done
+	if a.err != nil || b.err != nil {
+		t.Fatalf("recovery-fallback results: %v / %v", a.err, b.err)
+	}
+	var recv *Outcome
+	if a.out.Path != "" {
+		recv = a.out
+	} else {
+		recv = b.out
+	}
+	got, err := os.ReadFile(recv.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("output differs from source after failed direct recovery")
+	}
+	for name, log := range map[string]*pathLog{"sender": sendPaths, "receiver": recvPaths} {
+		log.mu.Lock()
+		paths := append([]string(nil), log.paths...)
+		log.mu.Unlock()
+		expectCutover(t, name, paths)
 	}
 }

--- a/apps/cli/internal/transfer/driver_test.go
+++ b/apps/cli/internal/transfer/driver_test.go
@@ -91,6 +91,19 @@ type relayEnd struct {
 	done      chan struct{}
 	killOnce  sync.Once
 	killSig   chan struct{} // closed by killSignaling to simulate a dead signaling socket
+
+	// resume records whether the driver armed this signal as a ReconnectSetter (V12-PR04).
+	resumeCalled bool
+	resumeRoom   int
+	resumeRole   string
+}
+
+// SetResume implements ReconnectSetter: it records the room/role the driver arms once the
+// handshake settles so a reconnectable signal can re-attach to the room.
+func (e *relayEnd) SetResume(room int, role string) {
+	e.resumeCalled = true
+	e.resumeRoom = room
+	e.resumeRole = role
 }
 
 func newRelayEnd(hub *relay, role string) *relayEnd {
@@ -385,9 +398,7 @@ func TestDriverSwitchesActiveDirectTransferToRelay(t *testing.T) {
 		log.mu.Lock()
 		paths := append([]string(nil), log.paths...)
 		log.mu.Unlock()
-		if len(paths) != 2 || paths[0] != "direct" || paths[1] != "relay" {
-			t.Fatalf("%s paths = %v, want [direct relay]", name, paths)
-		}
+		expectCutover(t, name, paths)
 	}
 }
 
@@ -433,5 +444,52 @@ func TestDriverReceiverRejectsMismatchedCode(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("destination dir has %d entries, want 0 after a failed handshake", len(entries))
+	}
+}
+
+// TestDriverArmsReconnectableSignal pins the V12-PR04 signaling-recovery wiring: once the
+// handshake settles, the driver arms a ReconnectSetter signal with the room and role so a later
+// signaling drop can re-attach to the room.
+func TestDriverArmsReconnectableSignal(t *testing.T) {
+	hub := newRelay()
+	payload := faultPayload(256 * 1024)
+	meta := wire.FileMeta{Name: "resume-arm.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	done := make(chan error, 2)
+	go func() {
+		_, err := Run(ctx, hub.off, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		})
+		done <- err
+	}()
+	go func() {
+		_, err := Run(ctx, hub.join, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:    dir,
+			ICEServers: []webrtc.ICEServer{},
+		})
+		done <- err
+	}()
+
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Fatalf("transfer error: %v", err)
+		}
+	}
+	for name, e := range map[string]*relayEnd{"offerer": hub.off, "joiner": hub.join} {
+		if !e.resumeCalled {
+			t.Fatalf("%s signal was not armed as a ReconnectSetter", name)
+		}
+		if e.resumeRoom != hub.room {
+			t.Fatalf("%s resume room = %d, want %d", name, e.resumeRoom, hub.room)
+		}
+		if e.resumeRole != name {
+			t.Fatalf("%s resume role = %q, want %q", name, e.resumeRole, name)
+		}
 	}
 }

--- a/apps/cli/internal/wsclient/reconnecting.go
+++ b/apps/cli/internal/wsclient/reconnecting.go
@@ -1,0 +1,216 @@
+// Package wsclient binds a rendezvous.Session to the SendBeam signaling server over a
+// WebSocket. It is the CLI's counterpart to the browser's SignalingClient +
+// rendezvous orchestrator (apps/web/src/lib/signaling, .../session): it dials the
+// server, JSON-encodes the session's outbound messages as text frames, decodes inbound
+// frames back into rendezvous.Message, and drives one handshake to completion.
+package wsclient
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/sendbeam/cli/internal/rendezvous"
+)
+
+// reconnectRetries bounds how many times a post-establishment socket drop is re-dialed and
+// resumed before the read loop gives up and surfaces the terminal error (the driver then keeps
+// a healthy direct path alive, or fails a relay path). Never infinite.
+const reconnectRetries = 5
+
+// reconnectBaseDelay is the base backoff between reconnect attempts.
+const reconnectBaseDelay = 250 * time.Millisecond
+
+// reconnectMaxDelay caps the reconnect backoff.
+const reconnectMaxDelay = 4 * time.Second
+
+// serverControlTypes are server→client control frames the reconnecting signal consumes
+// internally during the room resume flow: they describe signaling-room state, not application
+// frames, and would otherwise be mis-fed to the peer/relay transfer layer.
+var serverControlTypes = map[string]bool{
+	"resumed":       true, // the server re-attached this peer to its lingering room
+	"peer_left":     true, // the partner's socket dropped; room is resumable (byte path may live on)
+	"peer_rejoined": true, // the partner re-attached to the room
+}
+
+// ReconnectingSignal is a transfer.Signal (see apps/cli/internal/transfer) whose socket is
+// re-established after a post-establishment drop: it re-dials the server and resends the room
+// `resume` request so the room re-attaches, keeping an established direct transfer healthy
+// through a signaling blip and restoring signaling for a later ICE-restart renegotiation.
+//
+// It must be told the room number and role (SetResume) once the handshake settles — before
+// that, a drop is a handshake failure like the base client. Reconnect is bounded and cancellable.
+type ReconnectingSignal struct {
+	url   string
+	dopts DialOptions
+
+	mu     sync.Mutex
+	cur    *Client
+	closed bool
+
+	room      int
+	role      string
+	resumeSet bool
+}
+
+// NewReconnectingSignal builds a signal that re-establishes the signaling socket on drop. The
+// first connection is dialed eagerly (with the base backoff) so Sends succeed immediately; it
+// returns an error only if the initial connect fails, mirroring the base wsclient.Dial.
+func NewReconnectingSignal(ctx context.Context, url string, dopts DialOptions) (*ReconnectingSignal, error) {
+	client, err := Dial(ctx, url, dopts)
+	if err != nil {
+		return nil, err
+	}
+	return &ReconnectingSignal{url: url, dopts: dopts, cur: client}, nil
+}
+
+// SetResume records the room and role once the handshake settles, enabling post-establishment
+// reconnect. Must be called before any drop that should reconnect.
+func (s *ReconnectingSignal) SetResume(room int, role string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.room = room
+	s.role = role
+	s.resumeSet = true
+}
+
+// Send writes one signaling message to the current socket.
+func (s *ReconnectingSignal) Send(m rendezvous.Message) error {
+	s.mu.Lock()
+	c := s.cur
+	s.mu.Unlock()
+	if c == nil {
+		return errors.New("wsclient: signaling not connected")
+	}
+	return c.Send(m)
+}
+
+// SendBinary writes one opaque encrypted relay frame to the current socket.
+func (s *ReconnectingSignal) SendBinary(frame []byte) error {
+	s.mu.Lock()
+	c := s.cur
+	s.mu.Unlock()
+	if c == nil {
+		return errors.New("wsclient: signaling not connected")
+	}
+	return c.SendBinary(frame)
+}
+
+// Run reads and dispatches inbound frames, re-establishing the socket on a post-establishment
+// drop while resume info is set. It returns when the socket closes cleanly, the caller closes,
+// ctx is cancelled, or reconnect attempts are exhausted.
+func (s *ReconnectingSignal) Run(
+	ctx context.Context,
+	onMessage func(rendezvous.Message),
+	onBinary func([]byte),
+) error {
+	for {
+		s.mu.Lock()
+		c := s.cur
+		s.mu.Unlock()
+		if c == nil {
+			return errors.New("wsclient: signaling not connected")
+		}
+		runErr := c.Run(ctx, s.filter(onMessage), onBinary)
+		if runErr == nil {
+			return nil // clean close
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !s.wantReconnect() {
+			return runErr
+		}
+		if !s.reconnect(ctx) {
+			return runErr
+		}
+	}
+}
+
+// wantReconnect reports whether a drop should trigger a reconnect: resume info is set and the
+// signal is not closed.
+func (s *ReconnectingSignal) wantReconnect() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.resumeSet && !s.closed
+}
+
+// reconnect re-establishes the socket: re-dial with bounded backoff and resend the resume
+// request so the room re-attaches. Returns true on success.
+func (s *ReconnectingSignal) reconnect(ctx context.Context) bool {
+	for n := 0; n < reconnectRetries; n++ {
+		s.mu.Lock()
+		room, role := s.room, s.role
+		closed := s.closed
+		s.mu.Unlock()
+		if closed || ctx.Err() != nil {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(reconnectDelay(n)):
+		}
+		client, err := Dial(ctx, s.url, s.dopts)
+		if err != nil {
+			continue
+		}
+		s.swap(client)
+		if err := client.Send(rendezvous.Message{Type: "resume", Room: &room, Role: role}); err != nil {
+			client.Close()
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// filter wraps the inbound dispatch so server-control frames are consumed internally rather
+// than forwarded to the transfer layer, which only understands application signaling and relay
+// frames.
+func (s *ReconnectingSignal) filter(onMessage func(rendezvous.Message)) func(rendezvous.Message) {
+	return func(m rendezvous.Message) {
+		if serverControlTypes[m.Type] {
+			return
+		}
+		onMessage(m)
+	}
+}
+
+func (s *ReconnectingSignal) swap(c *Client) {
+	s.mu.Lock()
+	old := s.cur
+	s.cur = c
+	s.mu.Unlock()
+	if old != nil {
+		old.Close()
+	}
+}
+
+// Close tears down the signal. Idempotent.
+func (s *ReconnectingSignal) Close() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	c := s.cur
+	s.mu.Unlock()
+	if c != nil {
+		c.Close()
+	}
+}
+
+// reconnectDelay computes the bounded backoff for attempt n.
+func reconnectDelay(n int) time.Duration {
+	d := reconnectBaseDelay
+	for i := 0; i < n; i++ {
+		d *= 2
+	}
+	if d > reconnectMaxDelay {
+		d = reconnectMaxDelay
+	}
+	return d
+}

--- a/apps/cli/internal/wsclient/reconnecting_test.go
+++ b/apps/cli/internal/wsclient/reconnecting_test.go
@@ -1,0 +1,199 @@
+package wsclient
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sendbeam/cli/internal/rendezvous"
+)
+
+// testResumeServer is a minimal localhost signaling server that supports the room resume flow:
+// it replies `resumed` to a resume request and forwards every other inbound message to `inbound`.
+// Each accepted connection is served in its own goroutine, like the real server, so a re-dialing
+// ReconnectingSignal can re-attach to the room.
+type testResumeServer struct {
+	url     string
+	inbound chan rendezvous.Message
+	srv     *http.Server
+}
+
+func runTestResumeServer(t *testing.T) *testResumeServer {
+	t.Helper()
+	s := &testResumeServer{inbound: make(chan rendezvous.Message, 64)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		go func() {
+			defer func() { _ = c.Close(websocket.StatusNormalClosure, "") }()
+			readCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			for {
+				typ, data, err := c.Read(readCtx)
+				if err != nil {
+					return
+				}
+				if typ != websocket.MessageText {
+					continue
+				}
+				var m rendezvous.Message
+				if json.Unmarshal(data, &m) != nil {
+					continue
+				}
+				if m.Type == "resume" {
+					_ = c.Write(readCtx, websocket.MessageText, []byte(`{"type":"resumed","room":7}`))
+					continue
+				}
+				s.inbound <- m
+			}
+		}()
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s.srv = &http.Server{Handler: mux}
+	go func() { _ = s.srv.Serve(ln) }()
+	t.Cleanup(func() { _ = s.srv.Close() })
+	s.url = "ws://" + ln.Addr().String() + "/ws"
+	return s
+}
+
+func TestReconnectingSignalSendFlows(t *testing.T) {
+	srv := runTestResumeServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sig, err := NewReconnectingSignal(ctx, srv.url, DialOptions{})
+	if err != nil {
+		t.Fatalf("new reconnecting signal: %v", err)
+	}
+	defer sig.Close()
+	if err := sig.Send(rendezvous.Message{Type: "sdp", Sdp: "hello"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	select {
+	case m := <-srv.inbound:
+		if m.Sdp != "hello" {
+			t.Fatalf("inbound sdp = %q, want hello", m.Sdp)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no inbound send received")
+	}
+}
+
+func TestReconnectingSignalResumesAfterDrop(t *testing.T) {
+	srv := runTestResumeServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sig, err := NewReconnectingSignal(ctx, srv.url, DialOptions{})
+	if err != nil {
+		t.Fatalf("new reconnecting signal: %v", err)
+	}
+	defer sig.Close()
+	sig.SetResume(7, "offerer")
+
+	got := make(chan rendezvous.Message, 16)
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		_ = sig.Run(ctx, func(m rendezvous.Message) { got <- m }, func(_ []byte) {})
+	}()
+
+	// A normal frame forwards and is received by the server.
+	if err := sig.Send(rendezvous.Message{Type: "sdp", Sdp: "one"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	waitInbound(t, srv, "one")
+
+	// Drop the underlying socket: Run returns, then re-dials + resumes. The resumed control
+	// frame must be consumed internally (never forwarded) and the socket re-established.
+	sig.mu.Lock()
+	sig.cur.Close()
+	sig.mu.Unlock()
+
+	// After reconnect, a send must reach the server again.
+	sendAfter := make(chan string, 1)
+	go func() {
+		for {
+			if err := sig.Send(rendezvous.Message{Type: "sdp", Sdp: "after"}); err != nil {
+				time.Sleep(20 * time.Millisecond)
+				continue
+			}
+			sendAfter <- "after"
+			return
+		}
+	}()
+
+	select {
+	case m := <-srv.inbound:
+		if m.Sdp != "after" {
+			t.Fatalf("post-reconnect inbound sdp = %q, want after", m.Sdp)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no inbound after reconnect (socket not re-established)")
+	}
+	select {
+	case <-sendAfter:
+	default:
+	}
+
+	// Control frames must never reach the transfer layer: nothing of type resumed/peer_left
+	// may be forwarded, and the only forwarded message here is the sdp we sent.
+	sig.Close()
+	<-runDone
+	closeSelectNothing(t, got)
+}
+
+func waitInbound(t *testing.T, srv *testResumeServer, want string) {
+	t.Helper()
+	select {
+	case m := <-srv.inbound:
+		if m.Sdp != want {
+			t.Fatalf("inbound sdp = %q, want %q", m.Sdp, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for inbound %q", want)
+	}
+}
+
+// closeSelectNothing asserts that no control-frame was forwarded: draining `got` immediately (it
+// may still hold the sdp we sent) yields no resumed/peer_left/peer_rejoined types.
+func closeSelectNothing(t *testing.T, got chan rendezvous.Message) {
+	t.Helper()
+	for {
+		select {
+		case m := <-got:
+			if serverControlTypes[m.Type] {
+				t.Fatalf("server control frame %q was forwarded to the transfer layer", m.Type)
+			}
+		default:
+			return
+		}
+	}
+}
+
+func TestReconnectingSignalFilterConsumesControlTypes(t *testing.T) {
+	srv := runTestResumeServer(t)
+	sig, err := NewReconnectingSignal(context.Background(), srv.url, DialOptions{})
+	if err != nil {
+		t.Fatalf("new reconnecting signal: %v", err)
+	}
+	defer sig.Close()
+
+	var forwarded []string
+	filtered := sig.filter(func(m rendezvous.Message) { forwarded = append(forwarded, m.Type) })
+	for _, typ := range []string{"resumed", "peer_left", "peer_rejoined"} {
+		filtered(rendezvous.Message{Type: typ})
+	}
+	filtered(rendezvous.Message{Type: "sdp"})
+	if len(forwarded) != 1 || forwarded[0] != "sdp" {
+		t.Fatalf("forwarded = %v, want [sdp]", forwarded)
+	}
+}

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -56,7 +56,7 @@
   let rateBps = $state(0);
   let etaSeconds = $state<number | undefined>(undefined);
   let transferState = $state<'running' | 'paused' | 'canceled'>('running');
-  let transportPath = $state<'connecting' | 'direct' | 'relay'>('connecting');
+  let transportPath = $state<'connecting' | 'direct' | 'recovering' | 'relay'>('connecting');
   let outcome = $state<TransferOutcome | null>(null);
   let downloadUrl = $state<string | null>(null);
 
@@ -522,7 +522,9 @@
                   ? 'Encrypted relay'
                   : transportPath === 'direct'
                     ? 'Direct P2P'
-                    : 'Connecting…'}
+                    : transportPath === 'recovering'
+                      ? 'Recovering connection…'
+                      : 'Connecting…'}
               </span>
             </div>
           </div>

--- a/apps/web/src/lib/session/rendezvous.ts
+++ b/apps/web/src/lib/session/rendezvous.ts
@@ -153,6 +153,7 @@ function run(
         onMessage: (handler) => (route = handler),
         onBinary: (handler) => (routeBinary = handler),
         onClose: (handler) => (routeClose = handler),
+        setResume: (room, role) => client.setResume(room, role),
         close: () => client.close(),
       };
     },

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -52,8 +52,8 @@ export interface TransferController {
   total(): number | undefined;
   /** A coherent acknowledged-byte, smoothed-rate, ETA, and run-state snapshot. */
   snapshot(): TransferSnapshot;
-  /** Active byte path, including automatic relay fallback. */
-  transport(): 'connecting' | 'direct' | 'relay';
+  /** Active byte path, including automatic relay fallback and transient recovery. */
+  transport(): 'connecting' | 'direct' | 'recovering' | 'relay';
   /** Resolves when the transfer completes and verifies; rejects on any failure. */
   readonly done: Promise<TransferOutcome>;
   /** Stop producing new data frames; already-buffered transport bytes may drain. */
@@ -124,6 +124,7 @@ function run(
   let writer: ChannelWriter | undefined;
   let relay: RelayTransport | undefined;
   let transport: 'connecting' | 'direct' | 'relay' = 'connecting';
+  let recovering = false;
   let switchPromise: Promise<void> | undefined;
   let cancelTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -193,6 +194,14 @@ function run(
             warmRelaySignal?.();
           }
         },
+        onRecovering: (rec) => {
+          if (!generation.isCurrent(gen)) return;
+          recovering = rec;
+        },
+        onRecoverFailed: () => {
+          if (!generation.isCurrent(gen)) return;
+          void switchToRelay().catch(() => {});
+        },
       });
       peer = p;
       const relayPath = new RelayTransport(signaling);
@@ -213,6 +222,11 @@ function run(
         if (!generation.isCurrent(gen)) return;
         relayPath.handleBinary(frame);
       });
+
+      // Arm post-establishment signaling reconnect with the persistent room/role, so a signaling
+      // drop on a healthy direct path re-attaches to the room and a later ICE-restart
+      // renegotiation can still exchange its SDP/ICE frames (V12-PR04 signaling recovery).
+      signaling.setResume(rendezvous.room, rendezvous.role);
 
       const w = new Worker(new URL('../transfer/transfer.worker.ts', import.meta.url), {
         type: 'module',
@@ -396,7 +410,7 @@ function run(
     progress: () => progress.snapshot().bytes,
     total: () => total,
     snapshot: () => progress.snapshot(),
-    transport: () => transport,
+    transport: () => (recovering && transport === 'direct' ? 'recovering' : transport),
     done: donePromise,
     pause: () => {
       if (settled || progress.snapshot().state === 'paused') return;

--- a/apps/web/src/lib/signaling/client.test.ts
+++ b/apps/web/src/lib/signaling/client.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SignalMsg } from '@sendbeam/protocol';
+import { SignalingClient, type SignalingClientOptions } from './client.js';
+
+/**
+ * Minimal fake WebSocket with a hand-triggered lifecycle, so the signaling client's
+ * connect, post-open drop, and resume-reconnect paths are fully deterministic in unit tests
+ * (no real sockets, no real timers beyond the injectable backoff).
+ */
+class FakeWebSocket {
+  static OPEN = 1;
+  readyState = 0; // CONNECTING
+  binaryType = 'blob';
+  onopen: (() => void) | null = null;
+  onclose: ((ev: { wasClean: boolean; code: number; reason: string }) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  sent: string[] = [];
+
+  constructor(
+    readonly url: string,
+    private readonly onSocket?: (socket: FakeWebSocket) => void,
+  ) {}
+
+  static instances: FakeWebSocket[] = [];
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(code = 1000, reason = ''): void {
+    this.dispatchClose(true, code, reason);
+  }
+
+  /** Test helper: open the fake socket.
+   */
+  _open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  /** Test helper: simulate a network (unclean) drop.
+   */
+  _drop(): void {
+    this.readyState = 3; // CLOSED
+    this.onclose?.({ wasClean: false, code: 1006, reason: 'network' });
+  }
+
+  /** Test helper: simulate a clean server close.
+   */
+  _cleanClose(code = 1000, reason = ''): void {
+    this.readyState = 3;
+    this.onclose?.({ wasClean: true, code, reason });
+  }
+
+  /** Test helper: push a text frame to the client.
+   */
+  _receiveText(payload: string): void {
+    this.onmessage?.({ data: payload });
+  }
+
+  private dispatchClose(wasClean: boolean, code: number, reason: string): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    this.onclose?.({ wasClean, code, reason });
+  }
+}
+
+function installFakeWebSocket(onSocket?: (socket: FakeWebSocket) => void): void {
+  const Ws = class extends FakeWebSocket {
+    constructor(url: string) {
+      super(url, onSocket);
+      FakeWebSocket.instances.push(this);
+      onSocket?.(this);
+    }
+  } as unknown as typeof WebSocket;
+  vi.stubGlobal('WebSocket', Ws);
+}
+
+function client(overrides: Partial<SignalingClientOptions> = {}) {
+  const onMessage = vi.fn<(msg: SignalMsg) => void>();
+  const onClose = vi.fn<(err: Error) => void>();
+  const c = new SignalingClient({
+    url: 'ws://example.test/ws',
+    onMessage,
+    onClose: (clean, code, reason) => onClose(new Error(`${clean} ${code} ${reason}`)),
+    backoff: { retries: 5, baseMs: 1, maxMs: 2, factor: 1, jitter: 0 },
+    ...overrides,
+  });
+  return { c, onMessage, onClose };
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('SignalingClient — post-establishment reconnect/resume', () => {
+  it('keeps a post-open drop terminal until resume is armed', async () => {
+    installFakeWebSocket();
+    const { c, onClose } = client();
+    const connect = c.connect();
+    const sock = FakeWebSocket.instances[0]!;
+    sock._open();
+    await connect;
+    sock._drop();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt resume on a clean server close even when armed', async () => {
+    installFakeWebSocket();
+    const { c, onClose } = client();
+    const connect = c.connect();
+    c.setResume(7, 'offerer');
+    const sock = FakeWebSocket.instances[0]!;
+    sock._open();
+    await connect;
+    sock._cleanClose(1000, 'peer left');
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(FakeWebSocket.instances.length).toBe(1);
+  });
+
+  it('reconnects with resume on an unclean drop when armed, and consumes the resumed ack', async () => {
+    // Second socket (the reconnect) is created automatically by the client; capture its sends.
+    installFakeWebSocket();
+    const { c, onMessage } = client();
+    const connect = c.connect();
+    c.setResume(7, 'offerer');
+    const first = FakeWebSocket.instances[0]!;
+    first._open();
+    await connect;
+    first._drop();
+
+    // Give the (near-instant) backoff timer a chance to re-dial.
+    await vi.waitFor(() => {
+      expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+    });
+    const resumed = FakeWebSocket.instances[1]!;
+    resumed._open();
+    expect(resumed.sent).toContain(JSON.stringify({ type: 'resume', room: 7, role: 'offerer' }));
+
+    // The server's resumed ack must never reach the app layer.
+    resumed._receiveText(JSON.stringify({ type: 'resumed', room: 7 }));
+    expect(onMessage).not.toHaveBeenCalled();
+
+    // Ordinary frames keep flowing after reconnect.
+    resumed._receiveText('{"type":"sdp","sdp":"hi"}');
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'sdp', sdp: 'hi' }));
+  });
+
+  it('gives up reconnecting after the retry budget and surfaces a terminal close', async () => {
+    installFakeWebSocket();
+    const { c, onClose } = client({ resumeRetries: 1 });
+    const connect = c.connect();
+    c.setResume(7, 'joiner');
+    const first = FakeWebSocket.instances[0]!;
+    first._open();
+    await connect;
+    first._drop();
+
+    // The first reconnect opens, then drops again — exhausting the single retry budget.
+    await vi.waitFor(() => {
+      expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+    });
+    const rejoined = FakeWebSocket.instances[1]!;
+    rejoined._open();
+    rejoined._drop();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect((onClose.mock.calls[0]![0] as Error).message).toContain('1006');
+  });
+
+  it('forwards peer_left/peer_rejoined intact (resume bookkeeping is server control, not hidden)', async () => {
+    installFakeWebSocket();
+    const { c, onMessage } = client();
+    const connect = c.connect();
+    const sock = FakeWebSocket.instances[0]!;
+    sock._open();
+    await connect;
+    sock._receiveText('{"type":"peer_left","resumable":true}');
+    sock._receiveText('{"type":"peer_rejoined"}');
+    expect(onMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels a pending reconnect on close', async () => {
+    installFakeWebSocket();
+    const { c, onClose } = client();
+    const connect = c.connect();
+    c.setResume(7, 'offerer');
+    const sock = FakeWebSocket.instances[0]!;
+    sock._open();
+    await connect;
+    // An unclean drop arms the reconnect timer; closing before it fires must cancel it and not
+    // surface any terminal close.
+    sock._drop();
+    c.close();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(FakeWebSocket.instances.length).toBe(1);
+  });
+});

--- a/apps/web/src/lib/signaling/client.ts
+++ b/apps/web/src/lib/signaling/client.ts
@@ -5,11 +5,13 @@
  * connection with exponential backoff so a briefly-unreachable server (cold start, a
  * flaky network) does not fail the session before it begins.
  *
- * Reconnection is deliberately limited to that first connect. Once the socket has opened,
- * the server holds this session's room and pairing on *this* connection; a drop tears the
- * room down and notifies the peer with `bye`, so a fresh socket cannot resume it — it
- * would only allocate a new, unrelated room. A post-open close is surfaced as a terminal
- * event for the caller to handle.
+ * Reconnection is deliberately limited to that first connect while the room is being
+ * negotiated. Once the handshake settles and the transfer layer arms {@link SignalChannel.setResume}
+ * with the room number and role, a post-establishment drop is no longer terminal: the socket
+ * is re-dialed (bounded backoff) and re-attached to the lingering room with a `resume` request
+ * (the CLI twin is `wsclient.ReconnectingSignal`), so a later ICE-restart renegotiation's
+ * SDP/ICE frames can still flow while a healthy direct path keeps transferring. Until resume is
+ * armed, a post-open close stays a terminal event for the caller to handle.
  */
 
 import type { SignalMsg } from '@sendbeam/protocol';
@@ -25,6 +27,13 @@ export interface SignalChannel {
   onMessage(handler: (msg: SignalMsg) => void): void;
   onBinary(handler: (frame: ArrayBuffer) => void): void;
   onClose(handler: (err: Error) => void): void;
+  /**
+   * Arm post-open reconnect: once the room number and role are known, a dropped socket is
+   * re-dialed and resumed onto the lingering room (V12-PR04 signaling recovery) so a later
+   * ICE-restart renegotiation's SDP/ICE frames can still flow. Until this is called, a
+   * post-open drop stays terminal (the handshake/transfer fails closed).
+   */
+  setResume(room: number, role: string): void;
   close(): void;
 }
 
@@ -57,19 +66,33 @@ export interface SignalingClientOptions {
   /** A transport-level problem (connect exhausted, malformed inbound frame). */
   onError?: (err: Error) => void;
   backoff?: Partial<BackoffOptions>;
+  /** Number of re-dial attempts after a post-establishment drop before giving up. */
+  resumeRetries?: number;
 }
+
+/** Server → client control frames the reconnecting client consumes internally during the room
+ * resume flow: they describe signaling-room state, not application frames. Only `resumed` is
+ * filtered here; `peer_left`/`peer_rejoined` are forwarded intact to the active handler. */
+const SERVER_CONTROL_TYPES: ReadonlySet<string> = new Set(['resumed']);
 
 export class SignalingClient {
   private readonly opts: SignalingClientOptions;
   private readonly backoff: BackoffOptions;
+  private readonly resumeRetries: number;
   private ws?: WebSocket;
   private opened = false;
   private closedByUser = false;
   private retryTimer?: ReturnType<typeof setTimeout>;
 
+  // Post-establishment resume state, armed via setResume() once the room is known.
+  private resume?: { room: number; role: string };
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private reconnectAttempt = 0;
+
   constructor(opts: SignalingClientOptions) {
     this.opts = opts;
     this.backoff = { ...DEFAULT_BACKOFF, ...opts.backoff };
+    this.resumeRetries = opts.resumeRetries ?? DEFAULT_BACKOFF.retries;
   }
 
   /** True once the underlying socket is open and accepting sends. */
@@ -111,7 +134,14 @@ export class SignalingClient {
     };
     ws.onclose = (ev: CloseEvent) => {
       if (this.opened) {
-        // A drop after opening is terminal for this session (see the file header).
+        this.opened = false;
+        // A drop after opening: the session is resumable once resume is armed and the drop was
+        // a network blip (unclean). A clean close is a deliberate server teardown and stays
+        // terminal. Before resume is armed this path is terminal for the caller (handshake).
+        if (this.resume && !ev.wasClean) {
+          this.scheduleReconnect();
+          return;
+        }
         this.opts.onClose?.(ev.wasClean, ev.code, ev.reason);
         return;
       }
@@ -122,6 +152,60 @@ export class SignalingClient {
         new Error(`signaling: connect failed (code ${ev.code})`),
       );
     };
+  }
+
+  /**
+   * Arm post-open reconnect with the persistent room number and role. Until this is called a
+   * post-open drop stays terminal; after it, an unclean drop re-dials and resumes the room.
+   */
+  setResume(room: number, role: string): void {
+    this.resume = { room, role };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closedByUser) return;
+    if (this.reconnectAttempt >= this.resumeRetries) {
+      this.opts.onClose?.(false, 0, 'signaling: reconnect exhausted');
+      return;
+    }
+    const n = this.reconnectAttempt++;
+    const raw = Math.min(this.backoff.maxMs, this.backoff.baseMs * this.backoff.factor ** n);
+    const delay = raw * (1 + Math.random() * this.backoff.jitter);
+    this.reconnectTimer = setTimeout(() => void this.tryReconnect(), delay);
+  }
+
+  // Re-dial the socket and resume the lingering room. Control frames (`resumed`) are consumed
+  // internally; all application frames keep routing through the same handlers as the original.
+  private tryReconnect(): void {
+    if (this.closedByUser || !this.resume) return;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(this.opts.url);
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+    ws.binaryType = 'arraybuffer';
+    ws.onopen = () => {
+      this.ws = ws;
+      this.opened = true;
+      const { room, role } = this.resume!;
+      ws.send(JSON.stringify({ type: 'resume', room, role }));
+    };
+    ws.onmessage = (ev: MessageEvent) => this.dispatch(ev);
+    ws.onerror = () => {
+      // The error event carries no detail; the following close drives the retry/terminal path.
+    };
+    ws.onclose = (ev: CloseEvent) => {
+      if (this.closedByUser) return;
+      this.opened = false;
+      if (this.resume && !ev.wasClean && this.reconnectAttempt < this.resumeRetries) {
+        this.scheduleReconnect();
+        return;
+      }
+      this.opts.onClose?.(ev.wasClean, ev.code, ev.reason);
+    };
+    this.ws = ws;
   }
 
   private retryOrFail(
@@ -163,6 +247,9 @@ export class SignalingClient {
       this.opts.onError?.(new Error(`signaling: malformed frame: ${toError(err).message}`));
       return;
     }
+    // `resumed` is the room-resume acknowledgement for our own resume request, not an app frame;
+    // consume it so it never reaches (and could otherwise confuse) the active handler.
+    if (SERVER_CONTROL_TYPES.has(msg.type)) return;
     this.opts.onMessage(msg);
   }
 
@@ -182,6 +269,7 @@ export class SignalingClient {
   close(code = 1000, reason = ''): void {
     this.closedByUser = true;
     if (this.retryTimer) clearTimeout(this.retryTimer);
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.ws?.close(code, reason);
   }
 }

--- a/apps/web/src/lib/transfer/peer.ts
+++ b/apps/web/src/lib/transfer/peer.ts
@@ -10,6 +10,7 @@
 
 import type { IceMsg, Role, SdpMsg } from '@sendbeam/protocol';
 import type { SignalAuthenticator } from './authed-signaling.js';
+import { RecoveryController } from './recovery.js';
 
 /** A public STUN server is sufficient for the common NAT case. */
 export const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
@@ -25,7 +26,27 @@ export interface CreatePeerOptions {
    * and adaptive selection.
    */
   onIceState?: (state: ICEState) => void;
+  /**
+   * Invoked with true when an established direct path enters the transient-disconnected
+   * recovery window (an ICE restart is under way) and false once it recovers to connected.
+   * Used to expose a distinct "recovering connection" state.
+   */
+  onRecovering?: (recovering: boolean) => void;
+  /**
+   * Invoked when the recovery window elapses (or the ICE restart fails) without returning to
+   * connected: the direct path is gone and the caller should fall back to the relay without
+   * restarting transfer progress.
+   */
+  onRecoverFailed?: () => void;
+  /**
+   * Bounds the observation of a transient disconnect before recovery is declared failed.
+   * Zero uses {@link DEFAULT_RECOVER_WINDOW_MS}.
+   */
+  recoverWindowMs?: number;
 }
+
+/** Default bound for observing a transient ICE disconnect before recovery fails over. */
+export const DEFAULT_RECOVER_WINDOW_MS = 6_000;
 
 /** A sanitized snapshot of a peer's ICE setup for diagnostics. */
 export interface PeerDiagnostics {
@@ -66,7 +87,6 @@ export interface Peer {
   /** Tear down the peer connection. Idempotent. */
   close(): void;
 }
-
 export function createPeer(opts: CreatePeerOptions): Peer {
   const pc = new RTCPeerConnection({ iceServers: opts.iceServers ?? DEFAULT_ICE_SERVERS });
 
@@ -101,6 +121,22 @@ export function createPeer(opts: CreatePeerOptions): Peer {
   let closedByUser = false;
   let disconnectHandler: ((err: Error) => void) | undefined;
   let disconnectError: Error | undefined;
+
+  // Recovery from a transient disconnect on an established direct path. The RecoveryController
+  // owns the bounded observation window and the start/clear/fail state machine (see recovery.ts).
+  const recovery = new RecoveryController({
+    windowMs: opts.recoverWindowMs ?? DEFAULT_RECOVER_WINDOW_MS,
+    callbacks: {
+      onStart: () => opts.onRecovering?.(true),
+      onRecover: () => opts.onRecovering?.(false),
+      onFail: onRecoverFail,
+    },
+  });
+  // onRecoverFail is referenced above ahead of its definition (the callback fires only later).
+  function onRecoverFail(): void {
+    opts.onRecoverFailed?.();
+    disconnected(new Error('direct recovery failed'));
+  }
 
   // Remote ICE can arrive before the remote description is set (network reorder, or the peer
   // trickling early). Buffer such candidates and flush them once the description lands.
@@ -162,10 +198,17 @@ export function createPeer(opts: CreatePeerOptions): Peer {
   };
   pc.oniceconnectionstatechange = () => {
     connectionStates.push(pc.iceConnectionState);
-    if (pc.iceConnectionState === 'connected' || pc.iceConnectionState === 'completed') {
+    const state = pc.iceConnectionState;
+    if (state === 'connected' || state === 'completed') {
       void captureSelectedPairType();
     }
     publishIceState();
+    // Recovery applies only to an established direct path (the channel already opened).
+    // Before the channel opens, disconnected/failed continue to fail the peer outright.
+    if (!channelOpen) return;
+    if (state === 'disconnected') startRecovery();
+    else if (state === 'connected' || state === 'completed') recovery.clear();
+    else if (state === 'failed') recovery.fail();
   };
   pc.onconnectionstatechange = () => {
     if (pc.connectionState === 'failed') disconnected(new Error('peer connection failed'));
@@ -211,6 +254,26 @@ export function createPeer(opts: CreatePeerOptions): Peer {
   } else {
     pc.ondatachannel = (ev) => wireChannel(ev.channel);
   }
+
+  // Restart ICE as the offerer: a fresh negotiation with restartIce() so the ICE credentials change
+  // and the partners re-establish the transport, sent over signaling so the joiner answers while the
+  // existing data channel (and the transfer progress) stays alive.
+  const restartAsOfferer = async (): Promise<void> => {
+    pc.restartIce();
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    opts.send(await opts.auth.signSdp(offer.sdp ?? ''));
+  };
+
+  // startRecovery begins the recovery window for a transient disconnect and has the offerer
+  // issue an ICE restart over signaling; a restart failure fails recovery immediately.
+  const startRecovery = (): void => {
+    if (closedByUser) return;
+    recovery.start();
+    if (opts.role === 'offerer') {
+      void restartAsOfferer().catch(() => recovery.fail());
+    }
+  };
 
   const applyRemoteDescription = async (type: RTCSdpType, sdp: string): Promise<void> => {
     await pc.setRemoteDescription({ type, sdp });
@@ -259,6 +322,7 @@ export function createPeer(opts: CreatePeerOptions): Peer {
     close: () => {
       closedByUser = true;
       settled = true;
+      recovery.dispose();
       pc.close();
     },
   };

--- a/apps/web/src/lib/transfer/recovery.test.ts
+++ b/apps/web/src/lib/transfer/recovery.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { RecoveryController, type RecoveryScheduler } from './recovery.js';
+
+/** Manual scheduler for deterministic tests: fires callbacks only when advanced. */
+class FakeScheduler implements RecoveryScheduler {
+  private tasks: { handle: number; fn: () => void; at: number }[] = [];
+  private clock = 0;
+  private nextHandle = 1;
+
+  schedule(fn: () => void, ms: number): unknown {
+    const handle = this.nextHandle++;
+    this.tasks.push({ handle, fn, at: this.clock + ms });
+    return handle;
+  }
+
+  cancel(handle: unknown): void {
+    this.tasks = this.tasks.filter((t) => t.handle !== handle);
+  }
+
+  /** Advance the clock by ms, firing any due tasks in order. */
+  advance(ms: number): void {
+    this.clock += ms;
+    const due = this.tasks.filter((t) => t.at <= this.clock).sort((a, b) => a.at - b.at);
+    this.tasks = this.tasks.filter((t) => t.at > this.clock);
+    for (const t of due) t.fn();
+  }
+
+  get pending(): number {
+    return this.tasks.length;
+  }
+}
+
+function make(opts: { windowMs?: number } = {}) {
+  const sched = new FakeScheduler();
+  const started: boolean[] = [];
+  const failed: boolean[] = [];
+  let recoveredCount = 0;
+  const ctrl = new RecoveryController({
+    windowMs: opts.windowMs ?? 5000,
+    callbacks: {
+      onStart: () => started.push(true),
+      onRecover: () => recoveredCount++,
+      onFail: () => failed.push(true),
+    },
+    scheduler: sched,
+  });
+  return { sched, ctrl, started, failed, recovered: () => recoveredCount };
+}
+
+describe('RecoveryController — transient disconnect recovery', () => {
+  it('enters recovery on start and reports recovering', () => {
+    const { sched, ctrl, started } = make();
+    expect(ctrl.recovering()).toBe(false);
+    ctrl.start();
+    expect(ctrl.recovering()).toBe(true);
+    expect(started).toEqual([true]);
+    expect(sched.pending).toBe(1); // bounded observation timer armed
+  });
+
+  it('repeated disconnects do not re-arm the window', () => {
+    const { sched, ctrl, started } = make();
+    ctrl.start();
+    ctrl.start();
+    expect(started).toEqual([true]);
+    expect(sched.pending).toBe(1);
+  });
+
+  it('clears recovery on reconnect within the window', () => {
+    const { sched, ctrl, recovered } = make();
+    ctrl.start();
+    ctrl.clear();
+    expect(ctrl.recovering()).toBe(false);
+    expect(sched.pending).toBe(0);
+    expect(recovered()).toBe(1);
+  });
+
+  it('fails over when the window elapses without recovery', () => {
+    const { sched, ctrl, failed } = make({ windowMs: 5000 });
+    ctrl.start();
+    sched.advance(4999);
+    expect(failed).toEqual([]);
+    sched.advance(1);
+    expect(failed).toEqual([true]);
+    expect(ctrl.recovering()).toBe(false);
+    expect(sched.pending).toBe(0);
+  });
+
+  it('fails at most once (idempotent)', () => {
+    const { sched, ctrl, failed } = make({ windowMs: 100 });
+    ctrl.start();
+    sched.advance(100);
+    ctrl.fail();
+    ctrl.fail();
+    expect(failed).toEqual([true]);
+  });
+
+  it('ignore further transition events after a failed recovery', () => {
+    const { sched, ctrl, failed, recovered } = make({ windowMs: 100 });
+    ctrl.start();
+    sched.advance(100);
+    ctrl.clear(); // stale "connected" after failure is ignored
+    expect(recovered()).toBe(0);
+    expect(failed).toEqual([true]);
+  });
+
+  it('dispose cancels the timer and does not fire callbacks', () => {
+    const { sched, ctrl, failed, started } = make({ windowMs: 100 });
+    ctrl.start();
+    expect(started).toEqual([true]);
+    ctrl.dispose();
+    expect(sched.pending).toBe(0);
+    sched.advance(200);
+    expect(failed).toEqual([]);
+  });
+
+  it('force-fail from a failed restart is idempotent', () => {
+    const { sched, ctrl, failed } = make({ windowMs: 5000 });
+    ctrl.start();
+    ctrl.fail();
+    expect(failed).toEqual([true]);
+    expect(sched.pending).toBe(0);
+    expect(ctrl.recovering()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/transfer/recovery.ts
+++ b/apps/web/src/lib/transfer/recovery.ts
@@ -1,0 +1,99 @@
+/**
+ * Recovery controller — the browser twin of the CLI's transient-disconnect recovery in
+ * `apps/cli/internal/rtc/peer.go`. It owns the bounded "recovering connection" observation for
+ * an established direct path: once ICE reports `disconnected`, the path enters a recovery window
+ * during which an ICE restart is attempted; if the path returns to `connected` the window clears,
+ * and if the window elapses (or the restart fails) the controller reports failure so the caller
+ * can fall back to the relay without restarting transfer progress.
+ *
+ * Like `adaptive.ts`, this module is a pure state machine with no DOM/RTCPeerConnection
+ * dependency, so it is fully unit-testable with an injected clock/timer; the peer wiring in
+ * `peer.ts` drives it from the ICE callbacks.
+ */
+
+export interface RecoveryCallbacks {
+  /** Entering the transient-disconnect recovery window (a restart is under way). */
+  onStart?: () => void;
+  /** Recovered: the path returned to connected within the window. */
+  onRecover?: () => void;
+  /** The window elapsed (or a restart failed) without recovery: fail over to the relay. */
+  onFail?: () => void;
+}
+
+/** Injectable timer hook for deterministic tests; defaults to setTimeout/clearTimeout. */
+export interface RecoveryScheduler {
+  schedule(fn: () => void, ms: number): unknown;
+  cancel(handle: unknown): void;
+}
+
+export interface RecoveryControllerOptions {
+  /** Bound on how long to observe a transient disconnect before failing over. */
+  windowMs: number;
+  callbacks: RecoveryCallbacks;
+  scheduler?: RecoveryScheduler;
+}
+
+/**
+ * Bounds the observation of a transient ICE disconnect. Start/clear are idempotent and pushing
+ * a `disconnected` while already recovering does not re-arm the window (mirrors the CLI guard).
+ */
+export class RecoveryController {
+  private readonly windowMs: number;
+  private readonly callbacks: RecoveryCallbacks;
+  private readonly schedule: (fn: () => void, ms: number) => unknown;
+  private readonly cancelFn: (handle: unknown) => void;
+  private active = false;
+  private timer: unknown | undefined;
+
+  constructor(opts: RecoveryControllerOptions) {
+    this.windowMs = opts.windowMs;
+    this.callbacks = opts.callbacks;
+    const sched = opts.scheduler;
+    this.schedule = sched ? sched.schedule.bind(sched) : (fn, ms) => setTimeout(fn, ms);
+    this.cancelFn = sched
+      ? sched.cancel.bind(sched)
+      : (h) => clearTimeout(h as ReturnType<typeof setTimeout>);
+  }
+
+  /** Whether the recovery window is currently open. */
+  recovering(): boolean {
+    return this.active;
+  }
+
+  /** Enter the recovery window on a transient disconnect. No-op if already recovering. */
+  start(): void {
+    if (this.active) return;
+    this.active = true;
+    this.callbacks.onStart?.();
+    this.timer = this.schedule(() => this.fail(), this.windowMs);
+  }
+
+  /** Clear the window because the path returned to connected. No-op if not recovering. */
+  clear(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.cancelTimer();
+    this.callbacks.onRecover?.();
+  }
+
+  /** Force a failed recovery (restart failed, or the window elapsed). Idempotent. */
+  fail(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.cancelTimer();
+    this.callbacks.onFail?.();
+  }
+
+  /** Tear down without firing callbacks (caller closed the peer). Idempotent. */
+  dispose(): void {
+    this.active = false;
+    this.cancelTimer();
+  }
+
+  private cancelTimer(): void {
+    if (this.timer !== undefined) {
+      this.cancelFn(this.timer);
+      this.timer = undefined;
+    }
+  }
+}

--- a/apps/web/src/lib/transfer/relay.test.ts
+++ b/apps/web/src/lib/transfer/relay.test.ts
@@ -12,6 +12,7 @@ function fakeChannel() {
     onMessage: vi.fn(),
     onBinary: vi.fn(),
     onClose: vi.fn(),
+    setResume: vi.fn(),
     close: vi.fn(),
   };
   return { channel, messages, binary };

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -63,6 +63,27 @@ with no traffic. If a socket drops and reconnects within that window, `resume` r
 it to the same slot (routing only — it still must pass the SPAKE2 handshake), so a stray
 reconnect cannot hijack a session; the paired peer sees `peer_left`/`peer_rejoined`.
 
+### Connection recovery
+
+Once the data channel is open (transfer already running), both CLI and browser treat a
+WebRTC ICE `disconnected` as a **transient** condition first, with a bounded observation
+window (default 6 s) rather than failing the path outright:
+
+1. Entering `disconnected` on an established direct path reports a distinct `recovering`
+   transport state and, on the offerer, issues an **ICE restart** (`CreateOffer` with
+   `ICERestart: true` / `pc.restartIce()`), renegotiating the SDP over signaling. The
+   existing data channel and its committed transfer progress are untouched.
+2. If the path returns to `connected`/`completed` before the window elapses, recovery clears
+   and the direct path keeps transferring.
+3. If the window elapses or the restart fails, the direct path is declared unrecoverable and
+   the transfer falls back to the encrypted relay (`resume` re-attaches the signaling socket
+   if it dropped, so the relay handshake and later SDP/ICE frames can still flow). Transfer
+   progress and AEAD counters are preserved across the cutover.
+
+The signaling socket itself is independently resumable: a post-establishment drop on an open
+room is re-dialed and re-attached with `resume` (bounded retries), so ICE-restart
+renegotiation can still exchange SDP/ICE even if signaling dropped earlier.
+
 ### Flow
 
 ```

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,8 @@
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

Treat WebRTC ICE `disconnected` on an established direct path as a **bounded transient** first instead of failing outright: attempt an ICE restart over signaling and only fall back to the encrypted relay when direct recovery fails — without restarting transfer progress.

Mirrored in the Pion (CLI) and browser peers, exposing a distinct `recovering` transport state. Both clients also reconnect their signaling socket onto the lingering room (`resume`) after a post-establishment drop, so a later ICE-restart renegotiation can still exchange SDP/ICE frames while a healthy direct path keeps transferring.

## Changes

- **Peer (Pion + browser):** prompt bounded ICE `disconnected` observation (`SetICETimeouts` / recovery window); offerer issues an ICE restart over signaling; recovers to `connected` or fails over after the window.
- **Recovery → relay fallback:** falling back preserves committed transfer progress and AEAD counters (direct→relay cutover already guards replay).
- **Signaling reconnect:** CLI `ReconnectingSignal` and browser `SignalingClient.setResume` re-attach to the room with `resume` (bounded, cancellable).
- **Tests:** ICE-restart byte-equivalence, repeated network-change cycles, teardown-during-recovery (race-clean), failed-recovery relay fallback (byte-identical), signaling reconnect/resume, browser recovery state machine.
- **Docs:** connection-recovery semantics added to `docs/protocol.md`.

## Verification

- Go: `go test -race ./...`, `go vet ./...`, `golangci-lint run ./...` — clean (cli, server, wire).
- Web: `pnpm test` (99), `pnpm typecheck`, `pnpm lint`, `pnpm exec prettier --check`, `pnpm build` — clean.