### PR TITLE
fix: harden path migration across partial blocks and terminal Complete

### DIFF
--- a/apps/cli/internal/transfer/driver_faults_test.go
+++ b/apps/cli/internal/transfer/driver_faults_test.go
@@ -326,6 +326,84 @@ func TestDriverCutoverAfterAllDataAcked(t *testing.T) {
 	}
 }
 
+// TestDriverCutoverMidData pins cutover phase "middle": the direct channel dies while bytes are
+// still mid-flight — some blocks committed, others in the unacknowledged window, and possibly a
+// block partially assembled — so the cutover must discard only the uncommitted work, retransmit
+// the inflight window over the relay, and still produce a byte-identical file. This is the phase
+// the before-data and after-all-data tests do not exercise.
+func TestDriverCutoverMidData(t *testing.T) {
+	hub := newRelay()
+	payload := faultPayload(4*1024*1024 + 67)
+	meta := wire.FileMeta{Name: "cutover-mid.bin", Size: int64(len(payload)), Mime: "application/octet-stream"}
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	trigger := make(chan struct{})
+	var triggerOnce sync.Once
+	half := int64(len(payload)) / 2
+	sendPaths, recvPaths := &pathLog{}, &pathLog{}
+	type result struct {
+		out *Outcome
+		err error
+	}
+	done := make(chan result, 2)
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+			Source:      wire.BytesSource(payload, meta, 64*1024),
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(sendPaths),
+			breakDirect: trigger,
+			OnProgress: func(bytes int64) {
+				// Cut over partway through the file, before the terminal phase.
+				if bytes >= half {
+					triggerOnce.Do(func() { close(trigger) })
+				}
+			},
+		})
+		done <- result{out: out, err: err}
+	}()
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Session:     rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+			DestDir:     dir,
+			ICEServers:  []webrtc.ICEServer{},
+			OnTransport: appendPath(recvPaths),
+		})
+		done <- result{out: out, err: err}
+	}()
+
+	a, b := <-done, <-done
+	if a.err != nil || b.err != nil {
+		t.Fatalf("mid-data cutover results: %v / %v", a.err, b.err)
+	}
+	var recv *Outcome
+	if a.out.Path != "" {
+		recv = a.out
+	} else {
+		recv = b.out
+	}
+	got, err := os.ReadFile(recv.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("output differs from source after mid-data cutover")
+	}
+	for name, log := range map[string]*pathLog{"sender": sendPaths, "receiver": recvPaths} {
+		log.mu.Lock()
+		paths := append([]string(nil), log.paths...)
+		log.mu.Unlock()
+		if len(paths) < 1 || paths[0] != "direct" {
+			t.Fatalf("%s paths = %v; want direct first", name, paths)
+		}
+		if len(paths) > 1 && paths[len(paths)-1] != "relay" {
+			t.Fatalf("%s paths = %v; want to settle on relay after mid-data cutover", name, paths)
+		}
+	}
+}
+
 // TestDriverFallsBackOnFailedDirectRecovery pins the V12-PR04 recovery wiring: when the direct
 // path's recovery window fails over (the peer's OnRecoverFailed hook firing), the driver falls
 // back to the relay without restarting transfer progress — the transfer still completes with a

--- a/packages/protocol/src/transfer-sender.test.ts
+++ b/packages/protocol/src/transfer-sender.test.ts
@@ -311,6 +311,68 @@ describe('TransferSender', () => {
     expect(outbound[1]).not.toEqual(outbound[3]);
   });
 
+  it('retransmits a sent-but-unsettled Complete after a transport change (terminal recovery)', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const outbound: Uint8Array[] = [];
+    const sender = new TransferSender({
+      file: bytesSource(data, { name: 'f', size: data.length, mime: '', lastModified: 0 }),
+      send: (frame) => void outbound.push(frame),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 8,
+      frameSize: 4,
+      window: 1,
+      ackTimeoutMs: 60_000,
+    });
+
+    const run = sender.run();
+    // With window=1 the sender blocks after its first (only) block until it is acknowledged;
+    // feed a verified ack so it proceeds to Complete, then cut over before Done arrives.
+    await waitFor(() => outbound.some((f) => f[9] === FrameType.BlockHash));
+    let ackCtr = 0;
+    const ackFrame = await seal(
+      keys.j2o,
+      ackCtr++,
+      {
+        version: FRAME_VERSION,
+        type: FrameType.Ack,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      encodeControl({ type: FrameType.Ack, fileIdx: 0, blockIdx: 0 }),
+    );
+    sender.handle(ackFrame);
+    await waitFor(() => outbound.some((f) => f[9] === FrameType.Complete));
+    sender.transportChanged();
+    await waitFor(() => outbound.filter((f) => f[9] === FrameType.Complete).length >= 2);
+    sender.cancel('test complete');
+    await expect(run).rejects.toThrow(/test complete/);
+
+    // Two Complete frames, each sealed under a different nonce (fresh AEAD counter).
+    const completes = outbound.filter((f) => f[9] === FrameType.Complete);
+    expect(completes.length).toBeGreaterThanOrEqual(2);
+    const opened: Array<{ type: number; counter: number }> = [];
+    let counter = 0;
+    for (const f of outbound) {
+      const o = await open(keys.o2j, counter, f);
+      counter++;
+      opened.push({ type: o.header.type, counter });
+    }
+    const completeIndexes = opened
+      .map((item, i) => ({ ...item, i }))
+      .filter((item) => item.type === FrameType.Complete)
+      .map((item) => item.counter);
+    expect(completeIndexes.length).toBeGreaterThanOrEqual(2);
+    // Retransmitted Complete must carry a distinct AEAD counter from the original.
+    expect(new Set(completeIndexes).size).toBe(completeIndexes.length);
+  });
+
   it('halts new data while paused and resumes without losing the window', async () => {
     const keys = await deriveTransferKeys(master);
     const outbound: Uint8Array[] = [];

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -94,6 +94,9 @@ export class TransferSender {
   private acknowledged = 0;
   private paused = false;
   private completeSent = false;
+  /** The canonical digest carried by the one-shot Complete control, kept so a path change
+   *  before settlement can retransmit Complete (the receiver settles then ignores duplicates). */
+  private completeDigest: string | undefined;
   private activeFileIdx = -1;
   private activeFileAcknowledged = 0;
   /** The validated manifest, kept so a path change before any acknowledgment can retransmit it. */
@@ -186,6 +189,16 @@ export class TransferSender {
       void this.sendControl(FrameType.Manifest, this.manifest).catch((e: unknown) =>
         this.fail(e instanceof Error ? e : new Error(String(e))),
       );
+    }
+    if (this.completeSent && this.completeDigest !== undefined) {
+      // Complete is a one-shot frame: sending it does not wait for an ack, so a cutover that
+      // tears the old path down right after it was written can starve it from the receiver.
+      // The receiver settles on Complete (then ignores a duplicate) and sends Done, so
+      // retransmitting it on the new path preserves the v1.1 terminal-Complete recovery.
+      void this.sendControl(FrameType.Complete, {
+        type: FrameType.Complete,
+        fileDigest: this.completeDigest,
+      }).catch((e: unknown) => this.fail(e instanceof Error ? e : new Error(String(e))));
     }
   }
 
@@ -282,6 +295,7 @@ export class TransferSender {
     }
 
     this.completeSent = true;
+    this.completeDigest = transferDigest;
     await this.sendControl(FrameType.Complete, {
       type: FrameType.Complete,
       fileDigest: transferDigest,

--- a/packages/wire/transfer_cutover_test.go
+++ b/packages/wire/transfer_cutover_test.go
@@ -1,0 +1,207 @@
+package wire
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// This file pins the direct→relay path-migration correctness contract asserted by V12-PR05: a
+// cutover to a new ordered byte path must (1) keep already-committed blocks authoritative,
+// (2) discard only the uncommitted partial block being assembled on the old path, (3) retransmit
+// the unacknowledged inflight window with fresh AEAD counters so the receiver can resync, and
+// (4) reject old-path frames that arrive late as replays rather than treating them as an
+// integrity violation. A path cutover mid-transfer never restarts progress at byte zero.
+
+// cutoverLink models two ordered byte paths (e.g. direct then relay). Engines write via route(),
+// which copies frames to the currently selected path; the active-path channels are drained so no
+// send blocks. At a cutover the test disarms the old path (its queued tail is dropped, as a
+// torn-down transport would) and swaps the active path so writes land on the new one.
+type cutoverLink struct {
+	oldS2R, oldR2S chan []byte
+	newS2R, newR2S chan []byte
+
+	path atomic.Int32
+}
+
+func newCutoverLink() *cutoverLink {
+	return &cutoverLink{
+		oldS2R: make(chan []byte, 8192), oldR2S: make(chan []byte, 8192),
+		newS2R: make(chan []byte, 8192), newR2S: make(chan []byte, 8192),
+	}
+}
+
+func (l *cutoverLink) route(dir int, frame []byte) error {
+	if l.path.Load() == cutPathNew {
+		return l.deliver(dir == dirS2R, l.newS2R, l.newR2S, frame)
+	}
+	return l.deliver(dir == dirS2R, l.oldS2R, l.oldR2S, frame)
+}
+
+func (l *cutoverLink) deliver(s2r bool, s2rCh, r2sCh chan []byte, frame []byte) error {
+	ch := r2sCh
+	if s2r {
+		ch = s2rCh
+	}
+	ch <- append([]byte(nil), frame...)
+	return nil
+}
+
+func (l *cutoverLink) switchPath() { l.path.Store(cutPathNew) }
+
+const (
+	cutPathOld = 0
+	cutPathNew = 1
+)
+
+// TestSenderReceiverMidTransferCutover drives a sender→receiver transfer over the old path,
+// cuts over to the new path mid-data once block 0 is committed while later blocks are still in
+// flight / partially assembled, and asserts the transfer still completes byte-identically:
+// committed blocks stay written, the uncommitted window is retransmitted with fresh counters, an
+// old-path frame replayed after the switch is ignored (not fatal), and Complete/Done settle.
+func TestSenderReceiverMidTransferCutover(t *testing.T) {
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := testData(128_000, 7)
+	const blockSize = 2048
+	const cutAfterBytes = blockSize // trigger after block 0 is committed
+	sink := &MemorySink{}
+	link := newCutoverLink()
+
+	var receiver *Receiver
+	sender := NewSender(SenderOptions{
+		File:        BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:        func(f []byte) error { return link.route(dirS2R, f) },
+		SendDir:     keys.O2J,
+		RecvDir:     keys.J2O,
+		BlockSize:   blockSize,
+		FrameSize:   512,
+		Window:      4,
+		AckTimeout:  5 * time.Second,
+		MaxRetries:  10,
+		DoneTimeout: 5 * time.Second,
+	})
+	// The cutover must not run inside the receiver's Handle (OnProgress holds handleMu, and
+	// TransportChanged re-enters it), so OnProgress only signals a dedicated switch goroutine.
+	cutRequested := make(chan struct{}, 1)
+	cutDone := make(chan struct{})
+	var cutOnce sync.Once
+	doCut := func() {
+		cutOnce.Do(func() {
+			link.switchPath()
+			receiver.TransportChanged()
+			sender.TransportChanged()
+			close(cutDone)
+		})
+	}
+	receiver = NewReceiver(ReceiverOptions{
+		Send:    func(f []byte) error { return link.route(dirR2S, f) },
+		SendDir: keys.J2O,
+		RecvDir: keys.O2J,
+		Sink:    sink,
+		OnProgress: func(acked int64) {
+			if acked >= cutAfterBytes {
+				select {
+				case cutRequested <- struct{}{}:
+				default:
+				}
+			}
+		},
+	})
+	go func() {
+		for {
+			select {
+			case <-cutRequested:
+				doCut()
+				select {
+				case <-cutDone:
+					return
+				default:
+				}
+			case <-cutDone:
+				return
+			}
+		}
+	}()
+
+	// Capture a signed old-path data frame for the post-cutover replay probe.
+	var replayProbe atomic.Pointer[[]byte]
+	var stop int32
+	drain := func(ch <-chan []byte, fn func([]byte), captureReplay bool) {
+		for {
+			select {
+			case f := <-ch:
+				if captureReplay && replayProbe.Load() == nil && len(f) > 0 && f[9] == FrameBlockData {
+					g := append([]byte(nil), f...)
+					replayProbe.Store(&g)
+				}
+				fn(f)
+			default:
+				if atomic.LoadInt32(&stop) == 1 {
+					return
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}
+
+	// Old-path side only delivers until the cut; afterwards the stale tail is dropped, exactly
+	// what a torn-down direct transport does. New-path drains run for the whole transfer.
+	go drain(link.oldS2R, func(f []byte) {
+		select {
+		case <-cutDone:
+			return
+		default:
+		}
+		receiver.Handle(f)
+	}, true)
+	go drain(link.oldR2S, sender.Handle, false)
+	go drain(link.newS2R, receiver.Handle, false)
+	go drain(link.newR2S, sender.Handle, false)
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	runErrCh := make(chan error, 1)
+	go func() { _, e := sender.Run(runCtx); runErrCh <- e }()
+	recvResCh := make(chan ReceiveResult, 1)
+	recvErrCh := make(chan error, 1)
+	go func() { r, e := receiver.Wait(runCtx); recvResCh <- r; recvErrCh <- e }()
+
+	// After the cutover, inject one old-path frame as a replay probe: the receiver must drop it
+	// (an already-consumed counter) rather than aborting the transfer as an integrity violation.
+	go func() {
+		<-cutDone
+		time.Sleep(10 * time.Millisecond)
+		if p := replayProbe.Load(); p != nil {
+			receiver.Handle(append([]byte(nil), (*p)...))
+		}
+	}()
+
+	var runErr error
+	select {
+	case runErr = <-runErrCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("sender.Run did not return within deadline")
+	}
+	recvRes := <-recvResCh
+	recvErr := <-recvErrCh
+	atomic.StoreInt32(&stop, 1)
+
+	if runErr != nil {
+		t.Fatalf("sender after mid-transfer cutover: %v", runErr)
+	}
+	if recvErr != nil {
+		t.Fatalf("receiver after mid-transfer cutover: %v", recvErr)
+	}
+	if !bytes.Equal(sink.Bytes(), data) {
+		t.Fatal("received bytes differ from source after mid-transfer cutover")
+	}
+	if len(recvRes.Digests) == 0 || recvRes.Digests[0] == "" {
+		t.Fatal("receiver produced no digest after cutover")
+	}
+}


### PR DESCRIPTION
## Summary

Hardens the direct→relay path-migration correctness for V12-PR05, closing a Go/TS parity gap and adding the mid-transfer cutover coverage the existing before-data and after-all-data tests left untested.

- **TS sender terminal-`Complete` recovery parity.** `TransferSender.transportChanged()` now retransmits a sent-but-unsettled `Complete` on a transport change, matching the Go `Sender.TransportChanged()`. Without this, a cutover that tears the old path down right after `Complete` is written can starve the receiver of the terminal frame and stall the transfer with a false retry-exhaustion failure.
- **Wire-level mid-transfer cutover test.** Cuts over while some blocks are committed, others are in the unacknowledged window, and a block is partially assembled; asserts committed data stays authoritative, the uncommitted window is retransmitted with fresh AEAD counters, an old-path frame replayed after the switch is ignored (not a fatal integrity abort), and `Complete`/`Done` settle the transfer.
- **CLI driver mid-data cutover test.** Cuts over from direct to relay while bytes are mid-flight, exercising the real supervisor/adaptive connection path, and asserts a byte-identical file.

"Never feed two unordered active paths into the engine" remains enforced by the existing supervisor unit tests (`TestNoDoubleActivation`, `TestActivateClosesLosers`, `TestLosingPathTeardown`) and engine-level `handleMu`/inbound-promise serialization; the new integration tests exercise that path under `-race`.

## Gates

- `go vet ./...`, `go test -race ./...` green for `packages/wire`, `apps/cli`, `apps/server`.
- `pnpm typecheck`, `pnpm lint`, `pnpm exec prettier --check`, `pnpm test`, `pnpm build` green for `packages/protocol` and `apps/web`.
- Cutover tests repeat cleanly under `-race` across multiple runs.