### PR TITLE
feat: optional TURN, sanitized diagnostics, and hostile-network lab

### DIFF
--- a/apps/cli/cmd/natbox/main.go
+++ b/apps/cli/cmd/natbox/main.go
@@ -40,6 +40,9 @@ const (
 	policyRestricted
 	policyPortRestricted
 	policySymmetric
+	// policyUDPBlocked drops all outbound UDP, so WebRTC direct cannot establish and the
+	// client must fall back to the encrypted WS relay (a UDP-blocked/restrictive network).
+	policyUDPBlocked
 )
 
 func parsePolicy(s string) (policy, error) {
@@ -52,6 +55,8 @@ func parsePolicy(s string) (policy, error) {
 		return policyPortRestricted, nil
 	case "symmetric":
 		return policySymmetric, nil
+	case "udp-blocked":
+		return policyUDPBlocked, nil
 	}
 	return 0, fmt.Errorf("unknown policy %q", s)
 }
@@ -147,6 +152,11 @@ func (n *natbox) handleFrame(frame []byte) {
 	}
 	ip := frame[14:]
 	if ip[0]>>4 != 4 || ip[9] != 17 { // UDP only; TCP rides the proxy
+		return
+	}
+	// UDP-blocked policy drops all outbound UDP, simulating a firewall that blocks WebRTC
+	// (forcing the encrypted WS relay fallback).
+	if n.policy == policyUDPBlocked {
 		return
 	}
 	ihl := int(ip[0]&0x0f) * 4

--- a/apps/cli/cmd/natlab/main.go
+++ b/apps/cli/cmd/natlab/main.go
@@ -5,6 +5,12 @@
 // CLI transfer and reports whether the file moved over the direct WebRTC path or fell
 // back to the encrypted relay, then verifies the received bytes.
 //
+// Hostile-network coverage (V12-PR06): any NAT policy pair, including `udp-blocked`
+// (drops all outbound UDP so WebRTC cannot establish and the client must fall back to the
+// relay), `netem` profiles for loss/delay/jitter/rate (with a `shift` bandwidth-upgrade
+// profile), and `-cycles N` for repeated reconnect cycles. `-measure` collects per-transfer
+// wall time, receiver peak RSS, and relay usage as JSON.
+//
 // The whole lab runs unprivileged: launch it with
 //
 //	unshare -Urnm natlab [flags]
@@ -15,6 +21,7 @@ package main
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -47,10 +54,12 @@ func main() {
 	fileSize := flag.Int("file-size", 4*1024*1024, "payload size in bytes")
 	serverBin := flag.String("server-bin", "", "path to the built sendbeamd binary (required)")
 	combos := flag.String("combos",
-		"full-cone/full-cone,restricted/restricted,port-restricted/port-restricted,symmetric/symmetric,full-cone/symmetric",
-		"comma-separated NAT policy pairs (A/B)")
+		"full-cone/full-cone,restricted/restricted,port-restricted/port-restricted,symmetric/symmetric,full-cone/symmetric,udp-blocked/udp-blocked",
+		"comma-separated NAT policy pairs (A/B); udp-blocked simulates a UDP-blocked network")
 	noproxy := flag.Bool("noproxy", false, "skip NAT boxes: both peers run in the public segment over forced relay (control)")
-	netem := flag.String("netem", "", "degraded-network profile applied to both bridge legs: 'loss 3%', 'delay 50ms', or 'rate 10mbit'")
+	netem := flag.String("netem", "", "degraded-network profile applied to both bridge legs: 'loss 3%', 'delay 50ms', 'jitter 20ms', 'rate 10mbit', or 'shift 1mbit-10mbit'")
+	cycles := flag.Int("cycles", 1, "repeated reconnect cycles per combo (back-to-back transfers)")
+	measure := flag.Bool("measure", false, "collect per-transfer metrics (wall time, receiver peak RSS, relay usage)")
 	flag.Parse()
 
 	if os.Geteuid() != 0 {
@@ -94,13 +103,13 @@ func main() {
 
 	lab := &lab{
 		sendbeam: sendbeam,
-		natbox:  natbox,
-		stund:   stund,
-		server:  *serverBin,
-		src:     src,
-		dstDir:  dstDir,
-		expect:  sha256.Sum256(payload),
-		noproxy: *noproxy,
+		natbox:   natbox,
+		stund:    stund,
+		server:   *serverBin,
+		src:      src,
+		dstDir:   dstDir,
+		expect:   sha256.Sum256(payload),
+		noproxy:  *noproxy,
 	}
 	if err := lab.setup(); err != nil {
 		lab.cleanup()
@@ -124,18 +133,50 @@ func main() {
 	}
 
 	failed := false
+	// A measurement is one completed transfer under a combo+cycle.
+	type cycleMetric struct {
+		Combo       string `json:"combo"`
+		Cycle       int    `json:"cycle"`
+		Transport   string `json:"transport"`
+		DigestOK    bool   `json:"digestOk"`
+		WallMS      int64  `json:"wallMs"`
+		ReceiverRSS int64  `json:"receiverRSSKiB,omitempty"`
+		RelayUsed   bool   `json:"relayUsed"`
+	}
+	var metrics []cycleMetric
 	for _, pair := range pairs {
-		start := time.Now()
-		ok, transport, err := lab.runTransfer(pair[0], pair[1])
-		if err != nil {
-			log.Printf("combo %s/%s: ERROR after %v: %v", pair[0], pair[1], time.Since(start).Round(time.Millisecond), err)
-			failed = true
-			continue
+		for c := 1; c <= *cycles; c++ {
+			start := time.Now()
+			ok, transport, err := lab.runTransfer(pair[0], pair[1])
+			recvRSS := lab.lastRecvRSS
+			wall := time.Since(start).Round(time.Millisecond)
+			if err != nil {
+				log.Printf("combo %s/%s cycle %d: ERROR after %v: %v", pair[0], pair[1], c, wall, err)
+				failed = true
+				continue
+			}
+			log.Printf("combo %s/%s cycle %d: %s, digest %t, %v", pair[0], pair[1], c, transport, ok, wall)
+			if !ok {
+				failed = true
+			}
+			if *measure {
+				metrics = append(metrics, cycleMetric{
+					Combo:       pair[0] + "/" + pair[1],
+					Cycle:       c,
+					Transport:   transport,
+					DigestOK:    ok,
+					WallMS:      wall.Milliseconds(),
+					ReceiverRSS: recvRSS,
+					RelayUsed:   transport == "relay",
+				})
+			}
 		}
-		log.Printf("combo %s/%s: %s, digest %t, %v", pair[0], pair[1], transport, ok, time.Since(start).Round(time.Millisecond))
-		if !ok {
-			failed = true
-		}
+	}
+	if *measure && len(metrics) > 0 {
+		b, _ := json.MarshalIndent(metrics, "", "  ")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "=== measurements ===")
+		fmt.Fprintln(os.Stderr, string(b))
 	}
 	if failed {
 		os.Exit(1)
@@ -144,9 +185,13 @@ func main() {
 
 type lab struct {
 	sendbeam, natbox, stund, server string
-	src, dstDir                    string
-	expect                         [32]byte
-	noproxy                        bool
+	src, dstDir                     string
+	expect                          [32]byte
+	noproxy                         bool
+
+	// lastRecvRSS records the receiver process's peak RSS (KiB) after the most recent
+	// transfer, for -measure memory instrumentation.
+	lastRecvRSS int64
 
 	mu    sync.Mutex
 	nses  []*netns
@@ -350,16 +395,32 @@ func (l *lab) setup() error {
 // the server→receiver relay leg. One qdisc per profile; loss and delay use netem,
 // rate limits use netem's own rate control (it segments like the real bottleneck).
 func (l *lab) applyNetem(spec string) error {
-	var qdisc string
+	var qdiscs []string
 	switch {
 	case strings.HasPrefix(spec, "loss "):
-		qdisc = "netem loss " + strings.TrimPrefix(spec, "loss ")
+		qdiscs = []string{"netem loss " + strings.TrimPrefix(spec, "loss ")}
 	case strings.HasPrefix(spec, "delay "):
-		qdisc = "netem delay " + strings.TrimPrefix(spec, "delay ")
+		qdiscs = []string{"netem delay " + strings.TrimPrefix(spec, "delay ")}
+	case strings.HasPrefix(spec, "jitter "):
+		// Fixed delay plus variation, approximating a jittery/loaded link.
+		qdiscs = []string{"netem delay " + strings.TrimPrefix(spec, "jitter ") + " " + strings.TrimPrefix(spec, "jitter ") + " distribution normal"}
 	case strings.HasPrefix(spec, "rate "):
-		qdisc = "netem rate " + strings.TrimPrefix(spec, "rate ")
+		qdiscs = []string{"netem rate " + strings.TrimPrefix(spec, "rate ")}
+	case strings.HasPrefix(spec, "shift "):
+		// Bandwidth shift: start at the slower rate, then re-apply the faster one shortly
+		// after the transfer begins (approximates a bandwidth upgrade mid-transfer).
+		parts := strings.SplitN(strings.TrimPrefix(spec, "shift "), "-", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("bad shift profile %q (want 'shift slow-fast')", spec)
+		}
+		qdiscs = []string{"netem rate " + parts[0]}
+		time.AfterFunc(4*time.Second, func() {
+			for _, leg := range []string{"pa1", "pb1"} {
+				_ = exec.Command("nsenter", "-t", fmt.Sprint(l.nsPID("pub")), "-n", "tc", "qdisc", "replace", "dev", leg, "root", "netem", "rate", parts[1]).Run()
+			}
+		})
 	default:
-		return fmt.Errorf("unsupported netem profile %q (want 'loss 3%%', 'delay 50ms', or 'rate 10mbit')", spec)
+		return fmt.Errorf("unsupported netem profile %q (want 'loss 3%%', 'delay 50ms', 'jitter 20ms', 'rate 10mbit', or 'shift 1mbit-10mbit')", spec)
 	}
 	l.mu.Lock()
 	var pub *netns
@@ -370,13 +431,27 @@ func (l *lab) applyNetem(spec string) error {
 	}
 	l.mu.Unlock()
 	for _, ifname := range []string{"pa1", "pb1"} {
-		args := append([]string{"qdisc", "add", "dev", ifname, "root"}, strings.Split(qdisc, " ")...)
-		if err := l.nsRun(pub, append([]string{"tc"}, args...)...); err != nil {
-			return fmt.Errorf("tc on %s: %w", ifname, err)
+		for _, q := range qdiscs {
+			args := append([]string{"qdisc", "add", "dev", ifname, "root"}, strings.Split(q, " ")...)
+			if err := l.nsRun(pub, append([]string{"tc"}, args...)...); err != nil {
+				return fmt.Errorf("tc on %s: %w", ifname, err)
+			}
 		}
 	}
-	log.Printf("netem: %q applied on pa1+pb1", qdisc)
+	log.Printf("netem: %q applied on pa1+pb1", spec)
 	return nil
+}
+
+// nsPID returns the PID of a named netns, or 0.
+func (l *lab) nsPID(name string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, n := range l.nses {
+		if n.name == name {
+			return n.pid
+		}
+	}
+	return 0
 }
 
 // runTransfer runs one CLI transfer with the given NAT policies and reports the
@@ -496,6 +571,7 @@ func (l *lab) runTransfer(polA, polB string) (bool, string, error) {
 		return false, "", fmt.Errorf("transfer timed out\n--- receiver ---\n%s\n--- sender ---\n%s", recvErr.String(), senderErr.String())
 	}
 	_ = sender.Wait()
+	l.lastRecvRSS = peakRSS(receiver.Process.Pid)
 
 	transport := "?"
 	joined := recvErr.String() + "\n" + senderErr.String()
@@ -593,11 +669,37 @@ func (l *lab) runPlainRelay(dst string) (bool, string, error) {
 		return false, "", fmt.Errorf("plain relay timed out")
 	}
 	_ = sender.Wait()
+	l.lastRecvRSS = peakRSS(receiver.Process.Pid)
 	got, err := os.ReadFile(filepath.Join(dst, filepath.Base(l.src)))
 	if err != nil {
 		return false, "relay", fmt.Errorf("read received file: %w\n--- receiver ---\n%s\n--- sender ---\n%s", err, recvErr.String(), senderErr.String())
 	}
 	return sha256.Sum256(got) == l.expect, "relay", nil
+}
+
+// peakRSS reads a process's VmRSS (KiB) from /proc. Returns 0 if the process or its stat
+// is unavailable (it may already be reaped). Used by -measure memory instrumentation.
+func peakRSS(pid int) int64 {
+	if pid <= 0 {
+		return 0
+	}
+	b, err := os.ReadFile(filepath.Join("/proc", fmt.Sprint(pid), "status"))
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(line, "VmRSS:") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				var v int64
+				if _, err := fmt.Sscanf(fields[1], "%d", &v); err == nil {
+					return v
+				}
+			}
+			return 0
+		}
+	}
+	return 0
 }
 
 func moduleRoot() (string, error) {

--- a/apps/cli/cmd/sendbeam/diagnose.go
+++ b/apps/cli/cmd/sendbeam/diagnose.go
@@ -1,0 +1,232 @@
+// Command diagnose: a standalone, sanitized connection diagnostic for SendBeam. It probes
+// the reachable surface (signaling /config.json, STUN/TURN servers) and reports local
+// interface/ICE capability counts — never full IPs, credentials, codes, or filenames.
+// Output is one JSON object (see ADR 0003 / V12-PR06).
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/pion/stun/v3"
+
+	"github.com/sendbeam/cli/internal/diagnostics"
+	"github.com/sendbeam/wire"
+)
+
+// diagnoseConfig is the subset of /config.json the CLI honors, mirrored here so the
+// diagnose command can report how the operator configures ICE without leaking it.
+type diagnoseConfig struct {
+	ICEServers []wire.ICEEntry `json:"iceServers"`
+}
+
+// diagnoseProbe is one sanitized server-reachability result.
+type diagnoseProbe struct {
+	Scheme    string `json:"scheme"`
+	Reachable bool   `json:"reachable"`
+	// HasCredentials reports a TURN/STUN entry carried credentials (never the credentials).
+	HasCredentials bool   `json:"hasCredentials,omitempty"`
+	Error          string `json:"error,omitempty"`
+}
+
+// diagnoseResult is the sanitized output of `sendbeam diagnose`.
+type diagnoseResult struct {
+	App string `json:"app"`
+	// ICEServersConfigured counts configured ICE servers.
+	ICEServersConfigured int `json:"iceServersConfigured"`
+	// TURNConfigured reports whether any TURN server was configured.
+	TURNConfigured bool `json:"turnConfigured"`
+	// Probes is the per-server reachability result.
+	Probes []diagnoseProbe `json:"probes,omitempty"`
+	// InterfaceIPv4/IPv6 report local stack capability (counts only, never addresses).
+	InterfaceIPv4 bool `json:"interfaceIPv4"`
+	InterfaceIPv6 bool `json:"interfaceIPv6"`
+	// SanitizedLog is a short list of sanitized observations.
+	SanitizedLog []string `json:"sanitizedLog,omitempty"`
+}
+
+func runDiagnose(args []string) int {
+	fs := flag.NewFlagSet("diagnose", flag.ExitOnError)
+	server := fs.String("server", defaultServer, "signaling server URL")
+	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
+	timeout := fs.Duration("timeout", 5*time.Second, "per-probe timeout")
+	_ = fs.Parse(args)
+
+	res := &diagnoseResult{App: "cli"}
+	res.SanitizedLog = append(res.SanitizedLog, "diagnose: probe start")
+
+	// Local stack capability: interface address family presence only.
+	v4, v6 := interfaceFamilies()
+	res.InterfaceIPv4 = v4
+	res.InterfaceIPv6 = v6
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout*4)
+	defer cancel()
+
+	cfg, err := fetchServerConfig(ctx, *server, *insecure, *timeout)
+	if err != nil {
+		res.SanitizedLog = append(res.SanitizedLog, "diagnose: "+diagnostics.Sanitize(err.Error()))
+	} else {
+		res.ICEServersConfigured = len(cfg.ICEServers)
+		for _, e := range cfg.ICEServers {
+			if strings.HasPrefix(strings.ToLower(e.URLs[0]), "turn:") || strings.HasPrefix(strings.ToLower(e.URLs[0]), "turns:") {
+				res.TURNConfigured = true
+			}
+		}
+		for _, e := range cfg.ICEServers {
+			probe := diagnoseProbe{
+				Scheme:         strings.ToLower(strings.SplitN(e.URLs[0], ":", 2)[0]),
+				HasCredentials: e.Username != "" || e.Credential != "",
+			}
+			switch probe.Scheme {
+			case "stun", "stuns":
+				if probe.Reachable = probeStun(ctx, e.URLs[0], *timeout); !probe.Reachable {
+					probe.Error = "STUN binding request timed out or failed"
+				}
+			case "turn", "turns":
+				probe.Reachable = true // TURN reachability requires credentials; presence is all we report
+			}
+			res.Probes = append(res.Probes, probe)
+		}
+	}
+	res.SanitizedLog = append(res.SanitizedLog, "diagnose: probe complete")
+
+	out, _ := json.MarshalIndent(res, "", "  ")
+	fmt.Println(string(out))
+	return 0
+}
+
+// fetchServerConfig requests /config.json from the signaling server and parses the ICE
+// entries. The full response is never echoed back; only the sanitized summary is.
+func fetchServerConfig(ctx context.Context, server string, insecure bool, timeout time.Duration) (*diagnoseConfig, error) {
+	u, err := url.Parse(server)
+	if err != nil || u.Host == "" {
+		return nil, fmt.Errorf("invalid server URL")
+	}
+	switch u.Scheme {
+	case "wss":
+		u.Scheme = "https"
+	case "ws":
+		u.Scheme = "http"
+	default:
+		return nil, fmt.Errorf("unsupported scheme %q", u.Scheme)
+	}
+	u.Path = "/config.json"
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: insecure}, // #nosec G402 -- explicit dev flag
+		},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	var cfg diagnoseConfig
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// probeStun sends a STUN binding request to the given server URL and reports whether a
+// binding response arrives within timeout. A response confirms the host is reachable and
+// speaks STUN; the source address it reports back is discarded.
+func probeStun(ctx context.Context, rawURL string, timeout time.Duration) bool {
+	addr, scheme := stunHostPort(rawURL)
+	if addr == "" {
+		return false
+	}
+	network := "udp"
+	if scheme == "stuns" {
+		network = "tcp"
+	}
+	conn, err := net.DialTimeout(network, addr, timeout)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = conn.Close() }()
+	c, err := stun.NewClient(conn)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = c.Close() }()
+	c.SetRTO(timeout / 2)
+
+	done := make(chan error, 1)
+	message, err := stun.Build(stun.TransactionID, stun.BindingRequest)
+	if err != nil {
+		return false
+	}
+	if err := c.Do(message, func(res stun.Event) { done <- res.Error }); err != nil {
+		return false
+	}
+	select {
+	case err := <-done:
+		return err == nil
+	case <-ctx.Done():
+		return false
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// stunHostPort extracts a dialable host:port from an ICE URL of the form
+// stun:host:port or stuns:host:port (authority or opaque), dropping any userinfo.
+func stunHostPort(raw string) (addr, scheme string) {
+	rest := raw
+	if i := strings.Index(rest, ":"); i >= 0 {
+		scheme = strings.ToLower(rest[:i])
+		rest = strings.TrimPrefix(rest[i+1:], "//")
+	}
+	if at := strings.LastIndex(rest, "@"); at >= 0 {
+		rest = rest[at+1:]
+	}
+	if rest == "" {
+		return "", scheme
+	}
+	return rest, scheme
+}
+
+// interfaceFamilies reports whether any interface has an IPv4 or IPv6 unicast address.
+// Counts only — the addresses themselves are never returned.
+func interfaceFamilies() (ipv4, ipv6 bool) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false, false
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok {
+			if ipnet.IP.To4() != nil {
+				ipv4 = true
+			} else if strings.Contains(ipnet.IP.String(), ":") {
+				ipv6 = true
+			}
+		}
+	}
+	return ipv4, ipv6
+}

--- a/apps/cli/cmd/sendbeam/diagnose_test.go
+++ b/apps/cli/cmd/sendbeam/diagnose_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestStunHostPort(t *testing.T) {
+	tests := []struct {
+		raw        string
+		wantAddr   string
+		wantScheme string
+	}{
+		{"stun:stun.example.com:3478", "stun.example.com:3478", "stun"},
+		{"stun://stun.example.com:3478", "stun.example.com:3478", "stun"},
+		{"stun:user:pass@stun.example.com:3478", "stun.example.com:3478", "stun"},
+		{"stuns:stun.example.com:5349", "stun.example.com:5349", "stuns"},
+	}
+	for _, tt := range tests {
+		addr, scheme := stunHostPort(tt.raw)
+		if addr != tt.wantAddr || scheme != tt.wantScheme {
+			t.Errorf("stunHostPort(%q) = (%q,%q), want (%q,%q)", tt.raw, addr, scheme, tt.wantAddr, tt.wantScheme)
+		}
+	}
+}
+
+func TestFetchServerConfigSanitizesSummary(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"iceServers":[{"urls":["stun:127.0.0.1:3478"]},{"urls":["turn:turn.example.com:3478"],"username":"u","credential":"p"}]}`))
+	}))
+	defer srv.Close()
+
+	// Convert http://127.0.0.1:PORT to the ws form the CLI accepts.
+	ws := "ws://" + srv.Listener.Addr().String() + "/ws"
+	cfg, err := fetchServerConfig(context.Background(), ws, false, 2*time.Second)
+	if err != nil {
+		t.Fatalf("fetchServerConfig: %v", err)
+	}
+	if len(cfg.ICEServers) != 2 {
+		t.Fatalf("got %d ICE servers, want 2", len(cfg.ICEServers))
+	}
+	if cfg.ICEServers[1].Username != "u" {
+		t.Errorf("TURN username leaked %q", cfg.ICEServers[1].Username)
+	}
+}

--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -40,6 +40,8 @@ func main() {
 		os.Exit(runSend(os.Args[2:]))
 	case "receive", "recv":
 		os.Exit(runReceive(os.Args[2:]))
+	case "diagnose":
+		os.Exit(runDiagnose(os.Args[2:]))
 	case "-h", "--help", "help":
 		usage(os.Stdout)
 		os.Exit(0)
@@ -57,6 +59,7 @@ func usage(w *os.File) {
 	_, _ = fmt.Fprintln(w, "Usage:")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam send")+" <file-or-folder>... [flags]")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam receive")+" <code|link> [flags]")
+	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam diagnose")+" [flags]")
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, s.dim("Common flags:"))
 	_, _ = fmt.Fprintln(w, "  --server URL             signaling server (default "+defaultServer+")")

--- a/apps/cli/internal/diagnostics/diagnostics.go
+++ b/apps/cli/internal/diagnostics/diagnostics.go
@@ -1,0 +1,131 @@
+// Package diagnostics builds sanitized connection diagnostics for SendBeam with no
+// secrets or personally-identifying leaks. It is the Go counterpart of the browser's
+// apps/web/src/lib/transfer/diagnostics.ts: both clients emit the same logical shape
+// (see ADR 0003 / V12-PR06) so a failing client or the `sendbeam diagnose` command can
+// surface a small, safe snapshot of path/ICE/timing/failure state.
+//
+// Sanitization guarantees: a snapshot never contains invite words/codes, full IP
+// addresses, filenames, SDP, ICE credentials, or payload metadata. Candidate types are
+// kept ("host"/"srflx"/"prflx"/"relay") because they are diagnostic and not sensitive;
+// the addresses themselves are dropped.
+package diagnostics
+
+import (
+	"encoding/json"
+	"regexp"
+
+	"github.com/sendbeam/wire"
+)
+
+// PathKind identifies the byte path a diagnostic refers to.
+type PathKind string
+
+const (
+	// PathDirect is the direct WebRTC path (host/srflx/prflx candidates).
+	PathDirect PathKind = "direct"
+	// PathDirectTURN is the direct WebRTC path whose selected candidate is a TURN relay.
+	PathDirectTURN PathKind = "direct-turn"
+	// PathRelay is the encrypted WebSocket relay fallback.
+	PathRelay PathKind = "relay"
+)
+
+// PathState mirrors the supervisor's lifecycle for the path snapshot.
+type PathState string
+
+// Lifecycle state values carried in a sanitized PathDiag.
+const (
+	StateCandidate PathState = "candidate"
+	StateWarming   PathState = "warming"
+	StateReady     PathState = "ready"
+	StateActive    PathState = "active"
+	StateDegraded  PathState = "degraded"
+	StateFailed    PathState = "failed"
+	StateClosed    PathState = "closed"
+)
+
+// PathDiag is one path's sanitized state at snapshot time.
+type PathDiag struct {
+	// State is the lifecycle state of the path.
+	State PathState `json:"state"`
+	// Kind is the path kind.
+	Kind PathKind `json:"kind"`
+	// SetupMS is the time to open this path, in ms (0 if never opened).
+	SetupMS int64 `json:"setupMs"`
+	// ICEStates is the ordered ICE connection-state history for a direct path ("" for relay).
+	ICEStates []string `json:"iceStates,omitempty"`
+	// SelectedPairType is the selected candidate pair type ("host"/"srflx"/"prflx"/"relay");
+	// "" if none or the path is not direct.
+	SelectedPairType string `json:"selectedPairType,omitempty"`
+}
+
+// FailureEvent is one sanitized failure observed during the exchange.
+type FailureEvent struct {
+	// Code is the stable wire error class (ADR 0002).
+	Code wire.ErrorCode `json:"code"`
+	// AtMS is the time since session start, in ms.
+	AtMS int64 `json:"atMs"`
+	// Path is the sanitized path kind the failure occurred on, if known.
+	Path PathKind `json:"path,omitempty"`
+	// Message is a short sanitized human message. It is scrubbed of IPs/filenames/secrets.
+	Message string `json:"message"`
+}
+
+// Snapshot is a sanitized connection diagnostics report.
+type Snapshot struct {
+	// App is "cli" or "web".
+	App string `json:"app"`
+	// Role is "offerer" or "joiner".
+	Role string `json:"role,omitempty"`
+	// SetupMS is pairing+connection time, in ms (0 until connected).
+	SetupMS int64 `json:"setupMs"`
+	// TransferMS is the time bytes moved, in ms.
+	TransferMS int64 `json:"transferMs,omitempty"`
+	// TotalMS is wall time from session start to snapshot, in ms.
+	TotalMS int64 `json:"totalMs,omitempty"`
+	// SelectedPath is the sanitized final path kind; "" if none yet.
+	SelectedPath PathKind `json:"selectedPath,omitempty"`
+	// SelectedPairType is the sanitized selected candidate type for the final path.
+	SelectedPairType string `json:"selectedPairType,omitempty"`
+	// Paths is the ordered set of candidate paths that were registered.
+	Paths []PathDiag `json:"paths,omitempty"`
+	// Failures is the ordered set of failures observed.
+	Failures []FailureEvent `json:"failures,omitempty"`
+	// ICEServersConfigured counts the ICE servers the client was configured with (raw
+	// details are never exposed; the count and TURN presence are non-sensitive).
+	ICEServersConfigured int `json:"iceServersConfigured,omitempty"`
+	// TURNConfigured reports whether a TURN server was configured (never its details).
+	TURNConfigured bool `json:"turnConfigured,omitempty"`
+}
+
+// JSON returns the snapshot as compact, stable JSON.
+func (s *Snapshot) JSON() []byte {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return []byte(`{"error":"diagnostics: marshal failed"}`)
+	}
+	return b
+}
+
+// Sanitize applies the shared redaction rules to a string, returning a version with full
+// IP addresses, credentials, invite codes, and filenames/paths removed. Used for any free
+// text (e.g. failure messages) before it enters a Snapshot or a failure message.
+func Sanitize(s string) string {
+	s = ipAddrRe.ReplaceAllString(s, "<ip>")
+	s = credRe.ReplaceAllString(s, "${1}=<redacted>")
+	s = codeRe.ReplaceAllString(s, "<code>")
+	s = pathRe.ReplaceAllString(s, "<path>")
+	return s
+}
+
+var (
+	// ipAddrRe matches a full IPv4 or IPv6 address, optionally with a port, followed by a
+	// word boundary so a trailing ":" in an unbracketed IPv6 is still caught.
+	ipAddrRe = regexp.MustCompile(`(?:\b(?:\d{1,3}\.){3}\d{1,3}\b|\[[0-9a-fA-F:]+\]|\b(?:[0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F]{0,4}\b)(?:[-:]\d{1,5})?`)
+	// credRe matches "label=value" or "label: value" or "label value" for credential-like
+	// keys and replaces only the value (group 1 is the key, group 2 the value).
+	credRe = regexp.MustCompile(`(?i)\b(credential|token|secret|password|passwd|key|username)\s*[=:]\s*(\S+)|(?i)\b(credential|token|secret|password|passwd|key|username)\s+(\S+)`)
+	// codeRe strips the invite-code shape (room-dash-two-words) from free text.
+	codeRe = regexp.MustCompile(`\b\d+-[a-z]+(?:-[a-z]+)+\b`)
+	// pathRe strips absolute and drive-relative filesystem paths that may embed filenames.
+	pathRe = regexp.MustCompile(`(?i)\b(?:/[a-zA-Z0-9_.\-]+)+|(?:[a-z]:\\)[\\a-zA-Z0-9_.\-]+`)
+)

--- a/apps/cli/internal/diagnostics/diagnostics_test.go
+++ b/apps/cli/internal/diagnostics/diagnostics_test.go
@@ -1,0 +1,109 @@
+package diagnostics
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sendbeam/wire"
+)
+
+func TestSanitizeRedactsSensitive(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string // substrings that must NOT appear
+	}{
+		{
+			name: "ipv4 with port",
+			in:   "peer at 203.0.113.7:3478 unreachable",
+			want: []string{"203.0.113.7", "203.0.113.7:3478"},
+		},
+		{
+			name: "ipv6",
+			in:   "route via 2001:db8::1 failed",
+			want: []string{"2001:db8::1"},
+		},
+		{
+			name: "credentials",
+			in:   "turn credential=supersecret123 failed",
+			want: []string{"supersecret123"},
+		},
+		{
+			name: "invite code",
+			in:   "bad room 42-alpha-bravo",
+			want: []string{"42-alpha-bravo"},
+		},
+		{
+			name: "filesystem path",
+			in:   "could not write /home/me/secret.txt",
+			want: []string{"/home/me/secret.txt", "secret.txt"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := Sanitize(tt.in)
+			for _, w := range tt.want {
+				if strings.Contains(out, w) {
+					t.Errorf("Sanitize(%q) = %q, still contains %q", tt.in, out, w)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeKeepsBenignText(t *testing.T) {
+	out := Sanitize("direct path recovery failed; relay warmed as fallback")
+	if !strings.Contains(out, "direct path recovery failed") {
+		t.Fatalf("Sanitize stripped benign text: %q", out)
+	}
+}
+
+func TestSnapshotJSONShape(t *testing.T) {
+	s := &Snapshot{
+		App:                  "cli",
+		Role:                 "offerer",
+		SetupMS:              1200,
+		TransferMS:           400,
+		TotalMS:              1600,
+		SelectedPath:         PathDirect,
+		SelectedPairType:     "srflx",
+		ICEServersConfigured: 2,
+		TURNConfigured:       true,
+		Paths: []PathDiag{
+			{State: StateActive, Kind: PathDirect, SetupMS: 1100, ICEStates: []string{"new", "connected"}, SelectedPairType: "srflx"},
+		},
+		Failures: []FailureEvent{
+			{Code: wire.CodeConnection, AtMS: 900, Path: PathDirect, Message: "transient disconnect observed"},
+		},
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(s.JSON(), &m); err != nil {
+		t.Fatalf("Snapshot.JSON not valid JSON: %v\n%s", err, s.JSON())
+	}
+	if m["selectedPath"] != "direct" {
+		t.Errorf("selectedPath = %v, want direct", m["selectedPath"])
+	}
+	if m["turnConfigured"] != true {
+		t.Errorf("turnConfigured = %v, want true", m["turnConfigured"])
+	}
+	paths, ok := m["paths"].([]any)
+	if !ok || len(paths) != 1 {
+		t.Fatalf("paths = %v, want one entry", m["paths"])
+	}
+	failures, ok := m["failures"].([]any)
+	if !ok || len(failures) != 1 {
+		t.Fatalf("failures = %v, want one entry", m["failures"])
+	}
+}
+
+func TestSnapshotJSONNeverMarshalsSensitiveLiteralLabels(t *testing.T) {
+	s := &Snapshot{App: "cli"}
+	j := string(s.JSON())
+	for _, banned := range []string{"stun:", "credential>", "iceServers>", "sdp"} {
+		if strings.Contains(j, banned) {
+			t.Errorf("Snapshot.JSON leaked sensitive label %q: %s", banned, j)
+		}
+	}
+}

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -6,6 +6,7 @@
   import type { SignalChannel } from './lib/signaling/client.js';
   import type { ReceiveDestinationSpec } from './lib/transfer/wire.js';
   import { baseUrl, iceServers, loadConfig } from './lib/config.js';
+  import { toJSON } from './lib/transfer/diagnostics.js';
   import QrCode from './lib/QrCode.svelte';
 
   loadConfig();
@@ -40,6 +41,8 @@
   let fingerprint = $state('');
   let peerCaps = $state<CapsPayload | undefined>(undefined);
   let errorText = $state('');
+  // Sanitized failure diagnostics (V12-PR06 / ADR 0003) shown on the failure screen.
+  let failureDiag = $state('');
 
   // Transfer state, live once the handshake settles and the socket is adopted.
   let role = $state<Role | undefined>(undefined);
@@ -232,6 +235,11 @@
       (err: unknown) => {
         if (transfer !== ctrl) return;
         clearInterval(progressTimer);
+        try {
+          failureDiag = toJSON(ctrl.diagnostics());
+        } catch {
+          failureDiag = '';
+        }
         errorText = describeError(asErrorLike(err));
         screen = 'failed';
       },
@@ -279,6 +287,7 @@
     fingerprint = '';
     peerCaps = undefined;
     errorText = '';
+    failureDiag = '';
   }
 
   function backHome() {
@@ -585,6 +594,14 @@
         </span>
         <h2>Connection failed</h2>
         <p class="muted">{errorText}</p>
+        {#if failureDiag}
+          <div class="diag-block">
+            <button class="link-btn" onclick={() => copy(failureDiag)}>
+              {copied ? 'Copied' : 'Copy diagnostics'}
+            </button>
+            <pre class="diag-json">{failureDiag}</pre>
+          </div>
+        {/if}
       </div>
       <button class="primary" onclick={backHome}>Try again</button>
     </section>
@@ -1174,6 +1191,32 @@
   }
   .result.bad h2 {
     color: #fca5a5;
+  }
+  .diag-block {
+    margin-top: 0.75rem;
+    text-align: left;
+  }
+  .link-btn {
+    background: none;
+    border: none;
+    color: #7aa2f7;
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    text-decoration: underline;
+  }
+  .diag-json {
+    margin-top: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(147, 160, 184, 0.25);
+    border-radius: 0.5rem;
+    font-size: 0.72rem;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 12rem;
+    overflow: auto;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -31,6 +31,8 @@ import type {
   WorkerToHost,
 } from '../transfer/wire.js';
 import { GenerationGuard } from './generation.js';
+import { type Snapshot, sanitize } from '../transfer/diagnostics.js';
+import type { PathKind } from '../transfer/diagnostics.js';
 
 /** Terminal outcome of a transfer. `file` is present on the receive side (the downloadable result). */
 export interface TransferOutcome {
@@ -54,6 +56,8 @@ export interface TransferController {
   snapshot(): TransferSnapshot;
   /** Active byte path, including automatic relay fallback and transient recovery. */
   transport(): 'connecting' | 'direct' | 'recovering' | 'relay';
+  /** A sanitized diagnostics snapshot (setup timing, path/ICE state, failures). */
+  diagnostics(): Snapshot;
   /** Resolves when the transfer completes and verifies; rejects on any failure. */
   readonly done: Promise<TransferOutcome>;
   /** Stop producing new data frames; already-buffered transport bytes may drain. */
@@ -128,6 +132,15 @@ function run(
   let switchPromise: Promise<void> | undefined;
   let cancelTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // Sanitized diagnostics (V12-PR06 / ADR 0003): setup timing, transport/path, ICE state, and
+  // failure events — all redacted so the snapshot is safe to surface on a failure report.
+  const diagStarted = performance.now();
+  let diagTransport: PathKind | undefined;
+  let diagSetupMs = 0;
+  let diagPairType = '';
+  const diagFailures: Snapshot['failures'] = [];
+  const diagIce = new Set<string>();
+
   // Adaptive direct/relay racing: the same ICE-progress policy as the CLI decides when to warm
   // the encrypted relay, replacing the former blind fixed-duration fallback.
   const adaptivePolicy = new AdaptivePolicy();
@@ -159,6 +172,12 @@ function run(
     resolveDone(o);
   };
   const fail = (err: Error): void => {
+    diagFailures.push({
+      code: 'INTERNAL',
+      atMs: Math.round(performance.now() - diagStarted),
+      ...(diagTransport !== undefined ? { path: diagTransport } : {}),
+      message: sanitize(err instanceof Error ? err.message : String(err)),
+    });
     if (settled) return;
     settled = true;
     cleanup();
@@ -183,6 +202,7 @@ function run(
         ...(spec.iceServers ? { iceServers: spec.iceServers } : {}),
         onIceState: (s) => {
           if (!generation.isCurrent(gen)) return;
+          diagIce.add(s.connection);
           if (
             adaptivePolicy.observe({
               gathering: s.gathering as AdaptiveGathering,
@@ -238,8 +258,11 @@ function run(
 
       const selected = await selectTransport(p, relayPath, warmRelayWhenDecided);
       transport = selected.kind;
+      diagSetupMs = Math.round(performance.now() - diagStarted);
+      diagTransport = selected.kind === 'direct' ? 'direct' : 'relay';
       if (selected.kind === 'direct') {
         writer = new ChannelWriter(selected.channel);
+        diagPairType = p.diagnostics().selectedPairType;
       } else {
         p.close();
       }
@@ -406,11 +429,36 @@ function run(
     }
   }
 
+  // Build a sanitized diagnostics snapshot (V12-PR06 / ADR 0003). Redacts everything the
+  // sanitizer would touch and reflects only path/ICE/timing/failure state, never secrets.
+  const diagSnapshot = (): Snapshot => ({
+    app: 'web',
+    role: rendezvous.role === 'offerer' ? 'offerer' : 'joiner',
+    setupMs: diagSetupMs,
+    totalMs: Math.round(performance.now() - diagStarted),
+    ...(diagTransport !== undefined ? { selectedPath: diagTransport } : {}),
+    ...(diagPairType !== '' ? { selectedPairType: diagPairType } : {}),
+    ...(diagIce.size > 0
+      ? {
+          paths: [
+            {
+              state: diagTransport ? 'active' : 'candidate',
+              kind: diagTransport ?? 'direct',
+              setupMs: diagSetupMs,
+              iceStates: [...diagIce],
+            },
+          ],
+        }
+      : {}),
+    ...(diagFailures.length > 0 ? { failures: diagFailures } : {}),
+  });
+
   return {
     progress: () => progress.snapshot().bytes,
     total: () => total,
     snapshot: () => progress.snapshot(),
     transport: () => (recovering && transport === 'direct' ? 'recovering' : transport),
+    diagnostics: diagSnapshot,
     done: donePromise,
     pause: () => {
       if (settled || progress.snapshot().state === 'paused') return;

--- a/apps/web/src/lib/transfer/diagnostics.test.ts
+++ b/apps/web/src/lib/transfer/diagnostics.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { sanitize, toJSON } from './diagnostics.js';
+
+describe('sanitize() redaction', () => {
+  it('redacts IPv4 with port', () => {
+    const out = sanitize('peer at 203.0.113.7:3478 unreachable');
+    expect(out).not.toContain('203.0.113.7');
+    expect(out).toContain('<ip>');
+  });
+
+  it('redacts IPv6', () => {
+    const out = sanitize('route via 2001:db8::1 failed');
+    expect(out).not.toContain('2001:db8::1');
+    expect(out).toContain('<ip>');
+  });
+
+  it('redacts credentials', () => {
+    const out = sanitize('turn credential=supersecret123 failed');
+    expect(out).not.toContain('supersecret123');
+    expect(out).toContain('<redacted>');
+  });
+
+  it('redacts invite codes', () => {
+    const out = sanitize('bad room 42-alpha-bravo');
+    expect(out).not.toContain('42-alpha-bravo');
+    expect(out).toContain('<code>');
+  });
+
+  it('keeps benign text', () => {
+    const out = sanitize('direct path recovery failed; relay warmed as fallback');
+    expect(out).toContain('direct path recovery failed');
+  });
+});
+
+describe('toJSON()', () => {
+  it('serializes a snapshot without leaking sensitive labels', () => {
+    const json = toJSON({
+      app: 'web',
+      role: 'offerer',
+      setupMs: 1200,
+      selectedPath: 'direct',
+      selectedPairType: 'srflx',
+      paths: [{ state: 'active', kind: 'direct', setupMs: 1100, iceStates: ['new', 'connected'] }],
+      failures: [{ code: 'CONNECTION', atMs: 900, message: 'transient disconnect observed' }],
+      turnConfigured: true,
+    });
+    expect(json).toContain('"selectedPath":"direct"');
+    expect(json).toContain('"turnConfigured":true');
+    for (const banned of ['stun:', 'credential>', 'iceServers>', 'sdp']) {
+      expect(json).not.toContain(banned);
+    }
+  });
+});

--- a/apps/web/src/lib/transfer/diagnostics.ts
+++ b/apps/web/src/lib/transfer/diagnostics.ts
@@ -1,0 +1,91 @@
+/**
+ * Sanitized connection diagnostics — the browser twin of the Go
+ * `apps/cli/internal/diagnostics` package (ADR 0003 / V12-PR06). Both clients emit the
+ * same logical shape so a failing client or `sendbeam diagnose` can surface a small, safe
+ * snapshot of path/ICE/timing/failure state.
+ *
+ * Sanitization guarantees: a snapshot never contains invite words/codes, full IP
+ * addresses, filenames, SDP, ICE credentials, or payload metadata. Candidate types are kept
+ * ("host"/"srflx"/"prflx"/"relay") because they are diagnostic and not sensitive; the
+ * addresses themselves are dropped.
+ */
+
+import type { ErrorCode as ErrorCodeT } from '@sendbeam/protocol';
+
+export type PathKind = 'direct' | 'direct-turn' | 'relay';
+
+export type PathState =
+  'candidate' | 'warming' | 'ready' | 'active' | 'degraded' | 'failed' | 'closed';
+
+export interface PathDiag {
+  /** Lifecycle state of the path. */
+  state: PathState;
+  /** Path kind. */
+  kind: PathKind;
+  /** Time to open this path, in ms (0 if never opened). */
+  setupMs: number;
+  /** Ordered ICE connection-state history for a direct path (absent for relay). */
+  iceStates?: string[];
+  /** Selected candidate pair type ("host"/"srflx"/"prflx"/"relay"); "" if none/direct. */
+  selectedPairType?: string;
+}
+
+export interface FailureEvent {
+  /** Stable wire error class (ADR 0002). */
+  code: ErrorCodeT;
+  /** Time since session start, in ms. */
+  atMs: number;
+  /** Sanitized path kind the failure occurred on, if known. */
+  path?: PathKind;
+  /** Short sanitized human message. */
+  message: string;
+}
+
+export interface Snapshot {
+  app: 'cli' | 'web';
+  role?: 'offerer' | 'joiner';
+  /** Pairing+connection time, in ms (0 until connected). */
+  setupMs: number;
+  /** Time bytes moved, in ms. */
+  transferMs?: number;
+  /** Wall time from session start to snapshot, in ms. */
+  totalMs?: number;
+  /** Sanitized final path kind; "" if none yet. */
+  selectedPath?: PathKind;
+  /** Sanitized selected candidate type for the final path. */
+  selectedPairType?: string;
+  /** Ordered set of candidate paths that were registered. */
+  paths?: PathDiag[];
+  /** Ordered set of failures observed. */
+  failures?: FailureEvent[];
+  /** Count of configured ICE servers (details never exposed). */
+  iceServersConfigured?: number;
+  /** Whether a TURN server was configured (never its details). */
+  turnConfigured?: boolean;
+}
+
+/**
+ * Apply the shared redaction rules to a string: removes full IP addresses, credentials,
+ * invite codes, and filesystem paths. Used for any free text (e.g. failure messages)
+ * before it enters a Snapshot.
+ */
+export function sanitize(s: string): string {
+  return s
+    .replace(/\[[0-9a-fA-F:]+\]/g, '<ip>')
+    .replace(
+      /(?:(?:\d{1,3}\.){3}\d{1,3}\b|(?:[0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F]{0,4}\b)(?:[-:]\d{1,5})?/g,
+      '<ip>',
+    )
+    .replace(
+      /\b(?:credential|token|secret|password|passwd|key|username)\s*[=:]\s*(\S+)/gi,
+      '<redacted>',
+    )
+    .replace(/\b\d+-[a-z]+(?:-[a-z]+)+\b/g, '<code>')
+    .replace(/(?:\/\/?)[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)+/g, '<path>')
+    .replace(/(?:[A-Za-z]:\\)[\\a-zA-Z0-9_.-]+/g, '<path>');
+}
+
+/** Returns the snapshot as a JSON string. */
+export function toJSON(s: Snapshot): string {
+  return JSON.stringify(s);
+}

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -103,12 +103,18 @@ allowlist. Any WebSocket-aware reverse proxy works.
   config is configurable at runtime: the server publishes an operator-chosen
   STUN list via `/config.json` (from `SENDBEAM_ICE_SERVERS`), which the web
   app fetches on load, validates, and passes to `RTCPeerConnection`.
-- **TURN** — SendBeam does not speak TURN. When a direct peer-to-peer path
-  is impossible (symmetric NATs on both ends), clients fall back to the
-  app-layer **encrypted relay** through this same server, which is exactly
-  the TURN role without needing a second service. The relay never sees
-  plaintext: payloads are end-to-end encrypted and framed inside WebSocket
-  messages.
+- **TURN** — optional. Operators who need better restrictive-network
+  reachability publish TURN URLs (alongside STUN) in `SENDBEAM_ICE_SERVERS`;
+  clients then gather a TURN relayed candidate and race it against direct
+  candidates. TURN credentials are served with `Cache-Control: no-cache` and
+  clients never reuse a fetched config past the 15-minute credential TTL, so
+  operators may serve short-lived credentials without embedding them in the
+  web bundle. **Default self-hosting requires no TURN service**: when no TURN is
+  configured, restricted pairs fall back to the app-layer **encrypted relay**
+  through this same server, which fills the TURN role without a second service.
+  The relay (and a TURN server, when used) never sees plaintext: payloads are
+  end-to-end encrypted and framed inside WebSocket messages, and a TURN server
+  observes only encrypted WebRTC datagrams. See `docs/adr/0003-path-selection.md`.
 
 For pairings behind symmetric NATs, make sure this server is reachable on
 the public port (it is the fallback path), and budget its bandwidth with

--- a/docs/adr/0003-path-selection.md
+++ b/docs/adr/0003-path-selection.md
@@ -1,0 +1,84 @@
+# ADR 0003 — Direct path selection: direct-only, direct+TURN, and hybrid relay
+
+Status: accepted
+Scope: v1.2 (V12-PR06)
+Applies to: `packages/wire` (Go), `packages/protocol` (TS), `apps/cli`, `apps/web`, `apps/server`
+
+## Context
+
+SendBeam moves bytes over one of three byte paths: an authenticated WebRTC
+DataChannel (direct), a TURN-relayed WebRTC DataChannel (direct still, but the
+transport is allocated through a TURN server), or the encrypted WebSocket relay
+(the zero-extra-service fallback). V12-PR06 asks us to decide, in one short ADR,
+how these should nest so that default self-hosting needs no extra service while
+optional TURN remains available for restrictive networks without weakening E2EE.
+
+## Options
+
+### A. Direct-only (no TURN)
+
+Clients gather host/srflx candidates over the bundled STUN server and, if the
+direct path does not connect, fall back to the encrypted WebSocket relay.
+
+- Pros: no extra service; the smallest moving surface; E2EE unchanged.
+- Cons: users whose network blocks or de-prioritizes UDP for WebRTC (some
+  hotels, symmetric/CGNAT-heavy operators, or UDP-blocking firewalls) always ride
+  the relay, so relay pressure grows and direct latency is never recovered.
+
+### B. Direct + optional TURN, encrypted WS relay as fallback
+
+Clients use operator-published ICE servers (STUN and, optionally, TURN). When a
+TURN server is configured, a relay candidate can be gathered and raced against
+host/srflx candidates; when it is not, behavior is identical to option A. The
+encrypted WebSocket relay remains the last-resort fallback and the default when
+no TURN is configured.
+
+- Pros: restrictive networks can recover a WebRTC path without touching the
+  transfer engine; the WS relay remains the zero-extra fallback by default;
+  TURN credentials are optional and short-lived; E2EE stays at the application
+  layer on every candidate. Direct latency when healthy is unchanged.
+- Cons: requires an operator to operate a TURN server for those networks.
+
+### C. Hybrid TURN allocation + WS relay racing
+
+Treat a TURN relay candidate exactly like the WS relay: warm both in parallel and
+race. This is a superset of B but doubles the number of fallback paths a peer may
+hold open.
+
+- Pros: maximum reachability.
+- Cons: more concurrent allocations (relay pressure, cost, memory), more states
+  to reason about in the supervisor, and the WS relay alone already provides the
+  same reachability with fewer moving parts (WebSocket over the same origin).
+
+## Decision
+
+Adopt **option B**.
+
+- Default self-hosting publishes no TURN URL, so `sendbeamd` out of the box
+  requires no extra service; the encrypted WebSocket relay is the fallback.
+- Operators who want better restricted-network reachability publish optional
+  TURN URLs via the existing `SENDBEAM_ICE_SERVERS` config. Clients already parse
+  and apply TURN entries (`wire.ParseICEServer` / `protocol.parseIceServer`) into
+  their WebRTC ICE agent, so a relay candidate can be gathered and raced against
+  direct candidates with no engine change.
+- TURN credentials are short-lived and served with `Cache-Control: no-cache`;
+  clients never cache a fetched ICE config past `wire.ICEConfigTTL`
+  (15 minutes) and never embed long-lived TURN credentials in the web bundle.
+  The browser fetches `/config.json` at runtime and applies the operator's
+  servers, matching the CLI's `--ice-server`.
+- We do **not** adopt C: the encrypted WS relay is the single fallback racing
+  surface. TURN's job is only to give the direct WebRTC path a relayed candidate,
+  not to add a second fallback plane.
+- Application-layer AES-GCM (the existing frame sealing) remains active on every
+  candidate — direct, TURN-relayed, and WS relay. A TURN server observes only
+  encrypted WebRTC datagrams and never plaintext file contents.
+
+## Consequences
+
+- Reference docs (`docs/protocol.md`, `docs/HOSTING.md`, `docs/threat-model.md`)
+  describe TURN as optional and never required for default self-hosting.
+- The supervisor must treat a TURN relayed candidate as a _direct-path_ candidate
+  (same epoch, same path identity), never as a relay fallback.
+- Sanitized diagnostics report whether the selected WebRTC candidate was a TURN
+  relay, so operators can see when TURN is actually being used — without
+  exposing candidates, credentials, or full IPs.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -84,6 +84,24 @@ The signaling socket itself is independently resumable: a post-establishment dro
 room is re-dialed and re-attached with `resume` (bounded retries), so ICE-restart
 renegotiation can still exchange SDP/ICE even if signaling dropped earlier.
 
+### Direct path and optional TURN
+
+The "direct" path is an authenticated WebRTC DataChannel. When the operator publishes TURN
+servers (see `HOSTING.md`), the ICE agent may also gather a **TURN relayed candidate**; such a
+candidate is still a _direct-path_ candidate, raced against host/srflx/prflx candidates and
+handled by the supervisor as the same path — never as the encrypted-relay fallback. When no
+TURN is configured, behavior is unchanged from direct-only. Application-layer AES-GCM frames
+are identical on every candidate, so TURN never weakens the protocol (see
+`docs/adr/0003-path-selection.md`).
+
+### Diagnostics
+
+Both clients can emit a **sanitized** snapshot of path/ICE/timing/failure state for
+troubleshooting (`sendbeam diagnose`; the web failure screen's "Copy diagnostics"). The
+snapshot intentionally excludes invite codes, full IP addresses, filenames, SDP, credentials,
+and payload metadata — it reports only candidate _types_ ("host"/"srflx"/"prflx"/"relay"),
+transport, timing, and error classes (see `docs/adr/0002-error-taxonomy.md`).
+
 ### Flow
 
 ```

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -51,6 +51,19 @@ the master key that the two humans can compare out of band.
 Sees ciphertext, message sizes, and timing only. No plaintext, no filenames, no keys. This
 is documented, not hidden — see accepted limitations below.
 
+### TURN server
+
+TURN is **optional** (`docs/adr/0003-path-selection.md`). When an operator configures a TURN
+server, it acts as a third-party relay for WebRTC datagrams: it sees only encrypted
+AEAD/DTLS datagrams, never plaintext file contents, filenames, or keys (the application-layer
+AES-GCM frame is the end-to-end confidentiality guarantee on every candidate). Like the relay,
+the TURN server observes connectivity metadata (source/destination addresses and ports,
+timing) that a passive network observer would see anyway. Because the authenticated SDP/ICE
+exchange binds the DTLS fingerprint and negotiating a second MITM SDP is impossible, a TURN
+server that dropped or tampered with datagrams would only cause a connectivity failure, not a
+confidentiality or integrity break. Operators may use short-lived TURN credentials, which
+clients honour via the 15-minute runtime-ICE-config TTL (`HOSTING.md`).
+
 ### Replay / reordering / tampering
 
 AES-256-GCM with a per-direction monotonic nonce counter; the frame header is the GCM AAD,


### PR DESCRIPTION
Add sanitized connection diagnostics with a CLI diagnose command and web failure output, a decision ADR for optional TURN, and expand the NAT lab with restrictive-network profiles and measurement collection.

- sanitized diagnostics in Go and TS (no invites, IPs, filenames, SDP, credentials, or payload metadata) with unit tests
- CLI `sendbeam diagnose` probes /config.json and STUN reachability
- web failure diagnostics with copyable JSON on the failure screen
- ADR 0003: direct + optional TURN; the encrypted WS relay stays the zero-extra fallback and default self-hosting needs no TURN
- lab: udp-blocked, jitter and bandwidth-shift netem, reconnect cycles, -measure wall time / relay usage / RSS
- docs: HOSTING, protocol, threat-model updated