### PR TITLE
fix: harden terminal settlement across direct to relay cutover

### DIFF
--- a/docs/RELEASE-v1.2.md
+++ b/docs/RELEASE-v1.2.md
@@ -22,5 +22,10 @@ against merged `main`. Evidence is a file:test or a measured number; all digests
 - The NAT lab was fixed and measured for this gate: invite codes are printed on the sender's
   stderr, and `natlab` now parses stderr (with a pinned unit test) and `-measure` reports
   time-to-active-path (`pathMs`) per cycle.
+- Terminal settlement was hardened for cutover (Req 5): a settled receiver now re-answers a
+  retransmitted `Complete` with a fresh `Done` (it previously ignored it, stalling the
+  sender), and the sender retransmits `Complete` on an interval while awaiting `Done`, so a
+  `Complete`/`Done` exchange lost in a direct→relay cutover converges instead of timing out.
+  Go + TS regression tests drop the receiver's `Done` mid-cutover and pin recovery.
 - Released as the release-tag trigger publishes the multi-arch image and CLI binaries
   (`publish.yml`); tag `v1.2` is created from this merge.

--- a/packages/protocol/src/transfer-loopback.test.ts
+++ b/packages/protocol/src/transfer-loopback.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { createHash } from 'node:crypto';
 import { deriveTransferKeys } from './keyschedule.js';
 import { bytesSource, MemorySink, type Destination, type Digest } from './transfer-ports.js';
+import { FrameType } from './transfer.js';
 import type { FileEntry, Manifest } from './transfer.js';
 import { TransferSender } from './transfer-sender.js';
 import { TransferReceiver } from './transfer-receiver.js';
@@ -98,6 +99,68 @@ describe('transfer loopback (no browser)', () => {
     });
     expect(result.some((r) => r.status === 'rejected')).toBe(true);
     expect(sink.isClosed).toBe(false);
+  });
+
+  it('re-sends Done when a cutover drops it after the receiver settled', async () => {
+    // The receiver settles and sends its one-shot Done, but that Done is lost — the exact
+    // loss a direct→relay cutover can cause right after every block is acknowledged. The
+    // sender retransmits Complete on the new path; a settled receiver must re-answer with
+    // a fresh Done or the sender stalls waiting for it.
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array(64_000).map((_, i) => (i * 131 + 7) & 0xff);
+    const sink = new MemorySink();
+
+    const box: { receiver?: TransferReceiver } = {};
+    let didCutover = false;
+    let doneDropped = false;
+    const sender = new TransferSender({
+      file: bytesSource(data, {
+        name: 'f',
+        size: data.length,
+        mime: 'application/octet-stream',
+        lastModified: 1,
+      }),
+      send: (frame) => queueMicrotask(() => box.receiver!.handle(frame)),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 1024,
+      frameSize: 256,
+      window: 4,
+      doneTimeoutMs: 2000, // keep the no-fix failure fast
+    });
+    const receiver = new TransferReceiver({
+      send: (frame) => {
+        queueMicrotask(() => {
+          // Drop the receiver's first Done (type byte at sealed offset 9), then simulate
+          // the sender's path change so it retransmits Complete.
+          if (!doneDropped && frame[9] === FrameType.Done) {
+            doneDropped = true;
+            if (!didCutover) {
+              didCutover = true;
+              sender.transportChanged();
+            }
+            return;
+          }
+          sender.handle(frame);
+        });
+      },
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink,
+    });
+    box.receiver = receiver;
+
+    const [digest, result] = await Promise.all([sender.run(), receiver.done]);
+    expect(doneDropped).toBe(true);
+    expect([...sink.bytes()]).toEqual([...data]);
+    expect(result.digest).toBe(createHash('sha256').update(data).digest('hex'));
+    expect(digest).toBe(result.digest);
   });
 
   it('streams a nested multi-file set with empty files and aggregate progress', async () => {

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -113,6 +113,7 @@ export class TransferReceiver {
   private inbound: Promise<void> = Promise.resolve();
   private outbound: Promise<void> = Promise.resolve();
   private settled = false;
+  private resolved = false;
 
   constructor(opts: TransferReceiverOptions) {
     this.o = opts;
@@ -187,7 +188,9 @@ export class TransferReceiver {
   }
 
   private async process(frame: Uint8Array): Promise<void> {
-    if (this.settled) return;
+    if (this.settled) {
+      return this.replyDoneAfterCutover(frame);
+    }
     let opened;
     try {
       opened = await openSequenced(this.o.recvDir, this.recvCounter, frame);
@@ -524,6 +527,7 @@ export class TransferReceiver {
     }
     await this.sendControl(FrameType.Done, { type: FrameType.Done });
     this.settled = true;
+    this.resolved = true;
     this.resolveDone({
       files: manifest.files,
       digests: [...this.digests],
@@ -531,6 +535,25 @@ export class TransferReceiver {
       file: manifest.files[0]!,
       digest: got,
     });
+  }
+
+  /**
+   * Handle a frame that arrives after the receiver has already settled. A direct→relay
+   * cutover can lose the receiver's one-shot Done after it settled; the sender then
+   * retransmits Complete on the new path and must get a fresh Done, or it stalls waiting
+   * for Done until it times out. A settled receiver ignores everything else.
+   */
+  private async replyDoneAfterCutover(frame: Uint8Array): Promise<void> {
+    if (!this.resolved) return;
+    let opened;
+    try {
+      opened = await openSequenced(this.o.recvDir, this.recvCounter, frame);
+    } catch {
+      return;
+    }
+    if (opened.header.type !== FrameType.Complete) return;
+    this.recvCounter = opened.counter + 1;
+    await this.sendControl(FrameType.Done, { type: FrameType.Done });
   }
 
   private async abortWith(

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -62,6 +62,12 @@ export interface TransferSenderOptions {
    * retry exhaustion. A dead peer otherwise stalls `run` forever.
    */
   doneTimeoutMs?: number;
+  /**
+   * How often to retransmit the terminal Complete while awaiting Done. A single shot can
+   * be lost in a path cutover, so retransmitting lets settlement converge once the new
+   * path is stable instead of stalling to doneTimeoutMs.
+   */
+  completeIntervalMs?: number;
   /** Reports bytes acknowledged after verify-and-sink. */
   onProgress?(acknowledgedBytes: number): void;
   /** Reports verified progress for the active file plus aggregate acknowledged bytes. */
@@ -79,6 +85,7 @@ interface InflightBlock {
 const DEFAULT_ACK_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_DONE_TIMEOUT_MS = 30_000;
+const DEFAULT_COMPLETE_INTERVAL_MS = 500;
 
 export class TransferSender {
   private readonly o: TransferSenderOptions;
@@ -306,19 +313,33 @@ export class TransferSender {
 
   private async waitForDone(): Promise<void> {
     const timeoutMs = this.o.doneTimeoutMs ?? DEFAULT_DONE_TIMEOUT_MS;
+    // A single Complete can be lost in a path cutover (it is not block-acked); retransmit
+    // it on an interval so the Complete/Done exchange converges once the new path is stable
+    // instead of stalling to doneTimeoutMs.
+    const intervalMs = this.o.completeIntervalMs ?? DEFAULT_COMPLETE_INTERVAL_MS;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let interval: ReturnType<typeof setInterval> | undefined;
     try {
-      await Promise.race([
-        this.done,
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(() => {
-            reject(new TransferError('retry_exhausted', 'receiver did not send done in time'));
-          }, timeoutMs);
-        }),
-      ]);
+      await new Promise<void>((resolve, reject) => {
+        interval = setInterval(() => void this.retransmitComplete(), intervalMs);
+        timer = setTimeout(() => {
+          reject(new TransferError('retry_exhausted', 'receiver did not send done in time'));
+        }, timeoutMs);
+        this.done.then(resolve, reject);
+      });
     } finally {
       if (timer !== undefined) clearTimeout(timer);
+      if (interval !== undefined) clearInterval(interval);
     }
+  }
+
+  /** Re-seal and re-send the terminal Complete while awaiting Done; a no-op once settled. */
+  private retransmitComplete(): void {
+    if (this.settled || !this.completeSent || this.completeDigest === undefined) return;
+    this.sendControl(FrameType.Complete, {
+      type: FrameType.Complete,
+      fileDigest: this.completeDigest,
+    }).catch((e: unknown) => this.fail(e instanceof Error ? e : new Error(String(e))));
   }
 
   private async processInbound(frame: Uint8Array): Promise<void> {

--- a/packages/wire/faults_test.go
+++ b/packages/wire/faults_test.go
@@ -183,6 +183,14 @@ func (l *faultLink) completeSeen() bool {
 	return l.counts[dirS2R][FrameComplete] > 0
 }
 
+// doneSeen reports whether the receiver has transmitted at least one FrameDone on
+// the r2s path (dropped or not).
+func (l *faultLink) doneSeen() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.counts[dirR2S][FrameDone] > 0
+}
+
 // randomAction draws a fault from a fixed probability table so seeds stay
 // comparable across runs.
 func (l *faultLink) randomAction(_ int, typ uint8) faultAction {

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -194,7 +194,7 @@ func (r *Receiver) Cancel(reason string) error {
 
 func (r *Receiver) process(frame []byte) error {
 	if r.isSettled() {
-		return nil
+		return r.replyDoneAfterCutover(frame)
 	}
 	opened, err := OpenSequenced(r.o.RecvDir, r.recvCounter, frame)
 	if err != nil {
@@ -537,6 +537,33 @@ func (r *Receiver) onPeerFail(payload []byte) error {
 	}
 	r.abortWith(NewTransferError(fail.Reason, "sender failed: "+string(fail.Reason)), false)
 	return nil
+}
+
+// settledOK reports whether the receiver already settled successfully (err is nil).
+func (r *Receiver) settledOK() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.settled && r.err == nil
+}
+
+// replyDoneAfterCutover handles a frame that arrives after the receiver has already settled.
+// A direct→relay cutover can lose the receiver's one-shot Done after it settled; the sender
+// then retransmits Complete on the new path and must get a fresh Done, or it stalls waiting
+// for Done until it times out. A settled receiver ignores everything else — it has no more
+// work to do and no longer validates data.
+func (r *Receiver) replyDoneAfterCutover(frame []byte) error {
+	if !r.settledOK() {
+		return nil
+	}
+	opened, err := OpenSequenced(r.o.RecvDir, r.recvCounter, frame)
+	if err != nil {
+		return nil
+	}
+	if opened.Header.Type != FrameComplete {
+		return nil
+	}
+	r.recvCounter = opened.Counter + 1
+	return r.sendControl(NewDone())
 }
 
 func (r *Receiver) onComplete(payload []byte) error {

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -27,6 +27,11 @@ const (
 	// sending Complete before failing with retry exhaustion (a dead peer otherwise
 	// stalls Run forever).
 	DefaultDoneTimeout = 30 * time.Second
+	// DefaultCompleteInterval is how often the sender retransmits the terminal Complete
+	// while it is waiting for the receiver's Done. A single shot can be lost in a path
+	// cutover (the exchange that gives settlement is not block-acked), so retransmitting
+	// lets settlement converge once the new path is stable instead of stalling to DoneTimeout.
+	DefaultCompleteInterval = 500 * time.Millisecond
 )
 
 // SenderOptions configures a Sender. Zero-valued sizing and retry fields select defaults.
@@ -54,6 +59,9 @@ type SenderOptions struct {
 	// DoneTimeout bounds the wait for the receiver's Done after Complete; zero selects
 	// DefaultDoneTimeout.
 	DoneTimeout time.Duration
+	// CompleteInterval is how often the terminal Complete is retransmitted while waiting
+	// for Done; zero selects DefaultCompleteInterval.
+	CompleteInterval time.Duration
 	// OnProgress reports bytes acknowledged after verify-and-sink.
 	OnProgress     func(acknowledgedBytes int64)
 	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
@@ -131,6 +139,9 @@ func NewSender(opts SenderOptions) *Sender {
 	}
 	if opts.DoneTimeout == 0 {
 		opts.DoneTimeout = DefaultDoneTimeout
+	}
+	if opts.CompleteInterval == 0 {
+		opts.CompleteInterval = DefaultCompleteInterval
 	}
 	if opts.CreateDigest == nil {
 		opts.CreateDigest = NewSHA256Digest
@@ -759,10 +770,41 @@ func (s *Sender) waitDone() error {
 			"transfer: receiver did not send Done within the deadline"))
 	})
 	defer timer.Stop()
+	// A single Complete can be lost in a path cutover (it is not block-acked), and a
+	// settled receiver that re-answered Done in that window would otherwise leave the
+	// sender stalled until DoneTimeout. Retransmit Complete on an interval so the
+	// Complete/Done exchange converges once the new path is stable.
+	retransmit := time.NewTicker(s.o.CompleteInterval)
+	defer retransmit.Stop()
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-retransmit.C:
+				s.retransmitComplete()
+			}
+		}
+	}()
 	for !s.settled {
 		s.cond.Wait()
 	}
 	return s.err
+}
+
+// retransmitComplete re-seals and re-sends the terminal Complete while the sender is
+// waiting for Done. It is a no-op once settled or before Complete was first attempted.
+func (s *Sender) retransmitComplete() {
+	s.mu.Lock()
+	if s.settled || !s.completeSent || s.complete == nil {
+		s.mu.Unlock()
+		return
+	}
+	complete := s.complete
+	s.mu.Unlock()
+	_ = s.sendControl(complete)
 }
 
 func (s *Sender) settle() {

--- a/packages/wire/transfer_sender_cutover_test.go
+++ b/packages/wire/transfer_sender_cutover_test.go
@@ -109,3 +109,105 @@ func TestSenderRetransmitsCompleteOnCutover(t *testing.T) {
 		t.Fatal("receiver did not produce a digest")
 	}
 }
+
+// TestReceiverResendsDoneOnCutover pins the terminal settlement in the opposite
+// direction from TestSenderRetransmitsCompleteOnCutover: the receiver settles and sends
+// its one-shot Done, but that Done is lost — the exact loss a direct→relay cutover can
+// cause right after every block is acknowledged. The receiver is already settled, so it
+// would never process the sender's retransmitted Complete and never re-send Done, leaving
+// the sender pinning in waitDone until its DoneTimeout.
+//
+// The harness drops the receiver's first Done, then simulates the cutover by calling
+// TransportChanged once the sender has attempted Complete. The settled receiver must
+// re-answer the retransmitted Complete with a fresh Done so the sender settles.
+func TestReceiverResendsDoneOnCutover(t *testing.T) {
+	data := testData(64_000, 7)
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := newFaultLink(faultScript{}.at(dirR2S, FrameDone, fDrop), nil)
+	doneTimeout := 2 * time.Second // keep the no-fix failure fast
+	sink := &MemorySink{}
+
+	sender := NewSender(SenderOptions{
+		File:        BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:        func(f []byte) error { return link.send(dirS2R, f) },
+		SendDir:     keys.O2J,
+		RecvDir:     keys.J2O,
+		BlockSize:   1024,
+		FrameSize:   256,
+		Window:      4,
+		AckTimeout:  250 * time.Millisecond,
+		MaxRetries:  5,
+		DoneTimeout: doneTimeout,
+	})
+	receiver := NewReceiver(ReceiverOptions{
+		Send:    func(f []byte) error { return link.send(dirR2S, f) },
+		SendDir: keys.J2O,
+		RecvDir: keys.O2J,
+		Sink:    sink,
+	})
+
+	go func() {
+		for {
+			if link.isClosed() {
+				return
+			}
+			f, ok := <-link.s2r
+			if !ok {
+				return
+			}
+			receiver.Handle(f)
+		}
+	}()
+	go func() {
+		for {
+			if link.isClosed() {
+				return
+			}
+			f, ok := <-link.r2s
+			if !ok {
+				return
+			}
+			sender.Handle(f)
+		}
+	}()
+
+	// Once the receiver has settled and sent (a now-lost) Done, simulate the cutover by
+	// telling the sender the path changed: it retransmits Complete, and the settled
+	// receiver must answer with a fresh Done.
+	go func() {
+		for !link.doneSeen() && !link.isClosed() {
+			time.Sleep(2 * time.Millisecond)
+		}
+		sender.TransportChanged()
+	}()
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	runErrCh := make(chan error, 1)
+	go func() {
+		_, e := sender.Run(runCtx)
+		runErrCh <- e
+	}()
+	recvRes, recvErr := receiver.Wait(runCtx)
+	var runErr error
+	select {
+	case runErr = <-runErrCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sender.Run did not return; re-sent Done missing")
+	}
+	if runErr != nil {
+		t.Fatalf("sender: %v", runErr)
+	}
+	if recvErr != nil {
+		t.Fatalf("receiver: %v", recvErr)
+	}
+	if string(sink.Bytes()) != string(data) {
+		t.Fatal("received bytes differ from source after cutover Done recovery")
+	}
+	if recvRes.Digest == "" {
+		t.Fatal("receiver did not produce a digest")
+	}
+}


### PR DESCRIPTION
## Summary

Completes the v1.2 release-gate terminal-settlement hardening. A path cutover right
after every block is acknowledged can lose the receiver's one-shot `Done` even though
the receiver already settled, leaving the sender waiting in `waitDone` until it times
out ("receiver did not send Done"). Two complementary fixes, mirrored in Go and TS:

- A settled receiver now re-answers a retransmitted `Complete` with a fresh `Done`
  instead of ignoring it (it previously discarded all frames after settling).
- The sender retransmits `Complete` on an interval while awaiting `Done`, so a
  `Complete`/`Done` exchange lost in the cutover transition converges once the new
  path is stable.

## Tests

Regression tests in both twins drop the receiver's `Done` mid-cutover and pin
recovery; each fails without the fix. Wire `-race`, protocol (170), CLI cutover,
web, e2e, and prettier all green.