### PR TITLE
feat: define durable transfer journal contract

### DIFF
--- a/docs/adr/0004-durable-journal.md
+++ b/docs/adr/0004-durable-journal.md
@@ -1,0 +1,228 @@
+# ADR 0004 — Durable transfer journal: durability contract and schema
+
+Status: accepted
+Scope: v1.3 (durable transfers)
+Applies to: `packages/wire/journal.go` (Go), `packages/protocol/src/journal.ts` (TS), and
+the future durability implementations in `apps/cli` (PR02) and `apps/web` (PR03)
+
+## Context
+
+A browser reload, app/process restart, crash, or temporary outage must not force a large
+verified transfer to restart from zero. Durability must never create silent corruption:
+only data that is **verified, durably persisted, and durably checkpointed** may be
+advertised as resumable progress, and the journal must never advance ahead of durable
+data.
+
+This ADR defines the durability contract, the versioned journal schema, the fail-closed
+loading rules, and the crash/torn-write/GC/expiry semantics that later CLI and browser
+durability work must honor. It establishes the foundation (PR01); it does not implement
+the full durable receive (PR02/PR03) or cross-session resume (PR06/PR07).
+
+## 1. Durability ordering (the contract)
+
+A checkpoint may be advertised as resumable only after the full ordering below:
+
+```
+receive/authenticate block
+        ↓
+verify block
+        ↓
+write block data
+        ↓
+required durability operation (flush/fsync of the data)
+        ↓
+atomically advance the journal checkpoint
+        ↓
+ONLY NOW may that checkpoint be advertised as resumable
+```
+
+- A crash **anywhere before** journal advancement leaves the previous checkpoint
+  authoritative. The journal is not updated, so nothing is claimed that is not durable.
+- A crash **after** checkpoint advancement must never leave the journal claiming bytes
+  that are not durable: advancement happens only after the durability barrier, and the
+  journal update itself is atomic (see §6).
+- There is no "probably written" journal state. Journal updates that fail are failed
+  closed: the previous checkpoint remains authoritative.
+
+The schema cannot observe whether block data reached stable storage; enforcing the
+durability barrier is the storage layer's job (PR02 CLI, PR03 browser). What the schema
+and its API enforce instead is that progress can only be *recorded* through the single
+checkpoint-advance API (`CommitBlocks` / `commitBlocks`), which refuses out-of-bounds and
+regressing values, and that any journal failing structural validation, fingerprint
+self-consistency, version dispatch, or checksum verification is rejected closed.
+
+## 2. Checkpoint granularity
+
+- Progress is recorded **per file** as `committedBlocks`: the count of leading blocks that
+  are verified, durably persisted, AND checkpointed. Resume restarts each file at its
+  committed high-water mark.
+- Checkpoints are **whole committed blocks**. There is no byte-offset field and no
+  byte-granular checkpoint; a fractional or otherwise non-integral block count is rejected.
+  `committedBytes(fileIdx)` is a derived value (`committedBlocks × blockSize`, final block
+  capped at file size), never stored.
+- Invariant: `0 ≤ committedBlocks ≤ blocks` for every file, where `blocks` comes from the
+  canonical manifest the journal is bound to.
+- Advancement is **monotonic**: the checkpoint API refuses regression.
+
+## 3. Journal trust boundary
+
+The journal is local, user-editable on-disk state. It is **claims, not proof**:
+
+- Nothing is trusted merely because it was loaded from a journal. Every field is bound
+  against authenticated transfer state at resume time (PR06/PR07): the transfer ID, the
+  manifest fingerprint, the per-file digests, and the identity envelopes.
+- The journal's checksum and fingerprint checks detect **accidental corruption, torn
+  writes, and casual tampering**. They are not a trust anchor: an attacker who can rewrite
+  the file can recompute them. The authoritative binding is the authenticated resume
+  protocol, not the journal itself.
+- A journal that fails any check is rejected **closed** — never partially applied, never
+  "probably read". A journal whose claims are internally consistent but wrong about the
+  world (e.g. a checkpoint that exceeds what is actually durable, or stale partial data)
+  is handled by the storage layer per §8 and by resume validation per PR06, not by
+  guessing.
+
+## 4. Schema
+
+The versioned schema lives in two twin modules that must serialize, validate, fingerprint,
+and checksum byte-identically, pinned by `docs/test-vectors/durable-journal.json`:
+
+- `packages/wire/journal.go` (Go, consumed by the CLI)
+- `packages/protocol/src/journal.ts` (TypeScript, consumed by the browser)
+
+The journal is a **local persistence format, not a wire format**: it is never transmitted
+between peers, carries no `sendbeam/1` wire-version implication, and requires no wire
+change or protocol-version bump.
+
+Schema version 1 fields:
+
+| Field | Semantics |
+| --- | --- |
+| `schemaVersion` | On-disk schema identifier (currently `1`). |
+| `transferId` | Stable 128-bit hex id carried by the authenticated manifest; must match the manifest's `transferId`. |
+| `manifestFingerprint` | Canonical SHA-256 over the validated manifest's canonical wire JSON (see §5). |
+| `protocolVersion` | Wire-protocol version the transfer ran under (`sendbeam/1`); recorded, never implied. |
+| `resumeVersion` | Durability resume protocol version (currently `1`); independent of schema and wire versions. |
+| `blockSize` | Transfer's negotiated logical block size; every file entry must match it. |
+| `createdAt` / `updatedAt` | Unix milliseconds; `updatedAt ≥ createdAt`. |
+| `sourceIdentity` / `destinationIdentity` | Opaque versioned identity envelopes (see §5). |
+| `files[]` | Per-file entries: the wire `FileEntry` geometry (`idx, name, size, mime, lastModified, blockSize, blocks, fileDigest`) plus `committedBlocks`. Stored so the journal alone can re-validate the resumed transfer and reproduce the fingerprint. |
+| `resumeSecret` (optional) | Opaque versioned resume-secret envelope (see §5). |
+| `checksum` | SHA-256 over the canonical JSON of every other field; a write-time derivation, verified on load. |
+
+## 5. Secret handling and identity
+
+The journal **never** persists:
+
+- the raw PAKE/session master secret,
+- existing directional traffic keys,
+- live AEAD counters as a shortcut for starting a new process/session,
+- unrelated credentials.
+
+The only secret-adjacent field is `resumeSecret`, an **opaque, versioned envelope** whose
+content is deliberately undefined by PR01: the cross-session authenticated resumption
+derivation is PR07. Its lifecycle contract: created only by the resume protocol, bound to
+the transfer ID and manifest fingerprint, invalidated when the transfer completes or the
+journal is deleted. Fresh processes/sessions must always use fresh traffic cryptographic
+state; nothing in the journal may make unsafe key/counter reuse necessary.
+
+`sourceIdentity` and `destinationIdentity` are opaque versioned envelopes whose values are
+defined by the durability implementation that writes them (destination-location identity
+in PR02/PR03, peer identity binding in PR07). Validation checks only the envelope shape
+(version, bounded hex/base64url value); the content is a claim bound at resume time.
+
+## 6. Versioning, migration, and atomicity
+
+- **Current schema version:** `1`. `DecodeJournal` accepts exactly it.
+- **Supported decode behavior:** schema v1 journals decode and validate; unknown fields,
+  malformed JSON, trailing data, and any structural inconsistency fail closed.
+- **Upgrade/migration entry point:** `decodeJournalVersion` is the dispatch point. When a
+  new schema lands it gains a case plus its migration path. There is deliberately no
+  fabricated earlier public format: v1 is the first, and tests prove supported transforms
+  and rejection behavior rather than pretending migration history exists.
+- **Unknown/future version:** rejected as unsupported (COMPAT); the message states the
+  journal is newer than the build supports. **Corrupted version** (missing, zero,
+  negative, fractional): rejected as corrupt (STORAGE).
+- **Downgrade expectations:** a journal written by a newer build is not readable by an
+  older build; it fails closed with the unsupported-version error. This is intentional.
+- **Atomicity:** native journal writes use the atomic-replacement primitive
+  (`WriteJournalAtomic`): write canonical bytes to a temp file in the same directory,
+  fsync, close, then rename over the target (POSIX-atomic; Windows `os.Rename` replaces).
+  A crash leaves either the old journal or the complete new one, never a torn mix. The
+  parent directory is fsynced on POSIX (best effort) so the rename itself is durable.
+  Browser storage atomicity is PR03 (transactional origin storage).
+
+## 7. Crash / torn-write contract
+
+The authoritative recovery point is always safe. Modeled cases:
+
+| Crash point | Recovery behavior |
+| --- | --- |
+| Before data write | Previous checkpoint authoritative; journal untouched. |
+| During data write | Partial/absent block data; journal claims nothing new. |
+| After data write, before durability barrier | Data may be lost on reboot; journal must not have advanced (the storage layer performs the barrier before `CommitBlocks`). |
+| After durable data, before journal update | Data durable but unclaimed; resume re-verifies and continues from the previous checkpoint (bytes may be re-requested). |
+| During journal update | Atomic replace leaves old or new journal; never torn; torn files fail closed on load. |
+| After journal commit | Checkpoint authoritative; must not claim bytes that were not made durable first. |
+| Truncated journal | JSON parse or checksum failure → reject closed. |
+| Malformed/corrupt journal | Validation or checksum failure → reject closed. |
+| Valid old supported version | v1 decodes. |
+| Unsupported future version | Rejected closed (COMPAT). |
+| Missing partial data | Journal may exist with no partial data → see §8. |
+| Checkpoint beyond available durable data | Impossible to *write* (bounds + API), and detected on load as inconsistent state → reject; storage layer never deletes potentially resumable data automatically on error (§8). |
+
+## 8. GC / expiry / disk policy (contract)
+
+PR01 defines the policy contract; the CLI/browser implementations (PR02/PR03) build the
+management UX and enforce limits.
+
+- **Staleness:** a journal is stale after the implementation-defined expiry (storage
+  layers choose a TTL and surface it; nothing in the schema expires implicitly).
+- **Expiry:** incomplete transfer state may expire per policy, and **only after**: the
+  journal's `resumeSecret` (if any) is invalidated, the user has been given the
+  Keep/Discard choice where applicable, and deletion is confirmed — never as a side effect
+  of startup error handling.
+- **Before deletion:** no journal or partial data is deleted while it is the only copy of
+  potentially resumable user data, and never silently on startup error.
+- **Disk-budget accounting:** partial data size ≈ the sum of each file's committed bytes
+  (`committedBytes`); implementations account for partial data + journal together and
+  enforce their budget at write/commit time (quota → fail the transfer closed, existing
+  `FailQuota` semantics).
+- **Partial data + journal cleanup:** the relationship is journal ⇒ partial data (the
+  journal names the files); cleanup removes both or neither, idempotently (a journal is
+  removed only after whole-transfer verification / atomic final rename, per PR02).
+- **Journal exists, partial data missing:** resume cannot validate → fail closed;
+  journal may be discarded only by explicit policy (see above).
+- **Partial data exists, journal unusable:** orphaned partial data is never deleted
+  automatically; it is surfaced and managed by the future management UX.
+- **Cleanup idempotency:** removal of journals/partials must be safe to repeat and must
+  never error-loop on already-missing files.
+
+## 9. What PR01 establishes vs later PRs
+
+PR01 establishes: the durability ordering contract, the versioned schema + validation +
+fail-closed loading, fingerprint/checksum definitions, version dispatch and migration
+policy, the atomic-write primitive (Go), the checkpoint-advance API, the secret-handling
+rules, and this ADR.
+
+Later work builds on it without rewriting it:
+
+- **PR02 (CLI durable receive):** `.sendbeam` storage layout, `.part` files, receiver
+  integration (durability barrier before `CommitBlocks`), atomic final rename after
+  whole-transfer verification, list/inspect/resume/discard UX, disk-budget enforcement.
+- **PR03 (browser durable receive):** OPFS data + transactional origin-storage journal,
+  dedicated-worker sync access handles, `flush()` before advancement, quota/eviction
+  handling, lock/lease semantics.
+- **PR06/PR07:** resume validation binding journal claims against authenticated transfer
+  state; the cross-session authenticated resume protocol that fills the `resumeSecret`
+  envelope and derives fresh traffic keys.
+
+## Consequences
+
+- New durability code must observe the §1 ordering; checkpoint advancement goes through
+  the single API and never precedes the durability barrier.
+- Journal code is fail-closed: corrupt, torn, unknown, or unsupported state is rejected,
+  never guessed.
+- No raw session key material may ever be written to a journal; `resumeSecret` is the only
+  secret-adjacent field and stays opaque until PR07.
+- The journal is local state with no wire-version implication; no `sendbeam/2` and no wire
+  change is introduced by durable journaling.

--- a/docs/adr/0004-durable-journal.md
+++ b/docs/adr/0004-durable-journal.md
@@ -46,7 +46,7 @@ ONLY NOW may that checkpoint be advertised as resumable
 
 The schema cannot observe whether block data reached stable storage; enforcing the
 durability barrier is the storage layer's job (PR02 CLI, PR03 browser). What the schema
-and its API enforce instead is that progress can only be *recorded* through the single
+and its API enforce instead is that progress can only be _recorded_ through the single
 checkpoint-advance API (`CommitBlocks` / `commitBlocks`), which refuses out-of-bounds and
 regressing values, and that any journal failing structural validation, fingerprint
 self-consistency, version dispatch, or checksum verification is rejected closed.
@@ -95,19 +95,19 @@ change or protocol-version bump.
 
 Schema version 1 fields:
 
-| Field | Semantics |
-| --- | --- |
-| `schemaVersion` | On-disk schema identifier (currently `1`). |
-| `transferId` | Stable 128-bit hex id carried by the authenticated manifest; must match the manifest's `transferId`. |
-| `manifestFingerprint` | Canonical SHA-256 over the validated manifest's canonical wire JSON (see §5). |
-| `protocolVersion` | Wire-protocol version the transfer ran under (`sendbeam/1`); recorded, never implied. |
-| `resumeVersion` | Durability resume protocol version (currently `1`); independent of schema and wire versions. |
-| `blockSize` | Transfer's negotiated logical block size; every file entry must match it. |
-| `createdAt` / `updatedAt` | Unix milliseconds; `updatedAt ≥ createdAt`. |
-| `sourceIdentity` / `destinationIdentity` | Opaque versioned identity envelopes (see §5). |
-| `files[]` | Per-file entries: the wire `FileEntry` geometry (`idx, name, size, mime, lastModified, blockSize, blocks, fileDigest`) plus `committedBlocks`. Stored so the journal alone can re-validate the resumed transfer and reproduce the fingerprint. |
-| `resumeSecret` (optional) | Opaque versioned resume-secret envelope (see §5). |
-| `checksum` | SHA-256 over the canonical JSON of every other field; a write-time derivation, verified on load. |
+| Field                                    | Semantics                                                                                                                                                                                                                                      |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion`                          | On-disk schema identifier (currently `1`).                                                                                                                                                                                                     |
+| `transferId`                             | Stable 128-bit hex id carried by the authenticated manifest; must match the manifest's `transferId`.                                                                                                                                           |
+| `manifestFingerprint`                    | Canonical SHA-256 over the validated manifest's canonical wire JSON (see §5).                                                                                                                                                                  |
+| `protocolVersion`                        | Wire-protocol version the transfer ran under (`sendbeam/1`); recorded, never implied.                                                                                                                                                          |
+| `resumeVersion`                          | Durability resume protocol version (currently `1`); independent of schema and wire versions.                                                                                                                                                   |
+| `blockSize`                              | Transfer's negotiated logical block size; every file entry must match it.                                                                                                                                                                      |
+| `createdAt` / `updatedAt`                | Unix milliseconds; `updatedAt ≥ createdAt`.                                                                                                                                                                                                    |
+| `sourceIdentity` / `destinationIdentity` | Opaque versioned identity envelopes (see §5).                                                                                                                                                                                                  |
+| `files[]`                                | Per-file entries: the wire `FileEntry` geometry (`idx, name, size, mime, lastModified, blockSize, blocks, fileDigest`) plus `committedBlocks`. Stored so the journal alone can re-validate the resumed transfer and reproduce the fingerprint. |
+| `resumeSecret` (optional)                | Opaque versioned resume-secret envelope (see §5).                                                                                                                                                                                              |
+| `checksum`                               | SHA-256 over the canonical JSON of every other field; a write-time derivation, verified on load.                                                                                                                                               |
 
 ## 5. Secret handling and identity
 
@@ -155,20 +155,20 @@ in PR02/PR03, peer identity binding in PR07). Validation checks only the envelop
 
 The authoritative recovery point is always safe. Modeled cases:
 
-| Crash point | Recovery behavior |
-| --- | --- |
-| Before data write | Previous checkpoint authoritative; journal untouched. |
-| During data write | Partial/absent block data; journal claims nothing new. |
-| After data write, before durability barrier | Data may be lost on reboot; journal must not have advanced (the storage layer performs the barrier before `CommitBlocks`). |
-| After durable data, before journal update | Data durable but unclaimed; resume re-verifies and continues from the previous checkpoint (bytes may be re-requested). |
-| During journal update | Atomic replace leaves old or new journal; never torn; torn files fail closed on load. |
-| After journal commit | Checkpoint authoritative; must not claim bytes that were not made durable first. |
-| Truncated journal | JSON parse or checksum failure → reject closed. |
-| Malformed/corrupt journal | Validation or checksum failure → reject closed. |
-| Valid old supported version | v1 decodes. |
-| Unsupported future version | Rejected closed (COMPAT). |
-| Missing partial data | Journal may exist with no partial data → see §8. |
-| Checkpoint beyond available durable data | Impossible to *write* (bounds + API), and detected on load as inconsistent state → reject; storage layer never deletes potentially resumable data automatically on error (§8). |
+| Crash point                                 | Recovery behavior                                                                                                                                                              |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Before data write                           | Previous checkpoint authoritative; journal untouched.                                                                                                                          |
+| During data write                           | Partial/absent block data; journal claims nothing new.                                                                                                                         |
+| After data write, before durability barrier | Data may be lost on reboot; journal must not have advanced (the storage layer performs the barrier before `CommitBlocks`).                                                     |
+| After durable data, before journal update   | Data durable but unclaimed; resume re-verifies and continues from the previous checkpoint (bytes may be re-requested).                                                         |
+| During journal update                       | Atomic replace leaves old or new journal; never torn; torn files fail closed on load.                                                                                          |
+| After journal commit                        | Checkpoint authoritative; must not claim bytes that were not made durable first.                                                                                               |
+| Truncated journal                           | JSON parse or checksum failure → reject closed.                                                                                                                                |
+| Malformed/corrupt journal                   | Validation or checksum failure → reject closed.                                                                                                                                |
+| Valid old supported version                 | v1 decodes.                                                                                                                                                                    |
+| Unsupported future version                  | Rejected closed (COMPAT).                                                                                                                                                      |
+| Missing partial data                        | Journal may exist with no partial data → see §8.                                                                                                                               |
+| Checkpoint beyond available durable data    | Impossible to _write_ (bounds + API), and detected on load as inconsistent state → reject; storage layer never deletes potentially resumable data automatically on error (§8). |
 
 ## 8. GC / expiry / disk policy (contract)
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -260,3 +260,11 @@ above; relayed payloads are the same AEAD frames, never re-encrypted or inspecte
    of the committed high-water mark — and the sender restarts each file from that offset,
    ignoring any `resume_state` that does not match the manifest. A transfer with no prior
    state reports all-zero marks.
+
+Durable resumption across process/session boundaries additionally relies on a **local
+durable-transfer journal** — a versioned on-device persistence contract (schema, checksum,
+fingerprint, fail-closed loading) defined in `docs/adr/0004-durable-journal.md` and
+implemented by the Go `packages/wire/journal.go` and TypeScript
+`packages/protocol/src/journal.ts` twins. The journal is **not** wire state: it is never
+transmitted between peers, is not part of `sendbeam/1`, and carries no wire-version
+implication. The wire `resume_state` message is unchanged.

--- a/docs/test-vectors/README.md
+++ b/docs/test-vectors/README.md
@@ -9,6 +9,7 @@ reference code. All hex is unprefixed lowercase.
 | `rfc9382-p256.json` | The official RFC 9382 §6 P-256 SPAKE2 vectors (fixed identities `A`/`B`, scalar `w`, shares, transcript, `Ke`/`Ka`, confirmation MACs). | `packages/protocol/src/spake2.test.ts`, `packages/wire/spake2_test.go` |
 | `sendbeam-crypto.json` | SendBeam domain-specific KATs: invite-code → SPAKE2 scalar `w` (`HKDF "sendbeam/1 spake2 w"`), the full SPAKE2 exchange with fixed secrets, `HKDF(Ke, "sendbeam/1 master" \|\| TT)` master derivation, directional AEAD keys (`sendbeam/1 o2j` / `j2o`), one AES-256-GCM seal vector (salt+counter nonce, header as AAD), and the SDP/ICE HMAC (`authmac`). | `packages/protocol/src/{spake2,keyschedule,aead,authmac}.test.ts`, `packages/wire/{spake2,authmac}_test.go` |
 | `transfer.json` | A complete 40-byte single-file transfer: derived keys, the file bytes and canonical SHA-256, and the byte-exact wire frame log (`s2r` frames the sender emitted, `r2s` frames the receiver replied). Replay the `s2r` frames in order through any receiver and expect the recorded `r2s` replies, the exact file bytes, and the recorded digest. | `packages/wire/transfer_vector_test.go` |
+| `durable-journal.json` | A canonical schema-v1 durable journal: the fixed inputs (transfer ID, manifest, identity envelopes, timestamps, per-file committed blocks), the expected manifest fingerprint, and the byte-exact canonical journal JSON including its checksum. The Go and TypeScript journal twins must reproduce the fingerprint and the `journal` JSON byte-for-byte, pinning the local persistence schema (a local format, not wire). | `packages/wire/journal_test.go`, `packages/protocol/src/journal.test.ts` |
 
 ## How the vectors are checked in CI
 
@@ -34,6 +35,16 @@ guarded by a normal (non-generated) test that fails if the committed vector stop
 reproducing. `sendbeam-crypto.json` and `rfc9382-p256.json` were produced once by the
 original implementation; only touch them with a protocol change, and update every
 consumer test in the same change.
+
+`durable-journal.json` is regenerated the same way:
+
+```sh
+cd packages/wire
+GENERATE_VECTORS=1 go test -run TestGenerateJournalVector ./...
+```
+
+and is asserted by both the Go and TypeScript suites, so any schema/codec drift between
+the two journal twins fails CI.
 
 ## Validation status
 

--- a/docs/test-vectors/durable-journal.json
+++ b/docs/test-vectors/durable-journal.json
@@ -1,0 +1,21 @@
+{
+  "description": "Canonical schema-v1 durable journal, produced by the Go implementation (packages/wire/journal.go). Both Go and TypeScript must reproduce `fingerprint` and the `journal` JSON byte-for-byte; a mismatch is a schema/codec violation.",
+  "transferId": "0123456789abcdef0123456789abcdef",
+  "manifest": "{\"type\":2,\"transferId\":\"0123456789abcdef0123456789abcdef\",\"files\":[{\"idx\":0,\"name\":\"a.txt\",\"size\":2048,\"mime\":\"text/plain\",\"lastModified\":1700000000,\"blockSize\":1024,\"blocks\":2,\"fileDigest\":\"abababababababababababababababababababababababababababababababab\"},{\"idx\":1,\"name\":\"b.bin\",\"size\":1024,\"mime\":\"application/octet-stream\",\"lastModified\":1700000001,\"blockSize\":1024,\"blocks\":1,\"fileDigest\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd\"}],\"totalSize\":3072}",
+  "sourceIdentity": {
+    "version": 1,
+    "value": "736f757263652d73616d706c65"
+  },
+  "destinationIdentity": {
+    "version": 1,
+    "value": "646573742d73616d706c65"
+  },
+  "createdAt": 1723500000000,
+  "updatedAt": 1723500060000,
+  "committedBlocks": [
+    1,
+    0
+  ],
+  "fingerprint": "c2b9e95e36d1ed0b807ae80c6f0bd85f1e100a3675e253e406bff185576fb5fa",
+  "journal": "{\"schemaVersion\":1,\"transferId\":\"0123456789abcdef0123456789abcdef\",\"manifestFingerprint\":\"c2b9e95e36d1ed0b807ae80c6f0bd85f1e100a3675e253e406bff185576fb5fa\",\"protocolVersion\":\"sendbeam/1\",\"resumeVersion\":1,\"blockSize\":1024,\"createdAt\":1723500000000,\"updatedAt\":1723500060000,\"sourceIdentity\":{\"version\":1,\"value\":\"736f757263652d73616d706c65\"},\"destinationIdentity\":{\"version\":1,\"value\":\"646573742d73616d706c65\"},\"files\":[{\"idx\":0,\"name\":\"a.txt\",\"size\":2048,\"mime\":\"text/plain\",\"lastModified\":1700000000,\"blockSize\":1024,\"blocks\":2,\"fileDigest\":\"abababababababababababababababababababababababababababababababab\",\"committedBlocks\":1},{\"idx\":1,\"name\":\"b.bin\",\"size\":1024,\"mime\":\"application/octet-stream\",\"lastModified\":1700000001,\"blockSize\":1024,\"blocks\":1,\"fileDigest\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd\",\"committedBlocks\":0}],\"checksum\":\"384dfe1b2c99052ca0bde62652f02e3fe5444fe3db579fae80f85098f45c9663\"}"
+}

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -24,6 +24,15 @@ protocol it refers to is specified in [`protocol.md`](./protocol.md).
   can authenticate. Authentication proves "you have the code," not a human identity.
 - The **local machine and browser are trusted** (out of scope: malware, a hostile browser
   extension, a compromised OS).
+- The **durable journal is local, user-editable state** (`docs/adr/0004-durable-journal.md`).
+  Its checksum and manifest-fingerprint checks detect corruption, torn writes, and casual
+  tampering; they are **not** a trust anchor — anything that can rewrite the file can
+  recompute them. Resume-time validation binds journal claims (transfer ID, manifest
+  fingerprint, per-file digests, identity envelopes) against authenticated transfer state,
+  and the journal never persists raw session key material (no master keys, directional
+  keys, live AEAD counters, or credentials; only the opaque versioned `resumeSecret`
+  envelope defined by the future resume protocol). Corrupt, torn, unknown, or unsupported
+  journal state fails closed and is never partially applied.
 
 ## Adversaries and mitigations
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -25,3 +25,4 @@ export * from './safe-path.js';
 export * from './transfer-set.js';
 export * from './errors.js';
 export * from './ice-servers.js';
+export * from './journal.js';

--- a/packages/protocol/src/journal.test.ts
+++ b/packages/protocol/src/journal.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from 'vitest';
+import {
+  JOURNAL_RESUME_VERSION,
+  JOURNAL_SCHEMA_VERSION,
+  commitBlocks,
+  committedBytes,
+  decodeJournal,
+  encodeJournal,
+  manifestFingerprint,
+  newJournal,
+  validateJournal,
+  type DurableJournal,
+  type JournalIdentity,
+} from './journal.js';
+import { decodeControl } from './transfer-messages.js';
+import { FrameType, type Manifest } from './transfer.js';
+import { utf8 } from './bytes.js';
+import { MAX_MANIFEST_BLOCK_BYTES, MAX_TRANSFER_FILES } from './safe-path.js';
+import { PROTOCOL_VERSION } from './constants.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TRANSFER_ID = '0123456789abcdef0123456789abcdef';
+
+function testManifest(): Manifest {
+  return {
+    type: FrameType.Manifest,
+    transferId: TRANSFER_ID,
+    files: [
+      {
+        idx: 0,
+        name: 'a.txt',
+        size: 2048,
+        mime: 'text/plain',
+        lastModified: 1700000000,
+        blockSize: 1024,
+        blocks: 2,
+        fileDigest: 'ab'.repeat(32),
+      },
+      {
+        idx: 1,
+        name: 'b.bin',
+        size: 1024,
+        mime: 'application/octet-stream',
+        lastModified: 1700000001,
+        blockSize: 1024,
+        blocks: 1,
+        fileDigest: 'cd'.repeat(32),
+      },
+    ],
+    totalSize: 3072,
+  };
+}
+
+function testIdentities(): [JournalIdentity, JournalIdentity] {
+  return [
+    { version: 1, value: '736f757263652d73616d706c65' },
+    { version: 1, value: '646573742d73616d706c65' },
+  ];
+}
+
+// The exact journal pinned by docs/test-vectors/durable-journal.json.
+async function vectorSample(): Promise<DurableJournal> {
+  const [source, destination] = testIdentities();
+  const j = await newJournal(TRANSFER_ID, testManifest(), source, destination, 1723500000000);
+  return commitBlocks(j, 0, 1, 1723500060000);
+}
+function cloneDeep<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
+
+async function decodeJsonObj(obj: unknown): Promise<DurableJournal> {
+  return decodeJournal(utf8(JSON.stringify(obj)));
+}
+
+describe('journal schema v1', () => {
+  it('round-trips byte-identically', async () => {
+    const j = await vectorSample();
+    const encoded = await encodeJournal(j);
+    const decoded = await decodeJournal(encoded);
+    expect(decoded.transferId).toBe(j.transferId);
+    expect(decoded.manifestFingerprint).toBe(j.manifestFingerprint);
+    expect(decoded.files[0]!.committedBlocks).toBe(1);
+    expect(decoded.files[1]!.committedBlocks).toBe(0);
+    // Re-encoding a decoded journal is byte-identical.
+    expect(await encodeJournal(decoded)).toEqual(encoded);
+    // No resumeSecret material is present by default.
+    expect(new TextDecoder().decode(encoded)).not.toContain('resumeSecret');
+  });
+
+  it('rejects missing or invalid required fields', async () => {
+    const base = await vectorSample();
+    const cases: Array<[string, (j: DurableJournal) => void]> = [
+      ['empty transferId', (j) => void (j.transferId = '')],
+      ['short transferId', (j) => void (j.transferId = 'abcd')],
+      ['uppercase transferId', (j) => void (j.transferId = TRANSFER_ID.toUpperCase())],
+      ['empty fingerprint', (j) => void (j.manifestFingerprint = '')],
+      ['missing protocol version', (j) => void (j.protocolVersion = '')],
+      ['wrong protocol version', (j) => void (j.protocolVersion = 'sendbeam/2')],
+      ['zero resume version', (j) => void (j.resumeVersion = 0)],
+      ['zero schema version', (j) => void (j.schemaVersion = 0)],
+      ['zero block size', (j) => void (j.blockSize = 0)],
+      ['huge block size', (j) => void (j.blockSize = MAX_MANIFEST_BLOCK_BYTES + 1)],
+      ['zero createdAt', (j) => void (j.createdAt = 0)],
+      ['updatedAt before createdAt', (j) => void (j.updatedAt = j.createdAt - 1)],
+      ['empty files', (j) => void (j.files = [])],
+      ['missing source identity', (j) => void (j.sourceIdentity = { version: 1, value: '' })],
+      ['bad identity charset', (j) => void (j.sourceIdentity.value = 'not hex or b64!!')],
+      ['unsupported identity version', (j) => void (j.sourceIdentity.version = 2)],
+      ['bad resume secret', (j) => void (j.resumeSecret = { version: 1, value: 'bad!!' })],
+      ['bad file digest', (j) => void (j.files[0]!.fileDigest = 'xyz')],
+      ['file blocks mismatch', (j) => void (j.files[0]!.blocks = 1)],
+      ['file size negative', (j) => void (j.files[0]!.size = -1)],
+      ['file block size differs', (j) => void (j.files[1]!.blockSize = 512)],
+      ['non-contiguous indexes', (j) => void (j.files[1]!.idx = 2)],
+      ['duplicate paths', (j) => void (j.files[1]!.name = 'a.txt')],
+      ['unsafe path', (j) => void (j.files[0]!.name = '../escape.txt')],
+      [
+        'too many files',
+        (j) =>
+          void (j.files = [
+            ...j.files,
+            ...Array.from({ length: MAX_TRANSFER_FILES }, (_, i) => ({
+              ...j.files[0]!,
+              idx: i + 2,
+              name: `f${i}.bin`,
+            })),
+          ]),
+      ],
+    ];
+    for (const [name, mutate] of cases) {
+      const bad = structuredClone(base);
+      bad.checksum = undefined;
+      mutate(bad);
+      await expect(validateJournal(bad), name).rejects.toThrow();
+      await expect(encodeJournal(bad), name).rejects.toThrow();
+    }
+  });
+
+  it('dispatches schema versions and fails closed on unknown ones', async () => {
+    const encoded = await encodeJournal(await vectorSample());
+    const obj = JSON.parse(new TextDecoder().decode(encoded)) as Record<string, unknown>;
+    await expect(decodeJournal(encoded)).resolves.toBeTruthy();
+
+    for (const future of [2, 99]) {
+      await expect(decodeJsonObj({ ...obj, schemaVersion: future })).rejects.toThrow(/newer/);
+    }
+    for (const corrupt of [0, -1]) {
+      await expect(decodeJsonObj({ ...obj, schemaVersion: corrupt })).rejects.toThrow(
+        /corrupt schema version/,
+      );
+    }
+    await expect(decodeJsonObj({ ...obj, schemaVersion: 1.5 })).rejects.toThrow();
+    const missing = { ...obj };
+    delete missing.schemaVersion;
+    await expect(decodeJsonObj(missing)).rejects.toThrow(/schemaVersion/);
+  });
+
+  it('rejects malformed, unknown-field, and torn input', async () => {
+    const encoded = await encodeJournal(await vectorSample());
+    const text = new TextDecoder().decode(encoded);
+    await expect(decodeJournal(utf8('{'))).rejects.toThrow();
+    await expect(decodeJournal(new Uint8Array())).rejects.toThrow();
+    await expect(decodeJournal(utf8('[1,2,3]'))).rejects.toThrow();
+    await expect(decodeJournal(utf8('"hello"'))).rejects.toThrow();
+
+    const obj = JSON.parse(text) as Record<string, unknown>;
+    await expect(decodeJsonObj({ ...obj, masterKey: '00'.repeat(32) })).rejects.toThrow(
+      /unexpected journal field/,
+    );
+    await expect(decodeJsonObj({ ...obj, sessionMasterKey: '00'.repeat(32) })).rejects.toThrow();
+
+    // Truncate at many byte positions: a torn journal must never decode.
+    for (let cut = 0; cut < encoded.length; cut += 7) {
+      await expect(decodeJournal(encoded.subarray(0, cut))).rejects.toThrow();
+    }
+  });
+
+  it('fails closed on tampered content, checksum, and checkpoint claims', async () => {
+    const encoded = await encodeJournal(await vectorSample());
+    const obj = JSON.parse(new TextDecoder().decode(encoded)) as Record<string, unknown>;
+
+    // Byte-level content flip (renamed file: 'a.txt' -> 'c.txt' keeps the length).
+    const flipped = encoded.slice();
+    const nameIdx = new TextDecoder().decode(flipped).indexOf('a.txt');
+    flipped[nameIdx] = flipped[nameIdx]! === 0x61 ? 0x63 : 0x61;
+    await expect(decodeJournal(flipped)).rejects.toThrow();
+
+    // A structurally valid but fingerprint-neutral change with a stale checksum.
+    await expect(decodeJsonObj({ ...obj, updatedAt: 1723500120000 })).rejects.toThrow(
+      /checksum mismatch/,
+    );
+
+    // Checkpoint beyond the file is impossible even with a valid-looking structure.
+    const beyond = cloneDeep(obj.files) as Array<Record<string, unknown>>;
+    beyond[0]!.committedBlocks = 99;
+    await expect(decodeJsonObj({ ...obj, files: beyond })).rejects.toThrow(/out of range/);
+
+    // Within-bounds checkpoint with a stale checksum is tamper-evident.
+    const stale = cloneDeep(obj.files) as Array<Record<string, unknown>>;
+    stale[0]!.committedBlocks = 2;
+    await expect(decodeJsonObj({ ...obj, files: stale })).rejects.toThrow(/checksum mismatch/);
+
+    // Tampered identity with a stale checksum.
+    const src = { version: 1, value: 'deadbeef' };
+    await expect(decodeJsonObj({ ...obj, sourceIdentity: src })).rejects.toThrow(
+      /checksum mismatch/,
+    );
+
+    // Tampered fingerprint fails the self-check before the checksum is consulted.
+    await expect(decodeJsonObj({ ...obj, manifestFingerprint: 'ef'.repeat(32) })).rejects.toThrow(
+      /fingerprint mismatch/,
+    );
+  });
+
+  it('binds checkpoints to the manifest fingerprint', async () => {
+    const base = await vectorSample();
+    const tamper: Array<[string, (j: DurableJournal) => void]> = [
+      ['renamed file', (j) => void (j.files[0]!.name = 'c.txt')],
+      ['swapped digest', (j) => void (j.files[0]!.fileDigest = 'ff'.repeat(32))],
+      ['changed transferId', (j) => void (j.transferId = '11'.repeat(16))],
+      ['changed mime', (j) => void (j.files[0]!.mime = 'image/png')],
+    ];
+    for (const [name, mutate] of tamper) {
+      const bad = structuredClone(base);
+      bad.checksum = undefined;
+      mutate(bad);
+      await expect(validateJournal(bad), name).rejects.toThrow(/fingerprint mismatch/);
+    }
+    const resized = structuredClone(base);
+    resized.checksum = undefined;
+    resized.files[0]!.size = 1024;
+    await expect(validateJournal(resized)).rejects.toThrow();
+  });
+
+  it('rejects non-block-aligned checkpoint claims', async () => {
+    const encoded = await encodeJournal(await vectorSample());
+    const obj = JSON.parse(new TextDecoder().decode(encoded)) as Record<string, unknown>;
+    // The only way to express a byte-level claim is a fractional block count.
+    const files = cloneDeep(obj.files) as Array<Record<string, unknown>>;
+    files[0]!.committedBlocks = 1.5;
+    await expect(decodeJsonObj({ ...obj, files })).rejects.toThrow();
+
+    const j = await vectorSample();
+    expect(committedBytes(j, 0)).toBe(1024);
+    const full = commitBlocks(j, 0, 2, 1723500120000);
+    expect(committedBytes(full, 0)).toBe(2048);
+  });
+
+  it('only advances checkpoints through commitBlocks', async () => {
+    const j = await vectorSample();
+    expect(() => commitBlocks(j, 0, 0, 1723500120000)).toThrow(/regress/);
+    expect(() => commitBlocks(j, 0, 3, 1723500120000)).toThrow(/out of range/);
+    expect(() => commitBlocks(j, 0, -1, 1723500120000)).toThrow();
+    expect(() => commitBlocks(j, 7, 0, 1723500120000)).toThrow();
+
+    const advanced = commitBlocks(j, 1, 1, 1723500120000);
+    expect(advanced.updatedAt).toBe(1723500120000);
+    expect(advanced.files[1]!.committedBlocks).toBe(1);
+    // The returned journal re-encodes and decodes cleanly.
+    const decoded = await decodeJournal(await encodeJournal(advanced));
+    expect(decoded.files[1]!.committedBlocks).toBe(1);
+  });
+
+  it('never serializes raw session key material', async () => {
+    // The schema is a closed set: no plausible key-material field may appear.
+    const encoded = await encodeJournal(await vectorSample());
+    const obj = JSON.parse(new TextDecoder().decode(encoded)) as Record<string, unknown>;
+    for (const key of [
+      'masterKey',
+      'sessionMasterKey',
+      'o2jKey',
+      'counter',
+      'nonce',
+      'invite',
+      'password',
+    ]) {
+      await expect(decodeJsonObj({ ...obj, [key]: '00'.repeat(32) })).rejects.toThrow(
+        /unexpected journal field/,
+      );
+    }
+    // Raw session bytes never appear in the serialized output.
+    const master = utf8('raw-pake-master-key-0000');
+    const dirKey = utf8('directional-o2j-key-0000');
+    const text = new TextDecoder().decode(encoded);
+    for (const secret of [new TextDecoder().decode(master), new TextDecoder().decode(dirKey)]) {
+      expect(text).not.toContain(secret);
+    }
+    // Only the documented resumeSecret envelope is allowed, and it stays opaque.
+    const j = await vectorSample();
+    j.resumeSecret = { version: 1, value: 'c2VjcmV0LW1hdGVyaWFs' };
+    const withSecret = await decodeJournal(await encodeJournal(j));
+    expect(withSecret.resumeSecret?.value).toBe('c2VjcmV0LW1hdGVyaWFs');
+  });
+
+  it('matches the cross-language vector byte-for-byte', async () => {
+    const vectorPath = join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'docs',
+      'test-vectors',
+      'durable-journal.json',
+    );
+    const doc = JSON.parse(readFileSync(vectorPath, 'utf8')) as {
+      transferId: string;
+      manifest: string;
+      sourceIdentity: JournalIdentity;
+      destinationIdentity: JournalIdentity;
+      createdAt: number;
+      updatedAt: number;
+      committedBlocks: number[];
+      fingerprint: string;
+      journal: string;
+    };
+    const manifest = decodeControl(utf8(doc.manifest)) as Manifest;
+    const j = await newJournal(
+      doc.transferId,
+      manifest,
+      doc.sourceIdentity,
+      doc.destinationIdentity,
+      doc.createdAt,
+    );
+    let current = j;
+    for (let i = 0; i < doc.committedBlocks.length; i++) {
+      current = commitBlocks(current, i, doc.committedBlocks[i]!, doc.updatedAt);
+    }
+    expect(current.manifestFingerprint).toBe(doc.fingerprint);
+    expect(new TextDecoder().decode(await encodeJournal(current))).toBe(doc.journal);
+    // The pinned constants hold.
+    expect(current.schemaVersion).toBe(JOURNAL_SCHEMA_VERSION);
+    expect(current.resumeVersion).toBe(JOURNAL_RESUME_VERSION);
+    expect(current.protocolVersion).toBe(PROTOCOL_VERSION);
+  });
+
+  it('derives the same fingerprint as the committed manifest', async () => {
+    const fingerprint = await manifestFingerprint(testManifest());
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/protocol/src/journal.ts
+++ b/packages/protocol/src/journal.ts
@@ -1,0 +1,575 @@
+/**
+ * Durable transfer journal — the versioned local persistence contract for resumable
+ * transfers (docs/adr/0004-durable-journal.md).
+ *
+ * The journal is LOCAL on-device state, NOT part of the sendbeam/1 wire protocol: it is
+ * never transmitted between peers and carries no wire-version implication. It lives in
+ * this package because the browser and the Go CLI must consume the same contract; it is
+ * the TypeScript twin of packages/wire/journal.go, and the two must serialize, validate,
+ * fingerprint, and checksum byte-identically (pinned by docs/test-vectors/durable-journal.json).
+ *
+ * Durability ordering (the contract). A checkpoint may be advertised as resumable only
+ * after the full ordering below; a crash at any earlier step leaves the previous
+ * checkpoint authoritative:
+ *
+ *   receive/authenticate block
+ *           ↓
+ *   verify block
+ *           ↓
+ *   write block data
+ *           ↓
+ *   required durability operation (flush of the data)
+ *           ↓
+ *   atomically advance the journal checkpoint   ← commitBlocks is the only advancement API
+ *           ↓
+ *   ONLY NOW may that checkpoint be advertised as resumable
+ *
+ * The schema cannot observe the data-durability barrier (browser storage backends own it,
+ * PR03); what it CAN do — and what this module proves with tests — is fail closed on any
+ * journal that is structurally invalid, fingerprint-inconsistent, unknown-versioned, or
+ * checksum-stale, and refuse checkpoints that are not whole committed blocks.
+ */
+
+import type { FileEntry, Manifest } from './transfer.js';
+import { FrameType } from './transfer.js';
+import { bytesToHex, utf8 } from './bytes.js';
+import { sha256 } from './webcrypto.js';
+import {
+  MAX_MANIFEST_BLOCK_BYTES,
+  MAX_TRANSFER_FILES,
+  normalizeTransferPath,
+  validateManifest,
+} from './safe-path.js';
+import { PROTOCOL_VERSION } from './constants.js';
+
+/** Current durable-journal schema version. Decode accepts exactly this value. */
+export const JOURNAL_SCHEMA_VERSION = 1;
+
+/**
+ * Version of the durability resume protocol whose checkpoint semantics the journal was
+ * written for. Independent of the schema version and of the wire PROTOCOL_VERSION.
+ */
+export const JOURNAL_RESUME_VERSION = 1;
+
+/**
+ * Opaque, versioned identity envelope. The value is deliberately opaque to the journal:
+ * its content and derivation are defined by the durability implementation that writes it
+ * (destination-location identity in PR02/PR03) or by the resume-authentication protocol
+ * (peer identity binding in PR07). A claim, never a trust anchor.
+ */
+export interface JournalIdentity {
+  version: number;
+  value: string;
+}
+
+/** One file's durable checkpoint within a journal. */
+export interface JournalFileState {
+  idx: number;
+  name: string;
+  size: number;
+  mime: string;
+  lastModified: number;
+  blockSize: number;
+  blocks: number;
+  fileDigest: string;
+  /**
+   * Count of leading blocks that are verified, durably persisted AND checkpointed. The
+   * only progress representation: whole-block granularity, never byte offsets.
+   * Invariant: 0 <= committedBlocks <= blocks.
+   */
+  committedBlocks: number;
+}
+
+/**
+ * Opaque, versioned envelope for the minimum resume-secret material the durability model
+ * requires. PR01 deliberately does not define its content (cross-session authenticated
+ * resume is PR07). Never carries the raw SPAKE2/session master key, directional traffic
+ * keys, live AEAD counters, or unrelated credentials.
+ */
+export interface JournalResumeSecret {
+  version: number;
+  value: string;
+}
+
+/** Versioned durable-transfer journal (schema version 1). */
+export interface DurableJournal {
+  /** On-disk schema identifier (JOURNAL_SCHEMA_VERSION). */
+  schemaVersion: number;
+  /** Stable 128-bit hex id carried by the authenticated manifest. */
+  transferId: string;
+  /** Canonical SHA-256 (hex) of the validated manifest (see manifestFingerprint). */
+  manifestFingerprint: string;
+  /** Wire-protocol version the transfer ran under (recorded, never implied). */
+  protocolVersion: string;
+  /** Durability resume protocol version (JOURNAL_RESUME_VERSION). */
+  resumeVersion: number;
+  /** Transfer's negotiated logical block size; every file entry must match it. */
+  blockSize: number;
+  /** Journal creation time, unix milliseconds. */
+  createdAt: number;
+  /** Last checkpoint-advance time, unix milliseconds; always >= createdAt. */
+  updatedAt: number;
+  /** Opaque claim about the sender, bound by the resume protocol. */
+  sourceIdentity: JournalIdentity;
+  /** Opaque claim about the local destination, bound by the durability implementation. */
+  destinationIdentity: JournalIdentity;
+  /** Per-file durable checkpoints, in manifest index order. */
+  files: JournalFileState[];
+  /** Optional opaque resume-secret envelope (PR07). Omitted when absent. */
+  resumeSecret?: JournalResumeSecret;
+  /** SHA-256 over the canonical JSON of every other field; a write-time derivation. */
+  checksum?: string;
+}
+
+const isLowerHex = (s: string, n: number): boolean => s.length === n && /^[0-9a-f]+$/.test(s);
+
+const OPAQUE_HEX = /^[0-9a-f]+$/;
+const OPAQUE_B64 = /^[A-Za-z0-9_-]+$/;
+
+function validateOpaqueValue(v: string, label: string): void {
+  if (v.length === 0) throw new Error(`journal: ${label} value must not be empty`);
+  if (v.length > 2048) throw new Error(`journal: ${label} value is too long`);
+  if (!OPAQUE_HEX.test(v) && !OPAQUE_B64.test(v)) {
+    throw new Error(`journal: ${label} value must be hex or base64url`);
+  }
+}
+
+function validateIdentity(id: JournalIdentity, label: string): void {
+  if (id.version !== 1) throw new Error(`journal: unsupported ${label} version ${id.version}`);
+  validateOpaqueValue(id.value, label);
+}
+
+function validateEnvelope(e: JournalResumeSecret, label: string): void {
+  if (e.version !== 1) throw new Error(`journal: unsupported ${label} version ${e.version}`);
+  validateOpaqueValue(e.value, label);
+}
+
+/**
+ * Canonical SHA-256 (hex) of a validated manifest — the same bytes JSON.stringify
+ * produces for the canonical manifest, byte-identical to the Go twin, so it pins the
+ * file set a journal's checkpoints refer to. A binding claim, not a trust anchor.
+ */
+export async function manifestFingerprint(manifest: Manifest): Promise<string> {
+  const canonical = validateManifest(manifest);
+  return bytesToHex(await sha256(utf8(JSON.stringify(canonical))));
+}
+
+async function fingerprintFromFiles(
+  transferId: string,
+  files: JournalFileState[],
+): Promise<string> {
+  const entries: FileEntry[] = files.map((f) => ({
+    idx: f.idx,
+    name: f.name,
+    size: f.size,
+    mime: f.mime,
+    lastModified: f.lastModified,
+    blockSize: f.blockSize,
+    blocks: f.blocks,
+    fileDigest: f.fileDigest,
+  }));
+  const totalSize = entries.reduce((acc, f) => acc + f.size, 0);
+  return manifestFingerprint({
+    type: FrameType.Manifest,
+    ...(transferId !== '' ? { transferId } : {}),
+    files: entries,
+    totalSize,
+  });
+}
+
+/**
+ * Build a fresh schema-v1 journal with zero committed checkpoints. `transferId` must be
+ * the stable 128-bit hex id carried by the authenticated manifest, and `manifest` must
+ * carry that same id (a manifest without one never opted into resumption).
+ */
+export async function newJournal(
+  transferId: string,
+  manifest: Manifest,
+  source: JournalIdentity,
+  destination: JournalIdentity,
+  nowMs: number,
+): Promise<DurableJournal> {
+  if (!isLowerHex(transferId, 32)) {
+    throw new Error('journal: transferId must be 32 lowercase hex characters');
+  }
+  if (manifest.transferId !== transferId) {
+    throw new Error('journal: transferId must match the authenticated manifest');
+  }
+  const fingerprint = await manifestFingerprint(manifest);
+  const files: JournalFileState[] = manifest.files.map((f) => ({
+    idx: f.idx,
+    name: f.name,
+    size: f.size,
+    mime: f.mime,
+    lastModified: f.lastModified,
+    blockSize: f.blockSize,
+    blocks: f.blocks,
+    fileDigest: f.fileDigest,
+    committedBlocks: 0,
+  }));
+  const j: DurableJournal = {
+    schemaVersion: JOURNAL_SCHEMA_VERSION,
+    transferId,
+    manifestFingerprint: fingerprint,
+    protocolVersion: PROTOCOL_VERSION,
+    resumeVersion: JOURNAL_RESUME_VERSION,
+    blockSize: manifest.files[0]!.blockSize,
+    createdAt: nowMs,
+    updatedAt: nowMs,
+    sourceIdentity: source,
+    destinationIdentity: destination,
+    files,
+  };
+  await validateJournal(j);
+  return j;
+}
+
+/**
+ * Structural validation plus fingerprint self-consistency. Does NOT verify the checksum
+ * (a serialization property checked by decodeJournal) and treats no field as a trust
+ * anchor. Async only because the fingerprint recompute uses WebCrypto.
+ */
+export async function validateJournal(j: DurableJournal): Promise<void> {
+  if (j.schemaVersion !== JOURNAL_SCHEMA_VERSION) {
+    throw new Error(`journal: unsupported schema version ${j.schemaVersion}`);
+  }
+  if (j.resumeVersion !== JOURNAL_RESUME_VERSION) {
+    throw new Error(`journal: unsupported resume version ${j.resumeVersion}`);
+  }
+  if (j.protocolVersion !== PROTOCOL_VERSION) {
+    throw new Error(`journal: unsupported protocol version ${j.protocolVersion}`);
+  }
+  if (!isLowerHex(j.transferId, 32)) {
+    throw new Error('journal: transferId must be 32 lowercase hex characters');
+  }
+  if (!isLowerHex(j.manifestFingerprint, 64)) {
+    throw new Error('journal: manifestFingerprint must be 64 lowercase hex characters');
+  }
+  if (
+    !Number.isSafeInteger(j.createdAt) ||
+    !Number.isSafeInteger(j.updatedAt) ||
+    j.createdAt <= 0 ||
+    j.updatedAt <= 0 ||
+    j.updatedAt < j.createdAt
+  ) {
+    throw new Error('journal: invalid timestamps');
+  }
+  if (
+    !Number.isSafeInteger(j.blockSize) ||
+    j.blockSize <= 0 ||
+    j.blockSize > MAX_MANIFEST_BLOCK_BYTES
+  ) {
+    throw new Error(`journal: invalid block size ${j.blockSize}`);
+  }
+  validateIdentity(j.sourceIdentity, 'sourceIdentity');
+  validateIdentity(j.destinationIdentity, 'destinationIdentity');
+  if (j.resumeSecret !== undefined) validateEnvelope(j.resumeSecret, 'resumeSecret');
+  if (j.files.length === 0 || j.files.length > MAX_TRANSFER_FILES) {
+    throw new Error(`journal: invalid file count ${j.files.length}`);
+  }
+  const recomputed = await fingerprintFromFiles(j.transferId, j.files);
+  if (recomputed !== j.manifestFingerprint) {
+    throw new Error('journal: manifest fingerprint mismatch');
+  }
+  const seen = new Set<string>();
+  for (let i = 0; i < j.files.length; i++) {
+    const f = j.files[i]!;
+    if (f.idx !== i) throw new Error('journal: file indexes must be contiguous');
+    for (const [label, value] of [
+      ['size', f.size],
+      ['lastModified', f.lastModified],
+      ['blockSize', f.blockSize],
+      ['blocks', f.blocks],
+    ] as const) {
+      if (!Number.isSafeInteger(value))
+        throw new Error(`journal: file ${i} ${label} is not a safe integer`);
+    }
+    if (f.size < 0 || f.lastModified < 0 || f.blockSize <= 0 || f.blocks < 0) {
+      throw new Error(`journal: file ${f.idx} has invalid geometry`);
+    }
+    if (f.blockSize > MAX_MANIFEST_BLOCK_BYTES) {
+      throw new Error(
+        `journal: file ${f.idx} block size ${f.blockSize} exceeds the ${MAX_MANIFEST_BLOCK_BYTES}-byte ceiling`,
+      );
+    }
+    if (f.blocks !== Math.ceil(f.size / f.blockSize)) {
+      throw new Error(`journal: file ${f.idx} has invalid block geometry`);
+    }
+    if (f.blockSize !== j.blockSize) {
+      throw new Error(
+        `journal: file ${f.idx} block size ${f.blockSize} differs from journal block size ${j.blockSize}`,
+      );
+    }
+    if (!isLowerHex(f.fileDigest, 64)) {
+      throw new Error(`journal: file ${f.idx} fileDigest must be 64 lowercase hex characters`);
+    }
+    if (
+      !Number.isInteger(f.committedBlocks) ||
+      f.committedBlocks < 0 ||
+      f.committedBlocks > f.blocks
+    ) {
+      throw new Error(
+        `journal: committedBlocks ${f.committedBlocks} out of range for file ${f.idx} (blocks ${f.blocks})`,
+      );
+    }
+    const name = normalizeTransferPath(f.name);
+    const key = name.toLowerCase();
+    if (seen.has(key)) throw new Error('journal: duplicate file path');
+    seen.add(key);
+  }
+}
+
+/**
+ * The canonical key-ordered body of a journal (every field except the checksum). The key
+ * order is the schema contract and MUST match the Go struct declaration order.
+ */
+function canonicalBody(j: DurableJournal): Record<string, unknown> {
+  return {
+    schemaVersion: j.schemaVersion,
+    transferId: j.transferId,
+    manifestFingerprint: j.manifestFingerprint,
+    protocolVersion: j.protocolVersion,
+    resumeVersion: j.resumeVersion,
+    blockSize: j.blockSize,
+    createdAt: j.createdAt,
+    updatedAt: j.updatedAt,
+    sourceIdentity: { version: j.sourceIdentity.version, value: j.sourceIdentity.value },
+    destinationIdentity: {
+      version: j.destinationIdentity.version,
+      value: j.destinationIdentity.value,
+    },
+    files: j.files.map((f) => ({
+      idx: f.idx,
+      name: f.name,
+      size: f.size,
+      mime: f.mime,
+      lastModified: f.lastModified,
+      blockSize: f.blockSize,
+      blocks: f.blocks,
+      fileDigest: f.fileDigest,
+      committedBlocks: f.committedBlocks,
+    })),
+    ...(j.resumeSecret !== undefined
+      ? { resumeSecret: { version: j.resumeSecret.version, value: j.resumeSecret.value } }
+      : {}),
+  };
+}
+
+/**
+ * Serialize a journal to its canonical JSON, appending the checksum (SHA-256 over the
+ * canonical JSON of every other field, recomputed on every encode). Output is
+ * byte-identical to the Go twin (pinned by docs/test-vectors/durable-journal.json).
+ */
+export async function encodeJournal(j: DurableJournal): Promise<Uint8Array> {
+  await validateJournal(j);
+  const body = canonicalBody(j);
+  const checksum = bytesToHex(await sha256(utf8(JSON.stringify(body))));
+  return utf8(JSON.stringify({ ...body, checksum }));
+}
+
+/**
+ * Parse, version-dispatch, validate, and checksum-verify a journal, failing closed on ANY
+ * deviation: malformed JSON, unknown fields, an unsupported or corrupt schema version,
+ * invalid content, or a checksum mismatch. Version policy: only schema version 1 is
+ * accepted; newer versions fail closed (COMPAT, "newer than this build supports"), and a
+ * missing/zero/negative/fractional version fails closed as corrupt. Downgrading a newer
+ * journal to an older reader is not supported.
+ */ export async function decodeJournal(data: Uint8Array): Promise<DurableJournal> {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(new TextDecoder().decode(data));
+  } catch {
+    throw new Error('journal: invalid JSON');
+  }
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    throw new Error('journal: not an object');
+  }
+  const m = obj as Record<string, unknown>;
+  const schemaVersion = m.schemaVersion;
+  if (typeof schemaVersion !== 'number' || !Number.isInteger(schemaVersion)) {
+    throw new Error('journal: missing or corrupt schemaVersion');
+  }
+  if (schemaVersion === JOURNAL_SCHEMA_VERSION) return decodeAndVerifyV1(m);
+  if (schemaVersion > JOURNAL_SCHEMA_VERSION) {
+    throw new Error(
+      `journal: schema version ${schemaVersion} is newer than this build supports (${JOURNAL_SCHEMA_VERSION})`,
+    );
+  }
+  throw new Error(`journal: corrupt schema version ${schemaVersion}`);
+}
+
+const JOURNAL_V1_KEYS = [
+  'schemaVersion',
+  'transferId',
+  'manifestFingerprint',
+  'protocolVersion',
+  'resumeVersion',
+  'blockSize',
+  'createdAt',
+  'updatedAt',
+  'sourceIdentity',
+  'destinationIdentity',
+  'files',
+  'resumeSecret',
+  'checksum',
+];
+
+const FILE_V1_KEYS = [
+  'idx',
+  'name',
+  'size',
+  'mime',
+  'lastModified',
+  'blockSize',
+  'blocks',
+  'fileDigest',
+  'committedBlocks',
+];
+
+const ENVELOPE_KEYS = ['version', 'value'];
+
+function assertKeys(m: Record<string, unknown>, allowed: string[], what: string): void {
+  for (const key of Object.keys(m)) {
+    if (!allowed.includes(key)) throw new Error(`journal: unexpected ${what} field ${key}`);
+  }
+}
+
+function intField(m: Record<string, unknown>, key: string): number {
+  const v = m[key];
+  if (typeof v !== 'number' || !Number.isSafeInteger(v)) {
+    throw new Error(`journal: ${key} is not a safe integer`);
+  }
+  return v;
+}
+
+function strField(m: Record<string, unknown>, key: string): string {
+  const v = m[key];
+  if (typeof v !== 'string') throw new Error(`journal: ${key} is not a string`);
+  return v;
+}
+
+function envelopeField(m: Record<string, unknown>, key: string): JournalIdentity {
+  const v = m[key];
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) {
+    throw new Error(`journal: ${key} is not an object`);
+  }
+  const e = v as Record<string, unknown>;
+  assertKeys(e, ENVELOPE_KEYS, `${key} envelope`);
+  return { version: intField(e, 'version'), value: strField(e, 'value') };
+}
+
+function fileField(v: unknown): JournalFileState {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) {
+    throw new Error('journal: file entry is not an object');
+  }
+  const f = v as Record<string, unknown>;
+  assertKeys(f, FILE_V1_KEYS, 'file entry');
+  return {
+    idx: intField(f, 'idx'),
+    name: strField(f, 'name'),
+    size: intField(f, 'size'),
+    mime: strField(f, 'mime'),
+    lastModified: intField(f, 'lastModified'),
+    blockSize: intField(f, 'blockSize'),
+    blocks: intField(f, 'blocks'),
+    fileDigest: strField(f, 'fileDigest'),
+    committedBlocks: intField(f, 'committedBlocks'),
+  };
+}
+
+function decodeJournalV1(m: Record<string, unknown>): DurableJournal {
+  assertKeys(m, JOURNAL_V1_KEYS, 'journal');
+  const files = m.files;
+  if (!Array.isArray(files) || files.length === 0)
+    throw new Error('journal: files missing or empty');
+  if (files.length > MAX_TRANSFER_FILES) {
+    throw new Error(`journal: invalid file count ${files.length}`);
+  }
+  const j: DurableJournal = {
+    schemaVersion: intField(m, 'schemaVersion'),
+    transferId: strField(m, 'transferId'),
+    manifestFingerprint: strField(m, 'manifestFingerprint'),
+    protocolVersion: strField(m, 'protocolVersion'),
+    resumeVersion: intField(m, 'resumeVersion'),
+    blockSize: intField(m, 'blockSize'),
+    createdAt: intField(m, 'createdAt'),
+    updatedAt: intField(m, 'updatedAt'),
+    sourceIdentity: envelopeField(m, 'sourceIdentity'),
+    destinationIdentity: envelopeField(m, 'destinationIdentity'),
+    files: files.map(fileField),
+  };
+  if (m.resumeSecret !== undefined) j.resumeSecret = envelopeField(m, 'resumeSecret');
+  if (m.checksum !== undefined) j.checksum = strField(m, 'checksum');
+  return j;
+}
+
+async function verifyChecksum(j: DurableJournal): Promise<void> {
+  const stored = j.checksum;
+  if (stored === undefined || !isLowerHex(stored, 64))
+    throw new Error('journal: malformed checksum');
+  const body = canonicalBody(j);
+  const sum = bytesToHex(await sha256(utf8(JSON.stringify(body))));
+  if (sum !== stored) throw new Error('journal: checksum mismatch (corrupt or tampered)');
+} /**
+ * Full v1 pipeline: strict parse, validation, checksum verification. The returned
+ * journal keeps its stored checksum so re-encoding is byte-identical; encodeJournal
+ * recomputes it on the next write.
+ */
+async function decodeAndVerifyV1(m: Record<string, unknown>): Promise<DurableJournal> {
+  const j = decodeJournalV1(m);
+  await validateJournal(j);
+  await verifyChecksum(j);
+  return j;
+}
+
+/**
+ * Advance one file's durable high-water checkpoint — the ONLY way committed progress may
+ * be recorded. Documented precondition: every block in [0, committedBlocks) has been
+ * verified, written, and made durable BEFORE this call. Refuses regression and values
+ * beyond the file's block count; stamps updatedAt. Returns a new journal (the checksum is
+ * stale afterwards and recomputed by encodeJournal).
+ */
+export function commitBlocks(
+  j: DurableJournal,
+  fileIdx: number,
+  committedBlocks: number,
+  nowMs: number,
+): DurableJournal {
+  if (!Number.isInteger(fileIdx) || fileIdx < 0 || fileIdx >= j.files.length) {
+    throw new Error(`journal: no file ${fileIdx} in journal`);
+  }
+  const f = j.files[fileIdx]!;
+  if (!Number.isInteger(committedBlocks) || committedBlocks < 0 || committedBlocks > f.blocks) {
+    throw new Error(
+      `journal: committedBlocks ${committedBlocks} out of range for file ${fileIdx} (blocks ${f.blocks})`,
+    );
+  }
+  if (committedBlocks < f.committedBlocks) {
+    throw new Error(
+      `journal: committed progress may not regress (file ${fileIdx}: ${f.committedBlocks} -> ${committedBlocks})`,
+    );
+  }
+  return {
+    schemaVersion: j.schemaVersion,
+    transferId: j.transferId,
+    manifestFingerprint: j.manifestFingerprint,
+    protocolVersion: j.protocolVersion,
+    resumeVersion: j.resumeVersion,
+    blockSize: j.blockSize,
+    createdAt: j.createdAt,
+    updatedAt: nowMs,
+    sourceIdentity: j.sourceIdentity,
+    destinationIdentity: j.destinationIdentity,
+    files: j.files.map((entry, i) => (i === fileIdx ? { ...entry, committedBlocks } : entry)),
+    ...(j.resumeSecret !== undefined ? { resumeSecret: j.resumeSecret } : {}),
+  };
+}
+
+/** Durable byte count a file's checkpoint claims: whole committed blocks, final block capped. */
+export function committedBytes(j: DurableJournal, fileIdx: number): number {
+  if (!Number.isInteger(fileIdx) || fileIdx < 0 || fileIdx >= j.files.length) {
+    throw new Error(`journal: no file ${fileIdx} in journal`);
+  }
+  const f = j.files[fileIdx]!;
+  return Math.min(f.committedBlocks * f.blockSize, f.size);
+}

--- a/packages/wire/journal.go
+++ b/packages/wire/journal.go
@@ -1,0 +1,573 @@
+package wire
+
+// Durable transfer journal — the versioned local persistence contract for resumable
+// transfers (docs/adr/0004-durable-journal.md).
+//
+// The journal is LOCAL on-device state, NOT part of the sendbeam/1 wire protocol: it is
+// never transmitted between peers and carries no wire-version implication. It lives in
+// this package because the Go CLI and the browser must consume the same contract; it is
+// the Go twin of packages/protocol/src/journal.ts, and the two must serialize, validate,
+// fingerprint, and checksum byte-identically (pinned by docs/test-vectors/durable-journal.json).
+//
+// Durability ordering (the contract). A checkpoint may be advertised as resumable only
+// after the full ordering below; a crash at any earlier step leaves the previous
+// checkpoint authoritative:
+//
+//	receive/authenticate block
+//	        ↓
+//	verify block
+//	        ↓
+//	write block data
+//	        ↓
+//	required durability operation (flush/fsync of the data)
+//	        ↓
+//	atomically advance the journal checkpoint   ← CommitBlocks is the only advancement API
+//	        ↓
+//	ONLY NOW may that checkpoint be advertised as resumable
+//
+// The journal schema cannot observe the data-durability barrier (whether bytes reached
+// stable storage); enforcing the ordering is the storage layer's job (PR02 CLI, PR03
+// browser). What the schema DOES enforce, and what this file proves with tests, is that
+// the journal can never represent more than it is given: checkpoints are whole committed
+// blocks bounded by the manifest, they can only advance through CommitBlocks (never
+// regress, never exceed the file), and any journal that fails structural validation,
+// fingerprint self-consistency, version dispatch, or checksum verification is rejected
+// closed — it is never "probably read".
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// JournalSchemaVersion is the current durable-journal schema version. Journals are written
+// with exactly this value; DecodeJournal accepts exactly it. A new schema bumps it and
+// adds a decode/migration path in decodeJournalVersion. There is deliberately no
+// fabricated earlier public format: version 1 is the first.
+const JournalSchemaVersion = 1
+
+// JournalResumeVersion is the version of the durability resume protocol whose checkpoint
+// semantics the journal was written for. It is independent of both JournalSchemaVersion
+// (on-disk layout) and the wire ProtocolVersion (sendbeam/1): a future resume protocol may
+// change what committedBlocks means without changing the layout, or vice versa. Only
+// version 1 exists today; the cross-session authenticated resume protocol (PR07) must
+// either reuse it or define the next value and its migration here.
+const JournalResumeVersion = 1
+
+// JournalIdentity is an opaque, versioned identity envelope. The value is deliberately
+// opaque to the journal: its content and derivation are defined by the durability
+// implementation that writes it (destination-location identity in PR02/PR03) or by the
+// resume-authentication protocol (peer identity binding in PR07). Journal validation only
+// checks the envelope shape; the value is a claim, never a trust anchor — resume-time
+// validation binds it against authenticated transfer state.
+type JournalIdentity struct {
+	Version int    `json:"version"`
+	Value   string `json:"value"`
+}
+
+// JournalFileState is one file's durable checkpoint within a journal. The wire FileEntry
+// geometry (idx, name, size, mime, lastModified, blockSize, blocks, fileDigest) is stored
+// so the journal alone can re-validate the resumed transfer and reproduce the canonical
+// manifest fingerprint. CommittedBlocks is the per-file durable high-water mark.
+type JournalFileState struct {
+	Idx          int    `json:"idx"`
+	Name         string `json:"name"`
+	Size         int64  `json:"size"`
+	Mime         string `json:"mime"`
+	LastModified int64  `json:"lastModified"`
+	BlockSize    int    `json:"blockSize"`
+	Blocks       int    `json:"blocks"`
+	FileDigest   string `json:"fileDigest"`
+	// CommittedBlocks is the count of leading blocks of this file that are verified,
+	// durably persisted, AND checkpointed. It is the only progress representation:
+	// checkpoints are whole-block granularity, never byte offsets. Invariant:
+	// 0 <= CommittedBlocks <= Blocks.
+	CommittedBlocks int `json:"committedBlocks"`
+}
+
+// JournalResumeSecret is the opaque, versioned envelope for the minimum resume-secret
+// material the durability model requires. PR01 deliberately does not define its content:
+// the cross-session authenticated resume derivation is PR07. The field exists so the
+// schema is complete and versioned from day one. Lifecycle rules: created only by the
+// resume protocol; NEVER carries the raw SPAKE2/session master key, directional traffic
+// keys, live AEAD counters, or unrelated credentials; invalidated when the transfer
+// completes or the journal is deleted.
+type JournalResumeSecret struct {
+	Version int    `json:"version"`
+	Value   string `json:"value"`
+}
+
+// DurableJournal is the versioned durable-transfer journal (schema version 1). Field
+// declaration order is the canonical JSON key order and must match the TypeScript twin
+// exactly. Every field is a claim loaded from local, user-editable state: nothing here is
+// trusted merely because it was loaded from a journal.
+type DurableJournal struct {
+	// SchemaVersion identifies the on-disk schema (JournalSchemaVersion).
+	SchemaVersion int `json:"schemaVersion"`
+	// TransferID is the stable 128-bit hex id carried by the authenticated manifest that
+	// this journal's checkpoints belong to.
+	TransferID string `json:"transferId"`
+	// ManifestFingerprint is the canonical SHA-256 (hex) of the validated manifest (see
+	// ManifestFingerprint). It binds every checkpoint to the exact file set.
+	ManifestFingerprint string `json:"manifestFingerprint"`
+	// ProtocolVersion is the wire-protocol version the transfer ran under. It is recorded,
+	// never implied: the journal is not wire state.
+	ProtocolVersion string `json:"protocolVersion"`
+	// ResumeVersion is the durability resume protocol version (JournalResumeVersion).
+	ResumeVersion int `json:"resumeVersion"`
+	// BlockSize is the transfer's negotiated logical block size; every file entry's
+	// BlockSize must equal it, so a checkpoint's byte meaning is unambiguous.
+	BlockSize int `json:"blockSize"`
+	// CreatedAt is the journal creation time, unix milliseconds.
+	CreatedAt int64 `json:"createdAt"`
+	// UpdatedAt is the last checkpoint-advance time, unix milliseconds. Always >= CreatedAt.
+	UpdatedAt int64 `json:"updatedAt"`
+	// SourceIdentity is an opaque claim about the sender, bound by the resume protocol.
+	SourceIdentity JournalIdentity `json:"sourceIdentity"`
+	// DestinationIdentity is an opaque claim about the local destination, bound by the
+	// durability implementation.
+	DestinationIdentity JournalIdentity `json:"destinationIdentity"`
+	// Files holds the per-file durable checkpoints, in manifest index order.
+	Files []JournalFileState `json:"files"`
+	// ResumeSecret is the optional opaque resume-secret envelope (PR07). Omitted when the
+	// transfer has no cross-session resume material yet.
+	ResumeSecret *JournalResumeSecret `json:"resumeSecret,omitempty"`
+	// Checksum is SHA-256 over the canonical JSON of every other field. It is a
+	// write-time derivation: EncodeJournal recomputes it, DecodeJournal verifies it, and
+	// callers never set it by hand. It detects corruption and tampering; it is not a
+	// trust anchor against a local attacker who can recompute it (see ADR 0004 §3).
+	Checksum string `json:"checksum,omitempty"`
+}
+
+var (
+	journalOpaqueHex = regexp.MustCompile(`^[0-9a-f]+$`)
+	journalOpaqueB64 = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+)
+
+// isLowerHex reports whether s is exactly n lowercase hex characters.
+func isLowerHex(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// ManifestFingerprint returns the canonical SHA-256 (hex) of a validated manifest. The
+// fingerprint is computed over the exact canonical wire serialization of the manifest (the
+// same bytes EncodeControl produces), so it is byte-identical across Go and TypeScript and
+// pins the file set a journal's checkpoints refer to. It is a binding claim, not a trust
+// anchor: resume validation (PR06/PR07) binds it against authenticated transfer state.
+func ManifestFingerprint(manifest Manifest) (string, error) {
+	validated, err := ValidateManifest(manifest)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := EncodeControl(&validated)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// NewJournal builds a fresh schema-v1 journal for one transfer with zero committed
+// checkpoints. transferID must be the stable 128-bit hex id carried by the authenticated
+// manifest, and manifest must carry that same id (a manifest without one never opted into
+// resumption, so it has no durable journal); manifest must describe the exact file set the
+// transfer will deliver; source and destination are the identity envelopes the durability
+// implementation binds; now seeds both timestamps.
+func NewJournal(transferID string, manifest Manifest, source, destination JournalIdentity, now time.Time) (DurableJournal, error) {
+	if !isLowerHex(transferID, 32) {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: transferId must be 32 lowercase hex characters")
+	}
+	if manifest.TransferID != transferID {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: transferId must match the authenticated manifest")
+	}
+	fingerprint, err := ManifestFingerprint(manifest)
+	if err != nil {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: %v", err)
+	}
+	files := make([]JournalFileState, len(manifest.Files))
+	for i, file := range manifest.Files {
+		files[i] = JournalFileState{
+			Idx: file.Idx, Name: file.Name, Size: file.Size, Mime: file.Mime,
+			LastModified: file.LastModified, BlockSize: file.BlockSize, Blocks: file.Blocks,
+			FileDigest: file.FileDigest,
+		}
+	}
+	created := now.UnixMilli()
+	j := DurableJournal{
+		SchemaVersion:       JournalSchemaVersion,
+		TransferID:          transferID,
+		ManifestFingerprint: fingerprint,
+		ProtocolVersion:     ProtocolVersion,
+		ResumeVersion:       JournalResumeVersion,
+		BlockSize:           manifest.Files[0].BlockSize,
+		CreatedAt:           created,
+		UpdatedAt:           created,
+		SourceIdentity:      source,
+		DestinationIdentity: destination,
+		Files:               files,
+	}
+	if err := ValidateJournal(j); err != nil {
+		return DurableJournal{}, err
+	}
+	return j, nil
+}
+
+// ValidateJournal checks a journal's structural validity and self-consistency. It does NOT
+// verify the checksum (that is a serialization property checked by DecodeJournal), and it
+// does NOT treat any field as a trust anchor. Classification: version incompatibilities
+// are COMPAT; everything else is STORAGE (local durable state unusable).
+func ValidateJournal(j DurableJournal) error {
+	if j.SchemaVersion != JournalSchemaVersion {
+		return Errorf(CodeCompat, "journal: unsupported schema version %d", j.SchemaVersion)
+	}
+	if j.ResumeVersion != JournalResumeVersion {
+		return Errorf(CodeCompat, "journal: unsupported resume version %d", j.ResumeVersion)
+	}
+	if j.ProtocolVersion != ProtocolVersion {
+		return Errorf(CodeCompat, "journal: unsupported protocol version %q", j.ProtocolVersion)
+	}
+	if !isLowerHex(j.TransferID, 32) {
+		return Errorf(CodeStorage, "journal: transferId must be 32 lowercase hex characters")
+	}
+	if !isLowerHex(j.ManifestFingerprint, 64) {
+		return Errorf(CodeStorage, "journal: manifestFingerprint must be 64 lowercase hex characters")
+	}
+	if j.CreatedAt <= 0 || j.UpdatedAt <= 0 || j.UpdatedAt < j.CreatedAt {
+		return Errorf(CodeStorage, "journal: invalid timestamps")
+	}
+	if j.BlockSize <= 0 || j.BlockSize > MaxManifestBlockBytes {
+		return Errorf(CodeStorage, "journal: invalid block size %d", j.BlockSize)
+	}
+	if err := validateIdentity(j.SourceIdentity, "sourceIdentity"); err != nil {
+		return err
+	}
+	if err := validateIdentity(j.DestinationIdentity, "destinationIdentity"); err != nil {
+		return err
+	}
+	if j.ResumeSecret != nil {
+		if err := validateEnvelope(j.ResumeSecret, "resumeSecret"); err != nil {
+			return err
+		}
+	}
+	if len(j.Files) == 0 || len(j.Files) > MaxTransferFiles {
+		return Errorf(CodeStorage, "journal: invalid file count %d", len(j.Files))
+	}
+	// Fingerprint self-consistency: the stored fingerprint must equal one recomputed from
+	// the journal's own transferId + file entries, so a journal cannot drift from the file
+	// set its checkpoints claim.
+	recomputed, err := fingerprintFromFiles(j.TransferID, j.Files)
+	if err != nil {
+		return Errorf(CodeStorage, "journal: %v", err)
+	}
+	if recomputed != j.ManifestFingerprint {
+		return Errorf(CodeStorage, "journal: manifest fingerprint mismatch")
+	}
+	seen := make(map[string]struct{}, len(j.Files))
+	for i, f := range j.Files {
+		if f.Idx != i {
+			return Errorf(CodeStorage, "journal: file indexes must be contiguous")
+		}
+		if f.Size < 0 || f.LastModified < 0 || f.BlockSize <= 0 || f.Blocks < 0 {
+			return Errorf(CodeStorage, "journal: file %d has invalid geometry", f.Idx)
+		}
+		if f.BlockSize > MaxManifestBlockBytes {
+			return Errorf(CodeStorage, "journal: file %d block size %d exceeds the %d-byte ceiling",
+				f.Idx, f.BlockSize, MaxManifestBlockBytes)
+		}
+		wantBlocks := 0
+		if f.Size > 0 {
+			wantBlocks = int((f.Size-1)/int64(f.BlockSize) + 1)
+		}
+		if f.Blocks != wantBlocks {
+			return Errorf(CodeStorage, "journal: file %d has invalid block geometry", f.Idx)
+		}
+		if f.BlockSize != j.BlockSize {
+			return Errorf(CodeStorage, "journal: file %d block size %d differs from journal block size %d",
+				f.Idx, f.BlockSize, j.BlockSize)
+		}
+		if !isLowerHex(f.FileDigest, 64) {
+			return Errorf(CodeStorage, "journal: file %d fileDigest must be 64 lowercase hex characters", f.Idx)
+		}
+		if f.CommittedBlocks < 0 || f.CommittedBlocks > f.Blocks {
+			return Errorf(CodeStorage, "journal: committedBlocks %d out of range for file %d (blocks %d)",
+				f.CommittedBlocks, f.Idx, f.Blocks)
+		}
+		name, err := NormalizeTransferPath(f.Name)
+		if err != nil {
+			return Errorf(CodeStorage, "journal: %v", err)
+		}
+		key := strings.ToLower(name)
+		if _, exists := seen[key]; exists {
+			return Errorf(CodeStorage, "journal: duplicate file path")
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func validateIdentity(id JournalIdentity, label string) error {
+	if id.Version != 1 {
+		return Errorf(CodeCompat, "journal: unsupported %s version %d", label, id.Version)
+	}
+	if err := validateOpaqueValue(id.Value, label); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateEnvelope(e *JournalResumeSecret, label string) error {
+	if e.Version != 1 {
+		return Errorf(CodeCompat, "journal: unsupported %s version %d", label, e.Version)
+	}
+	return validateOpaqueValue(e.Value, label)
+}
+
+func validateOpaqueValue(v, label string) error {
+	if v == "" {
+		return Errorf(CodeStorage, "journal: %s value must not be empty", label)
+	}
+	if len(v) > 2048 {
+		return Errorf(CodeStorage, "journal: %s value is too long", label)
+	}
+	if !journalOpaqueHex.MatchString(v) && !journalOpaqueB64.MatchString(v) {
+		return Errorf(CodeStorage, "journal: %s value must be hex or base64url", label)
+	}
+	return nil
+}
+
+// fingerprintFromFiles recomputes the canonical manifest fingerprint from a journal's own
+// transferId and file entries, so ValidateJournal can prove self-consistency.
+func fingerprintFromFiles(transferID string, files []JournalFileState) (string, error) {
+	entries := make([]FileEntry, len(files))
+	var total int64
+	for i, f := range files {
+		entries[i] = FileEntry{
+			Idx: f.Idx, Name: f.Name, Size: f.Size, Mime: f.Mime,
+			LastModified: f.LastModified, BlockSize: f.BlockSize, Blocks: f.Blocks,
+			FileDigest: f.FileDigest,
+		}
+		total += f.Size
+	}
+	return ManifestFingerprint(Manifest{TransferID: transferID, Files: entries, TotalSize: total})
+}
+
+// EncodeJournal serializes a journal to its canonical JSON, appending the checksum. The
+// checksum is SHA-256 over the canonical JSON of every field except the checksum itself
+// and is recomputed on every encode, so re-encoding a loaded journal yields a fresh,
+// correct checksum. Output is byte-identical to the TypeScript twin (pinned by
+// docs/test-vectors/durable-journal.json).
+func EncodeJournal(j DurableJournal) ([]byte, error) {
+	if err := ValidateJournal(j); err != nil {
+		return nil, err
+	}
+	j.Checksum = ""
+	body, err := marshalJournalJSON(j)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(body)
+	j.Checksum = hex.EncodeToString(sum[:])
+	return marshalJournalJSON(j)
+}
+
+// marshalJournalJSON is the canonical JSON encoder used for journals: no HTML escaping and
+// no trailing newline, byte-identical to JavaScript's JSON.stringify (same rules as the
+// wire control codec).
+func marshalJournalJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
+}
+
+// DecodeJournal parses, version-dispatches, validates, and checksum-verifies a journal,
+// failing closed on ANY deviation: malformed JSON, unknown fields, trailing data, an
+// unsupported or corrupt schema version, invalid content, or a checksum mismatch.
+//
+// Version policy (ADR 0004 §6):
+//   - schemaVersion == JournalSchemaVersion (1): decoded and validated as v1.
+//   - schemaVersion > JournalSchemaVersion: rejected as unsupported-future (COMPAT). When
+//     a new schema lands, the migration entry point is the case added to
+//     decodeJournalVersion; downgrading a newer journal to an older reader is not
+//     supported.
+//   - anything else (missing, zero, negative, non-integer): rejected as corrupt (STORAGE).
+func DecodeJournal(data []byte) (DurableJournal, error) {
+	var head struct {
+		SchemaVersion *int `json:"schemaVersion"`
+	}
+	// Lenient first pass: only the version is needed for dispatch; the full document is
+	// re-parsed strictly after the schema is known.
+	if err := json.Unmarshal(data, &head); err != nil {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: malformed journal: %v", err)
+	}
+	if head.SchemaVersion == nil {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: missing schemaVersion")
+	}
+	return decodeJournalVersion(*head.SchemaVersion, data)
+}
+
+func decodeJournalVersion(version int, data []byte) (DurableJournal, error) {
+	switch version {
+	case JournalSchemaVersion:
+		return decodeJournalV1(data)
+	default:
+		if version > JournalSchemaVersion {
+			return DurableJournal{}, Errorf(CodeCompat,
+				"journal: schema version %d is newer than this build supports (%d)",
+				version, JournalSchemaVersion)
+		}
+		return DurableJournal{}, Errorf(CodeStorage, "journal: corrupt schema version %d", version)
+	}
+}
+
+func decodeJournalV1(data []byte) (DurableJournal, error) {
+	var j DurableJournal
+	if err := unmarshalStrict(data, &j); err != nil {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: malformed journal: %v", err)
+	}
+	if err := ValidateJournal(j); err != nil {
+		return DurableJournal{}, err
+	}
+	stored := j.Checksum
+	if !isLowerHex(stored, 64) {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: malformed checksum")
+	}
+	j.Checksum = ""
+	body, err := marshalJournalJSON(j)
+	if err != nil {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: %v", err)
+	}
+	sum := sha256.Sum256(body)
+	if hex.EncodeToString(sum[:]) != stored {
+		return DurableJournal{}, Errorf(CodeStorage, "journal: checksum mismatch (corrupt or tampered)")
+	}
+	j.Checksum = stored
+	return j, nil
+}
+
+// unmarshalStrict decodes exactly one JSON value into v, rejecting unknown fields and
+// trailing data so an unexpected field (for example a stray key-material field) or a torn
+// tail fails closed.
+func unmarshalStrict(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	if dec.More() {
+		return errors.New("trailing data after JSON document")
+	}
+	return nil
+}
+
+// CommitBlocks advances one file's durable high-water checkpoint. It is the ONLY way
+// committed progress may be recorded, and its documented precondition is the durability
+// contract: every block in [0, committedBlocks) has been verified, written, and made
+// durable (flushed/fsynced) BEFORE this call. It refuses to regress committed progress and
+// refuses values beyond the file's block count; it stamps UpdatedAt. EncodeJournal
+// recomputes the checksum afterwards.
+func (j *DurableJournal) CommitBlocks(fileIdx, committedBlocks int, now time.Time) error {
+	if fileIdx < 0 || fileIdx >= len(j.Files) {
+		return Errorf(CodeStorage, "journal: no file %d in journal", fileIdx)
+	}
+	f := &j.Files[fileIdx]
+	if committedBlocks < 0 || committedBlocks > f.Blocks {
+		return Errorf(CodeStorage, "journal: committedBlocks %d out of range for file %d (blocks %d)",
+			committedBlocks, fileIdx, f.Blocks)
+	}
+	if committedBlocks < f.CommittedBlocks {
+		return Errorf(CodeStorage, "journal: committed progress may not regress (file %d: %d -> %d)",
+			fileIdx, f.CommittedBlocks, committedBlocks)
+	}
+	f.CommittedBlocks = committedBlocks
+	j.UpdatedAt = now.UnixMilli()
+	return nil
+}
+
+// CommittedBytes returns the durable byte count a file's checkpoint claims: whole committed
+// blocks, with the final block capped at the file size. The checkpoint is block-aligned by
+// construction — committedBlocks is a count of blocks, never a byte offset.
+func (j DurableJournal) CommittedBytes(fileIdx int) (int64, error) {
+	if fileIdx < 0 || fileIdx >= len(j.Files) {
+		return 0, Errorf(CodeStorage, "journal: no file %d in journal", fileIdx)
+	}
+	f := j.Files[fileIdx]
+	bytes := int64(f.CommittedBlocks) * int64(f.BlockSize)
+	if bytes > f.Size {
+		bytes = f.Size
+	}
+	return bytes, nil
+}
+
+// WriteJournalAtomic writes a journal to path through the atomic-replacement primitive:
+// the canonical encoding goes to a temp file in the same directory, is fsynced, closed,
+// then renamed over path, so a crash at any point leaves either the old journal or the
+// complete new one — never a torn mix. The temp file is removed on any failure. On POSIX
+// the parent directory is fsynced afterwards (best effort) so the rename itself is
+// durable; Go's os.Rename replaces an existing file on Windows too
+// (MoveFileEx, MOVEFILE_REPLACE_EXISTING). The temp file inherits CreateTemp's 0600 mode,
+// keeping the local filenames and identity material private to the user.
+func WriteJournalAtomic(path string, j DurableJournal) error {
+	data, err := EncodeJournal(j)
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(path, data)
+}
+
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return Errorf(CodeStorage, "journal: create temp: %v", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return Errorf(CodeStorage, "journal: write temp: %v", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return Errorf(CodeStorage, "journal: sync temp: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return Errorf(CodeStorage, "journal: close temp: %v", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return Errorf(CodeStorage, "journal: replace: %v", err)
+	}
+	syncDir(dir)
+	return nil
+}
+
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = d.Close() }()
+	_ = d.Sync()
+}

--- a/packages/wire/journal_test.go
+++ b/packages/wire/journal_test.go
@@ -1,0 +1,631 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// journalTestManifest is the canonical two-file manifest used across journal tests: a
+// 2048-byte file (2 blocks of 1024) and a 1024-byte file (1 block), 3072 bytes total.
+func journalTestManifest() Manifest {
+	m := NewManifest([]FileEntry{
+		{Idx: 0, Name: "a.txt", Size: 2048, Mime: "text/plain", LastModified: 1700000000,
+			BlockSize: 1024, Blocks: 2, FileDigest: strings.Repeat("ab", 32)},
+		{Idx: 1, Name: "b.bin", Size: 1024, Mime: "application/octet-stream", LastModified: 1700000001,
+			BlockSize: 1024, Blocks: 1, FileDigest: strings.Repeat("cd", 32)},
+	}, 3072)
+	m.TransferID = "0123456789abcdef0123456789abcdef"
+	return *m
+}
+
+func journalTestIdentities() (JournalIdentity, JournalIdentity) {
+	return JournalIdentity{Version: 1, Value: "736f757263652d73616d706c65"}, // hex("source-sample")
+		JournalIdentity{Version: 1, Value: "646573742d73616d706c65"} // hex("dest-sample")
+}
+
+func journalTestTimes() (time.Time, time.Time) {
+	return time.UnixMilli(1723500000000), time.UnixMilli(1723500060000)
+}
+
+// journalVectorSample builds the exact journal pinned by docs/test-vectors/durable-journal.json:
+// zero checkpoints at creation, then file 0 committed through its first block.
+func journalVectorSample(t *testing.T) DurableJournal {
+	t.Helper()
+	created, updated := journalTestTimes()
+	source, destination := journalTestIdentities()
+	j, err := NewJournal("0123456789abcdef0123456789abcdef", journalTestManifest(), source, destination, created)
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
+	if err := j.CommitBlocks(0, 1, updated); err != nil {
+		t.Fatalf("CommitBlocks: %v", err)
+	}
+	return j
+}
+
+func TestJournalRoundTrip(t *testing.T) {
+	j := journalVectorSample(t)
+	encoded, err := EncodeJournal(j)
+	if err != nil {
+		t.Fatalf("EncodeJournal: %v", err)
+	}
+	decoded, err := DecodeJournal(encoded)
+	if err != nil {
+		t.Fatalf("DecodeJournal: %v", err)
+	}
+	if decoded.TransferID != j.TransferID || decoded.ManifestFingerprint != j.ManifestFingerprint ||
+		decoded.BlockSize != j.BlockSize || decoded.CreatedAt != j.CreatedAt || decoded.UpdatedAt != j.UpdatedAt {
+		t.Fatalf("round-trip lost fields: %#v", decoded)
+	}
+	if len(decoded.Files) != 2 || decoded.Files[0].CommittedBlocks != 1 || decoded.Files[1].CommittedBlocks != 0 {
+		t.Fatalf("round-trip lost checkpoints: %#v", decoded.Files)
+	}
+	// Re-encoding a decoded journal is byte-identical (canonical form).
+	again, err := EncodeJournal(decoded)
+	if err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	if !bytes.Equal(again, encoded) {
+		t.Fatalf("re-encode is not byte-identical:\n got %s\nwant %s", again, encoded)
+	}
+	// A journal with no resume secret round-trips without the field.
+	if bytes.Contains(encoded, []byte("resumeSecret")) {
+		t.Fatalf("unexpected resumeSecret in output: %s", encoded)
+	}
+}
+
+func TestJournalRequiredFields(t *testing.T) {
+	base := journalVectorSample(t)
+	cases := []struct {
+		name   string
+		mutate func(*DurableJournal)
+	}{
+		{"empty transferId", func(j *DurableJournal) { j.TransferID = "" }},
+		{"short transferId", func(j *DurableJournal) { j.TransferID = "abcd" }},
+		{"uppercase transferId", func(j *DurableJournal) { j.TransferID = strings.ToUpper(base.TransferID) }},
+		{"empty fingerprint", func(j *DurableJournal) { j.ManifestFingerprint = "" }},
+		{"missing protocol version", func(j *DurableJournal) { j.ProtocolVersion = "" }},
+		{"wrong protocol version", func(j *DurableJournal) { j.ProtocolVersion = "sendbeam/2" }},
+		{"zero resume version", func(j *DurableJournal) { j.ResumeVersion = 0 }},
+		{"zero schema version", func(j *DurableJournal) { j.SchemaVersion = 0 }},
+		{"zero block size", func(j *DurableJournal) { j.BlockSize = 0 }},
+		{"huge block size", func(j *DurableJournal) { j.BlockSize = MaxManifestBlockBytes + 1 }},
+		{"zero createdAt", func(j *DurableJournal) { j.CreatedAt = 0 }},
+		{"updatedAt before createdAt", func(j *DurableJournal) { j.UpdatedAt = j.CreatedAt - 1 }},
+		{"empty files", func(j *DurableJournal) { j.Files = nil }},
+		{"too many files", func(j *DurableJournal) { j.Files = append(j.Files, make([]JournalFileState, MaxTransferFiles)...) }},
+		{"missing source identity", func(j *DurableJournal) { j.SourceIdentity = JournalIdentity{} }},
+		{"missing destination value", func(j *DurableJournal) { j.DestinationIdentity.Value = "" }},
+		{"bad identity charset", func(j *DurableJournal) { j.SourceIdentity.Value = "not hex or b64!!" }},
+		{"unsupported identity version", func(j *DurableJournal) { j.SourceIdentity.Version = 2 }},
+		{"empty resume secret value", func(j *DurableJournal) { j.ResumeSecret = &JournalResumeSecret{Version: 1, Value: ""} }},
+		{"unsupported resume secret version", func(j *DurableJournal) { j.ResumeSecret = &JournalResumeSecret{Version: 2, Value: "00"} }},
+		{"bad file digest", func(j *DurableJournal) { j.Files[0].FileDigest = "xyz" }},
+		{"file blocks mismatch", func(j *DurableJournal) { j.Files[0].Blocks = 1 }},
+		{"file size negative", func(j *DurableJournal) { j.Files[0].Size = -1 }},
+		{"file block size differs from journal", func(j *DurableJournal) { j.Files[1].BlockSize = 512 }},
+		{"non-contiguous file indexes", func(j *DurableJournal) { j.Files[1].Idx = 2 }},
+		{"duplicate paths", func(j *DurableJournal) { j.Files[1].Name = "a.txt" }},
+		{"unsafe path", func(j *DurableJournal) { j.Files[0].Name = "../escape.txt" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := base
+			bad.Checksum = ""
+			tc.mutate(&bad)
+			if err := ValidateJournal(bad); err == nil {
+				t.Fatalf("ValidateJournal accepted %s", tc.name)
+			}
+			if _, err := EncodeJournal(bad); err == nil {
+				t.Fatalf("EncodeJournal accepted %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestJournalSchemaVersionDispatch(t *testing.T) {
+	base, err := EncodeJournal(journalVectorSample(t))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if _, err := DecodeJournal(base); err != nil {
+		t.Fatalf("version 1 must decode: %v", err)
+	}
+	for _, future := range []int{2, 99} {
+		raw := rewriteJSON(t, base, func(m map[string]any) { m["schemaVersion"] = future })
+		_, derr := DecodeJournal(raw)
+		if derr == nil || CodeOf(derr) != CodeCompat {
+			t.Fatalf("future version %d must fail closed with COMPAT, got %v", future, derr)
+		}
+		if !strings.Contains(derr.Error(), "newer") {
+			t.Fatalf("future version error should name the version policy, got: %v", derr)
+		}
+	}
+	for _, bad := range []int{0, -1} {
+		raw := rewriteJSON(t, base, func(m map[string]any) { m["schemaVersion"] = bad })
+		_, derr := DecodeJournal(raw)
+		if derr == nil || CodeOf(derr) != CodeStorage {
+			t.Fatalf("corrupt version %d must fail closed with STORAGE, got %v", bad, derr)
+		}
+	}
+	// A version that is not an integer is corrupt, not "future".
+	frac := rewriteJSON(t, base, func(m map[string]any) { m["schemaVersion"] = 1.5 })
+	if _, err := DecodeJournal(frac); err == nil {
+		t.Fatalf("fractional schema version must fail closed")
+	}
+	missing := rewriteJSON(t, base, func(m map[string]any) { delete(m, "schemaVersion") })
+	_, merr := DecodeJournal(missing)
+	if merr == nil || !strings.Contains(merr.Error(), "missing schemaVersion") {
+		t.Fatalf("missing schema version must fail closed, got %v", merr)
+	}
+}
+
+func TestJournalMalformedRejected(t *testing.T) {
+	encoded, err := EncodeJournal(journalVectorSample(t))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	cases := map[string][]byte{
+		"not json":        []byte(`{`),
+		"empty":           nil,
+		"array":           []byte(`[1,2,3]`),
+		"string":          []byte(`"hello"`),
+		"unknown field":   rewriteJSON(t, encoded, func(m map[string]any) { m["masterKey"] = "deadbeef" }),
+		"secret-looking":  rewriteJSON(t, encoded, func(m map[string]any) { m["sessionMasterKey"] = strings.Repeat("00", 32) }),
+		"trailing data":   append(append([]byte(nil), encoded...), []byte(" x")...),
+		"double document": append(append([]byte(nil), encoded...), encoded...),
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeJournal(data); err == nil {
+				t.Fatalf("DecodeJournal accepted %s", name)
+			}
+		})
+	}
+	// Unknown fields must also be rejected even when the checksum field is untouched.
+}
+
+func TestJournalTamperedRejected(t *testing.T) {
+	encoded, err := EncodeJournal(journalVectorSample(t))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	t.Run("content byte flip", func(t *testing.T) {
+		tampered := append([]byte(nil), encoded...)
+		// Flip one byte inside the first file name ("a.txt" -> "c.txt" keeps length).
+		idx := bytes.Index(tampered, []byte("a.txt"))
+		if idx < 0 {
+			t.Fatal("name not found in encoded journal")
+		}
+		tampered[idx] = 'c'
+		// A renamed file breaks the fingerprint self-check, so it fails closed either way.
+		if _, err := DecodeJournal(tampered); err == nil {
+			t.Fatalf("tampered content must fail closed")
+		}
+	})
+
+	t.Run("checksum byte flip", func(t *testing.T) {
+		tampered := append([]byte(nil), encoded...)
+		idx := bytes.LastIndex(tampered, []byte(`"checksum":"`))
+		if idx < 0 {
+			t.Fatal("checksum not found in encoded journal")
+		}
+		flip := idx + len(`"checksum":"`)
+		if tampered[flip] == '0' {
+			tampered[flip] = '1'
+		} else {
+			tampered[flip] = '0'
+		}
+		if _, err := DecodeJournal(tampered); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+			t.Fatalf("flipped checksum must fail closed, got %v", err)
+		}
+	})
+
+	t.Run("checkpoint beyond file", func(t *testing.T) {
+		raw := rewriteJSON(t, encoded, func(m map[string]any) {
+			files := m["files"].([]any)
+			f0 := files[0].(map[string]any)
+			f0["committedBlocks"] = 99 // > blocks (2)
+		})
+		if _, err := DecodeJournal(raw); err == nil || !strings.Contains(err.Error(), "out of range") {
+			t.Fatalf("impossible high-water must fail closed, got %v", err)
+		}
+	})
+
+	t.Run("updatedAt moved forward but checksum stale", func(t *testing.T) {
+		// A valid, fingerprint-neutral content change with a stale checksum must fail on
+		// the checksum — this is the pure tamper-evidence path.
+		raw := rewriteJSON(t, encoded, func(m map[string]any) { m["updatedAt"] = 1723500120000 })
+		if _, err := DecodeJournal(raw); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+			t.Fatalf("stale-checksum content must fail closed, got %v", err)
+		}
+	})
+
+	t.Run("checkpoint within bounds but checksum stale", func(t *testing.T) {
+		raw := rewriteJSON(t, encoded, func(m map[string]any) {
+			files := m["files"].([]any)
+			f0 := files[0].(map[string]any)
+			f0["committedBlocks"] = 2 // valid claim, but checksum was not recomputed
+		})
+		if _, err := DecodeJournal(raw); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+			t.Fatalf("stale-checksum checkpoint must fail closed, got %v", err)
+		}
+	})
+
+	t.Run("tampered identity", func(t *testing.T) {
+		raw := rewriteJSON(t, encoded, func(m map[string]any) {
+			src := m["sourceIdentity"].(map[string]any)
+			src["value"] = "deadbeef" // structurally fine, checksum stale
+		})
+		if _, err := DecodeJournal(raw); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+			t.Fatalf("tampered identity must fail closed on checksum, got %v", err)
+		}
+	})
+
+	t.Run("tampered fingerprint", func(t *testing.T) {
+		raw := rewriteJSON(t, encoded, func(m map[string]any) {
+			m["manifestFingerprint"] = strings.Repeat("ef", 32) // no longer matches the files
+		})
+		// The fingerprint self-check catches this before the checksum is even consulted.
+		if _, err := DecodeJournal(raw); err == nil || !strings.Contains(err.Error(), "fingerprint mismatch") {
+			t.Fatalf("tampered fingerprint must fail closed, got %v", err)
+		}
+	})
+}
+
+// TestJournalFingerprintBinding proves the fingerprint is a semantic binding, not just a
+// string: any change to the file set a journal claims (name, size, digest, transferId) is
+// rejected even if the checksum were recomputed — ValidateJournal recomputes the
+// fingerprint from the journal's own entries and compares.
+func TestJournalFingerprintBinding(t *testing.T) {
+	base := journalVectorSample(t)
+	// Each mutation keeps the journal structurally plausible (valid geometry, valid
+	// envelopes) but changes the file set the checkpoints claim, so only the fingerprint
+	// self-check can catch it — the way an attacker recomputing the checksum would still
+	// be stopped by ValidateJournal.
+	tamper := []struct {
+		name   string
+		mutate func(*DurableJournal)
+	}{
+		{"renamed file", func(j *DurableJournal) { j.Files[0].Name = "c.txt" }},
+		{"swapped digest", func(j *DurableJournal) { j.Files[0].FileDigest = strings.Repeat("ff", 32) }},
+		{"changed transferId", func(j *DurableJournal) { j.TransferID = strings.Repeat("11", 16) }},
+		{"changed mime", func(j *DurableJournal) { j.Files[0].Mime = "image/png" }},
+	}
+	for _, tc := range tamper {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := base
+			bad.Checksum = ""
+			tc.mutate(&bad)
+			err := ValidateJournal(bad)
+			if err == nil || !strings.Contains(err.Error(), "fingerprint mismatch") {
+				t.Fatalf("fingerprint must bind %s, got %v", tc.name, err)
+			}
+		})
+	}
+	// A tampered field that also breaks manifest geometry (size) is caught by geometry
+	// validation before the fingerprint check — still fail closed.
+	bad := base
+	bad.Checksum = ""
+	bad.Files[0].Size = 1024
+	if err := ValidateJournal(bad); err == nil {
+		t.Fatalf("resized file must fail closed")
+	}
+}
+
+func TestJournalNonBlockAlignedCheckpoint(t *testing.T) {
+	encoded, err := EncodeJournal(journalVectorSample(t))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// The schema has no byte-offset field: committedBlocks is a whole-block count, so the
+	// only way to express a non-block-aligned claim is a fractional count, which is not a
+	// valid integer and must fail closed.
+	frac := rewriteJSON(t, encoded, func(m map[string]any) {
+		files := m["files"].([]any)
+		f0 := files[0].(map[string]any)
+		f0["committedBlocks"] = 1.5
+	})
+	if _, err := DecodeJournal(frac); err == nil {
+		t.Fatalf("fractional committedBlocks must fail closed")
+	}
+
+	j := journalVectorSample(t)
+	got, err := j.CommittedBytes(0)
+	if err != nil {
+		t.Fatalf("CommittedBytes: %v", err)
+	}
+	if got != 1024 { // 1 block x 1024
+		t.Fatalf("CommittedBytes(file 0) = %d, want 1024", got)
+	}
+	// Committing every block of file 0 claims exactly the file size (final block capped).
+	if err := j.CommitBlocks(0, 2, time.UnixMilli(1723500120000)); err != nil {
+		t.Fatalf("CommitBlocks: %v", err)
+	}
+	if got, _ := j.CommittedBytes(0); got != 2048 {
+		t.Fatalf("CommittedBytes(file 0) = %d, want 2048", got)
+	}
+}
+
+func TestJournalTornTruncated(t *testing.T) {
+	encoded, err := EncodeJournal(journalVectorSample(t))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// Truncate at many byte positions: a torn journal must never decode, whether the cut
+	// lands mid-structure (JSON error) or on a clean field boundary (validation/checksum).
+	for cut := 0; cut < len(encoded); cut += 7 {
+		if _, err := DecodeJournal(encoded[:cut]); err == nil {
+			t.Fatalf("truncated journal at byte %d/%d decoded successfully", cut, len(encoded))
+		}
+	}
+}
+
+func TestJournalCommitBlocksContract(t *testing.T) {
+	j := journalVectorSample(t)
+	now := time.UnixMilli(1723500120000)
+
+	// Regression is refused.
+	if err := j.CommitBlocks(0, 0, now); err == nil {
+		t.Fatalf("regression must be refused")
+	}
+	// Bounds are enforced.
+	if err := j.CommitBlocks(0, 3, now); err == nil {
+		t.Fatalf("beyond-blocks checkpoint must be refused")
+	}
+	if err := j.CommitBlocks(0, -1, now); err == nil {
+		t.Fatalf("negative checkpoint must be refused")
+	}
+	if err := j.CommitBlocks(7, 0, now); err == nil {
+		t.Fatalf("unknown file must be refused")
+	}
+	// Advancement stamps UpdatedAt and survives a round-trip.
+	if err := j.CommitBlocks(1, 1, now); err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	if j.UpdatedAt != now.UnixMilli() {
+		t.Fatalf("UpdatedAt = %d, want %d", j.UpdatedAt, now.UnixMilli())
+	}
+	encoded, err := EncodeJournal(j)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := DecodeJournal(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Files[1].CommittedBlocks != 1 {
+		t.Fatalf("committed checkpoint lost: %#v", decoded.Files)
+	}
+	// A fully committed file is still a valid journal (progress exactly equals the file).
+	if err := j.CommitBlocks(0, 2, now); err != nil {
+		t.Fatalf("final commit: %v", err)
+	}
+	if _, err := EncodeJournal(j); err != nil {
+		t.Fatalf("fully committed journal must encode: %v", err)
+	}
+}
+
+func TestJournalAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "journal.json")
+
+	j := journalVectorSample(t)
+	if err := WriteJournalAtomic(path, j); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if _, err := DecodeJournal(first); err != nil {
+		t.Fatalf("written journal must decode: %v", err)
+	}
+
+	// No temp files may survive an atomic write.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Fatalf("leftover temp file %s", e.Name())
+		}
+	}
+
+	// Overwrite with an advanced checkpoint: the file is replaced atomically.
+	if err := j.CommitBlocks(0, 2, time.UnixMilli(1723500120000)); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := WriteJournalAtomic(path, j); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	decoded, err := DecodeJournal(second)
+	if err != nil {
+		t.Fatalf("overwritten journal must decode: %v", err)
+	}
+	if decoded.Files[0].CommittedBlocks != 2 {
+		t.Fatalf("overwrite did not replace content: %#v", decoded.Files)
+	}
+
+	// A failed write (missing parent directory) is an error and creates nothing.
+	if err := WriteJournalAtomic(filepath.Join(dir, "missing", "journal.json"), j); err == nil {
+		t.Fatalf("write into missing directory must fail")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "missing")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed write created something: %v", err)
+	}
+}
+
+func TestJournalNeverSerializesKeyMaterial(t *testing.T) {
+	// The schema is a closed set: no field may carry raw session material. Assert the
+	// serialized form of every journal type contains only the documented keys, that a
+	// journal loaded with an unexpected key-material field fails closed, and that bytes
+	// passed alongside construction never leak into the output.
+	forbidden := []string{
+		"master", "sessionKey", "sessionkey", "trafficKey", "aeadKey", "aead",
+		"counter", "nonce", "invite", "password", "credential", "token", "secret",
+	}
+	types := []any{DurableJournal{}, JournalFileState{}, JournalIdentity{}, JournalResumeSecret{}}
+	for _, typ := range types {
+		rv := reflect.TypeOf(typ)
+		for i := 0; i < rv.NumField(); i++ {
+			tag := rv.Field(i).Tag.Get("json")
+			key := strings.Split(tag, ",")[0]
+			for _, pattern := range forbidden {
+				// resumeSecret is the one documented opaque envelope; its content is
+				// versioned and defined by the resume protocol, not raw key material.
+				if key == "resumeSecret" {
+					continue
+				}
+				if strings.Contains(strings.ToLower(key), pattern) {
+					t.Fatalf("journal field %q matches forbidden key-material pattern %q", key, pattern)
+				}
+			}
+		}
+	}
+
+	// Unknown fields — including plausible key-material names — are rejected on load.
+	encoded, err := EncodeJournal(journalVectorSample(t))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	for _, key := range []string{"masterKey", "sessionMasterKey", "o2jKey", "counter"} {
+		raw := rewriteJSON(t, encoded, func(m map[string]any) { m[key] = strings.Repeat("00", 32) })
+		if _, err := DecodeJournal(raw); err == nil {
+			t.Fatalf("journal with %q field must fail closed", key)
+		}
+	}
+
+	// Serializing a journal next to raw session material never embeds it.
+	master := []byte("raw-pake-master-key-0000")
+	dirKey := []byte("directional-o2j-key-0000")
+	j := journalVectorSample(t)
+	out, err := EncodeJournal(j)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	for _, secret := range [][]byte{master, dirKey} {
+		if bytes.Contains(out, secret) {
+			t.Fatalf("serialized journal contains raw key material")
+		}
+	}
+}
+
+func TestJournalChecksumIsWriteTimeDerivation(t *testing.T) {
+	// The checksum is recomputed on encode: mutating a decoded journal and re-encoding
+	// must produce a valid, updated journal, never one that fails its own checksum.
+	j := journalVectorSample(t)
+	encoded, err := EncodeJournal(j)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := DecodeJournal(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if err := decoded.CommitBlocks(0, 2, time.UnixMilli(1723500120000)); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	reencoded, err := EncodeJournal(decoded)
+	if err != nil {
+		t.Fatalf("re-encode after mutation: %v", err)
+	}
+	if _, err := DecodeJournal(reencoded); err != nil {
+		t.Fatalf("re-encoded journal must decode: %v", err)
+	}
+}
+
+func TestJournalResumeSecretOpaque(t *testing.T) {
+	j := journalVectorSample(t)
+	j.ResumeSecret = &JournalResumeSecret{Version: 1, Value: "c2VjcmV0LW1hdGVyaWFs"} // base64url, opaque
+	encoded, err := EncodeJournal(j)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := DecodeJournal(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.ResumeSecret == nil || decoded.ResumeSecret.Value != j.ResumeSecret.Value {
+		t.Fatalf("resume secret lost: %#v", decoded.ResumeSecret)
+	}
+	// A secret that is not a valid opaque value is rejected.
+	bad := j
+	bad.ResumeSecret.Value = "not valid material!"
+	bad.Checksum = ""
+	if err := ValidateJournal(bad); err == nil {
+		t.Fatalf("malformed resume secret must be rejected")
+	}
+}
+
+// TestJournalVector pins the committed cross-language vector: rebuilding the sample
+// journal from the vector's inputs must reproduce the recorded fingerprint and the
+// byte-exact canonical JSON (including its checksum). The TypeScript twin asserts the
+// same file, so any drift between the two implementations fails one of them.
+func TestJournalVector(t *testing.T) {
+	var doc journalVectorDoc
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "test-vectors", "durable-journal.json"))
+	if err != nil {
+		t.Fatalf("read vector: %v (regenerate with GENERATE_VECTORS=1)", err)
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse vector: %v", err)
+	}
+	msg, err := DecodeControl([]byte(doc.Manifest))
+	if err != nil {
+		t.Fatalf("decode vector manifest: %v", err)
+	}
+	manifest, ok := msg.(*Manifest)
+	if !ok {
+		t.Fatalf("vector manifest is not a manifest")
+	}
+	j, err := NewJournal(doc.TransferID, *manifest, doc.SourceIdentity, doc.DestinationIdentity,
+		time.UnixMilli(doc.CreatedAt))
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
+	for i, blocks := range doc.CommittedBlocks {
+		if err := j.CommitBlocks(i, blocks, time.UnixMilli(doc.UpdatedAt)); err != nil {
+			t.Fatalf("CommitBlocks(%d, %d): %v", i, blocks, err)
+		}
+	}
+	if j.ManifestFingerprint != doc.Fingerprint {
+		t.Fatalf("fingerprint mismatch:\n got %s\nwant %s", j.ManifestFingerprint, doc.Fingerprint)
+	}
+	encoded, err := EncodeJournal(j)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if string(encoded) != doc.Journal {
+		t.Fatalf("journal bytes mismatch:\n got %s\nwant %s", encoded, doc.Journal)
+	}
+}
+
+// rewriteJSON round-trips encoded JSON through a mutation for tamper tests, preserving the
+// untouched fields verbatim apart from the mutation.
+func rewriteJSON(t *testing.T, encoded []byte, mutate func(map[string]any)) []byte {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(encoded, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	mutate(m)
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return out
+}

--- a/packages/wire/journal_vector_gen_test.go
+++ b/packages/wire/journal_vector_gen_test.go
@@ -1,0 +1,85 @@
+package wire
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// journalVectorDoc is the committed shape of docs/test-vectors/durable-journal.json: the
+// fixed inputs a reader needs to rebuild the sample journal, plus the expected fingerprint
+// and the byte-exact canonical journal JSON (including its checksum). Both the Go and the
+// TypeScript suites must reproduce `journal` byte-for-byte, pinning the schema's key order,
+// the fingerprint definition, and the checksum definition across languages.
+type journalVectorDoc struct {
+	Description         string          `json:"description"`
+	TransferID          string          `json:"transferId"`
+	Manifest            string          `json:"manifest"` // canonical wire JSON of the validated manifest
+	SourceIdentity      JournalIdentity `json:"sourceIdentity"`
+	DestinationIdentity JournalIdentity `json:"destinationIdentity"`
+	CreatedAt           int64           `json:"createdAt"`
+	UpdatedAt           int64           `json:"updatedAt"`
+	CommittedBlocks     []int           `json:"committedBlocks"`
+	Fingerprint         string          `json:"fingerprint"`
+	Journal             string          `json:"journal"` // canonical encoded journal incl. checksum
+}
+
+// TestGenerateJournalVector rewrites docs/test-vectors/durable-journal.json from the Go
+// implementation. Run with GENERATE_VECTORS=1 (see docs/test-vectors/README.md):
+//
+//	cd packages/wire && GENERATE_VECTORS=1 go test -run TestGenerateJournalVector ./...
+func TestGenerateJournalVector(t *testing.T) {
+	if os.Getenv("GENERATE_VECTORS") != "1" {
+		t.Skip("set GENERATE_VECTORS=1 to regenerate docs/test-vectors/durable-journal.json")
+	}
+	j := journalVectorSample(t)
+	doc, err := buildJournalVectorDoc(j)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join("..", "..", "docs", "test-vectors", "durable-journal.json")
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(out, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %s", path)
+}
+
+// buildJournalVectorDoc derives the committed vector document from a journal.
+func buildJournalVectorDoc(j DurableJournal) (journalVectorDoc, error) {
+	encoded, err := EncodeJournal(j)
+	if err != nil {
+		return journalVectorDoc{}, err
+	}
+	manifest := journalTestManifest()
+	validated, err := ValidateManifest(manifest)
+	if err != nil {
+		return journalVectorDoc{}, err
+	}
+	manifestJSON, err := EncodeControl(&validated)
+	if err != nil {
+		return journalVectorDoc{}, err
+	}
+	committed := make([]int, len(j.Files))
+	for i, f := range j.Files {
+		committed[i] = f.CommittedBlocks
+	}
+	return journalVectorDoc{
+		Description: "Canonical schema-v1 durable journal, produced by the Go implementation " +
+			"(packages/wire/journal.go). Both Go and TypeScript must reproduce `fingerprint` " +
+			"and the `journal` JSON byte-for-byte; a mismatch is a schema/codec violation.",
+		TransferID:          j.TransferID,
+		Manifest:            string(manifestJSON),
+		SourceIdentity:      j.SourceIdentity,
+		DestinationIdentity: j.DestinationIdentity,
+		CreatedAt:           j.CreatedAt,
+		UpdatedAt:           j.UpdatedAt,
+		CommittedBlocks:     committed,
+		Fingerprint:         j.ManifestFingerprint,
+		Journal:             string(encoded),
+	}, nil
+}


### PR DESCRIPTION
## Summary

- define the versioned durable-transfer journal and its checkpoint invariants: only verified + durably persisted + durably checkpointed blocks may be advertised as resumable
- establish fail-closed corruption/version handling and secret-storage rules (no raw master keys, directional keys, or live AEAD counters in the journal)
- add deterministic schema, tamper, torn-write, and version/compatibility coverage, plus a cross-language Go/TypeScript vector pinning the schema byte-for-byte

This is a local persistence contract only: no wire-protocol change, no `sendbeam/2`.

## Validation

- Go (`packages/wire`): `gofmt`, `go vet`, `go test`, `go test -race`, `golangci-lint` — all clean
- TypeScript (`packages/protocol` + `apps/web`): `pnpm typecheck`, `pnpm lint`, `pnpm exec prettier --check`, `pnpm test`, `pnpm build` — all green (protocol 181 tests, web 106 tests)
- `git diff --check` clean