### PR TITLE
feat: add durable browser receive storage

### DIFF
--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -27,6 +27,7 @@
     progressPercent,
     rateLabel,
     etaLabel,
+    humanBytes,
     sasFingerprint,
     type ErrorLike,
   } from './lib/session/present.js';
@@ -44,6 +45,9 @@
   let errorText = $state('');
   // Sanitized failure diagnostics (V12-PR06 / ADR 0003) shown on the failure screen.
   let failureDiag = $state('');
+  // Durable-receive Keep/Discard surface (V13-PR03): an interrupted resumable receive keeps
+  // its journal + partials until the user explicitly discards them.
+  let durableDiscarded = $state(false);
 
   // Transfer state, live once the handshake settles and the socket is adopted.
   let role = $state<Role | undefined>(undefined);
@@ -289,6 +293,16 @@
     peerCaps = undefined;
     errorText = '';
     failureDiag = '';
+    durableDiscarded = false;
+  }
+
+  async function discardDurable() {
+    try {
+      await transfer?.discardDurable();
+      durableDiscarded = true;
+    } catch {
+      // Keep the block visible if the discard itself failed; the data is still kept.
+    }
   }
 
   function backHome() {
@@ -592,6 +606,20 @@
               {copied ? 'Copied' : 'Copy diagnostics'}
             </button>
             <pre class="diag-json">{failureDiag}</pre>
+          </div>
+        {/if}
+        {#if !durableDiscarded && transfer?.durable()}
+          <div class="durable-block">
+            <p class="muted">
+              {#if transfer.durable()!.resumed}
+                Resuming — partial data kept so retrying with the same code continues where it
+                stopped.
+              {:else}
+                Partial data kept ({humanBytes(transfer.durable()!.committedBytes)} of
+                {humanBytes(transfer.durable()!.totalBytes)}) — retry with the same code to resume.
+              {/if}
+            </p>
+            <button class="danger" onclick={discardDurable}>Discard partial data</button>
           </div>
         {/if}
       </div>
@@ -1210,6 +1238,20 @@
     word-break: break-all;
     max-height: 12rem;
     overflow: auto;
+  }
+
+  /* ————— durable keep/discard ————— */
+  .durable-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+    margin-top: 0.75rem;
+    padding: 0.9rem 1rem;
+    border-radius: 0.85rem;
+    background: rgba(52, 211, 153, 0.07);
+    border: 1px solid rgba(52, 211, 153, 0.28);
+    text-align: left;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -24,6 +24,7 @@ import {
 } from '../transfer/adaptive.js';
 import { ProgressTracker, type TransferSnapshot } from '../transfer/progress.js';
 import { readOpfsOutput, removeOpfsOutput } from '../transfer/sink.js';
+import { indexedDbDurableStore } from '../transfer/durable-store.js';
 import type {
   HostToWorker,
   ReceiveDestinationSpec,
@@ -66,6 +67,19 @@ export interface TransferController {
   resume(): void;
   /** Abort the transfer and tear down the worker, peer, and socket. Idempotent. */
   cancel(reason?: string): void;
+  /** Durable-receive metadata (journal + lease) once a resumable receive is prepared. */
+  durable(): DurableInfo | undefined;
+  /** Explicitly discard the kept journal + partials for this transfer (idempotent). */
+  discardDurable(): Promise<void>;
+}
+
+/** Resumable receive state the host surfaces for Keep/Discard. */
+export interface DurableInfo {
+  transferId: string;
+  ownerId: string;
+  resumed: boolean;
+  committedBytes: number;
+  totalBytes: number;
 }
 
 export interface SendOptions {
@@ -131,6 +145,18 @@ function run(
   let recovering = false;
   let switchPromise: Promise<void> | undefined;
   let cancelTimer: ReturnType<typeof setTimeout> | undefined;
+  // Durable-receive state reported by the worker (journal + lease). The lease must be
+  // released when the tab goes away (pagehide) so a retry is not blocked by the TTL.
+  let durableInfo: DurableInfo | undefined;
+  let releaseLeaseOnPageHide: (() => void) | undefined;
+  const armPageHideRelease = (info: DurableInfo): void => {
+    if (releaseLeaseOnPageHide) return;
+    const onPageHide = (): void => {
+      void indexedDbDurableStore().releaseLease(info.transferId, info.ownerId);
+    };
+    addEventListener('pagehide', onPageHide);
+    releaseLeaseOnPageHide = () => removeEventListener('pagehide', onPageHide);
+  };
 
   // Sanitized diagnostics (V12-PR06 / ADR 0003): setup timing, transport/path, ICE state, and
   // failure events — all redacted so the snapshot is safe to surface on a failure report.
@@ -159,6 +185,8 @@ function run(
   const cleanup = (): void => {
     generation.bump();
     clearTimeout(cancelTimer);
+    releaseLeaseOnPageHide?.();
+    releaseLeaseOnPageHide = undefined;
     wakeLock.setActive(false);
     worker?.terminate();
     peer?.close();
@@ -353,6 +381,10 @@ function run(
             total = msg.totalSize;
             progress.setTotal(msg.totalSize);
             return;
+          case 'durable':
+            durableInfo = { ...msg };
+            armPageHideRelease(durableInfo);
+            return;
           case 'state':
             progress.setState(msg.state);
             return;
@@ -481,6 +513,11 @@ function run(
       }
       worker.postMessage({ kind: 'control', op: 'cancel' } satisfies HostToWorker);
       cancelTimer = setTimeout(() => fail(new Error(reason)), 1000);
+    },
+    durable: () => durableInfo,
+    discardDurable: async () => {
+      if (!durableInfo) return;
+      await indexedDbDurableStore().discard(durableInfo.transferId);
     },
   };
 }

--- a/apps/web/src/lib/transfer/durable-destination.test.ts
+++ b/apps/web/src/lib/transfer/durable-destination.test.ts
@@ -1,0 +1,750 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  FrameType,
+  TransferError,
+  bytesToHex,
+  commitBlocks as advanceJournal,
+  decodeJournal,
+  encodeJournal,
+  newJournal,
+  sha256,
+  type Digest,
+  type DurableJournal,
+  type Manifest,
+} from '@sendbeam/protocol';
+import { createSha256DigestFactory } from './digest.js';
+import { DurableDestination } from './durable-destination.js';
+import {
+  DURABLE_LEASE_TTL_MS,
+  webDestinationIdentity,
+  type DurableFiles,
+  type DurableJournalStore,
+  type JournalLoad,
+  type LeaseOutcome,
+  type LeaseRecord,
+  type PartialWriter,
+  type WritableFileLike,
+} from './durable-store.js';
+
+// ---------------------------------------------------------------------------
+// In-memory store + files fakes sharing an event log so tests can assert the
+// flush-before-commit ordering deterministically (no sleeps).
+// ---------------------------------------------------------------------------
+
+const TRANSFER_ID = 'a'.repeat(32);
+const IDENTITY = { version: 1, value: '0'.repeat(64) };
+
+class MemoryStore implements DurableJournalStore {
+  journals = new Map<string, Uint8Array>();
+  leases = new Map<string, LeaseRecord>();
+  /** Shared ordering log: 'flush' (files) and 'commit:<blocks>' (store). */
+  events: string[] = [];
+  /** Fault hooks. */
+  failCommit = false;
+  failCreate = false;
+
+  async loadJournal(transferId: string): Promise<JournalLoad> {
+    const bytes = this.journals.get(transferId);
+    if (bytes === undefined) return { kind: 'none' };
+    try {
+      return { kind: 'ok', journal: await decodeJournal(bytes) };
+    } catch (e) {
+      return { kind: 'corrupt', error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  async createJournal(
+    transferId: string,
+    manifest: Manifest,
+    source: { version: number; value: string },
+    destination: { version: number; value: string },
+    nowMs: number,
+  ): Promise<DurableJournal> {
+    if (this.failCreate) throw new Error('create journal failed');
+    const journal = await newJournal(transferId, manifest, source, destination, nowMs);
+    this.journals.set(transferId, await encodeJournal(journal));
+    return journal;
+  }
+
+  async commitBlocks(
+    journal: DurableJournal,
+    fileIdx: number,
+    blocks: number,
+    nowMs: number,
+    ownerId: string,
+  ): Promise<DurableJournal> {
+    if (this.failCommit) throw new Error('journal commit failed');
+    const lease = this.leases.get(journal.transferId);
+    if (!lease || lease.ownerId !== ownerId) {
+      throw new TransferError(
+        'sink_error',
+        'durable lease lost; another receiver owns this transfer',
+      );
+    }
+    const next = advanceJournal(journal, fileIdx, blocks, nowMs);
+    this.journals.set(next.transferId, await encodeJournal(next));
+    this.leases.set(next.transferId, {
+      ...lease,
+      expiresAt: nowMs + DURABLE_LEASE_TTL_MS,
+    });
+    this.events.push(`commit:${fileIdx}:${blocks}`);
+    return next;
+  }
+
+  async acquireLease(transferId: string, ownerId: string, nowMs: number): Promise<LeaseOutcome> {
+    const lease = this.leases.get(transferId);
+    const expiresAt = nowMs + DURABLE_LEASE_TTL_MS;
+    if (!lease) {
+      this.leases.set(transferId, { transferId, ownerId, expiresAt });
+      return { kind: 'acquired' };
+    }
+    if (lease.expiresAt <= nowMs) {
+      this.leases.set(transferId, { transferId, ownerId, expiresAt });
+      return { kind: 'stale-taken' };
+    }
+    if (lease.ownerId === ownerId) {
+      this.leases.set(transferId, { transferId, ownerId, expiresAt });
+      return { kind: 'renewed' };
+    }
+    return { kind: 'contended' };
+  }
+
+  async renewLease(transferId: string, ownerId: string, nowMs: number): Promise<void> {
+    const lease = this.leases.get(transferId);
+    if (lease && lease.ownerId === ownerId) {
+      this.leases.set(transferId, { ...lease, expiresAt: nowMs + DURABLE_LEASE_TTL_MS });
+    }
+  }
+
+  async releaseLease(transferId: string, ownerId: string): Promise<void> {
+    const lease = this.leases.get(transferId);
+    if (lease && lease.ownerId === ownerId) this.leases.delete(transferId);
+  }
+
+  async discard(transferId: string): Promise<void> {
+    this.journals.delete(transferId);
+    this.leases.delete(transferId);
+  }
+}
+
+class MemoryFiles implements DurableFiles {
+  /** relPath → partial bytes. Shared across destination instances (same browser storage). */
+  data = new Map<string, Uint8Array>();
+  /** Outputs written by openOutput (ZIP finalize), key → bytes. */
+  outputs = new Map<string, Uint8Array>();
+  syncAvailable = true;
+  /** Fault hook: writer.write throws a QuotaExceededError. */
+  quotaOnWrite = false;
+  events: string[] = [];
+
+  async dataDir(): Promise<FileSystemDirectoryHandle> {
+    throw new Error('dataDir is not used by the in-memory files fake');
+  }
+  async probeSync(): Promise<boolean> {
+    return this.syncAvailable;
+  }
+  partialKey(transferId: string, relPath: string): string {
+    return `sendbeam/durable/${transferId}/${relPath}.part`;
+  }
+  async openWriter(
+    transferId: string,
+    relPath: string,
+    committedBytes: number,
+    sync: boolean,
+  ): Promise<PartialWriter> {
+    const existing = this.data.get(relPath) ?? new Uint8Array();
+    if (existing.length < committedBytes) {
+      throw new TransferError(
+        'sink_error',
+        `partial ${relPath} truncated (have ${existing.length} bytes, checkpoint claims ${committedBytes})`,
+      );
+    }
+    return new MemoryWriter(this, transferId, relPath, existing.slice(0, committedBytes), sync);
+  }
+  async partialSize(_transferId: string, relPath: string): Promise<number | undefined> {
+    return this.data.get(relPath)?.length;
+  }
+  async readPrefix(
+    _transferId: string,
+    relPath: string,
+    length: number,
+    digest: Digest,
+  ): Promise<void> {
+    const bytes = this.data.get(relPath) ?? new Uint8Array();
+    if (bytes.length < length) {
+      throw new TransferError('sink_error', `partial ${relPath} shorter than its checkpoint`);
+    }
+    digest.update(bytes.slice(0, length));
+  }
+  async readPartialChunks(
+    _transferId: string,
+    relPath: string,
+    visit: (chunk: Uint8Array) => void | Promise<void>,
+  ): Promise<void> {
+    const bytes = this.data.get(relPath);
+    if (!bytes) throw new TransferError('sink_error', `partial ${relPath} missing at finalize`);
+    for (let i = 0; i < bytes.length; i += 64) {
+      await visit(bytes.slice(i, i + 64));
+    }
+  }
+  async listRelPaths(): Promise<string[]> {
+    return [...this.data.keys()].sort();
+  }
+  async openOutput(
+    transferId: string,
+    fileName: string,
+  ): Promise<{ key: string; writable: WritableFileLike }> {
+    const key = `sendbeam/durable/${transferId}/${fileName}`;
+    return {
+      key,
+      writable: new OutputWritable(this.outputs, key),
+    };
+  }
+  async removePartial(_transferId: string, relPath: string): Promise<void> {
+    this.data.delete(relPath);
+  }
+  async removeData(): Promise<void> {
+    this.data.clear();
+  }
+}
+
+class MemoryWriter implements PartialWriter {
+  private readonly base: Uint8Array;
+  constructor(
+    private readonly files: MemoryFiles,
+    private readonly transferId: string,
+    private readonly rel: string,
+    base: Uint8Array,
+    private readonly sync: boolean,
+  ) {
+    this.base = base.slice();
+    this.files.data.set(rel, this.base);
+  }
+  async write(offset: number, bytes: Uint8Array): Promise<void> {
+    if (this.files.quotaOnWrite) {
+      throw new DOMException('storage quota exceeded', 'QuotaExceededError');
+    }
+    const current = this.files.data.get(this.rel) ?? this.base;
+    const end = offset + bytes.length;
+    const grown = new Uint8Array(Math.max(end, current.length));
+    grown.set(current);
+    grown.set(bytes, offset);
+    this.files.data.set(this.rel, grown);
+    if (this.sync) this.files.events.push('flush');
+  }
+  async close(): Promise<void> {
+    this.files.events.push('close');
+  }
+  async abort(): Promise<void> {
+    this.files.events.push('abort');
+  }
+}
+
+class OutputWritable implements WritableFileLike {
+  bytes = new Uint8Array();
+  closed = false;
+  constructor(
+    private readonly outputs: Map<string, Uint8Array>,
+    private readonly key: string,
+  ) {}
+  async write(request: { type: 'write'; position: number; data: Uint8Array }): Promise<void> {
+    const end = request.position + request.data.length;
+    if (end > this.bytes.length) {
+      const grown = new Uint8Array(end);
+      grown.set(this.bytes);
+      this.bytes = grown;
+    }
+    this.bytes.set(request.data, request.position);
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+    this.outputs.set(this.key, this.bytes);
+  }
+  async abort(): Promise<void> {
+    this.outputs.delete(this.key);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function manifest(names: Array<[string, number]>): Manifest {
+  return {
+    type: FrameType.Manifest,
+    transferId: TRANSFER_ID,
+    files: names.map(([name, size], idx) => ({
+      idx,
+      name,
+      size,
+      mime: 'application/octet-stream',
+      lastModified: 0,
+      blockSize: 8,
+      blocks: Math.ceil(size / 8),
+      fileDigest: 'a'.repeat(64),
+    })),
+    totalSize: names.reduce((total, [, size]) => total + size, 0),
+  };
+}
+
+interface Harness {
+  store: MemoryStore;
+  files: MemoryFiles;
+  makeDestination: (overrides?: Partial<{ now: () => number }>) => DurableDestination;
+  digest: () => Digest;
+  advance: (ms: number) => void;
+}
+
+async function harness(): Promise<Harness> {
+  const store = new MemoryStore();
+  const files = new MemoryFiles();
+  store.events = files.events;
+  const digestFactory = await createSha256DigestFactory();
+  let clock = 1_000;
+  const now = () => clock;
+  const makeDestination = (overrides: Partial<{ now: () => number }> = {}): DurableDestination =>
+    new DurableDestination({
+      createDigest: () => digestFactory(),
+      files,
+      store,
+      now,
+      renewMs: 0,
+      ensureSpace: async () => {},
+      ...overrides,
+    });
+  return {
+    store,
+    files,
+    makeDestination,
+    digest: () => digestFactory(),
+    advance: (ms) => {
+      clock += ms;
+    },
+  };
+}
+
+/** Write `blocks` blocks of the given sizes through a destination sink. */
+function committed(journal: DurableJournal | undefined, fileIdx: number): number {
+  return journal?.files[fileIdx]?.committedBlocks ?? -1;
+}
+
+/** Split a fresh transfer's verified data into a per-file partial map for a fake journal. */
+async function journalFor(
+  store: MemoryStore,
+  files: MemoryFiles,
+  names: Array<[string, number]>,
+  committedPerFile: number[],
+): Promise<DurableJournal> {
+  // The destination binds journals to the browser storage location; journals the tests
+  // fabricate must carry the same claim or prepare rejects them as foreign.
+  const destination = await webDestinationIdentity('web');
+  return newJournal(TRANSFER_ID, manifest(names), IDENTITY, destination, 1_000).then(async (j) => {
+    for (let i = 0; i < names.length; i++) {
+      const f = j.files[i]!;
+      const rel = names[i]![0];
+      // Persisted bytes mirror the checkpoint claim: one full block per committed count.
+      const bytes = new Uint8Array(f.blockSize * committedPerFile[i]!);
+      for (let b = 0; b < committedPerFile[i]!; b++) {
+        bytes.set(
+          new Uint8Array(f.blockSize).map((_, k) => (b * f.blockSize + k + 1) & 0xff),
+          b * f.blockSize,
+        );
+      }
+      files.data.set(rel, bytes);
+    }
+    const advanced = committedPerFile.reduce((acc, count, i) => {
+      return count === 0 ? acc : advanceJournal(acc, i, count, 2_000);
+    }, j);
+    store.journals.set(TRANSFER_ID, await encodeJournal(advanced));
+    store.leases.set(TRANSFER_ID, {
+      transferId: TRANSFER_ID,
+      ownerId: 'x'.repeat(16),
+      expiresAt: 1_000 + DURABLE_LEASE_TTL_MS,
+    });
+    return advanced;
+  });
+}
+
+function hasSignature(bytes: Uint8Array, signature: number): boolean {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  for (let idx = 0; idx <= bytes.length - 4; idx++) {
+    if (view.getUint32(idx, true) === signature) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DurableDestination', () => {
+  it('fresh receive: writes → flush → checkpoint per block, then finalize removes the journal', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 24]]);
+    await d.prepare(m);
+    expect(d.durableMeta()).toMatchObject({
+      transferId: TRANSFER_ID,
+      resumed: false,
+      totalBytes: 24,
+      committedBytes: 0,
+    });
+
+    const sink = await d.open(m.files[0]!);
+    await sink.write(0, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    expect(h.store.events).toEqual(['flush', 'commit:0:1']);
+
+    await sink.write(8, new Uint8Array([9, 10, 11, 12, 13, 14, 15, 16]));
+    await sink.write(16, new Uint8Array([17, 18, 19, 20, 21, 22, 23, 24]));
+    await sink.close();
+    expect(h.store.events.at(-1)).toBe('close');
+
+    // Journal advanced ahead of nothing: committed equals written.
+    const loaded = await h.store.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('ok');
+    if (loaded.kind !== 'ok') return;
+    expect(committed(loaded.journal, 0)).toBe(3);
+
+    await d.close();
+    // Finalize removed journal + lease; the verified partial is the deliverable.
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(h.files.data.get('a.bin')).toEqual(
+      new Uint8Array([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+      ]),
+    );
+    expect(d.result()).toMatchObject({
+      kind: 'opfs',
+      key: `sendbeam/durable/${TRANSFER_ID}/a.bin.part`,
+      name: 'a.bin',
+    });
+  });
+
+  it('flushed data is never advertised when the journal commit fails', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 16]]);
+    await d.prepare(m);
+    const sink = await d.open(m.files[0]!);
+    await sink.write(0, new Uint8Array(8));
+    h.store.failCommit = true;
+    await expect(sink.write(8, new Uint8Array(8))).rejects.toThrow(/commit failed/);
+    h.store.failCommit = false;
+
+    const loaded = await h.store.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('ok');
+    if (loaded.kind !== 'ok') return;
+    // The checkpoint stays at block 1: flushed-but-uncommitted block 2 is never advertised.
+    expect(committed(loaded.journal, 0)).toBe(1);
+    expect(h.files.data.get('a.bin')?.length).toBe(16);
+  });
+
+  it('reload + resume from a committed checkpoint rehashes the persisted prefix', async () => {
+    const h = await harness();
+    const first = h.makeDestination();
+    const m = manifest([['a.bin', 24]]);
+    await first.prepare(m);
+    const sink = await first.open(m.files[0]!);
+    await sink.write(0, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    await sink.write(8, new Uint8Array([9, 10, 11, 12, 13, 14, 15, 16]));
+    // Tab crash: the first destination is abandoned (lease lives on via its TTL).
+
+    // Reloaded receiver in the same room: same storage, expired lease → stale takeover.
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const second = h.makeDestination();
+    await second.prepare(m);
+    expect(second.durableMeta()?.resumed).toBe(true);
+
+    const resume = second.resumeStateFor();
+    expect(resume?.transferId).toBe(TRANSFER_ID);
+    const file = resume?.files.get(0);
+    expect(file?.haveBlocks).toBe(2);
+    const expectedPrefix = bytesToHex(
+      await sha256(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])),
+    );
+    expect(await file?.seedDigest.hexDigest()).toBe(expectedPrefix);
+
+    // The receiver streams only the missing block; the sink resumes at the checkpoint.
+    const resumedSink = await second.open(m.files[0]!);
+    await resumedSink.write(16, new Uint8Array([17, 18, 19, 20, 21, 22, 23, 24]));
+    await resumedSink.close();
+    await second.close();
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(second.result()?.kind).toBe('opfs');
+    expect(h.files.data.get('a.bin')).toEqual(
+      new Uint8Array([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+      ]),
+    );
+  });
+
+  it('stale tail beyond the checkpoint is truncated and re-transferred on resume', async () => {
+    const h = await harness();
+    await journalFor(h.store, h.files, [['a.bin', 24]], [1]);
+    // Simulate a crash between write and journal commit: durable data beyond the checkpoint.
+    h.files.data.set('a.bin', new Uint8Array(16).fill(9));
+
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 24]]);
+    await d.prepare(m);
+    expect(d.resumeStateFor()?.files.get(0)?.haveBlocks).toBe(1);
+    const sink = await d.open(m.files[0]!);
+    // The stale tail was dropped: the writer starts from the authoritative checkpoint.
+    expect(h.files.data.get('a.bin')?.length).toBe(8);
+    await sink.write(8, new Uint8Array(8).fill(1));
+    await sink.write(16, new Uint8Array(8).fill(2));
+    await sink.close();
+    await d.close();
+  });
+
+  it('fails closed on missing or truncated partials at resume (never guessed, never deleted)', async () => {
+    const h = await harness();
+    await journalFor(h.store, h.files, [['a.bin', 24]], [2]);
+    h.files.data.delete('a.bin'); // evicted
+
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d = h.makeDestination();
+    await expect(d.prepare(manifest([['a.bin', 24]]))).rejects.toThrow(/missing or truncated/);
+    // Nothing was deleted.
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+
+    // Truncated variant.
+    await journalFor(h.store, h.files, [['a.bin', 24]], [2]);
+    h.files.data.set('a.bin', new Uint8Array(4));
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d2 = h.makeDestination();
+    await expect(d2.prepare(manifest([['a.bin', 24]]))).rejects.toThrow(/missing or truncated/);
+  });
+
+  it('concurrent tabs: the second receiver fails closed while the lease is held', async () => {
+    const h = await harness();
+    const first = h.makeDestination();
+    const m = manifest([['a.bin', 8]]);
+    await first.prepare(m);
+
+    const second = h.makeDestination();
+    await expect(second.prepare(m)).rejects.toThrow(/another window is already receiving/);
+    // The first receiver still owns the lease and can keep writing.
+    const sink = await first.open(m.files[0]!);
+    await sink.write(0, new Uint8Array(8));
+    const loaded = await h.store.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('ok');
+    if (loaded.kind !== 'ok') return;
+    expect(committed(loaded.journal, 0)).toBe(1);
+  });
+
+  it('Keep on abort: journal and partials survive, lease is released for an immediate retry', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 16]]);
+    await d.prepare(m);
+    const sink = await d.open(m.files[0]!);
+    await sink.write(0, new Uint8Array(8));
+    await d.abort();
+
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(h.files.data.get('a.bin')?.length).toBe(8);
+    expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
+
+    // A retry (same or another tab) acquires immediately and resumes from the checkpoint.
+    const retry = h.makeDestination();
+    await retry.prepare(m);
+    expect(retry.durableMeta()?.resumed).toBe(true);
+    await retry.abort();
+  });
+
+  it('rejects a corrupt journal and keeps it for explicit discard', async () => {
+    const h = await harness();
+    h.store.journals.set(TRANSFER_ID, new Uint8Array([9, 9, 9]));
+    const d = h.makeDestination();
+    await expect(d.prepare(manifest([['a.bin', 8]]))).rejects.toThrow(/unusable/);
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('corrupt');
+  });
+
+  it('rejects a journal whose fingerprint does not match the authenticated manifest', async () => {
+    const h = await harness();
+    await journalFor(h.store, h.files, [['a.bin', 8]], [0]);
+    const other = manifest([['different.bin', 8]]);
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d = h.makeDestination();
+    await expect(d.prepare(other)).rejects.toThrow(/does not match the authenticated manifest/);
+  });
+
+  it('fails closed on quota preflight and converts write-time quota exhaustion', async () => {
+    const h = await harness();
+    const m = manifest([['a.bin', 16]]);
+
+    const low = new DurableDestination({
+      createDigest: () => h.digest(),
+      files: h.files,
+      store: h.store,
+      now: () => 1_000,
+      renewMs: 0,
+      ensureSpace: async () => {
+        throw new TransferError('quota', 'need 16 bytes but only 4 are available');
+      },
+    });
+    await expect(low.prepare(m)).rejects.toMatchObject({ reason: 'quota' });
+    // The failed preflight left the lease held (prepare failed after acquiring); the real
+    // flow's abort releases it, mirror that here so the next attempt can acquire.
+    await low.abort();
+
+    const d = h.makeDestination();
+    await d.prepare(m);
+    h.files.quotaOnWrite = true;
+    const sink = await d.open(m.files[0]!);
+    await expect(sink.write(0, new Uint8Array(8))).rejects.toMatchObject({ reason: 'quota' });
+    // Fail closed: no checkpoint advanced, nothing deleted.
+    const loaded = await h.store.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('ok');
+    if (loaded.kind !== 'ok') return;
+    expect(committed(loaded.journal, 0)).toBe(0);
+    expect(h.files.data.get('a.bin')?.length ?? 0).toBe(0);
+  });
+
+  it('multi-file finalize builds a valid ZIP from the partials and removes the journal + partials', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([
+      ['folder/a.bin', 10],
+      ['folder/empty.txt', 0],
+    ]);
+    await d.prepare(m);
+    const first = await d.open(m.files[0]!);
+    await first.write(0, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    await first.write(8, new Uint8Array([9, 10]));
+    await first.close();
+    const second = await d.open(m.files[1]!);
+    await second.close();
+    await d.close();
+
+    const zipBytes = h.files.outputs.get(`sendbeam/durable/${TRANSFER_ID}/__receive.zip`);
+    expect(zipBytes).toBeDefined();
+    const view = new DataView(zipBytes!.buffer);
+    expect(view.getUint32(0, true)).toBe(0x04034b50);
+    expect(view.getUint32(zipBytes!.length - 22, true)).toBe(0x06054b50);
+    expect(hasSignature(zipBytes!, 0x02014b50)).toBe(true);
+
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(h.files.data.size).toBe(0); // consumed partials removed
+    expect(d.result()).toMatchObject({ kind: 'opfs', name: 'folder.zip', mime: 'application/zip' });
+
+    const dir = mkdtempSync(join(tmpdir(), 'sendbeam-durable-zip-'));
+    try {
+      const path = join(dir, 'folder.zip');
+      writeFileSync(path, zipBytes!);
+      expect(execFileSync('unzip', ['-t', path], { encoding: 'utf8' })).toContain('No errors');
+      expect(execFileSync('unzip', ['-p', path, 'folder/a.bin'])).toEqual(
+        Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('finalize refuses to remove the journal when a file is not fully committed', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 16]]);
+    await d.prepare(m);
+    const sink = await d.open(m.files[0]!);
+    await sink.write(0, new Uint8Array(8));
+    // Only 1 of 2 blocks committed: close() must fail closed and keep everything.
+    await expect(d.close()).rejects.toThrow(/not fully committed/);
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(h.files.data.get('a.bin')?.length).toBe(8);
+  });
+
+  it('idempotent discard removes the journal and lease without touching others', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 8]]);
+    await d.prepare(m);
+    const sink = await d.open(m.files[0]!);
+    await sink.write(0, new Uint8Array(8));
+    await d.abort();
+
+    await h.store.discard(TRANSFER_ID);
+    await h.store.discard(TRANSFER_ID); // idempotent
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
+
+    // A different transfer is untouched.
+    const otherId = 'b'.repeat(32);
+    const otherManifest: Manifest = {
+      ...manifest([['x', 1]]),
+      transferId: otherId,
+    };
+    h.store.journals.set(
+      otherId,
+      await encodeJournal(await newJournal(otherId, otherManifest, IDENTITY, IDENTITY, 1)),
+    );
+    await h.store.discard(TRANSFER_ID);
+    expect((await h.store.loadJournal(otherId)).kind).toBe('ok');
+  });
+
+  it('async fallback advances the journal only at file close (honest granularity)', async () => {
+    const h = await harness();
+    h.files.syncAvailable = false;
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 16]]);
+    await d.prepare(m);
+
+    const sink = await d.open(m.files[0]!);
+    await sink.write(0, new Uint8Array(8));
+    // No per-block checkpoint on the async path: the stream cannot flush per block.
+    let loaded = await h.store.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('ok');
+    if (loaded.kind !== 'ok') return;
+    expect(committed(loaded.journal, 0)).toBe(0);
+
+    await sink.write(8, new Uint8Array(8));
+    await sink.close();
+    loaded = await h.store.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('ok');
+    if (loaded.kind !== 'ok') return;
+    // The close flushed the stream; only now does the whole file checkpoint.
+    expect(committed(loaded.journal, 0)).toBe(2);
+    await d.close();
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+  });
+
+  it('never serializes secret material in the journal', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 8]]);
+    await d.prepare(m);
+    const sink = await d.open(m.files[0]!);
+    await sink.write(0, new Uint8Array(8));
+    const stored = h.store.journals.get(TRANSFER_ID)!;
+    const text = new TextDecoder().decode(stored);
+    const obj = JSON.parse(text) as Record<string, unknown>;
+    // The schema has exactly the journal contract keys — no invite code, session master
+    // key, directional keys, or AEAD counters can appear as fields.
+    expect(Object.keys(obj).sort()).toEqual(
+      [
+        'blockSize',
+        'checksum',
+        'createdAt',
+        'destinationIdentity',
+        'files',
+        'manifestFingerprint',
+        'protocolVersion',
+        'resumeVersion',
+        'schemaVersion',
+        'sourceIdentity',
+        'transferId',
+        'updatedAt',
+      ].sort(),
+    );
+    for (const secret of ['invite', 'master', 'sendDir', 'recvDir', 'counter', 'o2j', 'j2o']) {
+      expect(text.toLowerCase()).not.toContain(secret);
+    }
+    await d.abort();
+  });
+});

--- a/apps/web/src/lib/transfer/durable-destination.ts
+++ b/apps/web/src/lib/transfer/durable-destination.ts
@@ -1,0 +1,547 @@
+/**
+ * Browser durable receive destination (V13-PR03) — the browser twin of the CLI's
+ * DurableDestination (apps/cli/internal/transfer/durable.go). It runs inside the transfer
+ * worker so it can use `FileSystemSyncAccessHandle` where supported; verified blocks land in
+ * OPFS partials, each checkpoint advances only after the data is flushed, and the journal
+ * (IndexedDB) is the single source of resumable progress.
+ *
+ * Durability ordering (ADR 0004): verify (wire layer) → write → flush → atomic journal
+ * checkpoint → the wire ack. `Sink.write` resolves only after write+flush+commit, so the
+ * receiver's ack always follows a committed checkpoint.
+ *
+ * The async fallback (browsers without sync access handles) is honest about its limits: the
+ * stream can only be flushed at close, so a file's checkpoint advances only after its whole
+ * stream is closed — never block-by-block.
+ */
+
+import {
+  TransferError,
+  bytesToHex,
+  manifestFingerprint,
+  normalizeTransferPath,
+  sha256,
+  utf8,
+  type Digest,
+  type DurableJournal,
+  type FileEntry,
+  type JournalIdentity,
+  type Manifest,
+  type ReceiverResumeFile,
+  type ReceiverResumeState,
+  type Sink,
+} from '@sendbeam/protocol';
+import type { BrowserDestination, DestinationOutput } from './sink.js';
+import type {
+  DurableFiles,
+  DurableJournalStore,
+  PartialWriter,
+  WritableFileLike,
+} from './durable-store.js';
+import { webDestinationIdentity } from './durable-store.js';
+import {
+  centralHeader,
+  crc32Update,
+  dataDescriptor,
+  endOfCentralDirectory,
+  localHeader,
+  type ZipEntry,
+} from './zip.js';
+
+/** Metadata the host needs for lease release and the Keep/Discard failure surface. */
+export interface DurableMeta {
+  transferId: string;
+  ownerId: string;
+  resumed: boolean;
+  committedBytes: number;
+  totalBytes: number;
+}
+
+export interface DurableDestinationOptions {
+  createDigest(): Digest;
+  files: DurableFiles;
+  store: DurableJournalStore;
+  /** Injectable clock (unix ms); tests use a fixed clock with no sleeps. */
+  now?(): number;
+  /** Lease-renewal timer interval; 0 disables the timer (tests). Default 30s. */
+  renewMs?: number;
+  /** Quota preflight; defaults to a navigator.storage.estimate check. */
+  ensureSpace?(requiredBytes: number): Promise<void>;
+}
+
+const DURABLE_LEASE_RENEW_MS = 30_000;
+/** Files whose manifest path collides with the browser storage namespace fail closed. */
+const STORAGE_NAMESPACE = 'sendbeam';
+
+export class DurableDestination implements BrowserDestination {
+  private readonly createDigest: () => Digest;
+  private readonly files: DurableFiles;
+  private readonly store: DurableJournalStore;
+  private readonly now: () => number;
+  private readonly renewMs: number;
+  private readonly ensureSpace: (requiredBytes: number) => Promise<void>;
+  private readonly ownerId = randomOwnerId();
+
+  private prepared = false;
+  private closed = false;
+  private aborted = false;
+  private manifest: Manifest | undefined;
+  private journal: DurableJournal | undefined;
+  private transferId = '';
+  private resumed = false;
+  private sync = true;
+  private readonly sinks = new Map<number, DurableFileSink>();
+  private renewTimer: ReturnType<typeof setInterval> | undefined;
+  private resumeState: ReceiverResumeState | undefined;
+  private output: DestinationOutput | undefined;
+
+  constructor(options: DurableDestinationOptions) {
+    this.createDigest = options.createDigest;
+    this.files = options.files;
+    this.store = options.store;
+    this.now = options.now ?? (() => Date.now());
+    this.renewMs = options.renewMs ?? DURABLE_LEASE_RENEW_MS;
+    this.ensureSpace =
+      options.ensureSpace ?? ((required: number) => ensureSpaceInBrowser(required));
+  }
+
+  /** Revalidate the manifest, load/create the journal, acquire the lease, build the resume seed. */
+  async prepare(manifest: Manifest): Promise<void> {
+    if (this.prepared) throw new TransferError('sink_error', 'durable destination prepared twice');
+    this.prepared = true;
+    if (manifest.transferId === undefined) {
+      throw new TransferError(
+        'sink_error',
+        'durable destination requires a manifest with a transfer id',
+      );
+    }
+    for (const file of manifest.files) {
+      if (file.name === STORAGE_NAMESPACE || file.name.startsWith(`${STORAGE_NAMESPACE}/`)) {
+        throw new TransferError(
+          'sink_error',
+          `manifest path ${file.name} collides with the ${STORAGE_NAMESPACE} storage area`,
+        );
+      }
+    }
+    this.manifest = manifest;
+    this.transferId = manifest.transferId;
+
+    const loaded = await this.store.loadJournal(this.transferId);
+    if (loaded.kind === 'corrupt') {
+      throw new TransferError(
+        'sink_error',
+        `durable journal for ${this.transferId} is unusable (${loaded.error}); nothing was deleted — discard it to reset`,
+      );
+    }
+    if (loaded.kind === 'none') {
+      const destination = await webDestinationIdentity(origin());
+      const source = await unboundSourceIdentity();
+      const journal = await this.store.createJournal(
+        this.transferId,
+        manifest,
+        source,
+        destination,
+        this.now(),
+      );
+      this.journal = journal;
+    } else {
+      const journal = loaded.journal;
+      // Revalidate every user-editable claim against the authenticated manifest (ADR 0004 §3).
+      const fingerprint = await manifestFingerprint(manifest);
+      if (journal.manifestFingerprint !== fingerprint) {
+        throw new TransferError(
+          'sink_error',
+          `journal ${this.transferId} does not match the authenticated manifest; refusing to guess — discard it`,
+        );
+      }
+      const destination = await webDestinationIdentity(origin());
+      if (
+        journal.destinationIdentity.version !== destination.version ||
+        journal.destinationIdentity.value !== destination.value
+      ) {
+        throw new TransferError(
+          'sink_error',
+          'journal was created for a different destination; refusing to resume — discard it',
+        );
+      }
+      this.journal = journal;
+      this.resumed = true;
+    }
+
+    // Atomic test-and-set lease: concurrent tabs and stale holders fail closed; an expired
+    // lease is taken over deterministically.
+    const lease = await this.store.acquireLease(this.transferId, this.ownerId, this.now());
+    if (lease.kind === 'contended') {
+      throw new TransferError(
+        'sink_error',
+        'another window is already receiving this transfer; close it before retrying',
+      );
+    }
+
+    if (this.resumed) {
+      await this.buildResumeState();
+    }
+
+    // Decide the write path once: sync access handles in this worker context, else the
+    // honest async fallback that only checkpoints at file close.
+    this.sync = await this.files.probeSync(this.transferId);
+
+    const total = manifest.totalSize;
+    const committed = this.committedBytesTotal();
+    await this.ensureSpace(Math.max(0, total - committed));
+
+    if (this.renewMs > 0) {
+      this.renewTimer = setInterval(() => {
+        void this.store.renewLease(this.transferId, this.ownerId, this.now()).catch(() => {});
+      }, this.renewMs);
+    }
+  }
+
+  /** The resume seed the wire receiver applies after the manifest matches the journal. */
+  resumeStateFor(): ReceiverResumeState | undefined {
+    return this.resumeState;
+  }
+
+  async open(file: FileEntry): Promise<Sink> {
+    if (this.closed || this.aborted) {
+      throw new TransferError('sink_error', 'durable destination is closed');
+    }
+    const journal = this.journal;
+    const manifest = this.manifest;
+    if (!journal || !manifest) {
+      throw new TransferError('sink_error', 'durable destination opened before prepare');
+    }
+    const state = journal.files[file.idx];
+    if (!state) throw new TransferError('sink_error', `no journal entry for file ${file.idx}`);
+    const rel = normalizeTransferPath(file.name);
+    const committedBytes = Math.min(state.committedBlocks * state.blockSize, state.size);
+    const writer = await this.files.openWriter(this.transferId, rel, committedBytes, this.sync);
+    const sink = new DurableFileSink({
+      destination: this,
+      fileIdx: file.idx,
+      writer,
+      sync: this.sync,
+      blockSize: state.blockSize,
+      blocks: state.blocks,
+      startBlocks: state.committedBlocks,
+    });
+    this.sinks.set(file.idx, sink);
+    return sink;
+  }
+
+  /**
+   * Finalize — runs only after the wire receiver verified the whole transfer. The journal
+   * (and lease) are removed only after the deliverable is fully produced; any failure keeps
+   * every partial and the journal intact for retry or explicit discard.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.clearRenew();
+    if (this.aborted) return;
+    const journal = this.journal;
+    const manifest = this.manifest;
+    if (!journal || !manifest) return;
+    // Whole-transfer verification already happened (the receiver calls close() after
+    // onComplete); double-check no checkpoint lags so finalization is never partial.
+    for (let i = 0; i < journal.files.length; i++) {
+      const f = journal.files[i]!;
+      if (f.committedBlocks !== f.blocks) {
+        throw new TransferError('sink_error', `file ${i} not fully committed at finalize`);
+      }
+    }
+    if (manifest.files.length === 1) {
+      // The verified partial IS the deliverable; the host reads it and cleans it up.
+      // The journal is removed only after whole-transfer verification, then the output is
+      // advertised — never before.
+      const file = manifest.files[0]!;
+      const key = this.files.partialKey(this.transferId, normalizeTransferPath(file.name));
+      await this.store.discard(this.transferId);
+      this.output = { kind: 'opfs', key, name: file.name, mime: file.mime };
+      return;
+    }
+    // Multi-file: assemble a store-only ZIP from the verified partials, then remove the
+    // journal and the consumed partials — never before the ZIP is fully written and closed.
+    const zip = await this.buildZip();
+    await this.store.discard(this.transferId);
+    // Best-effort cleanup: the ZIP is the verified deliverable, so leftover partials after a
+    // removal failure are harmless orphans rather than a reason to fail a done transfer.
+    for (const file of manifest.files) {
+      await this.files
+        .removePartial(this.transferId, normalizeTransferPath(file.name))
+        .catch(() => {});
+    }
+    this.output = { kind: 'opfs', key: zip.key, name: zip.name, mime: 'application/zip' };
+  }
+
+  /**
+   * Abort deliberately KEEPS the journal and partials at their last durable checkpoint (they
+   * are the only resumable copy; ADR 0004 §8) and releases the lease so a retry — same or
+   * other tab — can acquire it immediately instead of waiting out the TTL.
+   */
+  async abort(): Promise<void> {
+    if (this.aborted) return;
+    this.aborted = true;
+    this.clearRenew();
+    for (const sink of this.sinks.values()) {
+      await sink.abort().catch(() => {});
+    }
+    if (this.prepared && !this.closed && this.transferId !== '') {
+      await this.store.releaseLease(this.transferId, this.ownerId).catch(() => {});
+    }
+  }
+
+  result(): DestinationOutput | undefined {
+    return this.output;
+  }
+
+  durableMeta(): DurableMeta | undefined {
+    if (!this.journal) return undefined;
+    return {
+      transferId: this.transferId,
+      ownerId: this.ownerId,
+      resumed: this.resumed,
+      committedBytes: this.committedBytesTotal(),
+      totalBytes: this.manifest?.totalSize ?? 0,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+
+  private committedBytesTotal(): number {
+    const journal = this.journal;
+    if (!journal) return 0;
+    let total = 0;
+    for (const file of journal.files) {
+      total += Math.min(file.committedBlocks * file.blockSize, file.size);
+    }
+    return total;
+  }
+
+  /** Advance one file's checkpoint after its data is flushed; the only journal mutation. */
+  async commitBlocks(fileIdx: number, blocks: number): Promise<void> {
+    const journal = this.journal;
+    if (!journal) throw new TransferError('sink_error', 'durable destination is not prepared');
+    this.journal = await this.store.commitBlocks(
+      journal,
+      fileIdx,
+      blocks,
+      this.now(),
+      this.ownerId,
+    );
+  }
+
+  /** Fail-closed resume seed: partials must back every checkpoint, prefixes are re-hashed. */
+  private async buildResumeState(): Promise<void> {
+    const journal = this.journal!;
+    const files = new Map<number, ReceiverResumeFile>();
+    for (let i = 0; i < journal.files.length; i++) {
+      const state = journal.files[i]!;
+      const digest = this.createDigest();
+      if (state.committedBlocks > 0) {
+        const committed = Math.min(state.committedBlocks * state.blockSize, state.size);
+        const size = await this.files.partialSize(
+          this.transferId,
+          normalizeTransferPath(state.name),
+        );
+        if (size === undefined || size < committed) {
+          throw new TransferError(
+            'sink_error',
+            `journal ${this.transferId} file ${state.name}: partial data missing or truncated; refusing to resume — discard it`,
+          );
+        }
+        await this.files.readPrefix(
+          this.transferId,
+          normalizeTransferPath(state.name),
+          committed,
+          digest,
+        );
+      }
+      files.set(i, { haveBlocks: state.committedBlocks, seedDigest: digest });
+    }
+    this.resumeState = { transferId: this.transferId, files };
+  }
+
+  private async buildZip(): Promise<{ key: string; name: string }> {
+    const manifest = this.manifest!;
+    const journal = this.journal!;
+    const name = zipName(manifest);
+    const { key, writable } = await this.files.openOutput(this.transferId, '__receive.zip');
+    let position = 0;
+    const entries: ZipEntry[] = [];
+    try {
+      for (const file of manifest.files) {
+        const rel = normalizeTransferPath(file.name);
+        const entryName = new TextEncoder().encode(rel);
+        const offset = position;
+        await writeAt(writable, position, localHeader(entryName));
+        position += 30 + entryName.length;
+        let crc = 0xffffffff;
+        let size = 0;
+        await this.files.readPartialChunks(this.transferId, rel, async (chunk) => {
+          await writeAt(writable, position, chunk);
+          position += chunk.length;
+          crc = crc32Update(crc, chunk);
+          size += chunk.length;
+        });
+        const expected = journal.files[file.idx]!.size;
+        if (size !== expected) {
+          throw new TransferError(
+            'sink_error',
+            `partial ${rel} size mismatch at finalize (have ${size}, want ${expected})`,
+          );
+        }
+        await writeAt(writable, position, dataDescriptor((crc ^ 0xffffffff) >>> 0, size));
+        position += 16;
+        entries.push({ name: entryName, crc: (crc ^ 0xffffffff) >>> 0, size, offset });
+      }
+      const centralOffset = position;
+      for (const entry of entries) {
+        const header = centralHeader(entry);
+        await writeAt(writable, position, header);
+        position += header.length;
+      }
+      const centralSize = position - centralOffset;
+      await writeAt(
+        writable,
+        position,
+        endOfCentralDirectory(entries.length, centralSize, centralOffset),
+      );
+      await writable.close();
+    } catch (e) {
+      await writable.abort?.().catch(() => {});
+      throw e;
+    }
+    return { key, name };
+  }
+
+  private clearRenew(): void {
+    if (this.renewTimer !== undefined) {
+      clearInterval(this.renewTimer);
+      this.renewTimer = undefined;
+    }
+  }
+}
+
+interface DurableFileSinkOptions {
+  destination: DurableDestination;
+  fileIdx: number;
+  writer: PartialWriter;
+  sync: boolean;
+  blockSize: number;
+  blocks: number;
+  /** Checkpoint already claimed by the journal when this sink opened (resume baseline). */
+  startBlocks: number;
+}
+
+/** One file's sink: write → flush → journal checkpoint, in that order, before resolving. */
+class DurableFileSink implements Sink {
+  private readonly destination: DurableDestination;
+  private readonly fileIdx: number;
+  private readonly writer: PartialWriter;
+  private readonly sync: boolean;
+  private readonly blocks: number;
+  private readonly startBlocks: number;
+  private written = 0;
+  private closed = false;
+
+  constructor(options: DurableFileSinkOptions) {
+    this.destination = options.destination;
+    this.fileIdx = options.fileIdx;
+    this.writer = options.writer;
+    this.sync = options.sync;
+    this.blocks = options.blocks;
+    this.startBlocks = options.startBlocks;
+  }
+
+  async write(offset: number, bytes: Uint8Array): Promise<void> {
+    if (this.closed) throw new TransferError('sink_error', 'write after sink close');
+    try {
+      await this.writer.write(offset, bytes);
+    } catch (e) {
+      throw asQuotaOrSinkError(e);
+    }
+    this.written++;
+    if (this.sync) {
+      // Sync path: the data is flushed; advance the checkpoint before the wire ack.
+      await this.destination.commitBlocks(this.fileIdx, this.startBlocks + this.written);
+    }
+    // Async path: the stream only flushes at close, so the checkpoint advances there.
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    try {
+      await this.writer.close();
+    } catch (e) {
+      throw asQuotaOrSinkError(e);
+    }
+    this.closed = true;
+    if (!this.sync) {
+      // The stream closed (flush barrier); the whole file is now durable and checkpoints.
+      await this.destination.commitBlocks(this.fileIdx, this.blocks);
+    }
+  }
+
+  async abort(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    await this.writer.abort().catch(() => {});
+  }
+}
+
+async function writeAt(w: WritableFileLike, position: number, data: Uint8Array): Promise<void> {
+  await w.write({ type: 'write', position, data });
+}
+
+function zipName(manifest: Manifest): string {
+  const top = manifest.files[0]!.name.split('/')[0]!;
+  if (manifest.files.every((file) => file.name.startsWith(`${top}/`))) return `${top}.zip`;
+  return 'sendbeam-files.zip';
+}
+
+/** Wrap a storage failure as a TransferError, mapping quota exhaustion to the quota reason. */
+function asQuotaOrSinkError(e: unknown): TransferError {
+  if (e instanceof TransferError) return e;
+  if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+    return new TransferError(
+      'quota',
+      'browser storage quota exhausted; partial data is kept and resumable',
+    );
+  }
+  return new TransferError('sink_error', e instanceof Error ? e.message : String(e));
+}
+
+/** Default quota preflight over navigator.storage.estimate; no-op when unavailable. */
+async function ensureSpaceInBrowser(requiredBytes: number): Promise<void> {
+  const storage = (navigator as Navigator & { storage?: StorageManager }).storage;
+  if (!storage || typeof storage.estimate !== 'function') return;
+  const estimate = await storage.estimate();
+  if (estimate.quota === undefined) return;
+  const available = Math.max(0, estimate.quota - (estimate.usage ?? 0));
+  if (available < requiredBytes) {
+    throw new TransferError(
+      'quota',
+      `need ${requiredBytes} bytes but only ${available} are available`,
+    );
+  }
+}
+
+function origin(): string {
+  try {
+    return globalThis.location?.origin ?? 'web';
+  } catch {
+    return 'web';
+  }
+}
+
+function randomOwnerId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return bytesToHex(bytes);
+}
+
+/** The PR02/PR03 source claim: peer identity binding is PR07, so the envelope is honest. */
+async function unboundSourceIdentity(): Promise<JournalIdentity> {
+  const sum = await sha256(utf8('sendbeam/source-unbound-v1'));
+  return { version: 1, value: bytesToHex(sum) };
+}

--- a/apps/web/src/lib/transfer/durable-store.test.ts
+++ b/apps/web/src/lib/transfer/durable-store.test.ts
@@ -1,0 +1,536 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FrameType, type Manifest } from '@sendbeam/protocol';
+import {
+  DURABLE_LEASE_TTL_MS,
+  durableOpfsFiles,
+  indexedDbDurableStore,
+  type DurableJournalStore,
+  type DurableFiles,
+} from './durable-store.js';
+import type { WritableFileLike } from './stream-sink.js';
+
+// ---------------------------------------------------------------------------
+// Minimal but faithful in-memory IndexedDB for the browser-backend tests. Requests
+// resolve on microtasks; a readwrite transaction completes after its requests, so the
+// store's await-request-then-await-commit ordering is exercised for real.
+// ---------------------------------------------------------------------------
+
+type EventHandler = ((ev: Event) => void) | null;
+
+class FakeRequest {
+  result: unknown = undefined;
+  error: DOMException | null = null;
+  onsuccess: EventHandler = null;
+  onerror: EventHandler = null;
+  constructor(
+    private readonly tx: FakeTransaction,
+    private readonly run: () => void,
+  ) {}
+  fire(): void {
+    this.run();
+    // Success handlers run before the transaction completion microtask is queued, so a
+    // store that awaits the request before registering tx.oncomplete still observes it.
+    if (this.error) this.onerror?.(new Event('error'));
+    else this.onsuccess?.(new Event('success'));
+    this.tx.requestDone();
+  }
+}
+
+class FakeObjectStore {
+  constructor(
+    private readonly tx: FakeTransaction,
+    private readonly data: Map<string, unknown>,
+  ) {}
+  get(key: string): FakeRequest {
+    return this.tx.request(() => this.data.get(key));
+  }
+  put(value: unknown, key: string): FakeRequest {
+    return this.tx.request(() => void this.data.set(key, value));
+  }
+  delete(key: string): FakeRequest {
+    return this.tx.request(() => void this.data.delete(key));
+  }
+  getAll(): FakeRequest {
+    return this.tx.request(() => [...this.data.values()]);
+  }
+}
+
+class FakeTransaction {
+  oncomplete: EventHandler = null;
+  onerror: EventHandler = null;
+  onabort: EventHandler = null;
+  private pending = 0;
+  private settled = false;
+  private aborted = false;
+  constructor(private readonly stores: Map<string, Map<string, unknown>>) {}
+  objectStore(name: string): FakeObjectStore {
+    return new FakeObjectStore(this, this.stores.get(name)!);
+  }
+  request<T>(run: () => T): FakeRequest {
+    const req = new FakeRequest(this, () => {
+      req.result = run();
+    });
+    this.pending++;
+    queueMicrotask(() => req.fire());
+    return req;
+  }
+  requestDone(): void {
+    this.pending--;
+    if (this.pending === 0 && !this.aborted) {
+      queueMicrotask(() => {
+        if (this.settled) return;
+        this.settled = true;
+        this.oncomplete?.(new Event('complete'));
+      });
+    }
+  }
+  abort(): void {
+    if (this.aborted) return;
+    this.aborted = true;
+    queueMicrotask(() => {
+      if (this.settled) return;
+      this.settled = true;
+      this.onabort?.(new Event('abort'));
+      this.onerror?.(new Event('error'));
+    });
+  }
+}
+
+class FakeDatabase {
+  readonly objectStoreNames = {
+    contains: (name: string) => this.stores.has(name),
+  };
+  constructor(private readonly stores: Map<string, Map<string, unknown>>) {}
+  createObjectStore(name: string): void {
+    if (!this.stores.has(name)) this.stores.set(name, new Map());
+  }
+  transaction(names: string[], mode: string): FakeTransaction {
+    void mode; // the fake serializes every readwrite transaction on the same store map
+    const selected = new Map<string, Map<string, unknown>>();
+    for (const name of names) selected.set(name, this.stores.get(name)!);
+    return new FakeTransaction(selected);
+  }
+  close(): void {}
+}
+
+class FakeOpenRequest {
+  result: FakeDatabase | undefined;
+  error: DOMException | null = null;
+  onupgradeneeded: EventHandler = null;
+  onsuccess: EventHandler = null;
+  onerror: EventHandler = null;
+}
+
+interface FakeIndexedDB {
+  open(name: string, version: number): FakeOpenRequest;
+  readonly db: FakeDatabase;
+}
+
+async function readLease(
+  idb: FakeIndexedDB,
+  transferId: string,
+): Promise<{ transferId: string; ownerId: string; expiresAt: number } | undefined> {
+  const tx = idb.db.transaction(['leases'], 'readwrite');
+  const req = tx.objectStore('leases').get(transferId);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return req.result as { transferId: string; ownerId: string; expiresAt: number } | undefined;
+}
+
+function makeFakeIndexedDB(): FakeIndexedDB {
+  const stores = new Map<string, Map<string, unknown>>();
+  const db = new FakeDatabase(stores);
+  return {
+    db,
+    open() {
+      const req = new FakeOpenRequest();
+      queueMicrotask(() => {
+        // Real IDB exposes the database on the request before the upgrade handler runs.
+        req.result = db;
+        for (const name of ['journals', 'leases']) db.createObjectStore(name);
+        req.onupgradeneeded?.(new Event('upgradeneeded'));
+        req.onsuccess?.(new Event('success'));
+      });
+      return req;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+function manifest(names: Array<[string, number]>): Manifest {
+  return {
+    type: FrameType.Manifest,
+    transferId: 'a'.repeat(32),
+    files: names.map(([name, size], idx) => ({
+      idx,
+      name,
+      size,
+      mime: 'application/octet-stream',
+      lastModified: 0,
+      blockSize: 8,
+      blocks: Math.ceil(size / 8),
+      fileDigest: 'a'.repeat(64),
+    })),
+    totalSize: names.reduce((total, [, size]) => total + size, 0),
+  };
+}
+
+const TRANSFER_ID = 'a'.repeat(32);
+const OWNER_A = 'a'.repeat(16);
+const OWNER_B = 'b'.repeat(16);
+const partKey = (rel: string): string => `sendbeam/durable/${TRANSFER_ID}/${rel}.part`;
+
+afterEach(() => vi.unstubAllGlobals());
+
+// ---------------------------------------------------------------------------
+// IndexedDB journal + lease store
+// ---------------------------------------------------------------------------
+
+describe('indexedDbDurableStore', () => {
+  function store(): DurableJournalStore {
+    const idb = makeFakeIndexedDB();
+    vi.stubGlobal('indexedDB', idb);
+    return indexedDbDurableStore();
+  }
+
+  it('round-trips a journal through real encode/decode with checksum verification', async () => {
+    const s = store();
+    const loaded = await s.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('none');
+
+    const created = await s.createJournal(
+      TRANSFER_ID,
+      manifest([['a.bin', 10]]),
+      { version: 1, value: '0'.repeat(64) },
+      { version: 1, value: '1'.repeat(64) },
+      1_000,
+    );
+    expect(created.files[0]!.committedBlocks).toBe(0);
+
+    const reloaded = await s.loadJournal(TRANSFER_ID);
+    expect(reloaded.kind).toBe('ok');
+    if (reloaded.kind !== 'ok') return;
+    expect(reloaded.journal.transferId).toBe(TRANSFER_ID);
+    expect(reloaded.journal.manifestFingerprint).toBe(created.manifestFingerprint);
+  });
+
+  it('fails closed on a corrupt journal and never deletes it', async () => {
+    const s = store();
+    // Opening the store creates the object stores.
+    expect((await s.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    const idb = (globalThis as unknown as { indexedDB: FakeIndexedDB }).indexedDB;
+    const tx = idb.db.transaction(['journals'], 'readwrite');
+    tx.objectStore('journals').put(new Uint8Array([1, 2, 3, 4]), TRANSFER_ID);
+    // Let the write land.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const loaded = await s.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('corrupt');
+    // Still present for explicit discard.
+    const again = await s.loadJournal(TRANSFER_ID);
+    expect(again.kind).toBe('corrupt');
+  });
+
+  it('advances a checkpoint only when the caller still owns the lease', async () => {
+    const s = store();
+    await s.createJournal(
+      TRANSFER_ID,
+      manifest([['a.bin', 16]]),
+      { version: 1, value: '0'.repeat(64) },
+      { version: 1, value: '1'.repeat(64) },
+      1_000,
+    );
+    expect((await s.acquireLease(TRANSFER_ID, OWNER_A, 1_000)).kind).toBe('acquired');
+
+    const loaded = await s.loadJournal(TRANSFER_ID);
+    if (loaded.kind !== 'ok') throw new Error('expected journal');
+    const j = await s.commitBlocks(loaded.journal, 0, 1, 2_000, OWNER_A);
+    expect(j.files[0]!.committedBlocks).toBe(1);
+
+    // A different owner (or a discarded lease) must not advance the journal.
+    await expect(s.commitBlocks(j, 0, 2, 3_000, OWNER_B)).rejects.toThrow(/lease lost/);
+    const reloaded = await s.loadJournal(TRANSFER_ID);
+    expect(reloaded.kind).toBe('ok');
+    if (reloaded.kind !== 'ok') return;
+    expect(reloaded.journal.files[0]!.committedBlocks).toBe(1);
+  });
+
+  it('serializes lease acquisition: acquired → contended → stale-taken on TTL expiry', async () => {
+    const s = store();
+    await s.createJournal(
+      TRANSFER_ID,
+      manifest([['a.bin', 8]]),
+      { version: 1, value: '0'.repeat(64) },
+      { version: 1, value: '1'.repeat(64) },
+      1_000,
+    );
+    expect((await s.acquireLease(TRANSFER_ID, OWNER_A, 1_000)).kind).toBe('acquired');
+    // Second tab, same owner: renewed (re-entry).
+    expect((await s.acquireLease(TRANSFER_ID, OWNER_A, 1_100)).kind).toBe('renewed');
+    // Another tab while unexpired: contended.
+    expect((await s.acquireLease(TRANSFER_ID, OWNER_B, 1_100)).kind).toBe('contended');
+    // After the (renewed) TTL the lease is stale and deterministically taken over.
+    expect(
+      (await s.acquireLease(TRANSFER_ID, OWNER_B, 1_100 + DURABLE_LEASE_TTL_MS + 1)).kind,
+    ).toBe('stale-taken');
+    // The new owner can now commit.
+    const j = await s.loadJournal(TRANSFER_ID);
+    if (j.kind !== 'ok') throw new Error('expected journal');
+    await s.commitBlocks(j.journal, 0, 1, 1_100 + DURABLE_LEASE_TTL_MS + 2, OWNER_B);
+  });
+
+  it('renews, releases (owner-bound), and discards idempotently', async () => {
+    const s = store();
+    await s.createJournal(
+      TRANSFER_ID,
+      manifest([['a.bin', 8]]),
+      { version: 1, value: '0'.repeat(64) },
+      { version: 1, value: '1'.repeat(64) },
+      1_000,
+    );
+    await s.acquireLease(TRANSFER_ID, OWNER_A, 1_000);
+    await s.renewLease(TRANSFER_ID, OWNER_A, 50_000);
+    // The renewal moved the expiry forward.
+    const idb = (globalThis as unknown as { indexedDB: FakeIndexedDB }).indexedDB;
+    expect(await readLease(idb, TRANSFER_ID)).toEqual({
+      transferId: TRANSFER_ID,
+      ownerId: OWNER_A,
+      expiresAt: 50_000 + DURABLE_LEASE_TTL_MS,
+    });
+
+    // A non-owner cannot release the lease.
+    await s.releaseLease(TRANSFER_ID, OWNER_B);
+    expect((await readLease(idb, TRANSFER_ID))?.ownerId).toBe(OWNER_A);
+
+    await s.releaseLease(TRANSFER_ID, OWNER_A);
+    await s.discard(TRANSFER_ID);
+    await s.discard(TRANSFER_ID); // idempotent
+    expect((await s.loadJournal(TRANSFER_ID)).kind).toBe('none');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPFS partial-data layer
+// ---------------------------------------------------------------------------
+
+/** In-memory OPFS handle tree with optional sync-access-handle availability. */
+function fakeStorage(opts: { sync?: boolean; quota?: number } = {}) {
+  const syncAvailable = opts.sync ?? true;
+  const files = new Map<string, Uint8Array>();
+  const writableStreams = new Map<string, FakeWritable>();
+
+  class FakeSyncHandle {
+    private size: number;
+    constructor(private readonly key: string) {
+      this.size = files.get(key)?.length ?? 0;
+    }
+    write(buffer: Uint8Array, options: { at?: number }): number {
+      const at = options.at ?? 0;
+      const cur = files.get(this.key) ?? new Uint8Array();
+      const end = at + buffer.length;
+      const grown = new Uint8Array(Math.max(end, cur.length));
+      grown.set(cur);
+      grown.set(buffer, at);
+      files.set(this.key, grown);
+      this.size = grown.length;
+      return buffer.length;
+    }
+    flush(): void {
+      // No-op for this test layer; flush-before-commit ordering is asserted at the
+      // destination layer where the store and files share an event log.
+    }
+    getSize(): number {
+      return this.size;
+    }
+    truncate(size: number): void {
+      const cur = files.get(this.key) ?? new Uint8Array();
+      files.set(this.key, cur.slice(0, size));
+      this.size = size;
+    }
+    close(): void {}
+  }
+
+  const makeFileHandle = (key: string): FileSystemHandle =>
+    ({
+      kind: 'file',
+      getFile: async () => {
+        const blob = files.get(key) ?? new Uint8Array();
+        return new File(
+          [blob.buffer.slice(blob.byteOffset, blob.byteOffset + blob.byteLength) as ArrayBuffer],
+          key,
+        );
+      },
+      createWritable: async () => {
+        const writable = new FakeWritable();
+        writableStreams.set(key, writable);
+        return writable;
+      },
+      createSyncAccessHandle: async () => {
+        if (!syncAvailable) throw new TypeError('sync access handles unavailable');
+        return new FakeSyncHandle(key);
+      },
+    }) as unknown as FileSystemHandle;
+
+  const join = (prefix: string, name: string): string =>
+    prefix === '' ? name : `${prefix}/${name}`;
+  const makeDir = (prefix: string): FileSystemDirectoryHandle => {
+    const dir = {
+      kind: 'directory',
+      getDirectoryHandle: (name: string, options: { create?: boolean }) => {
+        void options;
+        return Promise.resolve(makeDir(join(prefix, name)));
+      },
+      getFileHandle: (name: string, options: { create?: boolean }) => {
+        const key = join(prefix, name);
+        if (!options.create && !files.has(key)) throw new DOMException('missing', 'NotFoundError');
+        if (options.create && !files.has(key)) files.set(key, new Uint8Array()); // create-on-open
+        return Promise.resolve(makeFileHandle(key));
+      },
+      removeEntry: (name: string, options: { recursive?: boolean } = {}) => {
+        const key = join(prefix, name);
+        if (options.recursive) {
+          for (const existing of [...files.keys()]) {
+            if (existing.startsWith(`${key}/`)) files.delete(existing);
+          }
+        }
+        files.delete(key);
+        return Promise.resolve();
+      },
+      entries: () => {
+        const children = new Map<string, { kind: 'directory' | 'file' }>();
+        for (const key of files.keys()) {
+          if (prefix !== '' && !key.startsWith(`${prefix}/`)) continue;
+          const rest = prefix === '' ? key : key.slice(prefix.length + 1);
+          const slash = rest.indexOf('/');
+          const name = slash === -1 ? rest : rest.slice(0, slash);
+          const kind: 'directory' | 'file' = slash === -1 ? 'file' : 'directory';
+          children.set(name, { kind });
+        }
+        // Directory children are real directory handles so walk() can recurse; file
+        // children carry the read/write surface walk() and listRelPaths need.
+        const pairs: Array<[string, FileSystemHandle]> = [...children.entries()].map(
+          ([name, meta]) =>
+            meta.kind === 'directory'
+              ? [name, makeDir(join(prefix, name))]
+              : [name, makeFileHandle(join(prefix, name))],
+        );
+        return rootIterator(pairs);
+      },
+    } as unknown as FileSystemDirectoryHandle;
+    return dir;
+  };
+
+  vi.stubGlobal('navigator', {
+    storage: {
+      getDirectory: async () => makeDir(''),
+      ...(opts.quota !== undefined
+        ? {
+            estimate: async () => ({ quota: opts.quota, usage: 0 }),
+          }
+        : {}),
+    },
+  });
+
+  return { files, writableStreams };
+}
+
+class FakeWritable implements WritableFileLike {
+  bytes = new Uint8Array();
+  closed = false;
+  async write(request: { type: 'write'; position: number; data: Uint8Array }): Promise<void> {
+    const end = request.position + request.data.length;
+    if (end > this.bytes.length) {
+      const grown = new Uint8Array(end);
+      grown.set(this.bytes);
+      this.bytes = grown;
+    }
+    this.bytes.set(request.data, request.position);
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+function rootIterator(
+  entries: Array<[string, FileSystemHandle]>,
+): AsyncIterableIterator<[string, FileSystemHandle]> {
+  let i = 0;
+  return {
+    async next() {
+      if (i >= entries.length) return { done: true, value: undefined };
+      return { done: false, value: entries[i++]! };
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  } as AsyncIterableIterator<[string, FileSystemHandle]>;
+}
+
+describe('durableOpfsFiles', () => {
+  it('writes through the sync path with flush before every checkpoint and truncates stale tails', async () => {
+    const { files } = fakeStorage({ sync: true });
+    const f: DurableFiles = durableOpfsFiles();
+    expect(await f.probeSync(TRANSFER_ID)).toBe(true);
+
+    const writer = await f.openWriter(TRANSFER_ID, 'folder/a.bin', 0, true);
+    await writer.write(0, new Uint8Array([1, 2, 3]));
+    await writer.write(8, new Uint8Array([4]));
+    await writer.close();
+    expect(files.get(partKey('folder/a.bin'))).toEqual(new Uint8Array([1, 2, 3, 0, 0, 0, 0, 0, 4]));
+  });
+
+  it('fails closed when a partial is missing or shorter than the checkpoint claims', async () => {
+    fakeStorage({ sync: true });
+    const f: DurableFiles = durableOpfsFiles();
+    await expect(f.openWriter(TRANSFER_ID, 'a.bin', 16, true)).rejects.toThrow(/truncated/);
+  });
+
+  it('uses the async fallback and reports sync unavailability honestly', async () => {
+    const { writableStreams } = fakeStorage({ sync: false });
+    const f: DurableFiles = durableOpfsFiles();
+    expect(await f.probeSync(TRANSFER_ID)).toBe(false);
+    const writer = await f.openWriter(TRANSFER_ID, 'a.bin', 0, false);
+    await writer.write(0, new Uint8Array([9]));
+    await writer.close();
+    expect(writableStreams.get(partKey('a.bin'))?.bytes).toEqual(new Uint8Array([9]));
+    expect(writableStreams.get(partKey('a.bin'))?.closed).toBe(true);
+  });
+
+  it('lists, reads prefixes, streams chunks, and removes partials and data dirs', async () => {
+    fakeStorage({ sync: true });
+    const f: DurableFiles = durableOpfsFiles();
+    const writer = await f.openWriter(TRANSFER_ID, 'folder/a.bin', 0, true);
+    await writer.write(0, new Uint8Array([1, 2, 3]));
+    await writer.write(3, new Uint8Array([4, 5, 6, 7]));
+    await writer.close();
+    await f.openWriter(TRANSFER_ID, 'b.bin', 0, true).then((w) => w.close());
+
+    expect(await f.listRelPaths(TRANSFER_ID)).toEqual(['b.bin', 'folder/a.bin']);
+    expect(await f.partialSize(TRANSFER_ID, 'folder/a.bin')).toBe(7);
+
+    const digest = {
+      parts: [] as Uint8Array[],
+      update(b: Uint8Array): void {
+        this.parts.push(b.slice());
+      },
+      hexDigest: async (): Promise<string> => '',
+    };
+    await f.readPrefix(TRANSFER_ID, 'folder/a.bin', 5, digest);
+    expect(digest.parts).toEqual([new Uint8Array([1, 2, 3, 4, 5])]);
+
+    const chunks: Uint8Array[] = [];
+    await f.readPartialChunks(TRANSFER_ID, 'folder/a.bin', (c) => {
+      chunks.push(c.slice());
+    });
+    expect(chunks).toEqual([new Uint8Array([1, 2, 3, 4, 5, 6, 7])]);
+
+    await f.removePartial(TRANSFER_ID, 'b.bin');
+    expect(await f.listRelPaths(TRANSFER_ID)).toEqual(['folder/a.bin']);
+
+    await f.removeData(TRANSFER_ID);
+    await f.removeData(TRANSFER_ID); // idempotent
+    expect(await f.partialSize(TRANSFER_ID, 'folder/a.bin')).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/transfer/durable-store.ts
+++ b/apps/web/src/lib/transfer/durable-store.ts
@@ -1,0 +1,643 @@
+/**
+ * Durable browser receive storage (V13-PR03) — the browser twin of the CLI's
+ * `<out>/.sendbeam` store (apps/cli/internal/transfer/durable.go), implementing the same
+ * ADR 0004 contract over OPFS data + IndexedDB metadata:
+ *
+ *   OPFS:  sendbeam/durable/<transferId>/<rel>.part   (verified partial data)
+ *   IDB:   sendbeam-durable → journals, leases        (transactional journal + lease)
+ *
+ * Everything the destination touches goes through the {@link DurableFiles} and
+ * {@link DurableJournalStore} interfaces so the browser backend and deterministic test
+ * fakes are interchangeable. The journal contract (schema, checksum, fingerprint, block
+ * granularity) is `@sendbeam/protocol`'s journal module — never forked.
+ *
+ * The lease is the only new browser-specific primitive: an atomic IDB test-and-set record
+ * (transferId → ownerId, expiresAt) that serializes concurrent tabs, survives reloads and
+ * worker death via its TTL, and is renewed by journal commits plus a bounded timer.
+ */
+
+import {
+  bytesToHex,
+  commitBlocks as advanceJournal,
+  decodeJournal,
+  encodeJournal,
+  newJournal,
+  sha256,
+  TransferError,
+  utf8,
+  type Digest,
+  type DurableJournal,
+  type JournalIdentity,
+  type Manifest,
+} from '@sendbeam/protocol';
+
+/** OPFS root namespace for durable receive data. */
+export const DURABLE_ROOT = 'sendbeam/durable';
+/** IndexedDB database and store names for journal metadata + leases. */
+export const DURABLE_DB = 'sendbeam-durable';
+export const DURABLE_JOURNALS_STORE = 'journals';
+export const DURABLE_LEASES_STORE = 'leases';
+/** How long a lease survives without renewal; worker death recovers after this. */
+export const DURABLE_LEASE_TTL_MS = 120_000;
+
+/** The partial-data layer: verified block storage under the OPFS durable root. */
+export interface DurableFiles {
+  /** Resolve (and optionally create) the per-transfer data directory. */
+  dataDir(transferId: string, create: boolean): Promise<FileSystemDirectoryHandle>;
+  /** The OPFS key (path under the OPFS root) for one canonical manifest path. */
+  partialKey(transferId: string, relPath: string): string;
+  /**
+   * Probe whether sync access handles are usable in this context (dedicated workers on
+   * Chromium/Firefox). Deterministic: returns false when unavailable, never throws.
+   */
+  probeSync(transferId: string): Promise<boolean>;
+  /**
+   * Open a writer for one partial. When `committedBytes > 0` the partial must exist and be
+   * at least that long (fail closed otherwise), and a stale tail beyond the checkpoint is
+   * truncated away so unclaimed bytes are re-transferred, never trusted.
+   */
+  openWriter(
+    transferId: string,
+    relPath: string,
+    committedBytes: number,
+    sync: boolean,
+  ): Promise<PartialWriter>;
+  /** Size of one partial file, or undefined when absent. */
+  partialSize(transferId: string, relPath: string): Promise<number | undefined>;
+  /** Feed the first `length` bytes of a partial into `digest` in chunks (resume re-hash). */
+  readPrefix(transferId: string, relPath: string, length: number, digest: Digest): Promise<void>;
+  /** Visit every chunk of a partial in order (finalize ZIP assembly). */
+  readPartialChunks(
+    transferId: string,
+    relPath: string,
+    visit: (chunk: Uint8Array) => void | Promise<void>,
+  ): Promise<void>;
+  /** All canonical rel paths with a `.part` file present under the transfer dir. */
+  listRelPaths(transferId: string): Promise<string[]>;
+  /** Open a fresh output file inside the transfer dir (ZIP finalize). */
+  openOutput(
+    transferId: string,
+    fileName: string,
+  ): Promise<{ key: string; writable: WritableFileLike }>;
+  /** Remove one partial file. */
+  removePartial(transferId: string, relPath: string): Promise<void>;
+  /** Remove the entire per-transfer data directory (idempotent). */
+  removeData(transferId: string): Promise<void>;
+}
+
+/** One open partial file. Sync writers flush on every write; async writers flush on close. */
+export interface PartialWriter {
+  /** Persist one verified block at `offset`. Sync path flushes to disk before returning. */
+  write(offset: number, bytes: Uint8Array): Promise<void>;
+  /** Final flush + close. */
+  close(): Promise<void>;
+  /** Close without losing data — partials are resumable and never deleted here. */
+  abort(): Promise<void>;
+}
+
+/** A FileSystemWritableFileStream-shaped writer (used by the async fallback and ZIP output). */
+export interface WritableFileLike {
+  write(data: { type: 'write'; position: number; data: Uint8Array }): Promise<void>;
+  close(): Promise<void>;
+  abort?(reason?: unknown): Promise<void>;
+  truncate?(size: number): Promise<void>;
+}
+
+/** Result of an atomic lease acquisition. */
+export type LeaseOutcome =
+  { kind: 'acquired' } | { kind: 'renewed' } | { kind: 'contended' } | { kind: 'stale-taken' };
+
+export interface LeaseRecord {
+  transferId: string;
+  ownerId: string;
+  expiresAt: number;
+}
+
+/** Result of loading a journal: absent, valid, or corrupt (fail closed, nothing deleted). */
+export type JournalLoad =
+  { kind: 'none' } | { kind: 'ok'; journal: DurableJournal } | { kind: 'corrupt'; error: string };
+
+/** Transactional journal + lease metadata store. All writes are atomic IDB transactions. */
+export interface DurableJournalStore {
+  loadJournal(transferId: string): Promise<JournalLoad>;
+  /** Create and persist a fresh zero-checkpoint journal (validates + encodes). */
+  createJournal(
+    transferId: string,
+    manifest: Manifest,
+    source: JournalIdentity,
+    destination: JournalIdentity,
+    nowMs: number,
+  ): Promise<DurableJournal>;
+  /**
+   * Advance one file's checkpoint in a single transaction that also renews the lease.
+   * The caller must already hold the lease; a lost/foreign lease aborts the transaction and
+   * rejects, so two tabs can never both advance the same journal.
+   */
+  commitBlocks(
+    journal: DurableJournal,
+    fileIdx: number,
+    blocks: number,
+    nowMs: number,
+    ownerId: string,
+  ): Promise<DurableJournal>;
+  /** Atomic test-and-set acquire with TTL; stale records are taken over. */
+  acquireLease(transferId: string, ownerId: string, nowMs: number): Promise<LeaseOutcome>;
+  renewLease(transferId: string, ownerId: string, nowMs: number): Promise<void>;
+  releaseLease(transferId: string, ownerId: string): Promise<void>;
+  /** Remove the journal and lease for one transfer id, idempotently. */
+  discard(transferId: string): Promise<void>;
+}
+
+/**
+ * The opaque destination claim for browser journals: the OPFS storage is origin-scoped, so
+ * this binds a journal to the browser storage area (mirrors the CLI's destination-location
+ * identity). The origin is included for defense in depth across deployments.
+ */
+export async function webDestinationIdentity(origin: string): Promise<JournalIdentity> {
+  const sum = await sha256(utf8(`sendbeam/destination-location\x00web:opfs:${origin}`));
+  return { version: 1, value: bytesToHex(sum) };
+}
+
+// ---------------------------------------------------------------------------
+// IndexedDB backend
+// ---------------------------------------------------------------------------
+
+interface IDBRequestLike<T = unknown> {
+  result: T;
+  error: DOMException | null;
+  onsuccess: ((ev: Event) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+}
+interface IDBObjectStoreLike {
+  get(key: string): IDBRequestLike<unknown>;
+  put(value: unknown, key: string): IDBRequestLike;
+  delete(key: string): IDBRequestLike;
+  getAll(): IDBRequestLike<unknown[]>;
+}
+interface IDBTransactionLike {
+  objectStore(name: string): IDBObjectStoreLike;
+  abort(): void;
+  oncomplete: ((ev: Event) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onabort: ((ev: Event) => void) | null;
+}
+interface IDBDatabaseLike {
+  objectStoreNames: { contains(name: string): boolean };
+  transaction(storeNames: string[], mode: 'readonly' | 'readwrite'): IDBTransactionLike;
+  close(): void;
+}
+
+/** Wrap one IDB request as a promise. */
+function requestResult(r: IDBRequestLike): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error ?? new Error('indexeddb request failed'));
+  });
+}
+
+/** Resolve when a transaction completes; rejects on error or abort. */
+function transactionDone(tx: IDBTransactionLike): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(new Error('indexeddb transaction failed'));
+    tx.onabort = () => reject(new Error('indexeddb transaction aborted'));
+  });
+}
+
+/** The browser journal/lease store over IndexedDB. */
+export function indexedDbDurableStore(): DurableJournalStore {
+  return new IndexedDbDurableStore();
+}
+
+class IndexedDbDurableStore implements DurableJournalStore {
+  private dbPromise: Promise<IDBDatabaseLike> | undefined;
+
+  private db(): Promise<IDBDatabaseLike> {
+    if (!this.dbPromise) {
+      this.dbPromise = new Promise((resolve, reject) => {
+        const idb = (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+        if (!idb) {
+          reject(new Error('IndexedDB is unavailable in this browser'));
+          return;
+        }
+        const req = idb.open(DURABLE_DB, 1);
+        req.onupgradeneeded = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains(DURABLE_JOURNALS_STORE)) {
+            db.createObjectStore(DURABLE_JOURNALS_STORE);
+          }
+          if (!db.objectStoreNames.contains(DURABLE_LEASES_STORE)) {
+            db.createObjectStore(DURABLE_LEASES_STORE);
+          }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error('open sendbeam-durable failed'));
+      });
+    }
+    return this.dbPromise;
+  }
+
+  async loadJournal(transferId: string): Promise<JournalLoad> {
+    const db = await this.db();
+    const tx = db.transaction([DURABLE_JOURNALS_STORE], 'readonly');
+    const value = await requestResult(tx.objectStore(DURABLE_JOURNALS_STORE).get(transferId));
+    await transactionDone(tx);
+    if (value === undefined) return { kind: 'none' };
+    try {
+      const bytes =
+        value instanceof Uint8Array
+          ? value
+          : new Uint8Array((value as { buffer?: ArrayBuffer }).buffer ?? (value as ArrayBuffer));
+      return { kind: 'ok', journal: await decodeJournal(bytes) };
+    } catch (e) {
+      return { kind: 'corrupt', error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  async createJournal(
+    transferId: string,
+    manifest: Manifest,
+    source: JournalIdentity,
+    destination: JournalIdentity,
+    nowMs: number,
+  ): Promise<DurableJournal> {
+    const journal = await newJournal(transferId, manifest, source, destination, nowMs);
+    await this.putJournal(journal);
+    return journal;
+  }
+
+  async commitBlocks(
+    journal: DurableJournal,
+    fileIdx: number,
+    blocks: number,
+    nowMs: number,
+    ownerId: string,
+  ): Promise<DurableJournal> {
+    const next = advanceJournal(journal, fileIdx, blocks, nowMs);
+    const encoded = await encodeJournal(next);
+    const db = await this.db();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([DURABLE_JOURNALS_STORE, DURABLE_LEASES_STORE], 'readwrite');
+      const journals = tx.objectStore(DURABLE_JOURNALS_STORE);
+      const leases = tx.objectStore(DURABLE_LEASES_STORE);
+      const leaseReq = leases.get(next.transferId);
+      leaseReq.onsuccess = () => {
+        const lease = leaseReq.result as LeaseRecord | undefined;
+        if (!lease || lease.ownerId !== ownerId) {
+          // The lease is gone or owned by another receiver (expired + taken over, or the
+          // journal was discarded): never advance a journal we no longer own.
+          tx.abort();
+          reject(
+            new TransferError(
+              'sink_error',
+              'durable lease lost; another receiver owns this transfer — stop the duplicate receive',
+            ),
+          );
+          return;
+        }
+        journals.put(encoded, next.transferId);
+        leases.put(
+          { transferId: next.transferId, ownerId, expiresAt: nowMs + DURABLE_LEASE_TTL_MS },
+          next.transferId,
+        );
+      };
+      leaseReq.onerror = () => {
+        tx.abort();
+        reject(new Error('durable lease read failed'));
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error('durable journal commit failed'));
+      tx.onabort = () => reject(new Error('durable journal commit aborted'));
+    });
+    return next;
+  }
+
+  async acquireLease(transferId: string, ownerId: string, nowMs: number): Promise<LeaseOutcome> {
+    const db = await this.db();
+    return new Promise<LeaseOutcome>((resolve, reject) => {
+      const tx = db.transaction([DURABLE_LEASES_STORE], 'readwrite');
+      const leases = tx.objectStore(DURABLE_LEASES_STORE);
+      let outcome: LeaseOutcome = { kind: 'contended' };
+      const req = leases.get(transferId);
+      req.onsuccess = () => {
+        const lease = req.result as LeaseRecord | undefined;
+        const expiresAt = nowMs + DURABLE_LEASE_TTL_MS;
+        if (!lease) {
+          leases.put({ transferId, ownerId, expiresAt }, transferId);
+          outcome = { kind: 'acquired' };
+        } else if (lease.expiresAt <= nowMs) {
+          leases.put({ transferId, ownerId, expiresAt }, transferId);
+          outcome = { kind: 'stale-taken' };
+        } else if (lease.ownerId === ownerId) {
+          leases.put({ transferId, ownerId, expiresAt }, transferId);
+          outcome = { kind: 'renewed' };
+        }
+      };
+      req.onerror = () => reject(new Error('durable lease acquire failed'));
+      tx.oncomplete = () => resolve(outcome);
+      tx.onerror = () => reject(new Error('durable lease acquire failed'));
+      tx.onabort = () => reject(new Error('durable lease acquire aborted'));
+    });
+  }
+
+  async renewLease(transferId: string, ownerId: string, nowMs: number): Promise<void> {
+    const db = await this.db();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([DURABLE_LEASES_STORE], 'readwrite');
+      const leases = tx.objectStore(DURABLE_LEASES_STORE);
+      const req = leases.get(transferId);
+      req.onsuccess = () => {
+        const lease = req.result as LeaseRecord | undefined;
+        if (lease && lease.ownerId === ownerId) {
+          leases.put({ transferId, ownerId, expiresAt: nowMs + DURABLE_LEASE_TTL_MS }, transferId);
+        }
+      };
+      req.onerror = () => reject(new Error('durable lease renew failed'));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error('durable lease renew failed'));
+    });
+  }
+
+  async releaseLease(transferId: string, ownerId: string): Promise<void> {
+    const db = await this.db();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([DURABLE_LEASES_STORE], 'readwrite');
+      const leases = tx.objectStore(DURABLE_LEASES_STORE);
+      const req = leases.get(transferId);
+      req.onsuccess = () => {
+        const lease = req.result as LeaseRecord | undefined;
+        if (lease && lease.ownerId === ownerId) leases.delete(transferId);
+      };
+      req.onerror = () => reject(new Error('durable lease release failed'));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error('durable lease release failed'));
+    });
+  }
+
+  async discard(transferId: string): Promise<void> {
+    const db = await this.db();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([DURABLE_JOURNALS_STORE, DURABLE_LEASES_STORE], 'readwrite');
+      tx.objectStore(DURABLE_JOURNALS_STORE).delete(transferId);
+      tx.objectStore(DURABLE_LEASES_STORE).delete(transferId);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error('durable discard failed'));
+      tx.onabort = () => reject(new Error('durable discard aborted'));
+    });
+  }
+
+  private async putJournal(journal: DurableJournal): Promise<void> {
+    const encoded = await encodeJournal(journal);
+    const db = await this.db();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([DURABLE_JOURNALS_STORE], 'readwrite');
+      tx.objectStore(DURABLE_JOURNALS_STORE).put(encoded, journal.transferId);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error('durable journal write failed'));
+      tx.onabort = () => reject(new Error('durable journal write aborted'));
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OPFS backend
+// ---------------------------------------------------------------------------
+
+class SyncPartialWriter implements PartialWriter {
+  constructor(private readonly handle: FileSystemSyncAccessHandle) {}
+  async write(offset: number, bytes: Uint8Array): Promise<void> {
+    this.handle.write(bytes, { at: offset });
+    this.handle.flush();
+  }
+  async close(): Promise<void> {
+    // flush() before close() so the final bytes are durable even if close does not flush.
+    this.handle.flush();
+    this.handle.close();
+  }
+  async abort(): Promise<void> {
+    this.handle.close();
+  }
+}
+
+class AsyncPartialWriter implements PartialWriter {
+  constructor(private readonly writable: WritableFileLike) {}
+  async write(offset: number, bytes: Uint8Array): Promise<void> {
+    await this.writable.write({ type: 'write', position: offset, data: bytes });
+  }
+  async close(): Promise<void> {
+    await this.writable.close();
+  }
+  async abort(): Promise<void> {
+    if (this.writable.abort) await this.writable.abort();
+    else await this.writable.close();
+  }
+}
+
+/** The browser OPFS partial-data layer. */
+export function durableOpfsFiles(): DurableFiles {
+  return new OpfsDurableFiles();
+}
+
+class OpfsDurableFiles implements DurableFiles {
+  private async root(): Promise<FileSystemDirectoryHandle> {
+    const storage = (navigator as Navigator & { storage?: StorageManager }).storage;
+    if (!storage || typeof storage.getDirectory !== 'function') {
+      throw new TransferError('sink_error', 'Origin Private File System is unavailable');
+    }
+    return storage.getDirectory();
+  }
+
+  async dataDir(transferId: string, create: boolean): Promise<FileSystemDirectoryHandle> {
+    const root = await this.root();
+    let dir = await root.getDirectoryHandle(DURABLE_ROOT.split('/')[0]!, { create });
+    for (const part of DURABLE_ROOT.split('/').slice(1)) {
+      dir = await dir.getDirectoryHandle(part, { create });
+    }
+    return dir.getDirectoryHandle(transferId, { create });
+  }
+
+  private async partialHandle(
+    transferId: string,
+    relPath: string,
+    create: boolean,
+  ): Promise<FileSystemFileHandle> {
+    const dir = await this.dataDir(transferId, create);
+    const parts = relPath.split('/');
+    let current = dir;
+    for (const part of parts.slice(0, -1)) {
+      current = await current.getDirectoryHandle(part, { create });
+    }
+    return current.getFileHandle(`${parts.at(-1)}.part`, { create });
+  }
+
+  partialKey(transferId: string, relPath: string): string {
+    return `${DURABLE_ROOT}/${transferId}/${relPath}.part`;
+  }
+
+  async probeSync(transferId: string): Promise<boolean> {
+    try {
+      const dir = await this.dataDir(transferId, true);
+      const handle = await dir.getFileHandle('__sync-probe', { create: true });
+      const sync = await handle.createSyncAccessHandle();
+      sync.close();
+      await dir.removeEntry('__sync-probe').catch(() => {});
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async openWriter(
+    transferId: string,
+    relPath: string,
+    committedBytes: number,
+    sync: boolean,
+  ): Promise<PartialWriter> {
+    const handle = await this.partialHandle(transferId, relPath, true);
+    if (sync) {
+      let syncHandle: FileSystemSyncAccessHandle | undefined;
+      try {
+        syncHandle = await handle.createSyncAccessHandle();
+        const size = syncHandle.getSize();
+        if (size < committedBytes) {
+          throw new TransferError(
+            'sink_error',
+            `partial ${relPath} truncated (have ${size} bytes, checkpoint claims ${committedBytes})`,
+          );
+        }
+        if (size > committedBytes) syncHandle.truncate(committedBytes);
+        return new SyncPartialWriter(syncHandle);
+      } catch (e) {
+        try {
+          syncHandle?.close();
+        } catch {
+          // best effort
+        }
+        throw e;
+      }
+    }
+    const file = await handle.getFile().catch(() => undefined);
+    const size = file?.size ?? 0;
+    if (size < committedBytes) {
+      throw new TransferError(
+        'sink_error',
+        `partial ${relPath} truncated (have ${size} bytes, checkpoint claims ${committedBytes})`,
+      );
+    }
+    const writable = (await handle.createWritable({
+      keepExistingData: size > 0,
+    })) as WritableFileLike;
+    if (size > committedBytes && typeof writable.truncate === 'function') {
+      await writable.truncate(committedBytes);
+    }
+    return new AsyncPartialWriter(writable);
+  }
+
+  async partialSize(transferId: string, relPath: string): Promise<number | undefined> {
+    try {
+      const handle = await this.partialHandle(transferId, relPath, false);
+      const file = await handle.getFile();
+      return file.size;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async readStream(
+    transferId: string,
+    relPath: string,
+    visit: (chunk: Uint8Array) => void | Promise<void>,
+  ): Promise<void> {
+    const handle = await this.partialHandle(transferId, relPath, false);
+    const file = await handle.getFile();
+    const reader = file.stream().getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) return;
+        await visit(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  async readPrefix(
+    transferId: string,
+    relPath: string,
+    length: number,
+    digest: Digest,
+  ): Promise<void> {
+    let remaining = length;
+    await this.readStream(transferId, relPath, (chunk) => {
+      if (remaining <= 0) return;
+      const take = chunk.subarray(0, Math.min(chunk.length, remaining));
+      digest.update(take);
+      remaining -= take.length;
+    });
+    if (remaining > 0) {
+      throw new TransferError('sink_error', `partial ${relPath} shorter than its checkpoint`);
+    }
+  }
+
+  async readPartialChunks(
+    transferId: string,
+    relPath: string,
+    visit: (chunk: Uint8Array) => void | Promise<void>,
+  ): Promise<void> {
+    await this.readStream(transferId, relPath, visit);
+  }
+
+  async listRelPaths(transferId: string): Promise<string[]> {
+    const out: string[] = [];
+    const dir = await this.dataDir(transferId, false);
+    await walk(dir, '', out);
+    return out.sort();
+  }
+
+  async openOutput(
+    transferId: string,
+    fileName: string,
+  ): Promise<{ key: string; writable: WritableFileLike }> {
+    const dir = await this.dataDir(transferId, true);
+    const handle = await dir.getFileHandle(fileName, { create: true });
+    const writable = (await handle.createWritable({
+      keepExistingData: false,
+    })) as WritableFileLike;
+    return { key: `${DURABLE_ROOT}/${transferId}/${fileName}`, writable };
+  }
+
+  async removePartial(transferId: string, relPath: string): Promise<void> {
+    const dir = await this.dataDir(transferId, false);
+    const parts = relPath.split('/');
+    let current = dir;
+    for (const part of parts.slice(0, -1)) {
+      current = await current.getDirectoryHandle(part, { create: false });
+    }
+    await current.removeEntry(`${parts.at(-1)}.part`).catch(() => {});
+  }
+
+  async removeData(transferId: string): Promise<void> {
+    try {
+      const root = await this.root();
+      let dir = await root.getDirectoryHandle(DURABLE_ROOT.split('/')[0]!, { create: false });
+      for (const part of DURABLE_ROOT.split('/').slice(1)) {
+        dir = await dir.getDirectoryHandle(part, { create: false });
+      }
+      await dir.removeEntry(transferId, { recursive: true });
+    } catch {
+      // Nothing to remove.
+    }
+  }
+}
+
+async function walk(dir: FileSystemDirectoryHandle, prefix: string, out: string[]): Promise<void> {
+  for await (const [name, handle] of dir.entries()) {
+    const rel = prefix === '' ? name : `${prefix}/${name}`;
+    if (handle.kind === 'directory') {
+      await walk(handle as FileSystemDirectoryHandle, rel, out);
+    } else if (name.endsWith('.part')) {
+      out.push(rel.slice(0, -'.part'.length));
+    }
+  }
+}

--- a/apps/web/src/lib/transfer/sink.ts
+++ b/apps/web/src/lib/transfer/sink.ts
@@ -1,12 +1,23 @@
 import {
   TransferError,
   normalizeTransferPath,
+  type Digest,
   type Destination,
   type FileEntry,
   type Manifest,
   type Sink,
 } from '@sendbeam/protocol';
 import { streamSink, type WritableFileLike } from './stream-sink.js';
+import { DurableDestination, type DurableMeta } from './durable-destination.js';
+import { durableOpfsFiles, indexedDbDurableStore } from './durable-store.js';
+import {
+  centralHeader,
+  crc32Update,
+  dataDescriptor,
+  endOfCentralDirectory,
+  localHeader,
+  type ZipEntry,
+} from './zip.js';
 import type { ReceiveDestinationSpec } from './wire.js';
 
 export type DestinationOutput =
@@ -14,10 +25,21 @@ export type DestinationOutput =
 
 export interface BrowserDestination extends Destination {
   result(): DestinationOutput | undefined;
+  /** Durable-receive metadata the host needs for lease release and Keep/Discard. */
+  durableMeta?(): DurableMeta | undefined;
+  /** Resume seed a reloaded receiver applies after the authenticated manifest arrives. */
+  resumeStateFor?(manifest: Manifest): import('@sendbeam/protocol').ReceiverResumeState | undefined;
 }
 
-/** Select a concrete destination only after the authenticated manifest is available. */
-export function createBrowserDestination(spec: ReceiveDestinationSpec): BrowserDestination {
+/**
+ * Select a concrete destination only after the authenticated manifest is available. `auto`
+ * destinations whose manifest opted into resumption (carries a transfer id) route to the
+ * durable receive store; everything else keeps the fresh-key download behavior.
+ */
+export function createBrowserDestination(
+  spec: ReceiveDestinationSpec,
+  createDigest?: () => Digest,
+): BrowserDestination {
   let inner: BrowserDestination | undefined;
   const get = (): BrowserDestination => {
     if (!inner) throw new TransferError('sink_error', 'destination used before manifest');
@@ -28,7 +50,16 @@ export function createBrowserDestination(spec: ReceiveDestinationSpec): BrowserD
       if (spec.kind === 'direct-file') inner = new DirectFileDestination(spec.handle);
       else if (spec.kind === 'direct-directory')
         inner = new DirectDirectoryDestination(spec.handle);
-      else if (manifest.files.length === 1 && !manifest.files[0]!.name.includes('/')) {
+      else if (manifest.transferId !== undefined) {
+        if (!createDigest) {
+          throw new TransferError('sink_error', 'durable receive requires a digest factory');
+        }
+        inner = new DurableDestination({
+          createDigest,
+          files: durableOpfsFiles(),
+          store: indexedDbDurableStore(),
+        });
+      } else if (manifest.files.length === 1 && !manifest.files[0]!.name.includes('/')) {
         inner = new OpfsFileDestination();
       } else {
         inner = new ArchiveDestination();
@@ -39,6 +70,7 @@ export function createBrowserDestination(spec: ReceiveDestinationSpec): BrowserD
     close: () => get().close(),
     abort: (reason) => get().abort(reason),
     result: () => inner?.result(),
+    durableMeta: () => inner?.durableMeta?.(),
   };
 }
 
@@ -142,13 +174,6 @@ class OpfsFileDestination implements BrowserDestination {
   }
 }
 
-interface ZipEntry {
-  name: Uint8Array;
-  crc: number;
-  size: number;
-  offset: number;
-}
-
 /** Streaming, store-only ZIP destination used when direct directory access is unavailable. */
 export class ArchiveDestination implements BrowserDestination {
   private root: FileSystemDirectoryHandle | undefined;
@@ -249,7 +274,7 @@ class ArchiveEntrySink implements Sink {
   }
 }
 
-async function ensureQuota(required: number): Promise<void> {
+export async function ensureQuota(required: number): Promise<void> {
   const storage = navigator.storage as StorageManager | undefined;
   if (!storage) throw new TransferError('sink_error', 'browser storage is unavailable');
   const estimate = await storage.estimate();
@@ -266,13 +291,31 @@ function uniqueKey(name: string): string {
 }
 
 /**
+ * Resolve a '/'-separated key under the OPFS root to a file handle, walking directory
+ * components so durable-receive keys (`sendbeam/durable/<id>/<rel>.part`) resolve too.
+ */
+export async function opfsFileHandle(
+  root: FileSystemDirectoryHandle,
+  key: string,
+  create: boolean,
+): Promise<FileSystemFileHandle> {
+  const parts = key.split('/');
+  const leaf = parts.at(-1)!;
+  let directory = root;
+  for (const part of parts.slice(0, -1)) {
+    directory = await directory.getDirectoryHandle(part, { create });
+  }
+  return directory.getFileHandle(leaf, { create });
+}
+
+/**
  * Open a completed OPFS output without truncating or removing its backing entry.
  * Chromium-backed File snapshots become unreadable when that entry is removed, so the UI owns
  * cleanup and keeps it alive for as long as the download link is visible.
  */
 export async function readOpfsOutput(key: string, name: string, mime: string): Promise<File> {
   const root = await opfsRoot();
-  const handle = await root.getFileHandle(key, { create: false });
+  const handle = await opfsFileHandle(root, key, false);
   const file = await handle.getFile();
   return new File([file], name, {
     type: mime || file.type,
@@ -283,84 +326,23 @@ export async function readOpfsOutput(key: string, name: string, mime: string): P
 /** Remove an OPFS result once its download link is no longer exposed. */
 export async function removeOpfsOutput(key: string): Promise<void> {
   const root = await opfsRoot();
-  await root.removeEntry(key).catch(() => {});
+  const parts = key.split('/');
+  const leaf = parts.at(-1)!;
+  let directory = root;
+  for (const part of parts.slice(0, -1)) {
+    try {
+      directory = await directory.getDirectoryHandle(part, { create: false });
+    } catch {
+      return; // nothing to remove
+    }
+  }
+  await directory.removeEntry(leaf).catch(() => {});
 }
 
-async function opfsRoot(): Promise<FileSystemDirectoryHandle> {
+export async function opfsRoot(): Promise<FileSystemDirectoryHandle> {
   const storage = navigator.storage as StorageManager | undefined;
   if (!storage || typeof storage.getDirectory !== 'function') {
     throw new TransferError('sink_error', 'Origin Private File System is unavailable');
   }
   return storage.getDirectory();
-}
-
-const crcTable = Array.from({ length: 256 }, (_, value) => {
-  let crc = value;
-  for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
-  return crc >>> 0;
-});
-
-function crc32Update(crc: number, bytes: Uint8Array): number {
-  for (const byte of bytes) crc = (crc >>> 8) ^ crcTable[(crc ^ byte) & 0xff]!;
-  return crc >>> 0;
-}
-
-function record(size: number, write: (view: DataView) => void): Uint8Array {
-  const out = new Uint8Array(size);
-  write(new DataView(out.buffer));
-  return out;
-}
-
-function localHeader(name: Uint8Array): Uint8Array {
-  const header = record(30, (v) => {
-    v.setUint32(0, 0x04034b50, true);
-    v.setUint16(4, 20, true);
-    v.setUint16(6, 0x0808, true);
-    v.setUint16(26, name.length, true);
-  });
-  return join(header, name);
-}
-
-function dataDescriptor(crc: number, size: number): Uint8Array {
-  return record(16, (v) => {
-    v.setUint32(0, 0x08074b50, true);
-    v.setUint32(4, crc, true);
-    v.setUint32(8, size, true);
-    v.setUint32(12, size, true);
-  });
-}
-
-function centralHeader(entry: ZipEntry): Uint8Array {
-  const header = record(46, (v) => {
-    v.setUint32(0, 0x02014b50, true);
-    v.setUint16(4, 20, true);
-    v.setUint16(6, 20, true);
-    v.setUint16(8, 0x0808, true);
-    v.setUint32(16, entry.crc, true);
-    v.setUint32(20, entry.size, true);
-    v.setUint32(24, entry.size, true);
-    v.setUint16(28, entry.name.length, true);
-    v.setUint32(42, entry.offset, true);
-  });
-  return join(header, entry.name);
-}
-
-function endOfCentralDirectory(count: number, size: number, offset: number): Uint8Array {
-  return record(22, (v) => {
-    v.setUint32(0, 0x06054b50, true);
-    v.setUint16(8, count, true);
-    v.setUint16(10, count, true);
-    v.setUint32(12, size, true);
-    v.setUint32(16, offset, true);
-  });
-}
-
-function join(...parts: Uint8Array[]): Uint8Array {
-  const out = new Uint8Array(parts.reduce((size, part) => size + part.length, 0));
-  let offset = 0;
-  for (const part of parts) {
-    out.set(part, offset);
-    offset += part.length;
-  }
-  return out;
 }

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -12,6 +12,7 @@ import {
   TransferSender,
   TransferReceiver,
   TransferError,
+  bytesToHex,
   type Digest,
   type Destination,
   type FileEntry,
@@ -149,6 +150,9 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           sendCounterStart: msg.sendCounter,
           recvCounterStart: msg.recvCounter,
           createDigest: deps.createDigest,
+          // Mint a stable transfer id so the manifest opts into resumption and a crashed
+          // receiver can journal and resume this exact transfer (V13-PR03).
+          newTransferId: () => mintTransferId(),
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
           onManifest: (manifest) => {
             manifestFiles = manifest.files;
@@ -181,7 +185,10 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
         const destination = deps.createDestination
           ? deps.createDestination(_msg.destination)
           : sinkFactoryDestination(deps.createSink);
-        const receiver = new TransferReceiver({
+        // The resume seam mirrors the CLI driver (durable.go): a shared, mutable resume
+        // seed is filled from onManifestSet — after the destination prepares against the
+        // authenticated manifest — and the wire receiver applies it before streaming.
+        const receiverOpts: ConstructorParameters<typeof TransferReceiver>[0] = {
           send,
           sendDir: _msg.sendDir,
           recvDir: _msg.recvDir,
@@ -191,7 +198,7 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           destination,
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
           onStateChange: (state) => post({ kind: 'state', state }),
-          onManifestSet: (manifest) => {
+          onManifestSet: async (manifest) => {
             post({
               kind: 'manifest',
               files: manifest.files.map((file) => ({
@@ -201,8 +208,24 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
               })),
               totalSize: manifest.totalSize,
             });
+            if (isBrowserDestination(destination) && destination.durableMeta) {
+              const meta = destination.durableMeta();
+              if (meta) {
+                post({
+                  kind: 'durable',
+                  transferId: meta.transferId,
+                  ownerId: meta.ownerId,
+                  resumed: meta.resumed,
+                  committedBytes: meta.committedBytes,
+                  totalBytes: meta.totalBytes,
+                });
+                const state = destination.resumeStateFor?.(manifest);
+                if (state) receiverOpts.resume = state;
+              }
+            }
           },
-        });
+        };
+        const receiver = new TransferReceiver(receiverOpts);
         bind(receiver);
         const result = await receiver.done;
         const output = isBrowserDestination(destination) ? destination.result() : undefined;
@@ -257,4 +280,11 @@ function transferable(frame: Uint8Array): ArrayBuffer {
     return frame.buffer as ArrayBuffer;
   }
   return frame.slice().buffer;
+}
+
+/** Mint a stable 128-bit lowercase-hex transfer id so the manifest opts into resumption. */
+function mintTransferId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return bytesToHex(bytes);
 }

--- a/apps/web/src/lib/transfer/transfer.worker.ts
+++ b/apps/web/src/lib/transfer/transfer.worker.ts
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
     createSink: () => {
       throw new Error('browser worker uses a destination factory');
     },
-    createDestination: (spec) => createBrowserDestination(spec),
+    createDestination: (spec) => createBrowserDestination(spec, createDigest),
     fileSource: (file) => blobFileSource(file),
   });
 }

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -78,6 +78,16 @@ export interface StateMsg {
   kind: 'state';
   state: TransferRunState;
 }
+/** Worker → host, once a durable receive journal is prepared: lease + resumable progress. */
+export interface DurableInfoMsg {
+  kind: 'durable';
+  transferId: string;
+  /** Lease owner id so the main thread can release the lease (pagehide, discard). */
+  ownerId: string;
+  resumed: boolean;
+  committedBytes: number;
+  totalBytes: number;
+}
 export interface DoneMsg {
   kind: 'done';
   files: Array<{ name: string; size: number; digest: string }>;
@@ -97,6 +107,7 @@ export type WorkerToHost =
   | ManifestMsg
   | ProgressMsg
   | StateMsg
+  | DurableInfoMsg
   | DoneMsg
   | ErrorMsg;
 

--- a/apps/web/src/lib/transfer/zip.ts
+++ b/apps/web/src/lib/transfer/zip.ts
@@ -1,0 +1,82 @@
+/**
+ * Streaming, store-only ZIP primitives (no compression). Shared by the browser archive sink
+ * and the durable-receive finalize step, which builds a ZIP from verified partials.
+ */
+
+export interface ZipEntry {
+  name: Uint8Array;
+  crc: number;
+  size: number;
+  offset: number;
+}
+
+const crcTable = Array.from({ length: 256 }, (_, value) => {
+  let crc = value;
+  for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+  return crc >>> 0;
+});
+
+export function crc32Update(crc: number, bytes: Uint8Array): number {
+  for (const byte of bytes) crc = (crc >>> 8) ^ crcTable[(crc ^ byte) & 0xff]!;
+  return crc >>> 0;
+}
+
+function record(size: number, write: (view: DataView) => void): Uint8Array {
+  const out = new Uint8Array(size);
+  write(new DataView(out.buffer));
+  return out;
+}
+
+export function localHeader(name: Uint8Array): Uint8Array {
+  const header = record(30, (v) => {
+    v.setUint32(0, 0x04034b50, true);
+    v.setUint16(4, 20, true);
+    v.setUint16(6, 0x0808, true);
+    v.setUint16(26, name.length, true);
+  });
+  return join(header, name);
+}
+
+export function dataDescriptor(crc: number, size: number): Uint8Array {
+  return record(16, (v) => {
+    v.setUint32(0, 0x08074b50, true);
+    v.setUint32(4, crc, true);
+    v.setUint32(8, size, true);
+    v.setUint32(12, size, true);
+  });
+}
+
+export function centralHeader(entry: ZipEntry): Uint8Array {
+  const header = record(46, (v) => {
+    v.setUint32(0, 0x02014b50, true);
+    v.setUint16(4, 20, true);
+    v.setUint16(6, 20, true);
+    v.setUint16(8, 0x0808, true);
+    v.setUint32(16, entry.crc, true);
+    v.setUint32(20, entry.size, true);
+    v.setUint32(24, entry.size, true);
+    v.setUint16(28, entry.name.length, true);
+    v.setUint32(42, entry.offset, true);
+  });
+  return join(header, entry.name);
+}
+
+export function endOfCentralDirectory(count: number, size: number, offset: number): Uint8Array {
+  return record(22, (v) => {
+    v.setUint32(0, 0x06054b50, true);
+    v.setUint16(8, count, true);
+    v.setUint16(10, count, true);
+    v.setUint32(12, size, true);
+    v.setUint32(16, offset, true);
+  });
+}
+
+function join(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((size, part) => size + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}

--- a/apps/web/src/typings/opfs.d.ts
+++ b/apps/web/src/typings/opfs.d.ts
@@ -1,0 +1,24 @@
+/**
+ * OPFS declarations the stock DOM lib omits: the dedicated-worker-only
+ * `FileSystemSyncAccessHandle` (used by the durable receive writer, V13-PR03),
+ * `createSyncAccessHandle()` on file handles, and async iteration over directory
+ * handles. Mirrors the WHATWG File System standard surface.
+ */
+
+interface FileSystemSyncAccessHandle {
+  read(buffer: ArrayBuffer | ArrayBufferView, options?: { at?: number }): number;
+  write(buffer: ArrayBuffer | ArrayBufferView, options?: { at?: number }): number;
+  truncate(newSize: number): void;
+  getSize(): number;
+  flush(): void;
+  close(): void;
+}
+
+interface FileSystemFileHandle {
+  createSyncAccessHandle(): Promise<FileSystemSyncAccessHandle>;
+}
+
+interface FileSystemDirectoryHandle {
+  entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+  [Symbol.asyncIterator](): AsyncIterableIterator<[string, FileSystemHandle]>;
+}

--- a/docs/durable-receive.md
+++ b/docs/durable-receive.md
@@ -1,11 +1,76 @@
-# CLI durable receive (v1.3 PR02)
+# Durable receive (v1.3 PR02/PR03)
+
+Receivers keep verified progress so a crash, cancellation, or reload does not force a
+large transfer to restart from zero. This page documents the storage layout, the
+durability ordering, finalization, the management surfaces, and the limits that are
+deliberately deferred to later v1.3 PRs. The durability contract itself is defined in
+[ADR 0004](adr/0004-durable-journal.md); this page describes the CLI (PR02) and browser
+(PR03) implementations of it.
+
+## Browser (v1.3 PR03)
+
+The web receiver is durable by default: the sender mints a `transferId` in the manifest
+(the wire protocol already supports it), and the browser receive destination journals
+verified progress against that id. Storage is split across the two origin-scoped
+backends:
+
+```
+OPFS:  sendbeam/durable/<transferId>/<rel>.part   # verified partial data
+IDB:   sendbeam-durable → journals, leases         # journal + lock/lease metadata
+```
+
+- **OPFS partials** mirror manifest paths under a per-transfer directory and always
+  carry the `.part` suffix, so partial data can never be mistaken for a finished file.
+  The final deliverable appears only after whole-transfer verification: a single-file
+  transfer serves the verified partial itself; multi-file transfers assemble a
+  store-only ZIP from the partials (the same ZIP writer as the archive fallback).
+- **The journal** lives in IndexedDB (`sendbeam-durable`), never localStorage and never
+  an OPFS JSON sidecar pretending to be transactional. Every checkpoint advance is one
+  atomic readwrite transaction over the journal plus lease stores, using the same
+  schema-v1 `DurableJournal` contract (checksum, fingerprint, block granularity) as the
+  CLI — decode fails closed on any deviation.
+- **Writer**: where sync access handles are supported (dedicated workers on
+  Chromium/Firefox) the transfer worker writes each verified block with a
+  `FileSystemSyncAccessHandle`, then flushes it, then advances the journal checkpoint in
+  the same ordering as the CLI (`write → flush → commit → ack`). Browsers without sync
+  access handles (Safari) fall back to async `createWritable` streams with an honest
+  granularity: the stream can only be flushed at close, so a file's checkpoint advances
+  only when its whole stream is closed — never block-by-block.
+- **Lock/lease**: an atomic IDB test-and-set lease (`transferId → ownerId, expiresAt`)
+  serializes concurrent tabs and survives reloads and worker death. A second tab that
+  joins the same transfer fails closed with guidance; a lease that outlives its TTL is
+  taken over deterministically (bounded stale recovery). The lease is renewed by every
+  checkpoint commit plus a bounded timer, released best-effort on pagehide, and released
+  on abort so a retry acquires immediately. A lost/foreign lease makes the next
+  checkpoint commit abort — two receivers can never both advance one journal.
+- **Keep/Discard**: an interrupted receive deliberately keeps the journal and partials at
+  their last durable checkpoint (they are the only resumable copy; never silently
+  deleted). The failure screen shows a small "partial data kept" block with an explicit
+  **Discard partial data** button; discard is idempotent and removes exactly that
+  transfer's journal, lease, and partials.
+- **Fail-closed loading**: on reload the receiver revalidates every journal claim against
+  the authenticated manifest (checksum, manifest fingerprint, destination identity,
+  checkpoint bounds) and cross-checks each partial against its checkpoint — corrupt,
+  torn, tampered, foreign, mismatched, missing, or truncated state fails the receive
+  closed with guidance and deletes nothing. Quota is preflighted via
+  `navigator.storage.estimate()` and write-time exhaustion maps to the `quota` failure.
+- **Destinations**: `auto` downloads are reload-durable. The direct-file and
+  direct-directory picker modes are capability-gated and are **not** reload-durable:
+  their persistence/reopen semantics (a user-selected handle) do not satisfy the
+  contract, and the UI never claims otherwise.
+- **Resume**: same-session recovery. The sender stays in the room; the receiver re-joins
+  with the same code, re-hashes the persisted prefix per file (correctness-first;
+  digest-state checkpointing is V13-PR05), reports per-file high-water marks, and
+  streams only the missing blocks. Handshakes always derive fresh traffic keys.
+- **Secrets**: the journal never persists invite codes, the session master key,
+  directional traffic keys, or live AEAD counters.
+
+## CLI (v1.3 PR02)
 
 The CLI receiver keeps verified progress on disk so a crash, cancellation, or process
-restart does not force a large transfer to restart from zero. This page documents the
-storage layout, the durability ordering, finalization, the management commands, and the
-limits that are deliberately deferred to later v1.3 PRs. The durability contract itself
-is defined in [ADR 0004](adr/0004-durable-journal.md); this page describes the CLI
-implementation of it.
+restart does not force a large transfer to restart from zero. Everything lives under a
+hidden `.sendbeam` directory inside the receive out directory (the `--out` argument,
+default `.`):
 
 ## Storage layout
 
@@ -135,4 +200,3 @@ sendbeam transfers discard  <id>... [--out DIR] [--all] [--yes]
 - Resume validation against authenticated peer identity (beyond the manifest fingerprint
   and destination location) is PR06/PR07.
 - Digest-state checkpointing (avoid re-hashing the persisted prefix on resume) is PR05.
-- Browser (OPFS) durable receive is PR03.


### PR DESCRIPTION
Verified receive progress now journals to IndexedDB + OPFS so an interrupted or reloaded download resumes instead of restarting.

- The web sender mints a `transferId` in the manifest; the receiver stores verified partials under `sendbeam/durable/<id>/` and advances a schema-v1 `DurableJournal` checkpoint only after each block is flushed (`write → flush → commit → ack`).
- `FileSystemSyncAccessHandle` in the transfer worker provides the per-block durability barrier where supported; an honest file-granular async fallback (journal advances only at stream close) covers browsers without sync access handles.
- An atomic IndexedDB test-and-set lease serializes concurrent tabs, survives reloads/worker death via TTL with deterministic stale takeover, and renews on every commit plus a bounded timer.
- Interrupted receives keep their journal + partials; the failure screen adds an explicit Keep/Discard surface (idempotent). Finalize removes the journal only after whole-transfer verification — single-file transfers serve the verified partial, multi-file assemble a ZIP from partials.
- Fail-closed loading: corrupt/foreign/mismatched journals and missing or truncated partials are rejected without deleting anything; quota preflight + write-time exhaustion map to `quota`.
- Deterministic unit tests (store + destination: ordering, reload/resume, lease contention + stale takeover, quota, Keep/Discard, corrupt journals, finalize, no secrets) plus the full e2e transfer on Chromium and Firefox.