### PR TITLE
fix: harden durable browser receive cleanup

### DIFF
--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -24,7 +24,11 @@ import {
 } from '../transfer/adaptive.js';
 import { ProgressTracker, type TransferSnapshot } from '../transfer/progress.js';
 import { readOpfsOutput, removeOpfsOutput } from '../transfer/sink.js';
-import { indexedDbDurableStore } from '../transfer/durable-store.js';
+import {
+  discardDurableTransfer,
+  durableOpfsFiles,
+  indexedDbDurableStore,
+} from '../transfer/durable-store.js';
 import type {
   HostToWorker,
   ReceiveDestinationSpec,
@@ -517,7 +521,13 @@ function run(
     durable: () => durableInfo,
     discardDurable: async () => {
       if (!durableInfo) return;
-      await indexedDbDurableStore().discard(durableInfo.transferId);
+      // Full durable-receive cleanup: lease-guarded, OPFS data first, then journal + lease
+      // metadata; refuses to run underneath a live foreign lease and surfaces any failure so
+      // the UI never claims success while durable bytes still exist.
+      await discardDurableTransfer(durableInfo.transferId, durableInfo.ownerId, {
+        files: durableOpfsFiles(),
+        store: indexedDbDurableStore(),
+      });
     },
   };
 }

--- a/apps/web/src/lib/transfer/durable-destination.test.ts
+++ b/apps/web/src/lib/transfer/durable-destination.test.ts
@@ -46,6 +46,7 @@ class MemoryStore implements DurableJournalStore {
   /** Fault hooks. */
   failCommit = false;
   failCreate = false;
+  failDiscard = false;
 
   async loadJournal(transferId: string): Promise<JournalLoad> {
     const bytes = this.journals.get(transferId);
@@ -126,6 +127,7 @@ class MemoryStore implements DurableJournalStore {
   }
 
   async discard(transferId: string): Promise<void> {
+    if (this.failDiscard) throw new Error('discard failed');
     this.journals.delete(transferId);
     this.leases.delete(transferId);
   }
@@ -139,6 +141,8 @@ class MemoryFiles implements DurableFiles {
   syncAvailable = true;
   /** Fault hook: writer.write throws a QuotaExceededError. */
   quotaOnWrite = false;
+  /** Fault hook: openOutput throws (ZIP finalization failure). */
+  failOutput = false;
   events: string[] = [];
 
   async dataDir(): Promise<FileSystemDirectoryHandle> {
@@ -198,6 +202,7 @@ class MemoryFiles implements DurableFiles {
     transferId: string,
     fileName: string,
   ): Promise<{ key: string; writable: WritableFileLike }> {
+    if (this.failOutput) throw new Error('output write failed');
     const key = `sendbeam/durable/${transferId}/${fileName}`;
     return {
       key,
@@ -746,5 +751,113 @@ describe('DurableDestination', () => {
       expect(text.toLowerCase()).not.toContain(secret);
     }
     await d.abort();
+  });
+
+  it('finalize failure keeps journal + partials and releases the lease for an immediate retry', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([
+      ['folder/a.bin', 10],
+      ['folder/b.bin', 10],
+    ]);
+    await d.prepare(m);
+    const a = await d.open(m.files[0]!);
+    await a.write(0, new Uint8Array(8));
+    await a.write(8, new Uint8Array([9, 10]));
+    await a.close();
+    const b = await d.open(m.files[1]!);
+    await b.write(0, new Uint8Array(8));
+    await b.write(8, new Uint8Array([9, 10]));
+    await b.close();
+
+    // ZIP assembly fails: finalize must fail closed.
+    h.files.failOutput = true;
+    await expect(d.close()).rejects.toThrow(/output write failed/);
+    h.files.failOutput = false;
+
+    // Journal + recoverable partials remain usable (no journal removed prematurely).
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(h.files.data.size).toBe(2);
+    // The active lease was released promptly instead of lingering for the 120s stale TTL.
+    expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
+
+    // A retry acquires immediately and finalizes successfully.
+    const retry = h.makeDestination();
+    await retry.prepare(m);
+    expect(retry.durableMeta()?.resumed).toBe(true);
+    const ra = await retry.open(m.files[0]!);
+    await ra.close();
+    const rb = await retry.open(m.files[1]!);
+    await rb.close();
+    await retry.close();
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(h.files.outputs.has(`sendbeam/durable/${TRANSFER_ID}/__receive.zip`)).toBe(true);
+  });
+
+  it('failed metadata cleanup after a successful ZIP keeps journal + partials and releases the lease', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([
+      ['folder/a.bin', 10],
+      ['folder/b.bin', 10],
+    ]);
+    await d.prepare(m);
+    const a = await d.open(m.files[0]!);
+    await a.write(0, new Uint8Array(8));
+    await a.write(8, new Uint8Array([9, 10]));
+    await a.close();
+    const b = await d.open(m.files[1]!);
+    await b.write(0, new Uint8Array(8));
+    await b.write(8, new Uint8Array([9, 10]));
+    await b.close();
+
+    h.store.failDiscard = true;
+    await expect(d.close()).rejects.toThrow(/discard failed/);
+    h.store.failDiscard = false;
+
+    // The journal was not removed, the partials were not consumed, and the lease is free.
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(h.files.data.size).toBe(2);
+    expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
+
+    // Immediate retry acquires and completes finalization idempotently.
+    const retry = h.makeDestination();
+    await retry.prepare(m);
+    expect(retry.durableMeta()?.resumed).toBe(true);
+    const ra = await retry.open(m.files[0]!);
+    await ra.close();
+    const rb = await retry.open(m.files[1]!);
+    await rb.close();
+    await retry.close();
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+  });
+
+  it('failed single-file finalize keeps the partial and releases the lease; success removes resume metadata', async () => {
+    const h = await harness();
+    const d = h.makeDestination();
+    const m = manifest([['a.bin', 8]]);
+    await d.prepare(m);
+    const sink = await d.open(m.files[0]!);
+    await sink.write(0, new Uint8Array(8));
+    await sink.close();
+
+    h.store.failDiscard = true;
+    await expect(d.close()).rejects.toThrow(/discard failed/);
+    h.store.failDiscard = false;
+
+    // Partial data remains recoverable and the journal is intact.
+    expect(h.files.data.get('a.bin')).toEqual(new Uint8Array(8));
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
+
+    // Immediate retry: acquire, finalize, and the resume metadata (journal + lease) is gone.
+    const retry = h.makeDestination();
+    await retry.prepare(m);
+    expect(retry.durableMeta()?.resumed).toBe(true);
+    const resumed = await retry.open(m.files[0]!);
+    await resumed.close();
+    await retry.close();
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
   });
 });

--- a/apps/web/src/lib/transfer/durable-destination.ts
+++ b/apps/web/src/lib/transfer/durable-destination.ts
@@ -231,7 +231,8 @@ export class DurableDestination implements BrowserDestination {
   /**
    * Finalize — runs only after the wire receiver verified the whole transfer. The journal
    * (and lease) are removed only after the deliverable is fully produced; any failure keeps
-   * every partial and the journal intact for retry or explicit discard.
+   * every partial and the journal intact for retry or explicit discard, and releases the lease
+   * promptly so a retry can acquire immediately instead of waiting out the stale TTL.
    */
   async close(): Promise<void> {
     if (this.closed) return;
@@ -241,36 +242,49 @@ export class DurableDestination implements BrowserDestination {
     const journal = this.journal;
     const manifest = this.manifest;
     if (!journal || !manifest) return;
-    // Whole-transfer verification already happened (the receiver calls close() after
-    // onComplete); double-check no checkpoint lags so finalization is never partial.
-    for (let i = 0; i < journal.files.length; i++) {
-      const f = journal.files[i]!;
-      if (f.committedBlocks !== f.blocks) {
-        throw new TransferError('sink_error', `file ${i} not fully committed at finalize`);
+    try {
+      // Whole-transfer verification already happened (the receiver calls close() after
+      // onComplete); double-check no checkpoint lags so finalization is never partial.
+      for (let i = 0; i < journal.files.length; i++) {
+        const f = journal.files[i]!;
+        if (f.committedBlocks !== f.blocks) {
+          throw new TransferError('sink_error', `file ${i} not fully committed at finalize`);
+        }
       }
-    }
-    if (manifest.files.length === 1) {
-      // The verified partial IS the deliverable; the host reads it and cleans it up.
-      // The journal is removed only after whole-transfer verification, then the output is
-      // advertised — never before.
-      const file = manifest.files[0]!;
-      const key = this.files.partialKey(this.transferId, normalizeTransferPath(file.name));
+      if (manifest.files.length === 1) {
+        // The verified partial IS the deliverable; the host reads it and cleans it up.
+        // The journal is removed only after whole-transfer verification, then the output is
+        // advertised — never before.
+        const file = manifest.files[0]!;
+        const key = this.files.partialKey(this.transferId, normalizeTransferPath(file.name));
+        await this.store.discard(this.transferId);
+        this.output = { kind: 'opfs', key, name: file.name, mime: file.mime };
+        return;
+      }
+      // Multi-file: assemble a store-only ZIP from the verified partials, then remove the
+      // journal and the consumed partials — never before the ZIP is fully written and closed.
+      const zip = await this.buildZip();
       await this.store.discard(this.transferId);
-      this.output = { kind: 'opfs', key, name: file.name, mime: file.mime };
-      return;
+      // Best-effort cleanup: the ZIP is the verified deliverable, so leftover partials after a
+      // removal failure are harmless orphans rather than a reason to fail a done transfer.
+      for (const file of manifest.files) {
+        await this.files
+          .removePartial(this.transferId, normalizeTransferPath(file.name))
+          .catch(() => {});
+      }
+      this.output = { kind: 'opfs', key: zip.key, name: zip.name, mime: 'application/zip' };
+    } catch (e) {
+      // Finalization failed. The journal + recoverable partials must stay usable (they are the
+      // only resumable copy) and the active lease is released promptly rather than forcing the
+      // 120s stale TTL, so a retry — same or another tab — acquires immediately. Any still-open
+      // writers are aborted so no handles survive a failed finalize. Nothing is deleted on a
+      // failure path and no output is advertised.
+      await this.releaseLease();
+      for (const sink of this.sinks.values()) {
+        await sink.abort().catch(() => {});
+      }
+      throw e;
     }
-    // Multi-file: assemble a store-only ZIP from the verified partials, then remove the
-    // journal and the consumed partials — never before the ZIP is fully written and closed.
-    const zip = await this.buildZip();
-    await this.store.discard(this.transferId);
-    // Best-effort cleanup: the ZIP is the verified deliverable, so leftover partials after a
-    // removal failure are harmless orphans rather than a reason to fail a done transfer.
-    for (const file of manifest.files) {
-      await this.files
-        .removePartial(this.transferId, normalizeTransferPath(file.name))
-        .catch(() => {});
-    }
-    this.output = { kind: 'opfs', key: zip.key, name: zip.name, mime: 'application/zip' };
   }
 
   /**
@@ -285,9 +299,7 @@ export class DurableDestination implements BrowserDestination {
     for (const sink of this.sinks.values()) {
       await sink.abort().catch(() => {});
     }
-    if (this.prepared && !this.closed && this.transferId !== '') {
-      await this.store.releaseLease(this.transferId, this.ownerId).catch(() => {});
-    }
+    if (!this.closed) await this.releaseLease();
   }
 
   result(): DestinationOutput | undefined {
@@ -418,6 +430,13 @@ export class DurableDestination implements BrowserDestination {
     if (this.renewTimer !== undefined) {
       clearInterval(this.renewTimer);
       this.renewTimer = undefined;
+    }
+  }
+
+  /** Owner-bound lease release (no-op when not prepared or already released); best-effort. */
+  private async releaseLease(): Promise<void> {
+    if (this.prepared && this.transferId !== '') {
+      await this.store.releaseLease(this.transferId, this.ownerId).catch(() => {});
     }
   }
 }

--- a/apps/web/src/lib/transfer/durable-store.test.ts
+++ b/apps/web/src/lib/transfer/durable-store.test.ts
@@ -2,12 +2,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FrameType, type Manifest } from '@sendbeam/protocol';
 import {
   DURABLE_LEASE_TTL_MS,
+  discardDurableTransfer,
   durableOpfsFiles,
   indexedDbDurableStore,
   type DurableJournalStore,
   type DurableFiles,
 } from './durable-store.js';
 import type { WritableFileLike } from './stream-sink.js';
+import { DurableDestination } from './durable-destination.js';
+import { createSha256DigestFactory } from './digest.js';
 
 // ---------------------------------------------------------------------------
 // Minimal but faithful in-memory IndexedDB for the browser-backend tests. Requests
@@ -316,47 +319,70 @@ describe('indexedDbDurableStore', () => {
 // ---------------------------------------------------------------------------
 
 /** In-memory OPFS handle tree with optional sync-access-handle availability. */
-function fakeStorage(opts: { sync?: boolean; quota?: number } = {}) {
-  const syncAvailable = opts.sync ?? true;
-  const files = new Map<string, Uint8Array>();
-  const writableStreams = new Map<string, FakeWritable>();
+function fakeStorage(
+  opts: {
+    sync?: boolean;
+    quota?: number;
+    /** Per write() call return counts for the sync handle; empty queue means full writes. */
+    syncWriteResults?: number[];
+    /** Make removeEntry throw (surfaces removeData failures). */
+    failRemoveData?: boolean;
+  } = {},
+) {
+  const state = {
+    syncAvailable: opts.sync ?? true,
+    quota: opts.quota,
+    files: new Map<string, Uint8Array>(),
+    writableStreams: new Map<string, FakeWritable>(),
+    syncWriteResults: opts.syncWriteResults ? [...opts.syncWriteResults] : undefined,
+    syncEvents: [] as string[],
+    failRemoveData: opts.failRemoveData ?? false,
+  };
 
   class FakeSyncHandle {
     private size: number;
     constructor(private readonly key: string) {
-      this.size = files.get(key)?.length ?? 0;
+      this.size = state.files.get(key)?.length ?? 0;
     }
     write(buffer: Uint8Array, options: { at?: number }): number {
       const at = options.at ?? 0;
-      const cur = files.get(this.key) ?? new Uint8Array();
-      const end = at + buffer.length;
+      const requested = buffer.length;
+      const count =
+        state.syncWriteResults !== undefined && state.syncWriteResults.length > 0
+          ? state.syncWriteResults.shift()!
+          : requested;
+      const n = Math.min(count, requested);
+      const cur = state.files.get(this.key) ?? new Uint8Array();
+      const end = at + n;
       const grown = new Uint8Array(Math.max(end, cur.length));
       grown.set(cur);
-      grown.set(buffer, at);
-      files.set(this.key, grown);
+      grown.set(buffer.subarray(0, n), at);
+      state.files.set(this.key, grown);
       this.size = grown.length;
-      return buffer.length;
+      state.syncEvents.push(`write:${count}`);
+      return count;
     }
     flush(): void {
-      // No-op for this test layer; flush-before-commit ordering is asserted at the
-      // destination layer where the store and files share an event log.
+      state.syncEvents.push('flush');
     }
     getSize(): number {
       return this.size;
     }
     truncate(size: number): void {
-      const cur = files.get(this.key) ?? new Uint8Array();
-      files.set(this.key, cur.slice(0, size));
+      const cur = state.files.get(this.key) ?? new Uint8Array();
+      state.files.set(this.key, cur.slice(0, size));
       this.size = size;
     }
-    close(): void {}
+    close(): void {
+      state.syncEvents.push('close');
+    }
   }
 
   const makeFileHandle = (key: string): FileSystemHandle =>
     ({
       kind: 'file',
       getFile: async () => {
-        const blob = files.get(key) ?? new Uint8Array();
+        const blob = state.files.get(key) ?? new Uint8Array();
         return new File(
           [blob.buffer.slice(blob.byteOffset, blob.byteOffset + blob.byteLength) as ArrayBuffer],
           key,
@@ -364,11 +390,11 @@ function fakeStorage(opts: { sync?: boolean; quota?: number } = {}) {
       },
       createWritable: async () => {
         const writable = new FakeWritable();
-        writableStreams.set(key, writable);
+        state.writableStreams.set(key, writable);
         return writable;
       },
       createSyncAccessHandle: async () => {
-        if (!syncAvailable) throw new TypeError('sync access handles unavailable');
+        if (!state.syncAvailable) throw new TypeError('sync access handles unavailable');
         return new FakeSyncHandle(key);
       },
     }) as unknown as FileSystemHandle;
@@ -384,23 +410,25 @@ function fakeStorage(opts: { sync?: boolean; quota?: number } = {}) {
       },
       getFileHandle: (name: string, options: { create?: boolean }) => {
         const key = join(prefix, name);
-        if (!options.create && !files.has(key)) throw new DOMException('missing', 'NotFoundError');
-        if (options.create && !files.has(key)) files.set(key, new Uint8Array()); // create-on-open
+        if (!options.create && !state.files.has(key))
+          throw new DOMException('missing', 'NotFoundError');
+        if (options.create && !state.files.has(key)) state.files.set(key, new Uint8Array()); // create-on-open
         return Promise.resolve(makeFileHandle(key));
       },
       removeEntry: (name: string, options: { recursive?: boolean } = {}) => {
+        if (state.failRemoveData) throw new DOMException('removal failed', 'OperationError');
         const key = join(prefix, name);
         if (options.recursive) {
-          for (const existing of [...files.keys()]) {
-            if (existing.startsWith(`${key}/`)) files.delete(existing);
+          for (const existing of [...state.files.keys()]) {
+            if (existing.startsWith(`${key}/`)) state.files.delete(existing);
           }
         }
-        files.delete(key);
+        state.files.delete(key);
         return Promise.resolve();
       },
       entries: () => {
         const children = new Map<string, { kind: 'directory' | 'file' }>();
-        for (const key of files.keys()) {
+        for (const key of state.files.keys()) {
           if (prefix !== '' && !key.startsWith(`${prefix}/`)) continue;
           const rest = prefix === '' ? key : key.slice(prefix.length + 1);
           const slash = rest.indexOf('/');
@@ -425,15 +453,19 @@ function fakeStorage(opts: { sync?: boolean; quota?: number } = {}) {
   vi.stubGlobal('navigator', {
     storage: {
       getDirectory: async () => makeDir(''),
-      ...(opts.quota !== undefined
+      ...(state.quota !== undefined
         ? {
-            estimate: async () => ({ quota: opts.quota, usage: 0 }),
+            estimate: async () => ({ quota: state.quota, usage: 0 }),
           }
         : {}),
     },
   });
 
-  return { files, writableStreams };
+  return {
+    files: state.files,
+    writableStreams: state.writableStreams,
+    syncEvents: state.syncEvents,
+  };
 }
 
 class FakeWritable implements WritableFileLike {
@@ -532,5 +564,242 @@ describe('durableOpfsFiles', () => {
     await f.removeData(TRANSFER_ID);
     await f.removeData(TRANSFER_ID); // idempotent
     expect(await f.partialSize(TRANSFER_ID, 'folder/a.bin')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sync writer short-write handling
+// ---------------------------------------------------------------------------
+
+describe('sync partial writer short writes', () => {
+  it('loops on one short write, persists the whole block, and flushes only at the end', async () => {
+    const { files, syncEvents } = fakeStorage({ sync: true, syncWriteResults: [2] });
+    const f: DurableFiles = durableOpfsFiles();
+    const writer = await f.openWriter(TRANSFER_ID, 'a.bin', 0, true);
+    await writer.write(0, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    await writer.close();
+    expect(files.get(partKey('a.bin'))).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    const writes = syncEvents.filter((e) => e.startsWith('write:'));
+    expect(writes).toEqual(['write:2', 'write:6']);
+    // The durability barrier (flush) runs only after the complete block was written.
+    expect(syncEvents.indexOf('flush')).toBeGreaterThan(syncEvents.indexOf('write:6'));
+  });
+
+  it('handles several partial writes for one block', async () => {
+    const { files, syncEvents } = fakeStorage({ sync: true, syncWriteResults: [1, 2, 3] });
+    const f: DurableFiles = durableOpfsFiles();
+    const writer = await f.openWriter(TRANSFER_ID, 'a.bin', 0, true);
+    await writer.write(0, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    await writer.close();
+    expect(files.get(partKey('a.bin'))).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    expect(syncEvents.filter((e) => e.startsWith('write:'))).toEqual([
+      'write:1',
+      'write:2',
+      'write:3',
+      'write:2',
+    ]);
+    expect(syncEvents.indexOf('flush')).toBeGreaterThan(syncEvents.indexOf('write:2'));
+  });
+
+  it('fails closed on a zero/no-progress write instead of looping forever', async () => {
+    const { files, syncEvents } = fakeStorage({ sync: true, syncWriteResults: [0] });
+    const f: DurableFiles = durableOpfsFiles();
+    const writer = await f.openWriter(TRANSFER_ID, 'a.bin', 0, true);
+    await expect(writer.write(0, new Uint8Array(8))).rejects.toThrow(/no progress/);
+    // Nothing was persisted and no durability barrier ran.
+    expect(files.get(partKey('a.bin'))?.length ?? 0).toBe(0);
+    expect(syncEvents).not.toContain('flush');
+  });
+
+  it('fails closed when the API reports an impossible oversized count', async () => {
+    const { syncEvents } = fakeStorage({ sync: true, syncWriteResults: [9] });
+    const f: DurableFiles = durableOpfsFiles();
+    const writer = await f.openWriter(TRANSFER_ID, 'a.bin', 0, true);
+    await expect(writer.write(0, new Uint8Array(8))).rejects.toThrow(/impossible/);
+    expect(syncEvents).not.toContain('flush');
+  });
+
+  it('a failed short write never advances the journal checkpoint', async () => {
+    fakeStorage({ sync: true, syncWriteResults: [0] });
+    const idb = makeFakeIndexedDB();
+    vi.stubGlobal('indexedDB', idb);
+    const store = indexedDbDurableStore();
+    const digestFactory = await createSha256DigestFactory();
+    const d = new DurableDestination({
+      createDigest: () => digestFactory(),
+      files: durableOpfsFiles(),
+      store,
+      now: () => 1_000,
+      renewMs: 0,
+      ensureSpace: async () => {},
+    });
+    const m = manifest([['a.bin', 8]]);
+    await d.prepare(m);
+    const sink = await d.open(m.files[0]!);
+    await expect(sink.write(0, new Uint8Array(8))).rejects.toThrow(/no progress/);
+    const loaded = await store.loadJournal(TRANSFER_ID);
+    expect(loaded.kind).toBe('ok');
+    if (loaded.kind !== 'ok') return;
+    // The checkpoint never advanced for an incompletely-written block.
+    expect(loaded.journal.files[0]!.committedBlocks).toBe(0);
+    await d.abort();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Explicit discard: lease-guarded durable receive cleanup
+// ---------------------------------------------------------------------------
+
+describe('discardDurableTransfer', () => {
+  function setup(): {
+    files: DurableFiles;
+    store: DurableJournalStore;
+    idb: FakeIndexedDB;
+  } {
+    fakeStorage({ sync: true });
+    const idb = makeFakeIndexedDB();
+    vi.stubGlobal('indexedDB', idb);
+    return { files: durableOpfsFiles(), store: indexedDbDurableStore(), idb };
+  }
+
+  async function seed(
+    store: DurableJournalStore,
+    files: DurableFiles,
+    ownerId: string,
+    nowMs: number,
+  ): Promise<void> {
+    await store.createJournal(
+      TRANSFER_ID,
+      manifest([['a.bin', 8]]),
+      { version: 1, value: '0'.repeat(64) },
+      { version: 1, value: '1'.repeat(64) },
+      nowMs,
+    );
+    await store.acquireLease(TRANSFER_ID, ownerId, nowMs);
+    const writer = await files.openWriter(TRANSFER_ID, 'a.bin', 0, true);
+    await writer.write(0, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    await writer.close();
+  }
+
+  it('removes the journal, lease, and OPFS partials for exactly that transfer, idempotently', async () => {
+    const { files, store, idb } = setup();
+    await seed(store, files, OWNER_A, 1_000);
+
+    await discardDurableTransfer(TRANSFER_ID, OWNER_A, { files, store, now: () => 2_000 });
+
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(await files.partialSize(TRANSFER_ID, 'a.bin')).toBeUndefined();
+    expect(await readLease(idb, TRANSFER_ID)).toBeUndefined();
+
+    // Repeated discard remains safe.
+    await discardDurableTransfer(TRANSFER_ID, OWNER_A, { files, store, now: () => 2_000 });
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+  });
+
+  it('never touches another transfer', async () => {
+    const { files, store } = setup();
+    await seed(store, files, OWNER_A, 1_000);
+    const otherId = 'b'.repeat(32);
+    await store.createJournal(
+      otherId,
+      { ...manifest([['x.bin', 8]]), transferId: otherId },
+      { version: 1, value: '0'.repeat(64) },
+      { version: 1, value: '1'.repeat(64) },
+      1_000,
+    );
+    await store.acquireLease(otherId, OWNER_B, 1_000);
+    const otherWriter = await files.openWriter(otherId, 'x.bin', 0, true);
+    await otherWriter.write(0, new Uint8Array(8));
+    await otherWriter.close();
+
+    await discardDurableTransfer(TRANSFER_ID, OWNER_A, { files, store, now: () => 2_000 });
+
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(await files.partialSize(TRANSFER_ID, 'a.bin')).toBeUndefined();
+    // The other transfer's journal, lease, and partials are untouched.
+    expect((await store.loadJournal(otherId)).kind).toBe('ok');
+    expect(await files.partialSize(otherId, 'x.bin')).toBe(8);
+  });
+
+  it('refuses to discard while a live foreign lease owns the transfer', async () => {
+    const { files, store, idb } = setup();
+    await seed(store, files, OWNER_A, 1_000);
+
+    await expect(
+      discardDurableTransfer(TRANSFER_ID, OWNER_B, { files, store, now: () => 1_100 }),
+    ).rejects.toThrow(/actively using/);
+
+    // Nothing was deleted: journal, lease, and partials are untouched.
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect((await readLease(idb, TRANSFER_ID))?.ownerId).toBe(OWNER_A);
+    expect(await files.partialSize(TRANSFER_ID, 'a.bin')).toBe(8);
+  });
+
+  it('takes over a stale lease and discards', async () => {
+    const { files, store, idb } = setup();
+    await seed(store, files, OWNER_A, 1_000);
+
+    await discardDurableTransfer(TRANSFER_ID, OWNER_B, {
+      files,
+      store,
+      now: () => 1_000 + DURABLE_LEASE_TTL_MS + 1,
+    });
+
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(await files.partialSize(TRANSFER_ID, 'a.bin')).toBeUndefined();
+    expect(await readLease(idb, TRANSFER_ID)).toBeUndefined();
+  });
+
+  it('fails closed when OPFS removal fails: nothing deleted, lease released for retry', async () => {
+    fakeStorage({ sync: true, failRemoveData: true });
+    const idb = makeFakeIndexedDB();
+    vi.stubGlobal('indexedDB', idb);
+    const store = indexedDbDurableStore();
+    const files: DurableFiles = durableOpfsFiles();
+    await seed(store, files, OWNER_A, 1_000);
+
+    await expect(
+      discardDurableTransfer(TRANSFER_ID, OWNER_A, { files, store, now: () => 2_000 }),
+    ).rejects.toThrow(/removal failed/);
+
+    // Fail-closed: journal + partials stay fully intact and resumable.
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(await files.partialSize(TRANSFER_ID, 'a.bin')).toBe(8);
+    // The lease taken for the discard was released so a retry acquires immediately.
+    expect(await readLease(idb, TRANSFER_ID)).toBeUndefined();
+
+    // With healthy storage the retry succeeds.
+    fakeStorage({ sync: true });
+    await discardDurableTransfer(TRANSFER_ID, OWNER_A, { files, store, now: () => 3_000 });
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    expect(await files.partialSize(TRANSFER_ID, 'a.bin')).toBeUndefined();
+  });
+
+  it('removes OPFS data before journal + lease metadata (fail-closed ordering)', async () => {
+    const { files, store, idb } = setup();
+    await seed(store, files, OWNER_A, 1_000);
+    // Metadata removal fails after the data layer succeeded (IDB + OPFS are not atomic).
+    const failingStore = Object.create(store) as DurableJournalStore;
+    failingStore.discard = async () => {
+      throw new Error('idb discard failed');
+    };
+
+    await expect(
+      discardDurableTransfer(TRANSFER_ID, OWNER_A, {
+        files,
+        store: failingStore,
+        now: () => 2_000,
+      }),
+    ).rejects.toThrow(/idb discard failed/);
+
+    // Data-first: the partials are already gone, so the leftover journal is provably
+    // unusable (a resume fails closed, never silent), and the lease was released for retry.
+    expect(await files.partialSize(TRANSFER_ID, 'a.bin')).toBeUndefined();
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(await readLease(idb, TRANSFER_ID)).toBeUndefined();
+
+    // The retry completes the cleanup.
+    await discardDurableTransfer(TRANSFER_ID, OWNER_A, { files, store, now: () => 3_000 });
+    expect((await store.loadJournal(TRANSFER_ID)).kind).toBe('none');
   });
 });

--- a/apps/web/src/lib/transfer/durable-store.ts
+++ b/apps/web/src/lib/transfer/durable-store.ts
@@ -406,7 +406,27 @@ class IndexedDbDurableStore implements DurableJournalStore {
 class SyncPartialWriter implements PartialWriter {
   constructor(private readonly handle: FileSystemSyncAccessHandle) {}
   async write(offset: number, bytes: Uint8Array): Promise<void> {
-    this.handle.write(bytes, { at: offset });
+    // A sync access handle may persist only part of a buffer per call (short write). Loop
+    // on the returned byte count until the whole verified block is on disk, failing closed
+    // on zero/no-progress or impossible results instead of risking a torn checkpoint. The
+    // durability barrier (flush) runs only after the complete block has been written.
+    let written = 0;
+    while (written < bytes.length) {
+      const count = this.handle.write(bytes.subarray(written), { at: offset + written });
+      if (count <= 0) {
+        throw new TransferError(
+          'sink_error',
+          'sync write made no progress; failing closed rather than checkpointing a torn block',
+        );
+      }
+      if (count > bytes.length - written) {
+        throw new TransferError(
+          'sink_error',
+          'sync write reported an impossible byte count; failing closed',
+        );
+      }
+      written += count;
+    }
     this.handle.flush();
   }
   async close(): Promise<void> {
@@ -618,16 +638,87 @@ class OpfsDurableFiles implements DurableFiles {
   }
 
   async removeData(transferId: string): Promise<void> {
+    let dir: FileSystemDirectoryHandle;
     try {
       const root = await this.root();
-      let dir = await root.getDirectoryHandle(DURABLE_ROOT.split('/')[0]!, { create: false });
+      dir = await root.getDirectoryHandle(DURABLE_ROOT.split('/')[0]!, { create: false });
       for (const part of DURABLE_ROOT.split('/').slice(1)) {
         dir = await dir.getDirectoryHandle(part, { create: false });
       }
-      await dir.removeEntry(transferId, { recursive: true });
-    } catch {
-      // Nothing to remove.
+    } catch (e) {
+      // An absent durable namespace means there is nothing to remove; any other failure
+      // (storage unavailable, permissions, quota) must surface so discard never reports
+      // success while durable bytes may still exist.
+      if (e instanceof DOMException && e.name === 'NotFoundError') return;
+      throw e;
     }
+    try {
+      await dir.removeEntry(transferId, { recursive: true });
+    } catch (e) {
+      // Idempotent repeat: the per-transfer directory is already gone.
+      if (e instanceof DOMException && e.name === 'NotFoundError') return;
+      throw e;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Explicit discard: durable receive cleanup
+// ---------------------------------------------------------------------------
+
+export interface DurableCleanupDeps {
+  files: DurableFiles;
+  store: DurableJournalStore;
+  /** Injectable clock (unix ms); defaults to Date.now (tests use a fixed clock). */
+  now?(): number;
+}
+
+/**
+ * Explicitly discard one transfer's durable receive state — journal, lease, and every OPFS
+ * partial/output under its per-transfer namespace — idempotently and never touching any other
+ * transfer.
+ *
+ * Ordering (data first, metadata last) is deliberate because IDB + OPFS cannot be one atomic
+ * transaction; it is chosen to be fail-closed and retryable:
+ *
+ *  1. Acquire the transfer's lease first (test-and-set). A live lease owned by another
+ *     receiver means the transfer is actively being received there, so the discard is refused
+ *     rather than deleting state underneath it — a stale failure page can never destroy a live
+ *     receiver. An absent, stale, or self-owned lease lets the discard proceed and guarantees
+ *     exclusive ownership for the rest of the cleanup, so no receiver can start between steps.
+ *  2. Remove the OPFS data while the lease is held. Because we own the lease, this cannot
+ *     collide with a live receive, and a failure here aborts with the journal + partials still
+ *     fully intact and resumable.
+ *  3. Remove the journal + lease metadata last, only after the backing data is provably gone —
+ *     a journal never survives without its data. If metadata removal fails, the journal remains
+ *     but is provably unusable (partials are gone) and a repeat of the discard is safe.
+ *
+ * On any failure the lease taken for the discard is released so a retry can acquire
+ * immediately; no state is deleted on a failure path and no success is reported unless both the
+ * data and metadata are actually gone.
+ */
+export async function discardDurableTransfer(
+  transferId: string,
+  ownerId: string,
+  deps: DurableCleanupDeps,
+): Promise<void> {
+  if (transferId === '') {
+    throw new TransferError('sink_error', 'refusing to discard an empty transfer id');
+  }
+  const now = deps.now ?? (() => Date.now());
+  const outcome = await deps.store.acquireLease(transferId, ownerId, now());
+  if (outcome.kind === 'contended') {
+    throw new TransferError(
+      'sink_error',
+      'another receiver is actively using this transfer; refusing to discard underneath it',
+    );
+  }
+  try {
+    await deps.files.removeData(transferId);
+    await deps.store.discard(transferId);
+  } catch (e) {
+    await deps.store.releaseLease(transferId, ownerId).catch(() => {});
+    throw e;
   }
 }
 

--- a/docs/durable-receive.md
+++ b/docs/durable-receive.md
@@ -31,8 +31,10 @@ IDB:   sendbeam-durable → journals, leases         # journal + lock/lease meta
   CLI — decode fails closed on any deviation.
 - **Writer**: where sync access handles are supported (dedicated workers on
   Chromium/Firefox) the transfer worker writes each verified block with a
-  `FileSystemSyncAccessHandle`, then flushes it, then advances the journal checkpoint in
-  the same ordering as the CLI (`write → flush → commit → ack`). Browsers without sync
+  `FileSystemSyncAccessHandle`, looping on the returned byte counts until the whole block
+  is persisted (short writes are completed, zero-progress or impossible results fail
+  closed), then flushes it, then advances the journal checkpoint in the same ordering as
+  the CLI (`write → flush → commit → ack`). Browsers without sync
   access handles (Safari) fall back to async `createWritable` streams with an honest
   granularity: the stream can only be flushed at close, so a file's checkpoint advances
   only when its whole stream is closed — never block-by-block.
@@ -40,14 +42,17 @@ IDB:   sendbeam-durable → journals, leases         # journal + lock/lease meta
   serializes concurrent tabs and survives reloads and worker death. A second tab that
   joins the same transfer fails closed with guidance; a lease that outlives its TTL is
   taken over deterministically (bounded stale recovery). The lease is renewed by every
-  checkpoint commit plus a bounded timer, released best-effort on pagehide, and released
-  on abort so a retry acquires immediately. A lost/foreign lease makes the next
-  checkpoint commit abort — two receivers can never both advance one journal.
+  checkpoint commit plus a bounded timer, released best-effort on pagehide, released on
+  abort and on a failed finalization so a retry acquires immediately (never forcing the
+  120s stale TTL), and removed by a successful finalize. A lost/foreign lease makes the
+  next checkpoint commit abort — two receivers can never both advance one journal.
 - **Keep/Discard**: an interrupted receive deliberately keeps the journal and partials at
   their last durable checkpoint (they are the only resumable copy; never silently
   deleted). The failure screen shows a small "partial data kept" block with an explicit
-  **Discard partial data** button; discard is idempotent and removes exactly that
-  transfer's journal, lease, and partials.
+  **Discard partial data** button; discard is idempotent, removes that transfer's OPFS
+  partials first and its journal + lease only after the data is provably gone, and is
+  refused while another receiver's live lease owns the transfer (a stale failure page can
+  never destroy a live receive).
 - **Fail-closed loading**: on reload the receiver revalidates every journal claim against
   the authenticated manifest (checksum, manifest fingerprint, destination identity,
   checkpoint bounds) and cross-checks each partial against its checkpoint — corrupt,


### PR DESCRIPTION
Hardens the browser durable receive path around three defects in the merged PR03 implementation:

- Explicit Discard now truly removes a transfer's durable state: lease-guarded cleanup acquires the transfer's lease first (refusing to run underneath a live foreign lease), removes the OPFS partials/output, then removes the journal + lease only after the data is provably gone. Idempotent, never touches another transfer, and surfaces any failure so the UI never claims success while durable bytes remain.
- The sync OPFS writer now consumes the write() byte count and loops until the whole verified block is persisted, failing closed on zero-progress or impossible counts, flushing only after the complete write.
- Failed finalization keeps the journal and recoverable partials usable, releases the active lease promptly (no 120s stale TTL) so a retry acquires immediately, and aborts any still-open writers.

Deterministic regression tests cover short writes, discard ordering/concurrency, and finalization-failure lease behavior.