### PR TITLE
feat: add sender source reattachment

### DIFF
--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -106,6 +106,29 @@ func runSend(args []string) int {
 		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
 		return 1
 	}
+	// Sender restart state (V13-PR04): the stable transfer id and the canonical source
+	// identity are persisted strictly before the manifest frame is transmitted, so a
+	// crash can be resumed by re-running the same command. A missing, changed, or
+	// corrupt source state fails closed before anything is advertised.
+	senderDir, err := transfer.SenderStoreDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
+		return 1
+	}
+	senderStore, err := transfer.OpenSenderStore(senderDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
+		return 1
+	}
+	transferID, onSendManifest, reused, err := transfer.PrepareSender(senderStore, positionals, sources)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
+		return 1
+	}
+	if reused {
+		s := newStyle(os.Stderr)
+		fmt.Fprintln(os.Stderr, s.dim("Continuing interrupted transfer "+transferID+" — the source must be unchanged."))
+	}
 	progressFiles := make([]progressFile, len(sources))
 	for i, source := range sources {
 		meta := source.Meta()
@@ -137,6 +160,8 @@ func runSend(args []string) int {
 			OnPhase:   phasePrinter(rendezvous.RoleOfferer),
 		},
 		Sources:        sources,
+		TransferID:     transferID,
+		OnSendManifest: onSendManifest,
 		ForceRelay:     *relayOnly,
 		ICEServers:     ice,
 		OnTransport:    transportPrinter,
@@ -149,7 +174,20 @@ func runSend(args []string) int {
 	s := newStyle(os.Stderr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n%s\n", s.cross("Failed: "+handshakeError(err)))
+		// The sender record was persisted before the manifest went out: keep it and tell
+		// the user how to resume. Lookup is bounded to this source set and idempotent.
+		if srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(positionals)); lookupErr == nil && ok {
+			fmt.Fprintf(os.Stderr, "%s\n", s.dim("Sender state for transfer "+srec.TransferID+" was kept; re-run this command to resume it with the same receiver."))
+		}
 		return 1
+	}
+	// Verified success: drop the sender record for this source set (bounded cleanup, never
+	// implicit for other transfers). A corrupt record can only have appeared after the
+	// transfer, so surface it for manual discard without failing the send.
+	if srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(positionals)); lookupErr == nil && ok {
+		if err := senderStore.Discard(srec.TransferID); err != nil {
+			fmt.Fprintf(os.Stderr, "sendbeam send: warning: could not discard sender record %s: %v\n", srec.TransferID, err)
+		}
 	}
 	fmt.Println()
 	if len(out.Files) == 1 {

--- a/apps/cli/cmd/sendbeam/transfers.go
+++ b/apps/cli/cmd/sendbeam/transfers.go
@@ -24,9 +24,22 @@ func transfersUsage(w *os.File) {
 	_, _ = fmt.Fprintln(w, "  resume   verify a journal is resumable and how to resume it")
 	_, _ = fmt.Fprintln(w, "  discard  explicitly delete a journal and its partials (idempotent)")
 	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, s.dim("Sender records (kept under the user config dir):"))
+	_, _ = fmt.Fprintln(w, "  list     also shows interrupted sends and their source paths")
+	_, _ = fmt.Fprintln(w, "  discard  also removes the matching sender record (idempotent)")
+	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, s.dim("Discard flags:"))
 	_, _ = fmt.Fprintln(w, "  --all    discard every journal and orphaned partial tree in the store")
 	_, _ = fmt.Fprintln(w, "  --yes    confirm --all without prompting")
+}
+
+// senderStore opens the sender-state store, reporting honest failures.
+func senderStore() (*clitransfer.SenderStore, error) {
+	dir, err := clitransfer.SenderStoreDir()
+	if err != nil {
+		return nil, err
+	}
+	return clitransfer.OpenSenderStore(dir)
 }
 
 // runTransfers dispatches the transfers subcommand group.
@@ -80,28 +93,60 @@ func transfersList(args []string) int {
 	s := newStyle(os.Stderr)
 	if len(entries) == 0 {
 		fmt.Fprintln(os.Stderr, s.dim("No durable transfers in "+store.Root()+"."))
+	} else {
+		fmt.Fprintln(os.Stderr, s.dim("Durable receive state in "+store.Root()+":"))
+		fmt.Fprintln(os.Stderr)
+		for _, entry := range entries {
+			if !entry.JournalOK {
+				kind := "unreadable journal"
+				if entry.Orphaned {
+					kind = "orphaned partials"
+				}
+				fmt.Fprintf(os.Stderr, "  %s  %s\n", s.yellow(entry.TransferID), s.dim(kind+": "+entry.Err))
+				fmt.Fprintf(os.Stderr, "      %s\n", s.dim("run: sendbeam transfers discard "+entry.TransferID+" --out "+*outDir))
+				continue
+			}
+			label := entry.TransferID
+			if entry.Files > 1 {
+				label = fmt.Sprintf("%s (%d files)", label, entry.Files)
+			}
+			fmt.Fprintf(os.Stderr, "  %s  %s committed / %s total · updated %s\n",
+				s.cyan(label),
+				humanBytes(entry.CommittedBytes), humanBytes(entry.TotalSize),
+				formatTime(entry.UpdatedAt))
+		}
+	}
+	// Interrupted sends: the sender-side records of transfers whose manifest was
+	// advertised but which never completed. They are local to this machine.
+	fmt.Fprintln(os.Stderr)
+	sender, senderErr := senderStore()
+	if senderErr != nil {
+		fmt.Fprintln(os.Stderr, s.yellow("Sender records unavailable: "+senderErr.Error()+"."))
 		return 0
 	}
-	fmt.Fprintln(os.Stderr, s.dim("Durable receive state in "+store.Root()+":"))
+	senderEntries, senderListErr := sender.List()
+	if senderListErr != nil {
+		fmt.Fprintln(os.Stderr, s.yellow("Sender records unavailable: "+senderListErr.Error()+"."))
+		return 0
+	}
+	if len(senderEntries) == 0 {
+		fmt.Fprintln(os.Stderr, s.dim("No interrupted sends."))
+		return 0
+	}
+	fmt.Fprintln(os.Stderr, s.dim("Interrupted sends (re-run the same send command to resume):"))
 	fmt.Fprintln(os.Stderr)
-	for _, entry := range entries {
-		if !entry.JournalOK {
-			kind := "unreadable journal"
-			if entry.Orphaned {
-				kind = "orphaned partials"
-			}
-			fmt.Fprintf(os.Stderr, "  %s  %s\n", s.yellow(entry.TransferID), s.dim(kind+": "+entry.Err))
-			fmt.Fprintf(os.Stderr, "      %s\n", s.dim("run: sendbeam transfers discard "+entry.TransferID+" --out "+*outDir))
+	for _, entry := range senderEntries {
+		if !entry.RecordOK {
+			fmt.Fprintf(os.Stderr, "  %s  %s\n", s.yellow(entry.TransferID), s.dim("unreadable record: "+entry.Err))
+			fmt.Fprintf(os.Stderr, "      %s\n", s.dim("run: sendbeam transfers discard "+entry.TransferID))
 			continue
 		}
-		label := entry.TransferID
-		if entry.Files > 1 {
-			label = fmt.Sprintf("%s (%d files)", label, entry.Files)
-		}
-		fmt.Fprintf(os.Stderr, "  %s  %s committed / %s total · updated %s\n",
-			s.cyan(label),
-			humanBytes(entry.CommittedBytes), humanBytes(entry.TotalSize),
+		fmt.Fprintf(os.Stderr, "  %s  %d file(s) · %s · updated %s\n",
+			s.cyan(entry.TransferID), entry.Files, humanBytes(entry.TotalSize),
 			formatTime(entry.UpdatedAt))
+		for _, p := range entry.Paths {
+			fmt.Fprintf(os.Stderr, "      %s\n", s.dim(p))
+		}
 	}
 	return 0
 }
@@ -217,6 +262,13 @@ func transfersDiscard(args []string) int {
 			return 1
 		}
 		fmt.Fprintln(os.Stderr, s.check("Discarded all durable transfer state in "+store.Root()+"."))
+		// Also drop every interrupted-send record on this machine (idempotent).
+		if sender, err := senderStore(); err == nil {
+			if err := sender.DiscardAll(); err != nil {
+				fmt.Fprintf(os.Stderr, "sendbeam transfers discard: %s\n", err)
+				return 1
+			}
+		}
 		return 0
 	}
 	if len(positionals) == 0 {
@@ -229,6 +281,16 @@ func transfersDiscard(args []string) int {
 			return 1
 		}
 		fmt.Fprintln(os.Stderr, s.check("Discarded "+id+"."))
+	}
+	// A discarded id may also have an interrupted-send record on this machine; removing it
+	// is idempotent and bounded to the named id.
+	if sender, err := senderStore(); err == nil {
+		for _, id := range positionals {
+			if err := sender.Discard(id); err != nil {
+				fmt.Fprintf(os.Stderr, "sendbeam transfers discard: %s\n", err)
+				return 1
+			}
+		}
 	}
 	return 0
 }

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -56,6 +56,15 @@ type Spec struct {
 	Sources []wire.FileSource
 	// DestDir is the directory the received file is written into; used by a joiner.
 	DestDir string
+	// TransferID, when set, is the stable id to advertise in the manifest (V13-PR04
+	// sender restart): the wire layer prefers it over its mint. Empty keeps the existing
+	// NewTransferID mint.
+	TransferID string
+	// OnSendManifest, when set, is wired into the wire sender's OnManifest hook: it runs
+	// with the validated manifest strictly before its frame is transmitted, so a sender can
+	// persist or verify its restart record before the id is advertised. An error aborts the
+	// send without transmitting the manifest.
+	OnSendManifest func(wire.Manifest) error
 	// ICEServers overrides rtc.DefaultICEServers. An explicit empty slice uses host candidates
 	// only (loopback tests); nil takes the default STUN server.
 	ICEServers []webrtc.ICEServer
@@ -548,8 +557,11 @@ func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervi
 		FrameSize:        negotiate(res.LocalCaps.MaxFrame, res.RemoteCaps.MaxFrame, wire.DefaultFrameBytes),
 		// Advertise a stable random id in the manifest so a receiver that crashes mid-file
 		// can journal its verified progress and resume it (V13-PR02); the wire layer mints
-		// and validates it without any protocol change.
+		// and validates it without any protocol change. A restart (V13-PR04) reuses the
+		// record's id, which the wire layer prefers over the mint.
+		TransferID:     d.spec.TransferID,
 		NewTransferID:  newTransferID,
+		OnManifest:     d.spec.OnSendManifest,
 		OnProgress:     d.spec.OnProgress,
 		OnFileProgress: d.spec.OnFileProgress,
 		OnStateChange:  d.spec.OnStateChange,

--- a/apps/cli/internal/transfer/driver_test.go
+++ b/apps/cli/internal/transfer/driver_test.go
@@ -493,3 +493,141 @@ func TestDriverArmsReconnectableSignal(t *testing.T) {
 		}
 	}
 }
+
+// TestDriverSenderRestartResumesDurableReceive drives the full V13-PR04 restart loop
+// through the real driver and the real durable destination: the sender persists a record
+// before the manifest is advertised, the transfer is interrupted mid-file, and re-running
+// the same send reuses the recorded id and completes byte-identical against the receiver's
+// durable journal.
+func TestDriverSenderRestartResumesDurableReceive(t *testing.T) {
+	senderStore := testSenderStore(t)
+	outDir := t.TempDir()
+	srcDir := t.TempDir()
+	payload := make([]byte, 32<<20) // 32 MiB: plenty of headroom for a mid-file interrupt
+	for i := range payload {
+		payload[i] = byte(i*13 + 5)
+	}
+	srcPath := filepath.Join(srcDir, "payload.bin")
+	if err := os.WriteFile(srcPath, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{srcPath}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *Outcome
+		err error
+	}
+	runLeg := func(idempotent string, interrupt bool) (send, recv result, id string, reused bool) {
+		hub := newRelay()
+		sources, _, err := NewOSFileSources(args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var hook func(wire.Manifest) error
+		id, hook, reused, err = PrepareSender(senderStore, args, sources)
+		if err != nil {
+			t.Fatal(err)
+		}
+		legCtx, legCancel := context.WithCancel(ctx)
+		defer legCancel()
+		firstProgress := make(chan struct{})
+		var once sync.Once
+		if interrupt {
+			go func() {
+				select {
+				case <-firstProgress:
+					legCancel()
+				case <-legCtx.Done():
+				}
+			}()
+		}
+		sendDone := make(chan result, 1)
+		recvDone := make(chan result, 1)
+		go func() {
+			out, err := Run(legCtx, hub.off, Spec{
+				Session:        rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+				Sources:        sources,
+				TransferID:     id,
+				OnSendManifest: hook,
+				ICEServers:     []webrtc.ICEServer{},
+			})
+			sendDone <- result{out, err}
+		}()
+		go func() {
+			out, err := Run(legCtx, hub.join, Spec{
+				Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+				DestDir:    outDir,
+				ICEServers: []webrtc.ICEServer{},
+				OnProgress: func(int64) {
+					if interrupt {
+						once.Do(func() { close(firstProgress) })
+					}
+				},
+			})
+			recvDone <- result{out, err}
+		}()
+		send = <-sendDone
+		recv = <-recvDone
+		_ = idempotent
+		return send, recv, id, reused
+	}
+
+	// Leg 1: interrupt the transfer after the first committed block.
+	send1, recv1, _, _ := runLeg("interrupt", true)
+	if send1.err == nil || recv1.err == nil {
+		t.Fatalf("interrupted leg unexpectedly succeeded: send=%v recv=%v", send1.err, recv1.err)
+	}
+	recvStore, err := OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].CommittedBytes <= 0 || entries[0].CommittedBytes >= int64(len(payload)) {
+		t.Fatalf("leg 1 journal: %#v, want a strictly-partial committed checkpoint", entries)
+	}
+	srec, ok, err := senderStore.Lookup(PathKey(args))
+	if err != nil || !ok {
+		t.Fatalf("sender record not persisted after interruption: ok=%v err=%v", ok, err)
+	}
+
+	// Leg 2: restart the same send — the id is reused and the source identity verified.
+	send2, recv2, id2, reused := runLeg("resume", false)
+	if send2.err != nil || recv2.err != nil {
+		t.Fatalf("restart leg: send=%v recv=%v", send2.err, recv2.err)
+	}
+	if !reused || id2 != srec.TransferID {
+		t.Fatalf("restart reused=%v id=%q, want reuse of %s", reused, id2, srec.TransferID)
+	}
+	if send2.out.Digest != recv2.out.Digest {
+		t.Fatalf("digests differ: %s vs %s", send2.out.Digest, recv2.out.Digest)
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "payload.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("resumed receive produced %d bytes, want byte-identical payload", len(got))
+	}
+	// The receiver finalized: its journal is gone.
+	entries, err = recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.TransferID == srec.TransferID && entry.JournalOK {
+			t.Fatalf("journal %s still present after a verified resume", srec.TransferID)
+		}
+	}
+	// Bounded cleanup: the completed send's record is discarded.
+	if err := senderStore.Discard(srec.TransferID); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := senderStore.Lookup(PathKey(args)); err != nil || ok {
+		t.Fatalf("sender record still present after discard: ok=%v err=%v", ok, err)
+	}
+}

--- a/apps/cli/internal/transfer/sender_state.go
+++ b/apps/cli/internal/transfer/sender_state.go
@@ -1,0 +1,640 @@
+package transfer
+
+// CLI sender restart state (V13-PR04).
+//
+// The offerer persists a compact sender-side record binding the stable transfer id to the
+// canonical identity of its source, strictly BEFORE the manifest frame is transmitted
+// (via the wire SenderOptions.OnManifest hook). A crash after that point can be resumed by
+// re-running the same command: the id is reused and the receiver's durable journal (PR02)
+// continues the verified blocks. The record holds metadata and local paths only — never
+// file bytes, never keys, never AEAD counters (ADR 0004 §5) — so nothing is staged.
+//
+// Layout:
+//
+//	<config>/sendbeam/sender/
+//	  <transferId>.json       # SenderRecord schema v1, mode 0600, atomic replace
+//
+// <config> is os.UserConfigDir(), overridable with SENDBEAM_SENDER_STATE for tests.
+//
+// Identity (fail-closed rules): the record's manifest fingerprint is recomputed from the
+// stored transfer id + file set (the same canonical serialization the receiver journal
+// binds), so a record is self-verifying — tampering, torn writes, or an id/fields swap are
+// caught by both the checksum and the fingerprint. A record that fails decode, validation,
+// checksum, or fingerprint is rejected closed — never guessed, never deleted automatically;
+// only the explicit discard command removes records, idempotently.
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+// senderSchemaVersion is the current SenderRecord schema.
+const senderSchemaVersion = 1
+
+// senderStateEnv overrides the sender-state directory (tests).
+const senderStateEnv = "SENDBEAM_SENDER_STATE"
+
+// SenderFileState is one canonical file entry of a sender record, mirroring wire.FileEntry
+// so the record's fingerprint can be recomputed from it (the receiver journal binds the
+// same canonical manifest serialization).
+type SenderFileState struct {
+	Idx          int    `json:"idx"`
+	Name         string `json:"name"`
+	Size         int64  `json:"size"`
+	Mime         string `json:"mime"`
+	LastModified int64  `json:"lastModified"`
+	BlockSize    int    `json:"blockSize"`
+	Blocks       int    `json:"blocks"`
+	FileDigest   string `json:"fileDigest"`
+}
+
+// SenderRecord is the schema-v1 sender record: the stable transfer id plus the canonical
+// source identity (manifest fingerprint) and the exact file set it was computed from, and
+// the canonical absolute source paths the user invoked. It is local state, never sent.
+type SenderRecord struct {
+	SchemaVersion       int               `json:"schemaVersion"`
+	TransferID          string            `json:"transferId"`
+	ManifestFingerprint string            `json:"manifestFingerprint"`
+	ProtocolVersion     string            `json:"protocolVersion"`
+	CreatedAt           int64             `json:"createdAt"`
+	UpdatedAt           int64             `json:"updatedAt"`
+	Paths               []string          `json:"paths"`
+	Files               []SenderFileState `json:"files"`
+	Checksum            string            `json:"checksum"`
+}
+
+// SenderEntry is one row of the management list: a valid record or an unreadable one.
+type SenderEntry struct {
+	TransferID  string
+	RecordOK    bool
+	Err         string
+	Fingerprint string
+	Paths       []string
+	Files       int
+	TotalSize   int64
+	CreatedAt   int64
+	UpdatedAt   int64
+}
+
+// SenderStore owns the sender-state directory: record load/save with atomic replace,
+// path-keyed lookup, listing, and the explicit discard operation.
+type SenderStore struct {
+	dir string
+	// now is the clock for record timestamps; tests inject a fixed one.
+	now func() time.Time
+	// write writes a record atomically; tests inject failures (no sleeps). Defaults to
+	// writeRecordAtomic.
+	write func(path string, rec SenderRecord) error
+}
+
+// SenderStoreDir resolves the sender-state directory: SENDBEAM_SENDER_STATE if set, else
+// os.UserConfigDir()/sendbeam/sender. Resolution failure fails closed.
+func SenderStoreDir() (string, error) {
+	if dir := os.Getenv(senderStateEnv); dir != "" {
+		return filepath.Abs(dir)
+	}
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", wire.Errorf(wire.CodeStorage, "sender: resolve config dir: %v", err)
+	}
+	return filepath.Join(base, "sendbeam", "sender"), nil
+}
+
+// OpenSenderStore prepares (creating if needed) the sender-state directory and resolves it
+// absolutely so a later chdir cannot redirect writes.
+func OpenSenderStore(dir string) (*SenderStore, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, wire.Errorf(wire.CodeStorage, "sender: resolve state dir: %v", err)
+	}
+	if err := os.MkdirAll(abs, 0o700); err != nil {
+		return nil, wire.Errorf(wire.CodeStorage, "sender: create %s: %v", abs, err)
+	}
+	return &SenderStore{
+		dir:   abs,
+		now:   time.Now,
+		write: writeRecordAtomic,
+	}, nil
+}
+
+// Dir returns the resolved absolute sender-state directory.
+func (s *SenderStore) Dir() string { return s.dir }
+
+// Path returns the record file path for one transfer id.
+func (s *SenderStore) Path(transferID string) string {
+	return filepath.Join(s.dir, transferID+".json")
+}
+
+// Load reads, decodes, validates, and checksum-verifies the record for transferID. It
+// returns (record, false, nil) when no record exists, and fails closed (error) when the
+// file exists but is corrupt, torn, tampered, or from an unsupported version. Nothing is
+// deleted on a load error.
+func (s *SenderStore) Load(transferID string) (SenderRecord, bool, error) {
+	data, err := os.ReadFile(s.Path(transferID))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return SenderRecord{}, false, nil
+		}
+		return SenderRecord{}, true, wire.Errorf(wire.CodeStorage, "sender: read record: %v", err)
+	}
+	rec, err := decodeSenderRecord(data)
+	if err != nil {
+		return SenderRecord{}, true, err
+	}
+	return rec, true, nil
+}
+
+// Save validates and writes a record atomically through the configured writer.
+func (s *SenderStore) Save(rec SenderRecord) error {
+	if err := ValidateSenderRecord(rec); err != nil {
+		return err
+	}
+	if err := s.write(s.Path(rec.TransferID), rec); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Lookup finds the record whose canonical source paths produce pathKey. Corrupt or
+// unsupported records fail the lookup closed (never treated as absent): the store cannot
+// be trusted until the user explicitly discards the bad record, and a fresh transfer could
+// silently shadow a resumable one.
+func (s *SenderStore) Lookup(pathKey string) (SenderRecord, bool, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return SenderRecord{}, false, wire.Errorf(wire.CodeStorage, "sender: list %s: %v", s.dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		if id == "" {
+			continue
+		}
+		rec, ok, loadErr := s.Load(id)
+		if loadErr != nil {
+			return SenderRecord{}, false, wire.Errorf(wire.CodeStorage,
+				"sender: record %s is unusable (%v); nothing was deleted — run \"sendbeam transfers discard %s\" to remove it",
+				id, loadErr, id)
+		}
+		if !ok {
+			continue
+		}
+		if PathKey(rec.Paths) == pathKey {
+			return rec, true, nil
+		}
+	}
+	return SenderRecord{}, false, nil
+}
+
+// List scans the store and returns every record (valid or unreadable). A single bad record
+// never hides the others and is never deleted.
+func (s *SenderStore) List() ([]SenderEntry, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, wire.Errorf(wire.CodeStorage, "sender: list %s: %v", s.dir, err)
+	}
+	var out []SenderEntry
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		if id == "" {
+			continue
+		}
+		rec, ok, loadErr := s.Load(id)
+		if loadErr != nil || !ok {
+			out = append(out, SenderEntry{TransferID: id, RecordOK: false, Err: loadErr.Error()})
+			continue
+		}
+		var total int64
+		for _, f := range rec.Files {
+			total += f.Size
+		}
+		out = append(out, SenderEntry{
+			TransferID:  id,
+			RecordOK:    true,
+			Fingerprint: rec.ManifestFingerprint,
+			Paths:       rec.Paths,
+			Files:       len(rec.Files),
+			TotalSize:   total,
+			CreatedAt:   rec.CreatedAt,
+			UpdatedAt:   rec.UpdatedAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TransferID < out[j].TransferID })
+	return out, nil
+}
+
+// Discard removes one sender record, idempotently and bounded to that transfer: it never
+// touches other records or any receive-side storage.
+func (s *SenderStore) Discard(transferID string) error {
+	if !isLowerHex32(transferID) {
+		return wire.Errorf(wire.CodeStorage, "sender: invalid transfer id %q", transferID)
+	}
+	if err := os.Remove(s.Path(transferID)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return wire.Errorf(wire.CodeStorage, "sender: discard record: %v", err)
+	}
+	return nil
+}
+
+// DiscardAll discards every sender record. It is the explicit --all surface and never runs
+// implicitly.
+func (s *SenderStore) DiscardAll() error {
+	entries, err := s.List()
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, entry := range entries {
+		if err := s.Discard(entry.TransferID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// canonicalPaths resolves, cleans, and sorts the source arguments so the path key is
+// independent of argument order and of how each path was spelled.
+func canonicalPaths(paths []string) ([]string, error) {
+	out := make([]string, len(paths))
+	for i, p := range paths {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = filepath.Clean(abs)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// PathKey is the canonical SHA-256 identity of a source path set: the sorted canonical
+// absolute paths joined with NUL. Reordered or re-spelled arguments produce the same key.
+func PathKey(paths []string) string {
+	canonical, _ := canonicalPaths(paths)
+	h := sha256.New()
+	_, _ = h.Write([]byte("sendbeam/sender-paths\x00"))
+	for _, p := range canonical {
+		_, _ = h.Write([]byte(p))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// PrepareSender decides whether the source set resumes an interrupted transfer (V13-PR04
+// CLI flow). It returns the stable transfer id to advertise ("" = mint a fresh one), the
+// wire OnManifest hook that persists or verifies the sender record strictly before the
+// manifest frame is sent, and whether an existing record was reused. A record whose
+// canonical path key matches but whose cheap meta (name/size/mime/lastModified) differs,
+// or a corrupt/unsupported record, fails closed BEFORE anything is advertised; the
+// authoritative whole-file check runs in the returned hook.
+func PrepareSender(store *SenderStore, paths []string, sources []wire.FileSource) (transferID string, onManifest func(wire.Manifest) error, reused bool, err error) {
+	key := PathKey(paths)
+	rec, ok, lookupErr := store.Lookup(key)
+	if lookupErr != nil {
+		return "", nil, false, lookupErr
+	}
+	if !ok {
+		canonical, canonicalErr := canonicalPaths(paths)
+		if canonicalErr != nil {
+			return "", nil, false, wire.Errorf(wire.CodeStorage, "sender: resolve source paths: %v", canonicalErr)
+		}
+		return "", store.createHook(canonical), false, nil
+	}
+	// Cheap pre-check against the record's file set, in canonical order (both sides sort by
+	// name, so indexes line up). The authoritative fingerprint check still runs in the hook
+	// — a same-size, same-mtime edit is caught there, before the manifest frame goes out.
+	if err := cheapSourceCheck(sources, rec); err != nil {
+		return "", nil, false, wire.Errorf(wire.CodeStorage,
+			"sender: %v — the source changed since the interrupted transfer %s; re-select the original source, or discard the record with \"sendbeam transfers discard %s\"",
+			err, rec.TransferID, rec.TransferID)
+	}
+	return rec.TransferID, store.verifyHook(rec), true, nil
+}
+
+// cheapSourceCheck compares freshly-statted source meta against the record's file set.
+func cheapSourceCheck(sources []wire.FileSource, rec SenderRecord) error {
+	if len(sources) != len(rec.Files) {
+		return errors.New("file count changed")
+	}
+	for i, source := range sources {
+		meta := source.Meta()
+		want := rec.Files[i]
+		if meta.Name != want.Name || meta.Size != want.Size || meta.Mime != want.Mime ||
+			meta.LastModified != want.LastModified {
+			return fmt.Errorf("file %q changed (%s, %d bytes, mtime %d -> %s, %d bytes, mtime %d)",
+				want.Name, want.Name, want.Size, want.LastModified, meta.Name, meta.Size, meta.LastModified)
+		}
+	}
+	return nil
+}
+
+// createHook returns the OnManifest hook for a fresh transfer: it records the transfer id
+// the sender minted and the canonical source identity derived from the validated manifest,
+// strictly before that manifest is transmitted. A persist failure aborts the send before
+// the manifest — the id is never advertised unless a durable record backs it.
+func (s *SenderStore) createHook(paths []string) func(wire.Manifest) error {
+	return func(manifest wire.Manifest) error {
+		validated, err := wire.ValidateManifest(manifest)
+		if err != nil {
+			return err
+		}
+		fp, err := wire.ManifestFingerprint(validated)
+		if err != nil {
+			return err
+		}
+		now := s.now().UnixMilli()
+		rec := SenderRecord{
+			SchemaVersion:       senderSchemaVersion,
+			TransferID:          validated.TransferID,
+			ManifestFingerprint: fp,
+			ProtocolVersion:     wire.ProtocolVersion,
+			CreatedAt:           now,
+			UpdatedAt:           now,
+			Paths:               paths,
+			Files:               fileStatesFromManifest(validated.Files),
+		}
+		if err := s.Save(rec); err != nil {
+			return wire.Errorf(wire.CodeStorage, "sender: persist transfer record: %v", err)
+		}
+		return nil
+	}
+}
+
+// verifyHook returns the OnManifest hook for a resumed transfer: it verifies that the
+// manifest the sender is about to advertise carries the record's transfer id and the exact
+// canonical identity, then refreshes the timestamp. Any mismatch aborts the send before
+// the manifest frame — a changed source is never advertised under the old id.
+func (s *SenderStore) verifyHook(rec SenderRecord) func(wire.Manifest) error {
+	return func(manifest wire.Manifest) error {
+		validated, err := wire.ValidateManifest(manifest)
+		if err != nil {
+			return err
+		}
+		if validated.TransferID != rec.TransferID {
+			return wire.Errorf(wire.CodeStorage,
+				"sender: transfer id changed (%s -> %s); refusing to resume", rec.TransferID, validated.TransferID)
+		}
+		fp, err := wire.ManifestFingerprint(validated)
+		if err != nil {
+			return err
+		}
+		if fp != rec.ManifestFingerprint {
+			return wire.Errorf(wire.CodeStorage,
+				"sender: source does not match the interrupted transfer %s (fingerprint mismatch); nothing was sent — re-select the original source, or discard the record with \"sendbeam transfers discard %s\"",
+				rec.TransferID, rec.TransferID)
+		}
+		rec.UpdatedAt = s.now().UnixMilli()
+		if err := s.Save(rec); err != nil {
+			return wire.Errorf(wire.CodeStorage, "sender: refresh transfer record: %v", err)
+		}
+		return nil
+	}
+}
+
+// fileStatesFromManifest mirrors the validated manifest's file entries into the record.
+func fileStatesFromManifest(files []wire.FileEntry) []SenderFileState {
+	out := make([]SenderFileState, len(files))
+	for i, f := range files {
+		out[i] = SenderFileState{
+			Idx: f.Idx, Name: f.Name, Size: f.Size, Mime: f.Mime,
+			LastModified: f.LastModified, BlockSize: f.BlockSize, Blocks: f.Blocks,
+			FileDigest: f.FileDigest,
+		}
+	}
+	return out
+}
+
+// ValidateSenderRecord enforces the schema-v1 invariants, including the self-check that the
+// stored manifest fingerprint is exactly what the stored transfer id + file set produce —
+// the same identity the receiver's durable journal binds. Any deviation fails closed.
+func ValidateSenderRecord(rec SenderRecord) error {
+	switch {
+	case rec.SchemaVersion != senderSchemaVersion:
+		return wire.Errorf(wire.CodeStorage, "sender: corrupt schema version %d", rec.SchemaVersion)
+	case !isLowerHex32(rec.TransferID):
+		return wire.Errorf(wire.CodeStorage, "sender: malformed transferId")
+	case !isLowerHex64(rec.ManifestFingerprint):
+		return wire.Errorf(wire.CodeStorage, "sender: malformed manifestFingerprint")
+	case rec.ProtocolVersion == "" || rec.ProtocolVersion != wire.ProtocolVersion:
+		return wire.Errorf(wire.CodeCompat, "sender: unsupported protocol version %q", rec.ProtocolVersion)
+	case rec.CreatedAt < 0 || rec.UpdatedAt < rec.CreatedAt:
+		return wire.Errorf(wire.CodeStorage, "sender: corrupt timestamps")
+	case len(rec.Paths) == 0:
+		return wire.Errorf(wire.CodeStorage, "sender: missing source paths")
+	case len(rec.Files) == 0:
+		return wire.Errorf(wire.CodeStorage, "sender: missing file set")
+	}
+	// The record is created from canonical paths; a record whose entries would not
+	// canonicalize (relative or unclean) could never match a Lookup and is corrupt.
+	for _, p := range rec.Paths {
+		if p == "" || !filepath.IsAbs(p) || filepath.Clean(p) != p {
+			return wire.Errorf(wire.CodeStorage, "sender: source paths are not canonical")
+		}
+	}
+	var total int64
+	for i, f := range rec.Files {
+		if f.Idx != i {
+			return wire.Errorf(wire.CodeStorage, "sender: non-contiguous file indexes")
+		}
+		if f.Size < 0 || f.LastModified < 0 || f.BlockSize <= 0 ||
+			f.BlockSize > wire.MaxManifestBlockBytes || f.Blocks < 0 {
+			return wire.Errorf(wire.CodeStorage, "sender: invalid file entry %d", i)
+		}
+		if _, err := wire.NormalizeTransferPath(f.Name); err != nil {
+			return wire.Errorf(wire.CodeStorage, "sender: unsafe file name %q", f.Name)
+		}
+		wantBlocks := int((f.Size-1)/int64(f.BlockSize) + 1)
+		if f.Size == 0 {
+			wantBlocks = 0
+		}
+		if f.Blocks != wantBlocks {
+			return wire.Errorf(wire.CodeStorage, "sender: file %d block count %d does not match size %d / blockSize %d",
+				i, f.Blocks, f.Size, f.BlockSize)
+		}
+		if !isLowerHex64(f.FileDigest) {
+			return wire.Errorf(wire.CodeStorage, "sender: malformed file digest for %q", f.Name)
+		}
+		if f.Size > math.MaxInt64-total {
+			return wire.Errorf(wire.CodeStorage, "sender: total size overflow")
+		}
+		total += f.Size
+	}
+	// Self-verifying identity: the fingerprint claim must equal the fingerprint of the
+	// stored transfer id + file set (the exact bytes the receiver journal binds).
+	manifest := wire.Manifest{TransferID: rec.TransferID, Files: make([]wire.FileEntry, len(rec.Files)), TotalSize: total}
+	for i, f := range rec.Files {
+		manifest.Files[i] = wire.FileEntry{
+			Idx: f.Idx, Name: f.Name, Size: f.Size, Mime: f.Mime,
+			LastModified: f.LastModified, BlockSize: f.BlockSize, Blocks: f.Blocks,
+			FileDigest: f.FileDigest,
+		}
+	}
+	fp, err := wire.ManifestFingerprint(manifest)
+	if err != nil {
+		return err
+	}
+	if fp != rec.ManifestFingerprint {
+		return wire.Errorf(wire.CodeStorage, "sender: record fingerprint does not match its file set (corrupt or tampered)")
+	}
+	return nil
+}
+
+// encodeSenderRecord produces the canonical file encoding: the checksum covers the exact
+// bytes of every other field (same no-HTML-escape, no-trailing-newline rules as the wire
+// codec and journal, byte-identical to JSON.stringify so the web twin can share the
+// schema).
+func encodeSenderRecord(rec SenderRecord) ([]byte, error) {
+	if err := ValidateSenderRecord(rec); err != nil {
+		return nil, err
+	}
+	rec.Checksum = ""
+	body, err := marshalRecordJSON(rec)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(body)
+	rec.Checksum = hex.EncodeToString(sum[:])
+	return marshalRecordJSON(rec)
+}
+
+func decodeSenderRecord(data []byte) (SenderRecord, error) {
+	var rec SenderRecord
+	if err := unmarshalStrictRecord(data, &rec); err != nil {
+		return SenderRecord{}, wire.Errorf(wire.CodeStorage, "sender: malformed record: %v", err)
+	}
+	if rec.SchemaVersion != senderSchemaVersion {
+		if rec.SchemaVersion > senderSchemaVersion {
+			return SenderRecord{}, wire.Errorf(wire.CodeCompat,
+				"sender: record schema version %d is newer than this build supports (%d)",
+				rec.SchemaVersion, senderSchemaVersion)
+		}
+		return SenderRecord{}, wire.Errorf(wire.CodeStorage, "sender: corrupt schema version %d", rec.SchemaVersion)
+	}
+	stored := rec.Checksum
+	if !isLowerHex64(stored) {
+		return SenderRecord{}, wire.Errorf(wire.CodeStorage, "sender: malformed checksum")
+	}
+	rec.Checksum = ""
+	body, err := marshalRecordJSON(rec)
+	if err != nil {
+		return SenderRecord{}, wire.Errorf(wire.CodeStorage, "sender: %v", err)
+	}
+	sum := sha256.Sum256(body)
+	if hex.EncodeToString(sum[:]) != stored {
+		return SenderRecord{}, wire.Errorf(wire.CodeStorage, "sender: checksum mismatch (corrupt or tampered)")
+	}
+	rec.Checksum = stored
+	if err := ValidateSenderRecord(rec); err != nil {
+		return SenderRecord{}, err
+	}
+	return rec, nil
+}
+
+// marshalRecordJSON is the canonical JSON encoder for sender records: no HTML escaping and
+// no trailing newline, byte-identical to JavaScript's JSON.stringify.
+func marshalRecordJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
+}
+
+// unmarshalStrictRecord decodes exactly one JSON value into v, rejecting unknown fields
+// and trailing data so an unexpected field or a torn tail fails closed.
+func unmarshalStrictRecord(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	if dec.More() {
+		return errors.New("trailing data after JSON document")
+	}
+	return nil
+}
+
+// writeRecordAtomic writes the canonical encoding through the atomic-replacement primitive:
+// a temp file in the same directory, fsynced, closed, then renamed over the record, so a
+// crash at any point leaves either the old record or the complete new one — never a torn
+// mix. The temp file inherits CreateTemp's 0600 mode, keeping the local paths and identity
+// material private to the user; the parent directory is fsynced afterwards (best effort).
+func writeRecordAtomic(path string, rec SenderRecord) error {
+	data, err := encodeSenderRecord(rec)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return wire.Errorf(wire.CodeStorage, "sender: create temp: %v", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return wire.Errorf(wire.CodeStorage, "sender: write temp: %v", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return wire.Errorf(wire.CodeStorage, "sender: sync temp: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return wire.Errorf(wire.CodeStorage, "sender: close temp: %v", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return wire.Errorf(wire.CodeStorage, "sender: replace: %v", err)
+	}
+	syncSenderDir(dir)
+	return nil
+}
+
+// syncSenderDir fsyncs a directory so a rename inside it is durable. POSIX only; Windows
+// and filesystems that reject directory sync are best-effort (matching wire's journal
+// writer).
+func syncSenderDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = d.Close() }()
+	_ = d.Sync()
+}
+
+func isLowerHex32(s string) bool { return isLowerHexLen(s, 32) }
+
+func isLowerHex64(s string) bool { return isLowerHexLen(s, 64) }
+
+func isLowerHexLen(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/cli/internal/transfer/sender_state_test.go
+++ b/apps/cli/internal/transfer/sender_state_test.go
@@ -1,0 +1,396 @@
+package transfer
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+func testSenderStore(t *testing.T) *SenderStore {
+	t.Helper()
+	store, err := OpenSenderStore(filepath.Join(t.TempDir(), "sender"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.now = func() time.Time { return time.UnixMilli(1_700_000_000_000) }
+	return store
+}
+
+func testManifestFiles(t *testing.T) []wire.FileEntry {
+	t.Helper()
+	files := []wire.FileEntry{
+		{
+			Idx: 0, Name: "a.txt", Size: 2048, Mime: "text/plain", LastModified: 1_700_000_000_000,
+			BlockSize: 1024, Blocks: 2, FileDigest: strings.Repeat("ab", 32),
+		},
+		{
+			Idx: 1, Name: "sub/b.bin", Size: 1024, Mime: "application/octet-stream", LastModified: 1_700_000_000_001,
+			BlockSize: 1024, Blocks: 1, FileDigest: strings.Repeat("cd", 32),
+		},
+	}
+	manifest, err := wire.ValidateManifest(wire.Manifest{
+		TransferID: strings.Repeat("11", 16),
+		Files:      files,
+		TotalSize:  3072,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest.Files
+}
+
+func TestSenderRecordRoundTrip(t *testing.T) {
+	store := testSenderStore(t)
+	paths := []string{"/tmp/x/a", "/tmp/x/b"}
+	rec := SenderRecord{
+		SchemaVersion:   senderSchemaVersion,
+		TransferID:      strings.Repeat("11", 16),
+		ProtocolVersion: wire.ProtocolVersion,
+		CreatedAt:       1,
+		UpdatedAt:       2,
+		Paths:           paths,
+		Files:           fileStatesFromManifest(testManifestFiles(t)),
+	}
+	fp, err := wire.ManifestFingerprint(wire.Manifest{
+		TransferID: rec.TransferID,
+		Files:      testManifestFiles(t),
+		TotalSize:  3072,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.ManifestFingerprint = fp
+	if err := store.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, ok, err := store.Load(rec.TransferID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("record not found")
+	}
+	if got.TransferID != rec.TransferID || got.ManifestFingerprint != rec.ManifestFingerprint ||
+		len(got.Files) != 2 || got.Files[0].Name != "a.txt" || got.Paths[0] != paths[0] {
+		t.Fatalf("round-trip mismatch: %#v", got)
+	}
+	if got.Checksum == "" {
+		t.Fatal("checksum not stored")
+	}
+}
+
+func TestSenderRecordFailsClosed(t *testing.T) {
+	store := testSenderStore(t)
+	rec := SenderRecord{
+		SchemaVersion:   senderSchemaVersion,
+		TransferID:      strings.Repeat("11", 16),
+		ProtocolVersion: wire.ProtocolVersion,
+		CreatedAt:       1,
+		UpdatedAt:       2,
+		Paths:           []string{"/tmp/a"},
+		Files:           fileStatesFromManifest(testManifestFiles(t)),
+	}
+	fp, err := wire.ManifestFingerprint(wire.Manifest{
+		TransferID: rec.TransferID, Files: testManifestFiles(t), TotalSize: 3072,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.ManifestFingerprint = fp
+	data, err := encodeSenderRecord(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name   string
+		mutate func([]byte) []byte
+		want   string
+	}{
+		{
+			"tampered file name",
+			func(b []byte) []byte { return []byte(strings.ReplaceAll(string(b), `"a.txt"`, `"a.txtx"`)) },
+			"checksum mismatch",
+		},
+		{
+			"unknown field",
+			func(b []byte) []byte {
+				// Drop the closing brace and append a stray field on a fresh copy.
+				return append(append([]byte(nil), b[:len(b)-1]...), []byte(`,"stray":1}`)...)
+			},
+			"unknown field",
+		},
+		{
+			"trailing data",
+			func(b []byte) []byte { return append(append([]byte(nil), b...), []byte(`{}`)...) },
+			"trailing data",
+		},
+		{
+			"future schema version",
+			func(b []byte) []byte {
+				return []byte(strings.ReplaceAll(string(b), `"schemaVersion":1`, `"schemaVersion":2`))
+			},
+			"newer",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok, err := store.LoadFrom(tc.mutate(data))
+			if err == nil {
+				t.Fatalf("decoded corrupt record %s (ok=%v)", got.TransferID, ok)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want mention of %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// LoadFrom is a test helper mirroring Load over arbitrary bytes.
+func (s *SenderStore) LoadFrom(data []byte) (SenderRecord, bool, error) {
+	rec, err := decodeSenderRecord(data)
+	if err != nil {
+		return SenderRecord{}, true, err
+	}
+	return rec, true, nil
+}
+
+func TestSenderRecordFingerprintMismatchFailsClosed(t *testing.T) {
+	rec := SenderRecord{
+		SchemaVersion:   senderSchemaVersion,
+		TransferID:      strings.Repeat("11", 16),
+		ProtocolVersion: wire.ProtocolVersion,
+		CreatedAt:       1,
+		UpdatedAt:       2,
+		Paths:           []string{"/tmp/a"},
+		Files:           fileStatesFromManifest(testManifestFiles(t)),
+	}
+	// A plausible-but-wrong fingerprint: the recomputed fingerprint of the file set must
+	// differ, so the self-verifying identity check rejects the record even though the
+	// checksum would cover it.
+	rec.ManifestFingerprint = strings.Repeat("ff", 32)
+	if err := ValidateSenderRecord(rec); err == nil || !strings.Contains(err.Error(), "fingerprint") {
+		t.Fatalf("ValidateSenderRecord = %v, want fingerprint mismatch", err)
+	}
+}
+
+func TestSenderRecordRejectsNonCanonicalPaths(t *testing.T) {
+	files := testManifestFiles(t)
+	rec := SenderRecord{
+		SchemaVersion:   senderSchemaVersion,
+		TransferID:      strings.Repeat("11", 16),
+		ProtocolVersion: wire.ProtocolVersion,
+		CreatedAt:       1,
+		UpdatedAt:       2,
+		Paths:           []string{"relative/path"}, // not absolute
+		Files:           fileStatesFromManifest(files),
+	}
+	fp, err := wire.ManifestFingerprint(wire.Manifest{
+		TransferID: rec.TransferID, Files: files, TotalSize: 3072,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.ManifestFingerprint = fp
+	if err := ValidateSenderRecord(rec); err == nil || !strings.Contains(err.Error(), "canonical") {
+		t.Fatalf("ValidateSenderRecord = %v, want non-canonical path rejection", err)
+	}
+}
+
+func TestPathKeyIsOrderAndSpellingIndependent(t *testing.T) {
+	a := filepath.Join(t.TempDir(), "a.txt")
+	b := filepath.Join(t.TempDir(), "b.txt")
+	key1 := PathKey([]string{a, b})
+	key2 := PathKey([]string{b, a})
+	if key1 != key2 {
+		t.Fatalf("reordered args produced different keys")
+	}
+	key3 := PathKey([]string{b, a})
+	if key1 != key3 {
+		t.Fatalf("re-spelled args produced different keys")
+	}
+}
+
+func TestLookupMatchesByPathKeyAndFailsClosedOnCorrupt(t *testing.T) {
+	store := testSenderStore(t)
+	files := testManifestFiles(t)
+	fp, _ := wire.ManifestFingerprint(wire.Manifest{
+		TransferID: strings.Repeat("11", 16), Files: files, TotalSize: 3072,
+	})
+	rec := SenderRecord{
+		SchemaVersion: senderSchemaVersion, TransferID: strings.Repeat("11", 16),
+		ProtocolVersion: wire.ProtocolVersion, CreatedAt: 1, UpdatedAt: 2,
+		Paths: []string{"/tmp/one/a", "/tmp/one/b"},
+		Files: fileStatesFromManifest(files), ManifestFingerprint: fp,
+	}
+	if err := store.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := store.Lookup(PathKey([]string{"/tmp/one/b", "/tmp/one/a"}))
+	if err != nil || !ok || got.TransferID != rec.TransferID {
+		t.Fatalf("Lookup = (%v, %v, %v), want match", got, ok, err)
+	}
+	if _, ok, err := store.Lookup(PathKey([]string{"/tmp/other"})); err != nil || ok {
+		t.Fatalf("Lookup of unrelated paths = (%v, %v), want none", ok, err)
+	}
+	// A corrupt record must fail the lookup closed, never be treated as absent.
+	data, err := os.ReadFile(store.Path(rec.TransferID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Flip one hex digit of the checksum in place: valid JSON, valid hex format, but the
+	// recomputed checksum no longer matches.
+	corrupt := append([]byte(nil), data...)
+	marker := []byte(`"checksum":"`)
+	pos := bytes.Index(corrupt, marker)
+	if pos < 0 {
+		t.Fatal("checksum field not found in record")
+	}
+	digit := pos + len(marker)
+	if corrupt[digit] == '0' {
+		corrupt[digit] = '1'
+	} else {
+		corrupt[digit] = '0'
+	}
+	if err := os.WriteFile(store.Path(rec.TransferID), corrupt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.Lookup(PathKey([]string{"/tmp/other"})); err == nil {
+		t.Fatal("Lookup succeeded despite a corrupt record in the store")
+	}
+	// List surfaces it without deleting.
+	entries, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].RecordOK || !strings.Contains(entries[0].Err, "checksum mismatch") {
+		t.Fatalf("List = %#v, want the corrupt record surfaced", entries)
+	}
+	// Discard removes it idempotently.
+	if err := store.Discard(rec.TransferID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Discard(rec.TransferID); err != nil {
+		t.Fatalf("second discard: %v", err)
+	}
+	if _, ok, err := store.Load(rec.TransferID); err != nil || ok {
+		t.Fatalf("record still present after discard: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestPrepareSenderFreshRestartChangedAndVerify(t *testing.T) {
+	store := testSenderStore(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.txt")
+	content := []byte("hello sender restart")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sources, _, err := NewOSFileSources([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []string{path}
+
+	// Fresh: no record, mint id, hook persists.
+	id, hook, reused, err := PrepareSender(store, args, sources)
+	if err != nil {
+		t.Fatalf("fresh PrepareSender: %v", err)
+	}
+	if reused || id != "" {
+		t.Fatalf("fresh: reused=%v id=%q, want fresh mint", reused, id)
+	}
+	manifest, err := wire.ValidateManifest(wire.Manifest{
+		TransferID: strings.Repeat("22", 16),
+		Files:      manifestFromSources(t, sources),
+		TotalSize:  int64(len(content)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := hook(manifest); err != nil {
+		t.Fatalf("create hook: %v", err)
+	}
+	stored, ok, err := store.Lookup(PathKey(args))
+	if err != nil || !ok {
+		t.Fatalf("record not persisted: ok=%v err=%v", ok, err)
+	}
+	if stored.TransferID != manifest.TransferID {
+		t.Fatalf("record id = %s, want the minted %s", stored.TransferID, manifest.TransferID)
+	}
+
+	// Restart: matching source reuses the same id and the hook verifies.
+	sources2, _, err := NewOSFileSources([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, hook2, reused2, err := PrepareSender(store, args, sources2)
+	if err != nil {
+		t.Fatalf("restart PrepareSender: %v", err)
+	}
+	if !reused2 || id2 != stored.TransferID {
+		t.Fatalf("restart: reused=%v id=%q, want reuse of %s", reused2, id2, stored.TransferID)
+	}
+	if err := hook2(manifest); err != nil {
+		t.Fatalf("verify hook: %v", err)
+	}
+
+	// A changed source fails closed before anything is advertised.
+	if err := os.WriteFile(path, append(content, 'x'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sources3, _, err := NewOSFileSources([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := PrepareSender(store, args, sources3); err == nil || !strings.Contains(err.Error(), "discard") {
+		t.Fatalf("changed source PrepareSender = %v, want fail closed with discard guidance", err)
+	}
+
+	// Same meta but different content: the cheap pre-check passes, the verify hook fails
+	// closed on the fingerprint before the manifest could be sent.
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	changed := manifest
+	changed.Files = make([]wire.FileEntry, len(manifest.Files))
+	copy(changed.Files, manifest.Files)
+	sum := sha256.Sum256(append(content, 'x'))
+	changed.Files[0].FileDigest = hex.EncodeToString(sum[:])
+	if err := hook2(changed); err == nil || !strings.Contains(err.Error(), "fingerprint mismatch") {
+		t.Fatalf("verify hook on changed digest = %v, want fingerprint mismatch", err)
+	}
+
+	// Discard removes the record (bounded cleanup after a completed send).
+	if err := store.Discard(stored.TransferID); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := store.Lookup(PathKey(args)); err != nil || ok {
+		t.Fatalf("record still present after discard: ok=%v err=%v", ok, err)
+	}
+}
+
+func manifestFromSources(t *testing.T, sources []wire.FileSource) []wire.FileEntry {
+	t.Helper()
+	files := make([]wire.FileEntry, len(sources))
+	var total int64
+	for i, source := range sources {
+		meta := source.Meta()
+		files[i] = wire.FileEntry{
+			Idx: i, Name: meta.Name, Size: meta.Size, Mime: meta.Mime,
+			LastModified: meta.LastModified, BlockSize: 1024,
+			Blocks: int((meta.Size-1)/1024 + 1), FileDigest: strings.Repeat("ee", 32),
+		}
+		if meta.Size == 0 {
+			files[i].Blocks = 0
+		}
+		total += meta.Size
+	}
+	return files
+}

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -5,6 +5,17 @@
   import { offer, join, type RendezvousController } from './lib/session/rendezvous.js';
   import type { SignalChannel } from './lib/signaling/client.js';
   import type { ReceiveDestinationSpec } from './lib/transfer/wire.js';
+  import {
+    canonicalizeFiles,
+    cheapSourceCheck,
+    ensureReadPermission,
+    materializeHandle,
+  } from './lib/transfer/sender-reattach.js';
+  import {
+    senderRecordStoreWhenAvailable,
+    type SenderRecord,
+    type SenderRecordListEntry,
+  } from './lib/transfer/sender-record.js';
   import { baseUrl, iceServers, loadConfig } from './lib/config.js';
   import { toJSON } from './lib/transfer/diagnostics.js';
   import QrCode from './lib/QrCode.svelte';
@@ -48,6 +59,14 @@
   // Durable-receive Keep/Discard surface (V13-PR03): an interrupted resumable receive keeps
   // its journal + partials until the user explicitly discards them.
   let durableDiscarded = $state(false);
+  // Interrupted-send surface (V13-PR04): sender records persisted before the manifest frame
+  // let an interrupted send be reopened against its original source.
+  let senderRecordList = $state.raw<SenderRecordListEntry[]>([]);
+  let pendingResume = $state.raw<SenderRecord | undefined>(undefined);
+  let resumeHint = $state('');
+  let pickError = $state('');
+  let directoryPickerAvailable = $state(false);
+  directoryPickerAvailable = typeof (window as PickerWindow).showDirectoryPicker === 'function';
 
   // Transfer state, live once the handshake settles and the socket is adopted.
   let role = $state<Role | undefined>(undefined);
@@ -169,6 +188,7 @@
         // the joiner begins receiving straight away.
         screen = 'done';
         startTransferIfReady();
+        if (role === 'offerer') void refreshSenderRecords();
       },
       (err: unknown) => {
         if (controller !== ctrl) return;
@@ -185,7 +205,9 @@
 
   function onPick(ev: Event) {
     const input = ev.currentTarget as HTMLInputElement;
-    pickedFiles = Array.from(input.files ?? []);
+    // Canonical (sorted-by-relative-name) order: the same folder re-picked in any order
+    // yields the same manifest, so an interrupted send's fingerprint stays comparable.
+    pickedFiles = canonicalizeFiles(Array.from(input.files ?? []));
     startTransferIfReady();
   }
 
@@ -198,6 +220,27 @@
     const ice = iceServers();
     if (role === 'offerer') {
       if (pickedFiles.length === 0) return;
+      if (pendingResume) {
+        // Resuming an interrupted send: the picked selection is cheap-checked against the
+        // record first (a friendly refusal beats a pointless transfer), then re-verified
+        // authoritatively by the worker before the manifest frame goes out.
+        const mismatch = cheapSourceCheck(pendingResume, pickedFiles);
+        if (mismatch !== undefined) {
+          pickError = `Resume refused — ${mismatch}`;
+          return;
+        }
+        beginTransfer(
+          runSend(handshake, signaling, {
+            files: pickedFiles,
+            transferId: pendingResume.transferId,
+            reattachment: { kind: 'reselection' },
+            ...(ice ? { iceServers: ice } : {}),
+          }),
+        );
+        pendingResume = undefined;
+        resumeHint = '';
+        return;
+      }
       beginTransfer(
         runSend(handshake, signaling, {
           files: pickedFiles,
@@ -294,6 +337,10 @@
     errorText = '';
     failureDiag = '';
     durableDiscarded = false;
+    senderRecordList = [];
+    pendingResume = undefined;
+    resumeHint = '';
+    pickError = '';
   }
 
   async function discardDurable() {
@@ -302,6 +349,81 @@
       durableDiscarded = true;
     } catch {
       // Keep the block visible if the discard itself failed; the data is still kept.
+    }
+  }
+
+  /** Reload the interrupted-sends list from the sender record store. */
+  async function refreshSenderRecords() {
+    const store = senderRecordStoreWhenAvailable();
+    senderRecordList = store ? await store.list() : [];
+  }
+
+  /** Resume an interrupted send from its record. */
+  async function sendAgain(rec: SenderRecord) {
+    if (handshake === undefined || signaling === undefined) return;
+    pickError = '';
+    const ice = iceServers();
+    if (rec.reattachment.kind === 'handle') {
+      // The persisted handle reopens the original source directly; a revoked permission or a
+      // dead handle falls back to re-selection (the record keeps the transfer id either way).
+      const granted = await ensureReadPermission(rec.reattachment.handle);
+      if (granted) {
+        try {
+          const files = await materializeHandle(rec.reattachment.handle);
+          if (files.length === 0) throw new Error('the folder is empty');
+          beginTransfer(
+            runSend(handshake, signaling, {
+              files,
+              transferId: rec.transferId,
+              reattachment: rec.reattachment,
+              ...(ice ? { iceServers: ice } : {}),
+            }),
+          );
+          return;
+        } catch {
+          // fall through to re-selection
+        }
+      }
+    }
+    pendingResume = rec;
+    resumeHint = `Pick the original source to resume transfer ${rec.transferId.slice(0, 8)} — it will be verified before anything is sent.`;
+  }
+
+  /** Forget an interrupted-send record (keeps nothing; no transfer state depends on it). */
+  async function forgetSenderRecord(entry: SenderRecordListEntry) {
+    const store = senderRecordStoreWhenAvailable();
+    if (!store) return;
+    await store.remove(entry.transferId);
+    if (pendingResume?.transferId === entry.transferId) {
+      pendingResume = undefined;
+      resumeHint = '';
+    }
+    await refreshSenderRecords();
+  }
+
+  /**
+   * Fresh send via the File System Access picker (feature-detected): the persisted handle
+   * lets the folder be reopened after an interruption instead of re-picked.
+   */
+  async function sendFolderReopenable() {
+    if (handshake === undefined || signaling === undefined) return;
+    pickError = '';
+    const ice = iceServers();
+    try {
+      const handle = await (window as PickerWindow).showDirectoryPicker!();
+      const files = await materializeHandle(handle);
+      if (files.length === 0) throw new Error('the folder is empty');
+      beginTransfer(
+        runSend(handshake, signaling, {
+          files,
+          reattachment: { kind: 'handle', handleKind: 'directory', handle },
+          ...(ice ? { iceServers: ice } : {}),
+        }),
+      );
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      errorText = err instanceof Error ? err.message : String(err);
+      screen = 'failed';
     }
   }
 
@@ -577,6 +699,63 @@
             <span class="filepick-sub">all files inside</span>
             <input type="file" multiple webkitdirectory onchange={onPick} />
           </label>
+          {#if directoryPickerAvailable}
+            <button class="filepick" onclick={sendFolderReopenable}>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M10 4H4C2.9 4 2 4.9 2 6V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V8C22 6.9 21.1 6 20 6H12L10 4Z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span class="filepick-title">Send folder (reopenable){'\u{2026}'}</span>
+              <span class="filepick-sub">resumes after interruption without re-picking</span>
+            </button>
+          {/if}
+          {#if resumeHint}
+            <p class="resume-hint">{resumeHint}</p>
+          {/if}
+          {#if pickError}
+            <p class="resume-hint bad">{pickError}</p>
+          {/if}
+          {#if senderRecordList.length > 0}
+            <div class="resume-zone">
+              <h3>Interrupted sends</h3>
+              {#each senderRecordList as entry (entry.transferId)}
+                <div class="resume-card">
+                  {#if entry.kind === 'ok'}
+                    <p class="resume-name">
+                      {entry.record.files.length} file{entry.record.files.length === 1 ? '' : 's'}
+                      ({humanBytes(entry.record.files.reduce((total, f) => total + f.size, 0))})
+                    </p>
+                    <p class="muted">
+                      {entry.record.reattachment.kind === 'handle'
+                        ? 'Reopens the original folder'
+                        : 'Re-select the original source'}
+                      {'\u00b7'} interrupted {new Date(entry.record.updatedAt).toLocaleString()}
+                    </p>
+                    <div class="resume-actions">
+                      <button class="ghost" onclick={() => sendAgain(entry.record)}>
+                        Send again
+                      </button>
+                      <button class="ghost" onclick={() => forgetSenderRecord(entry)}>
+                        Forget
+                      </button>
+                    </div>
+                  {:else}
+                    <p class="resume-name">Corrupt sender record</p>
+                    <p class="muted">
+                      {entry.error} — nothing was sent; forget it to start a new transfer.
+                    </p>
+                    <div class="resume-actions">
+                      <button class="ghost" onclick={() => forgetSenderRecord(entry)}>
+                        Forget
+                      </button>
+                    </div>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/if}
         </div>
       {:else}
         <div class="phase" aria-live="polite">
@@ -1192,6 +1371,61 @@
   }
   .filepick input {
     display: none;
+  }
+  button.filepick {
+    font: inherit;
+    color: inherit;
+    text-align: center;
+  }
+
+  /* ————— interrupted sends (V13-PR04) ————— */
+  .resume-hint {
+    grid-column: 1 / -1;
+    margin: 0;
+    font-size: 0.85rem;
+    color: #a5b4fc;
+  }
+  .resume-hint.bad {
+    color: #fca5a5;
+  }
+  .resume-zone {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(139, 124, 246, 0.2);
+  }
+  .resume-zone h3 {
+    margin: 0;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #77849f;
+  }
+  .resume-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 0.75rem;
+    background: rgba(139, 124, 246, 0.06);
+    border: 1px solid rgba(139, 124, 246, 0.18);
+  }
+  .resume-name {
+    margin: 0;
+    font-weight: 600;
+    font-size: 0.92rem;
+  }
+  .resume-card .muted {
+    margin: 0;
+    font-size: 0.8rem;
+  }
+  .resume-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.35rem;
   }
 
   /* ————— failure ————— */

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -35,6 +35,7 @@ import type {
   SessionCrypto,
   WorkerToHost,
 } from '../transfer/wire.js';
+import type { SenderReattachment } from '../transfer/sender-record.js';
 import { GenerationGuard } from './generation.js';
 import { type Snapshot, sanitize } from '../transfer/diagnostics.js';
 import type { PathKind } from '../transfer/diagnostics.js';
@@ -88,6 +89,10 @@ export interface DurableInfo {
 
 export interface SendOptions {
   files: File[];
+  /** Reuse the stable transfer id of an interrupted send; the worker re-verifies the source. */
+  transferId?: string;
+  /** How this send's source can be reopened after an interruption (persisted with the record). */
+  reattachment?: SenderReattachment;
   /** Operator-published ICE servers; omitting keeps the bundled default STUN. */
   iceServers?: RTCIceServer[];
 }
@@ -102,7 +107,13 @@ export function runSend(
     role: 'send',
     total: opts.files.reduce((total, file) => total + file.size, 0),
     ...(opts.iceServers ? { iceServers: opts.iceServers } : {}),
-    start: () => ({ kind: 'start-send', files: opts.files, ...crypto(rendezvous) }),
+    start: () => ({
+      kind: 'start-send',
+      files: opts.files,
+      ...(opts.transferId !== undefined ? { transferId: opts.transferId } : {}),
+      ...(opts.reattachment !== undefined ? { reattachment: opts.reattachment } : {}),
+      ...crypto(rendezvous),
+    }),
   });
 }
 

--- a/apps/web/src/lib/transfer/file-source.ts
+++ b/apps/web/src/lib/transfer/file-source.ts
@@ -9,9 +9,18 @@ import type { FileMeta, FileSource } from '@sendbeam/protocol';
 
 const DEFAULT_CHUNK = 64 * 1024;
 
-export function blobFileSource(file: File, chunk: number = DEFAULT_CHUNK): FileSource {
+/**
+ * Adapt a browser File into a {@link FileSource}. `name` overrides the canonical manifest
+ * name — used for handle-derived Files whose relative path lives in their constructed
+ * name rather than `webkitRelativePath` (V13-PR04 reattachment).
+ */
+export function blobFileSource(
+  file: File,
+  chunk: number = DEFAULT_CHUNK,
+  name?: string,
+): FileSource {
   const meta: FileMeta = {
-    name: file.webkitRelativePath || file.name,
+    name: name ?? (file.webkitRelativePath || file.name),
     size: file.size,
     mime: file.type,
     lastModified: file.lastModified,

--- a/apps/web/src/lib/transfer/sender-reattach.test.ts
+++ b/apps/web/src/lib/transfer/sender-reattach.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalizeFiles,
+  cheapSourceCheck,
+  ensureReadPermission,
+  materializeHandle,
+  relName,
+} from './sender-reattach.js';
+import { newSenderRecord, type SenderRecord } from './sender-record.js';
+import { FrameType, type Manifest } from '@sendbeam/protocol';
+
+function manifest(): Manifest {
+  return {
+    type: FrameType.Manifest,
+    transferId: 'ab'.repeat(16),
+    files: [
+      {
+        idx: 0,
+        name: 'folder/a.bin',
+        size: 3,
+        mime: 'application/octet-stream',
+        lastModified: 2_000,
+        blockSize: 64 * 1024,
+        blocks: 1,
+        fileDigest: 'd2'.repeat(32),
+      },
+      {
+        idx: 1,
+        name: 'folder/b.bin',
+        size: 4,
+        mime: 'application/octet-stream',
+        lastModified: 1_000,
+        blockSize: 64 * 1024,
+        blocks: 1,
+        fileDigest: 'c1'.repeat(32),
+      },
+    ],
+    totalSize: 7,
+  };
+}
+
+describe('sender-reattach', () => {
+  it('uses webkitRelativePath as the canonical rel name when present', () => {
+    const file = new File(['x'], 'a.bin');
+    Object.defineProperty(file, 'webkitRelativePath', { value: 'folder/a.bin' });
+    expect(relName(file)).toBe('folder/a.bin');
+    expect(relName(new File(['x'], 'plain.bin'))).toBe('plain.bin');
+  });
+
+  it('sorts any selection into canonical relative order', () => {
+    const late = new File(['b'], 'b.bin');
+    Object.defineProperty(late, 'webkitRelativePath', { value: 'z/late.bin' });
+    const early = new File(['a'], 'a.bin');
+    Object.defineProperty(early, 'webkitRelativePath', { value: 'a/early.bin' });
+    const mid = new File(['c'], 'c.bin');
+    Object.defineProperty(mid, 'webkitRelativePath', { value: 'm/mid.bin' });
+    expect(canonicalizeFiles([late, mid, early]).map(relName)).toEqual([
+      'a/early.bin',
+      'm/mid.bin',
+      'z/late.bin',
+    ]);
+    // The input array is not mutated.
+    expect([late, mid, early].map(relName)).toEqual(['z/late.bin', 'm/mid.bin', 'a/early.bin']);
+  });
+
+  it('materializes a file handle into a canonical File whose name is its relative path', async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const handle: FileSystemFileHandle = {
+      kind: 'file',
+      name: 'photo.jpg',
+      getFile: async () =>
+        new File([bytes], 'photo.jpg', { type: 'image/jpeg', lastModified: 7_000 }),
+    } as FileSystemFileHandle;
+    const files = await materializeHandle(handle);
+    expect(files).toHaveLength(1);
+    expect(relName(files[0]!)).toBe('photo.jpg');
+    expect(files[0]!.size).toBe(3);
+    expect(files[0]!.type).toBe('image/jpeg');
+    expect(files[0]!.lastModified).toBe(7_000);
+    expect(new Uint8Array(await files[0]!.arrayBuffer())).toEqual(bytes);
+  });
+
+  it('materializes a directory handle recursively, in canonical order', async () => {
+    const dirEntries = new Map<string, FileSystemHandle>([
+      [
+        'z.txt',
+        {
+          kind: 'file',
+          name: 'z.txt',
+          getFile: async () => new File(['z'], 'z.txt'),
+        } as unknown as FileSystemFileHandle,
+      ],
+      [
+        'sub',
+        {
+          kind: 'directory',
+          name: 'sub',
+          entries: async function* entries(): AsyncGenerator<[string, FileSystemHandle]> {
+            yield [
+              'nested.bin',
+              {
+                kind: 'file',
+                name: 'nested.bin',
+                getFile: async () => new File(['n'], 'nested.bin'),
+              } as unknown as FileSystemFileHandle,
+            ];
+          },
+        } as unknown as FileSystemDirectoryHandle,
+      ],
+      [
+        'a.txt',
+        {
+          kind: 'file',
+          name: 'a.txt',
+          getFile: async () => new File(['a'], 'a.txt'),
+        } as unknown as FileSystemFileHandle,
+      ],
+    ]);
+    const handle = {
+      kind: 'directory',
+      name: 'photos',
+      entries: async function* entries(): AsyncGenerator<[string, FileSystemHandle]> {
+        yield* dirEntries;
+      },
+    } as unknown as FileSystemDirectoryHandle;
+
+    const files = await materializeHandle(handle);
+    expect(files.map(relName)).toEqual(['photos/a.txt', 'photos/sub/nested.bin', 'photos/z.txt']);
+    expect(new Uint8Array(await files[2]!.arrayBuffer())).toEqual(new TextEncoder().encode('z'));
+  });
+
+  it('grants when the permission API allows it and fails safe otherwise', async () => {
+    const permission = (
+      query: PermissionState,
+      request: PermissionState | undefined = undefined,
+    ): FileSystemHandle =>
+      ({
+        kind: 'file',
+        name: 'f',
+        queryPermission: async () => query,
+        ...(request !== undefined ? { requestPermission: async () => request } : {}),
+      }) as unknown as FileSystemHandle;
+    await expect(ensureReadPermission(permission('granted'))).resolves.toBe(true);
+    await expect(ensureReadPermission(permission('prompt', 'granted'))).resolves.toBe(true);
+    await expect(ensureReadPermission(permission('prompt', 'denied'))).resolves.toBe(false);
+    await expect(ensureReadPermission(permission('denied'))).resolves.toBe(false);
+    // No permission API at all (non-Chromium engine): fail safe, never throw.
+    await expect(
+      ensureReadPermission({ kind: 'file', name: 'f' } as FileSystemHandle),
+    ).resolves.toBe(false);
+  });
+
+  it('cheap-check: accepts the recorded source in any order, rejects real differences', async () => {
+    const record: SenderRecord = await newSenderRecord(manifest(), { kind: 'reselection' }, 1);
+    const pick = (name: string, size: number, mime: string, lastModified: number): File => {
+      const file = new File([new Uint8Array(size)], name, { type: mime, lastModified });
+      Object.defineProperty(file, 'webkitRelativePath', { value: `folder/${name}` });
+      return file;
+    };
+    const same = [
+      pick('b.bin', 4, 'application/octet-stream', 1_000),
+      pick('a.bin', 3, 'application/octet-stream', 2_000),
+    ];
+    expect(cheapSourceCheck(record, same)).toBeUndefined();
+    expect(cheapSourceCheck(record, [same[1]!, same[0]!])).toBeUndefined();
+
+    expect(cheapSourceCheck(record, [same[0]!])).toMatch(/1 files/);
+    const edited = pick('b.bin', 4, 'application/octet-stream', 9_999);
+    expect(cheapSourceCheck(record, [same[1]!, edited])).toMatch(/differs/);
+    const renamed = pick('other.bin', 4, 'application/octet-stream', 1_000);
+    expect(cheapSourceCheck(record, [same[1]!, renamed])).toMatch(/differs/);
+    const resized = pick('b.bin', 99, 'application/octet-stream', 1_000);
+    expect(cheapSourceCheck(record, [same[1]!, resized])).toMatch(/differs/);
+  });
+});

--- a/apps/web/src/lib/transfer/sender-reattach.ts
+++ b/apps/web/src/lib/transfer/sender-reattach.ts
@@ -1,0 +1,120 @@
+/**
+ * Web sender reattachment helpers (V13-PR04) — the browser half of reopening an
+ * interrupted send against its original source:
+ *
+ *  - {@link relName}: the canonical manifest name of a picked File (the same expression
+ *    `blobFileSource` uses), so cheap pre-checks and record comparisons agree with the
+ *    wire's file identities.
+ *  - {@link canonicalizeFiles}: stable sort by rel name — the browser analog of the CLI's
+ *    canonical sorted paths. A folder re-picked in any order yields the same manifest, so
+ *    the record's fingerprint stays comparable across attempts.
+ *  - {@link materializeHandle}: reopen a persisted File System Access handle into the
+ *    same canonical File[] (File names carry their relative paths, so the wire manifest
+ *    is identical to the original pick).
+ *  - {@link ensureReadPermission}: query/request read permission, failing safe (false)
+ *    whenever the API is unavailable — handle-based resume then falls back to reselection.
+ *  - {@link cheapSourceCheck}: an advisory pre-check mirroring the CLI's cheap meta check;
+ *    the authoritative identity check still runs in the worker before the manifest frame.
+ */
+
+import type { SenderRecord } from './sender-record.js';
+
+/** The canonical manifest name of a picked File — matches `blobFileSource`'s meta.name. */
+export function relName(file: File): string {
+  return file.webkitRelativePath || file.name;
+}
+
+/**
+ * Stable sort by canonical relative name (code-unit order — deterministic across engines
+ * and identical to the CLI's sorted-canonical-path ordering). Returns a new array.
+ */
+export function canonicalizeFiles(files: File[]): File[] {
+  return [...files].sort((a, b) => {
+    const an = relName(a);
+    const bn = relName(b);
+    return an < bn ? -1 : an > bn ? 1 : 0;
+  });
+}
+
+/**
+ * Reopen a persisted File System Access handle into canonical Files. Directory handles
+ * are walked recursively; every File's name is its relative path (e.g. `photos/a.jpg`),
+ * so the manifest is byte-identical to the original selection. Throws when the handle is
+ * dead or unreadable — the caller then falls back to reselection.
+ */
+export async function materializeHandle(handle: FileSystemHandle): Promise<File[]> {
+  const out: File[] = [];
+  if (handle.kind === 'file') {
+    const file = await (handle as FileSystemFileHandle).getFile();
+    out.push(relNamedFile(file, handle.name));
+  } else {
+    await walkDirectory(handle as FileSystemDirectoryHandle, handle.name, out);
+  }
+  return canonicalizeFiles(out);
+}
+
+async function walkDirectory(
+  dir: FileSystemDirectoryHandle,
+  prefix: string,
+  out: File[],
+): Promise<void> {
+  for await (const [name, entry] of dir.entries()) {
+    const rel = `${prefix}/${name}`;
+    if (entry.kind === 'directory') {
+      await walkDirectory(entry as FileSystemDirectoryHandle, rel, out);
+    } else {
+      const file = await (entry as FileSystemFileHandle).getFile();
+      out.push(relNamedFile(file, rel));
+    }
+  }
+}
+
+/** Wrap a handle-derived File so its name carries the relative path (relName stays intact). */
+function relNamedFile(file: File, rel: string): File {
+  return new File([file], rel, { type: file.type, lastModified: file.lastModified });
+}
+
+/**
+ * Best-effort read permission for a persisted handle. Returns false whenever the
+ * permission API is unavailable (non-Chromium engines), so the caller falls back to
+ * reselection instead of failing. Must run from a user gesture when the state is
+ * `prompt` (requestPermission requires one).
+ */
+export async function ensureReadPermission(handle: FileSystemHandle): Promise<boolean> {
+  const h = handle as FileSystemHandle & {
+    queryPermission?: (opts: { mode: 'read' }) => Promise<PermissionState>;
+    requestPermission?: (opts: { mode: 'read' }) => Promise<PermissionState>;
+  };
+  if (typeof h.queryPermission !== 'function') return false;
+  let state = await h.queryPermission({ mode: 'read' });
+  if (state === 'prompt' && typeof h.requestPermission === 'function') {
+    state = await h.requestPermission({ mode: 'read' });
+  }
+  return state === 'granted';
+}
+
+/**
+ * Advisory pre-check that the picked selection could be the recorded source. Compares
+ * count, canonical order, and per-file name/size/mime/lastModified — mirroring the CLI's
+ * cheap source check. Returns an error message on a definite mismatch, else undefined.
+ * The authoritative fingerprint check still runs in the worker before the manifest frame.
+ */
+export function cheapSourceCheck(record: SenderRecord, files: File[]): string | undefined {
+  const picked = canonicalizeFiles(files);
+  if (picked.length !== record.files.length) {
+    return `the selected source has ${picked.length} files, but interrupted transfer ${record.transferId} had ${record.files.length}`;
+  }
+  for (let i = 0; i < picked.length; i++) {
+    const have = picked[i]!;
+    const want = record.files[i]!;
+    if (
+      relName(have) !== want.name ||
+      have.size !== want.size ||
+      have.type !== want.mime ||
+      have.lastModified !== want.lastModified
+    ) {
+      return `file "${want.name}" differs from interrupted transfer ${record.transferId}; resuming requires the original source, unchanged`;
+    }
+  }
+  return undefined;
+}

--- a/apps/web/src/lib/transfer/sender-record.test.ts
+++ b/apps/web/src/lib/transfer/sender-record.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { FrameType, manifestFingerprint, type Manifest } from '@sendbeam/protocol';
+import {
+  memorySenderRecordStore,
+  newSenderRecord,
+  refreshSenderRecord,
+  senderRecordChecksum,
+  SENDER_SCHEMA_VERSION,
+  validateSenderRecord,
+  type SenderRecord,
+} from './sender-record.js';
+
+function testManifest(overrides: Partial<Manifest> = {}): Manifest {
+  return {
+    type: FrameType.Manifest,
+    transferId: 'ab'.repeat(16),
+    files: [
+      {
+        idx: 0,
+        name: 'folder/a.bin',
+        size: 3,
+        mime: 'application/octet-stream',
+        lastModified: 1_700_000_000_000,
+        blockSize: 64 * 1024,
+        blocks: 1,
+        fileDigest: 'c1'.repeat(32),
+      },
+      {
+        idx: 1,
+        name: 'folder/empty.txt',
+        size: 0,
+        mime: 'text/plain',
+        lastModified: 1_700_000_000_001,
+        blockSize: 64 * 1024,
+        blocks: 0,
+        fileDigest: 'd2'.repeat(32),
+      },
+    ],
+    totalSize: 3,
+    ...overrides,
+  };
+}
+
+describe('sender-record', () => {
+  it('builds a schema-v1 record from a manifest with a self-verifying checksum', async () => {
+    const manifest = testManifest();
+    const record = await newSenderRecord(manifest, { kind: 'reselection' }, 1_234);
+    expect(record.schemaVersion).toBe(SENDER_SCHEMA_VERSION);
+    expect(record.transferId).toBe(manifest.transferId);
+    expect(record.manifestFingerprint).toBe(await manifestFingerprint(manifest));
+    expect(record.createdAt).toBe(1_234);
+    expect(record.updatedAt).toBe(1_234);
+    expect(record.files).toEqual([
+      {
+        name: 'folder/a.bin',
+        size: 3,
+        mime: 'application/octet-stream',
+        lastModified: 1_700_000_000_000,
+      },
+      { name: 'folder/empty.txt', size: 0, mime: 'text/plain', lastModified: 1_700_000_000_001 },
+    ]);
+    expect(record.checksum).toMatch(/^[0-9a-f]{64}$/);
+    await expect(validateSenderRecord(record)).resolves.toBe(record);
+  });
+
+  it('round-trips through the store, including a persisted handle reattachment', async () => {
+    const store = memorySenderRecordStore();
+    const manifest = testManifest();
+    const handle = { kind: 'directory', name: 'photos' } as unknown as FileSystemHandle;
+    const record = await newSenderRecord(
+      manifest,
+      { kind: 'handle', handleKind: 'directory', handle },
+      1_234,
+    );
+    await store.put(record);
+    await expect(store.load(manifest.transferId!)).resolves.toEqual({ kind: 'ok', record });
+    await store.remove(manifest.transferId!);
+    await expect(store.load(manifest.transferId!)).resolves.toEqual({ kind: 'none' });
+  });
+
+  it('fails closed on any structural or checksum deviation', async () => {
+    const store = memorySenderRecordStore();
+    const record = await newSenderRecord(testManifest(), { kind: 'reselection' }, 1_234);
+
+    const tamper = async (mutate: (r: SenderRecord) => void, name: string): Promise<void> => {
+      const value = structuredClone(record) as SenderRecord;
+      mutate(value);
+      await (store as unknown as { entries: Map<string, unknown> }).entries.set(record.transferId, {
+        transferId: record.transferId,
+        record: value,
+      });
+      const loaded = await store.load(record.transferId);
+      expect(loaded.kind, name).toBe('corrupt');
+    };
+
+    await tamper((r) => (r.files[0]!.size = 99), 'changed file size');
+    await tamper((r) => (r.checksum = 'f'.repeat(64)), 'stale checksum');
+    await tamper(
+      (r) => void ((r as unknown as Record<string, unknown>).extra = 'x'),
+      'unknown field',
+    );
+    await tamper((r) => (r.schemaVersion = 2 as 1), 'future schema version');
+    await tamper((r) => (r.transferId = 'zz'.repeat(16)), 'non-hex transfer id');
+    await tamper((r) => (r.transferId = 'a'.repeat(31)), 'short transfer id');
+    await tamper((r) => (r.manifestFingerprint = 'a'.repeat(63)), 'short fingerprint');
+    await tamper((r) => (r.protocolVersion = 'sendbeam/2'), 'unsupported protocol version');
+    await tamper((r) => (r.files = []), 'empty file set');
+    await tamper((r) => void (r.files[0]!.name = ''), 'empty file name');
+    await tamper(
+      (r) => (r.reattachment = { kind: 'handle', handleKind: 'file', handle: undefined! }),
+      'handle reattachment without a handle',
+    );
+    await tamper(
+      (r) =>
+        (r.reattachment = {
+          kind: 'handle',
+          handleKind: 'nope' as 'file',
+          handle: {} as FileSystemHandle,
+        }),
+      'unknown handle kind',
+    );
+  });
+
+  it('surfaces corrupt records in list() without deleting them', async () => {
+    const store = memorySenderRecordStore();
+    const good = await newSenderRecord(
+      testManifest({ transferId: '11'.repeat(16) }),
+      { kind: 'reselection' },
+      1,
+    );
+    const bad = await newSenderRecord(
+      testManifest({ transferId: '22'.repeat(16) }),
+      { kind: 'reselection' },
+      2,
+    );
+    await store.put(good);
+    await (store as unknown as { entries: Map<string, unknown> }).entries.set(bad.transferId, {
+      transferId: bad.transferId,
+      record: { ...structuredClone(bad), checksum: '0'.repeat(64) },
+    });
+    const listed = await store.list();
+    expect(listed).toHaveLength(2);
+    const badEntry = listed.find((entry) => entry.transferId === bad.transferId)!;
+    expect(badEntry.kind).toBe('corrupt');
+    const goodEntry = listed.find((entry) => entry.transferId === good.transferId)!;
+    expect(goodEntry).toMatchObject({ kind: 'ok' });
+  });
+
+  it('refreshes a matching record (updatedAt + newer reattachment) on a verified resume', async () => {
+    const manifest = testManifest();
+    const prior = await newSenderRecord(manifest, { kind: 'reselection' }, 1_000);
+    const refreshed = await refreshSenderRecord(
+      prior,
+      manifest,
+      {
+        kind: 'handle',
+        handleKind: 'directory',
+        handle: { kind: 'directory' } as unknown as FileSystemHandle,
+      },
+      2_000,
+    );
+    expect(refreshed.createdAt).toBe(1_000);
+    expect(refreshed.updatedAt).toBe(2_000);
+    expect(refreshed.manifestFingerprint).toBe(prior.manifestFingerprint);
+    expect(refreshed.reattachment).toMatchObject({ kind: 'handle', handleKind: 'directory' });
+    expect(refreshed.checksum).toBe(await senderRecordChecksum(refreshed));
+    await expect(validateSenderRecord(refreshed)).resolves.toBe(refreshed);
+  });
+
+  it('rejects a resume whose canonical source identity changed', async () => {
+    const prior = await newSenderRecord(testManifest(), { kind: 'reselection' }, 1_000);
+    const changed = testManifest();
+    changed.files[0]!.size = 4;
+    changed.totalSize = 4;
+    await expect(refreshSenderRecord(prior, changed, undefined, 2_000)).rejects.toThrow(
+      /does not match interrupted transfer/,
+    );
+  });
+
+  it('rejects a refresh against a different transfer id', async () => {
+    const prior = await newSenderRecord(testManifest(), { kind: 'reselection' }, 1_000);
+    const other = testManifest({ transferId: 'ef'.repeat(16) });
+    await expect(refreshSenderRecord(prior, other, undefined, 2_000)).rejects.toThrow(
+      /belongs to transfer/,
+    );
+  });
+});

--- a/apps/web/src/lib/transfer/sender-record.ts
+++ b/apps/web/src/lib/transfer/sender-record.ts
@@ -1,0 +1,492 @@
+/**
+ * Web sender metadata (V13-PR04) — the browser twin of the CLI's sender store
+ * (apps/cli/internal/transfer/sender_state.go), implementing the same contract over
+ * IndexedDB: a per-transfer record carrying the stable transfer id and the canonical
+ * manifest fingerprint is durable BEFORE the manifest frame goes out (via the worker's
+ * `onManifest` hook), so an interrupted send can be reopened and verified against the
+ * exact source before the id is re-advertised.
+ *
+ * The record is stored as a structured-clone object (key = transferId) because the
+ * reattachment claim may carry a native {@link FileSystemHandle}, which cannot be
+ * JSON-encoded but survives both postMessage and IndexedDB structured clone. Fail-closed
+ * integrity comes from a strict shape validation plus a SHA-256 checksum over the
+ * canonical JSON of every JSON-safe field (the handle itself is opaque and excluded;
+ * a stale/revoked handle fails at reattachment time, falling back to reselection).
+ *
+ * Store contract: load/put/remove one record per transferId; list() surfaces corrupt
+ * records (never deletes, never treats them as absent) so the UI can offer Forget.
+ */
+
+import {
+  bytesToHex,
+  manifestFingerprint,
+  PROTOCOL_VERSION,
+  sha256,
+  TransferError,
+  utf8,
+  type Manifest,
+} from '@sendbeam/protocol';
+
+/** IndexedDB database and store names for sender metadata. */
+export const SENDER_DB = 'sendbeam-sender';
+export const SENDER_RECORDS_STORE = 'records';
+
+/** The per-transfer metadata schema this build persists and accepts. */
+export const SENDER_SCHEMA_VERSION = 1 as const;
+
+/** One file of the interrupted send, mirroring the CLI's SenderFileState fields. */
+export interface SenderFileState {
+  name: string;
+  size: number;
+  mime: string;
+  lastModified: number;
+}
+
+/**
+ * How a restart locates the original source. `reselection` (a plain picker selection)
+ * needs the user to re-pick the source; `handle` carries the persisted File System Access
+ * handle so the source can be reopened directly.
+ */
+export type SenderReattachment =
+  | { kind: 'reselection' }
+  | { kind: 'handle'; handleKind: 'file' | 'directory'; handle: FileSystemHandle };
+
+/**
+ * Sender metadata for one transfer id. The checksum is the SHA-256 (hex) of the canonical
+ * JSON core (everything except `checksum` and the opaque `reattachment.handle` object).
+ */
+export interface SenderRecord {
+  schemaVersion: 1;
+  transferId: string;
+  /** Canonical SHA-256 (hex) of the validated manifest — the identity to re-verify. */
+  manifestFingerprint: string;
+  /** Wire-protocol version the transfer ran under (mirrors the CLI + journal). */
+  protocolVersion: string;
+  createdAt: number;
+  updatedAt: number;
+  files: SenderFileState[];
+  reattachment: SenderReattachment;
+  checksum: string;
+}
+
+/** Result of loading one record: absent, valid, or corrupt (fail closed, nothing deleted). */
+export type SenderRecordLoad =
+  | { kind: 'none' }
+  | { kind: 'ok'; record: SenderRecord }
+  | { kind: 'corrupt'; transferId: string; error: string };
+
+/** What {@link SenderRecordStore.list} yields: every persisted entry, never `none`. */
+export type SenderRecordListEntry =
+  | { kind: 'ok'; transferId: string; record: SenderRecord }
+  | { kind: 'corrupt'; transferId: string; error: string };
+
+/** Sender metadata store. All writes are atomic IDB transactions. */
+export interface SenderRecordStore {
+  load(transferId: string): Promise<SenderRecordLoad>;
+  /** Every persisted record, with corrupt entries surfaced (never thrown, never deleted). */
+  list(): Promise<SenderRecordListEntry[]>;
+  /** Persist a validated record, replacing any prior record for the same transfer id. */
+  put(record: SenderRecord): Promise<void>;
+  /** Remove one record, idempotently. */
+  remove(transferId: string): Promise<void>;
+}
+
+/** The JSON-safe core of a record — the exact bytes the checksum covers. */
+function canonicalCore(record: SenderRecord): string {
+  const core = {
+    schemaVersion: record.schemaVersion,
+    transferId: record.transferId,
+    manifestFingerprint: record.manifestFingerprint,
+    protocolVersion: record.protocolVersion,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    files: record.files.map((f) => ({
+      name: f.name,
+      size: f.size,
+      mime: f.mime,
+      lastModified: f.lastModified,
+    })),
+    reattachment:
+      record.reattachment.kind === 'handle'
+        ? { kind: 'handle', handleKind: record.reattachment.handleKind }
+        : { kind: 'reselection' },
+  };
+  return JSON.stringify(core);
+}
+
+/** Compute the record checksum over the canonical JSON core (handle excluded, kind included). */
+export async function senderRecordChecksum(record: SenderRecord): Promise<string> {
+  return bytesToHex(await sha256(utf8(canonicalCore(record))));
+}
+
+function isLowerHex(value: unknown, length: number): value is string {
+  return typeof value === 'string' && value.length === length && /^[0-9a-f]+$/.test(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function exactKeys(value: unknown, keys: readonly string[]): boolean {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const actual = Object.keys(value);
+  if (actual.length !== keys.length) return false;
+  for (const key of keys) if (!(key in value)) return false;
+  return true;
+}
+
+/**
+ * Strict fail-closed validation: exact schema version, exact key sets at every level,
+ * field formats, and a self-verifying checksum. Throws on any deviation.
+ */
+export async function validateSenderRecord(record: unknown): Promise<SenderRecord> {
+  if (
+    !exactKeys(record, [
+      'schemaVersion',
+      'transferId',
+      'manifestFingerprint',
+      'protocolVersion',
+      'createdAt',
+      'updatedAt',
+      'files',
+      'reattachment',
+      'checksum',
+    ])
+  ) {
+    throw new Error('sender record: unexpected or missing fields');
+  }
+  const r = record as SenderRecord;
+  if (r.schemaVersion !== SENDER_SCHEMA_VERSION) {
+    throw new Error(`sender record: unsupported schema version ${String(r.schemaVersion)}`);
+  }
+  if (!isLowerHex(r.transferId, 32)) {
+    throw new Error('sender record: transferId must be 32 lowercase hex characters');
+  }
+  if (!isLowerHex(r.manifestFingerprint, 64)) {
+    throw new Error('sender record: manifestFingerprint must be 64 lowercase hex characters');
+  }
+  if (typeof r.protocolVersion !== 'string' || r.protocolVersion === '') {
+    throw new Error('sender record: invalid protocolVersion');
+  }
+  if (r.protocolVersion !== PROTOCOL_VERSION) {
+    throw new Error(`sender record: unsupported protocol version ${r.protocolVersion}`);
+  }
+  if (!isFiniteNumber(r.createdAt) || !isFiniteNumber(r.updatedAt)) {
+    throw new Error('sender record: invalid timestamp');
+  }
+  if (!Array.isArray(r.files) || r.files.length === 0) {
+    throw new Error('sender record: files must be a non-empty array');
+  }
+  for (const [idx, f] of r.files.entries()) {
+    if (!exactKeys(f, ['name', 'size', 'mime', 'lastModified'])) {
+      throw new Error(`sender record: file ${idx} has unexpected or missing fields`);
+    }
+    if (typeof f.name !== 'string' || f.name === '') {
+      throw new Error(`sender record: file ${idx} name must be a non-empty string`);
+    }
+    if (!Number.isInteger(f.size) || f.size < 0) {
+      throw new Error(`sender record: file ${idx} size must be a non-negative integer`);
+    }
+    if (typeof f.mime !== 'string') {
+      throw new Error(`sender record: file ${idx} mime must be a string`);
+    }
+    if (!isFiniteNumber(f.lastModified)) {
+      throw new Error(`sender record: file ${idx} lastModified must be a non-negative number`);
+    }
+  }
+  if (r.reattachment.kind === 'reselection') {
+    if (!exactKeys(r.reattachment, ['kind'])) {
+      throw new Error('sender record: reselection reattachment has unexpected fields');
+    }
+  } else if (r.reattachment.kind === 'handle') {
+    if (!exactKeys(r.reattachment, ['kind', 'handleKind', 'handle'])) {
+      throw new Error('sender record: handle reattachment has unexpected or missing fields');
+    }
+    if (r.reattachment.handleKind !== 'file' && r.reattachment.handleKind !== 'directory') {
+      throw new Error('sender record: unknown handle kind');
+    }
+    if (r.reattachment.handle === undefined || r.reattachment.handle === null) {
+      throw new Error('sender record: handle reattachment must carry a handle');
+    }
+  } else {
+    throw new Error('sender record: unknown reattachment kind');
+  }
+  if (!isLowerHex(r.checksum, 64)) {
+    throw new Error('sender record: checksum must be 64 lowercase hex characters');
+  }
+  const recomputed = await senderRecordChecksum(r);
+  if (recomputed !== r.checksum) {
+    throw new Error('sender record: checksum mismatch');
+  }
+  return r;
+}
+
+/**
+ * Build a fresh schema-v1 record for a validated manifest, persisting the canonical
+ * source identity before the manifest frame is advertised. `nowMs` is injectable so
+ * tests are deterministic.
+ */
+export async function newSenderRecord(
+  manifest: Manifest,
+  reattachment: SenderReattachment,
+  nowMs: number,
+): Promise<SenderRecord> {
+  if (manifest.transferId === undefined) {
+    throw new Error('sender record: a transfer id is required');
+  }
+  const record: SenderRecord = {
+    schemaVersion: SENDER_SCHEMA_VERSION,
+    transferId: manifest.transferId,
+    manifestFingerprint: await manifestFingerprint(manifest),
+    protocolVersion: PROTOCOL_VERSION,
+    createdAt: nowMs,
+    updatedAt: nowMs,
+    files: manifest.files.map((f) => ({
+      name: f.name,
+      size: f.size,
+      mime: f.mime,
+      lastModified: f.lastModified,
+    })),
+    reattachment,
+    checksum: '',
+  };
+  record.checksum = await senderRecordChecksum(record);
+  return record;
+}
+
+/**
+ * Verify a prior record against the manifest of a resend and refresh it (updatedAt, and
+ * the reattachment claim when the caller supplies a newer one, e.g. a re-materialized
+ * handle). Throws before anything is sent when the canonical source identity changed —
+ * the fingerprint covers the transfer id, block geometry, and every file's name, size,
+ * mime, timestamp, and content digest, so any difference means a different source.
+ */
+export async function refreshSenderRecord(
+  prior: SenderRecord,
+  manifest: Manifest,
+  reattachment: SenderReattachment | undefined,
+  nowMs: number,
+): Promise<SenderRecord> {
+  if (prior.transferId !== manifest.transferId) {
+    throw new TransferError(
+      'integrity',
+      `sender record belongs to transfer ${prior.transferId}, not ${manifest.transferId}`,
+    );
+  }
+  const fingerprint = await manifestFingerprint(manifest);
+  if (prior.manifestFingerprint !== fingerprint) {
+    throw new TransferError(
+      'integrity',
+      `the selected source does not match interrupted transfer ${prior.transferId}; ` +
+        'resuming requires the original source, unchanged. Start a new transfer instead.',
+    );
+  }
+  const next: SenderRecord = {
+    ...prior,
+    updatedAt: nowMs,
+    ...(reattachment !== undefined ? { reattachment } : {}),
+  };
+  next.checksum = await senderRecordChecksum(next);
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// IndexedDB backend
+// ---------------------------------------------------------------------------
+
+interface IDBRequestLike<T = unknown> {
+  result: T;
+  error: DOMException | null;
+  onsuccess: ((ev: Event) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+}
+interface IDBObjectStoreLike {
+  get(key: string): IDBRequestLike<unknown>;
+  put(value: unknown, key: string): IDBRequestLike;
+  delete(key: string): IDBRequestLike;
+  getAll(): IDBRequestLike<unknown[]>;
+}
+interface IDBTransactionLike {
+  objectStore(name: string): IDBObjectStoreLike;
+  oncomplete: ((ev: Event) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onabort: ((ev: Event) => void) | null;
+}
+interface IDBDatabaseLike {
+  objectStoreNames: { contains(name: string): boolean };
+  transaction(storeNames: string[], mode: 'readonly' | 'readwrite'): IDBTransactionLike;
+  close(): void;
+}
+
+/** The value stored per key: the key rides along so list() can report corrupt ids. */
+interface StoredRecord {
+  transferId: string;
+  record: unknown;
+}
+
+function requestResult(r: IDBRequestLike): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error ?? new Error('indexeddb request failed'));
+  });
+}
+
+function transactionDone(tx: IDBTransactionLike): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(new Error('indexeddb transaction failed'));
+    tx.onabort = () => reject(new Error('indexeddb transaction aborted'));
+  });
+}
+
+/** The browser sender-record store over IndexedDB. */
+export function indexedDbSenderRecordStore(): SenderRecordStore {
+  return new IndexedDbSenderRecordStore();
+}
+
+/**
+ * The store when IndexedDB exists, else undefined: the platform cannot persist sender
+ * metadata, so the send proceeds without restart/reopen support (a degraded feature,
+ * never a transfer blocker — mirroring how durable receive degrades without OPFS).
+ */
+export function senderRecordStoreWhenAvailable(): SenderRecordStore | undefined {
+  if (!(globalThis as { indexedDB?: IDBFactory }).indexedDB) return undefined;
+  return new IndexedDbSenderRecordStore();
+}
+
+class IndexedDbSenderRecordStore implements SenderRecordStore {
+  private dbPromise: Promise<IDBDatabaseLike> | undefined;
+
+  private db(): Promise<IDBDatabaseLike> {
+    if (!this.dbPromise) {
+      this.dbPromise = new Promise((resolve, reject) => {
+        const idb = (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+        if (!idb) {
+          reject(new Error('IndexedDB is unavailable in this browser'));
+          return;
+        }
+        const req = idb.open(SENDER_DB, 1);
+        req.onupgradeneeded = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains(SENDER_RECORDS_STORE)) {
+            db.createObjectStore(SENDER_RECORDS_STORE);
+          }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error('open sendbeam-sender failed'));
+      });
+    }
+    return this.dbPromise;
+  }
+
+  async load(transferId: string): Promise<SenderRecordLoad> {
+    const db = await this.db();
+    const tx = db.transaction([SENDER_RECORDS_STORE], 'readonly');
+    const value = await requestResult(tx.objectStore(SENDER_RECORDS_STORE).get(transferId));
+    await transactionDone(tx);
+    if (value === undefined) return { kind: 'none' };
+    const decoded = await decodeStored(value);
+    return decoded.kind === 'ok' ? { kind: 'ok', record: decoded.record } : decoded;
+  }
+
+  async list(): Promise<SenderRecordListEntry[]> {
+    const db = await this.db();
+    const tx = db.transaction([SENDER_RECORDS_STORE], 'readonly');
+    const values = await requestResult(tx.objectStore(SENDER_RECORDS_STORE).getAll());
+    await transactionDone(tx);
+    const out: SenderRecordListEntry[] = [];
+    for (const value of values as unknown[]) {
+      out.push(await decodeStored(value));
+    }
+    return out;
+  }
+
+  async put(record: SenderRecord): Promise<void> {
+    await validateSenderRecord(record);
+    const db = await this.db();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([SENDER_RECORDS_STORE], 'readwrite');
+      tx.objectStore(SENDER_RECORDS_STORE).put(
+        { transferId: record.transferId, record },
+        record.transferId,
+      );
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error('sender record write failed'));
+      tx.onabort = () => reject(new Error('sender record write aborted'));
+    });
+  }
+
+  async remove(transferId: string): Promise<void> {
+    const db = await this.db();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([SENDER_RECORDS_STORE], 'readwrite');
+      tx.objectStore(SENDER_RECORDS_STORE).delete(transferId);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error('sender record remove failed'));
+      tx.onabort = () => reject(new Error('sender record remove aborted'));
+    });
+  }
+}
+
+/** Strictly validate one stored value into a list entry (fail closed, nothing deleted). */
+async function decodeStored(value: unknown): Promise<SenderRecordListEntry> {
+  if (!exactKeys(value, ['transferId', 'record'])) {
+    return { kind: 'corrupt', transferId: '', error: 'sender record envelope is malformed' };
+  }
+  const stored = value as StoredRecord;
+  if (typeof stored.transferId !== 'string' || stored.transferId === '') {
+    return { kind: 'corrupt', transferId: '', error: 'sender record has no transfer id' };
+  }
+  try {
+    const record = await validateSenderRecord(stored.record);
+    if (record.transferId !== stored.transferId) {
+      throw new Error('sender record key does not match its transfer id');
+    }
+    return { kind: 'ok', transferId: record.transferId, record };
+  } catch (e) {
+    return {
+      kind: 'corrupt',
+      transferId: stored.transferId,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory backend (deterministic tests)
+// ---------------------------------------------------------------------------
+
+/** A deterministic in-memory store for tests; records keep structured-clone semantics. */
+export function memorySenderRecordStore(): SenderRecordStore {
+  return new MemorySenderRecordStore();
+}
+
+class MemorySenderRecordStore implements SenderRecordStore {
+  private readonly entries = new Map<string, unknown>();
+
+  async load(transferId: string): Promise<SenderRecordLoad> {
+    const value = this.entries.get(transferId);
+    if (value === undefined) return { kind: 'none' };
+    const cloned = structuredClone(value);
+    const decoded = await decodeStored({ transferId, record: cloned });
+    return decoded.kind === 'ok' ? { kind: 'ok', record: decoded.record } : decoded;
+  }
+
+  async list(): Promise<SenderRecordListEntry[]> {
+    const out: SenderRecordListEntry[] = [];
+    for (const [transferId, value] of this.entries) {
+      const cloned = structuredClone(value);
+      out.push(await decodeStored({ transferId, record: cloned }));
+    }
+    return out.sort((a, b) => a.transferId.localeCompare(b.transferId));
+  }
+
+  async put(record: SenderRecord): Promise<void> {
+    await validateSenderRecord(record);
+    this.entries.set(record.transferId, structuredClone(record));
+  }
+
+  async remove(transferId: string): Promise<void> {
+    this.entries.delete(transferId);
+  }
+}

--- a/apps/web/src/lib/transfer/transfer-core.test.ts
+++ b/apps/web/src/lib/transfer/transfer-core.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { deriveTransferKeys, sha256, bytesToHex, MemorySink } from '@sendbeam/protocol';
+import {
+  deriveTransferKeys,
+  sha256,
+  bytesToHex,
+  MemorySink,
+  FrameType,
+  type Manifest,
+} from '@sendbeam/protocol';
 import { runTransferCore, type TransferCoreDeps } from './transfer-core.js';
 import { blobFileSource } from './file-source.js';
 import { createSha256DigestFactory } from './digest.js';
+import {
+  memorySenderRecordStore,
+  newSenderRecord,
+  type SenderRecord,
+  type SenderRecordLoad,
+  type SenderRecordStore,
+} from './sender-record.js';
 import type { DuplexPort, HostToWorker, WorkerToHost } from './wire.js';
 
 /**
@@ -238,5 +252,260 @@ describe('transfer-core loopback', () => {
     expect(received?.files.map((file) => file.name)).toEqual(['folder/a.bin', 'folder/empty.txt']);
     expect(sinks.get('folder/a.bin')?.bytes()).toEqual(new Uint8Array([1, 2, 3]));
     expect(sinks.get('folder/empty.txt')?.bytes()).toEqual(new Uint8Array());
+  });
+});
+
+/** Build the sender record the worker would persist for one File with the given id. */
+async function recordForFile(file: File, transferId: string): Promise<SenderRecord> {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const manifest: Manifest = {
+    type: FrameType.Manifest,
+    transferId,
+    files: [
+      {
+        idx: 0,
+        name: file.webkitRelativePath || file.name,
+        size: file.size,
+        mime: file.type,
+        lastModified: file.lastModified,
+        blockSize: 64 * 1024,
+        blocks: Math.ceil(file.size / (64 * 1024)),
+        fileDigest: bytesToHex(await sha256(bytes)),
+      },
+    ],
+    totalSize: file.size,
+  };
+  return newSenderRecord(manifest, { kind: 'reselection' }, 1_000);
+}
+
+describe('sender-record seam (V13-PR04)', () => {
+  it('persists a fresh sender record before the manifest frame and removes it after success', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(11));
+    const bytes = new Uint8Array(50 * 1024).map((_, i) => (i * 13) & 0xff);
+    const file = new File([bytes], 'fresh.bin', { type: 'application/octet-stream' });
+    const store = memorySenderRecordStore();
+
+    const sendPort = new FakePort();
+    const recvPort = new FakePort();
+    const sink = new MemorySink();
+    let atFirstFrame: Promise<SenderRecordLoad[]> | undefined;
+    recvPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') {
+        if (atFirstFrame === undefined) atFirstFrame = store.list();
+        sendPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+      }
+    };
+    sendPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') recvPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+    };
+    const recvP = runTransferCore(recvPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => sink,
+      fileSource: blobFileSource,
+    });
+    const sendP = runTransferCore(sendPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: blobFileSource,
+      senderRecords: store,
+    });
+
+    recvPort.toWorker({
+      kind: 'start-recv',
+      destination: { kind: 'auto' },
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounter: 1,
+      recvCounter: 1,
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      files: [file],
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+      blockSize: 64 * 1024,
+      frameSize: 16 * 1024,
+    });
+    await Promise.all([recvP, sendP]);
+
+    // The record existed before the first (manifest) frame was transmitted...
+    const seen = await atFirstFrame!;
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ kind: 'ok' });
+    const record = (seen[0] as { kind: 'ok'; record: SenderRecord }).record;
+    expect(record.transferId).toMatch(/^[0-9a-f]{32}$/);
+    expect(record.reattachment).toEqual({ kind: 'reselection' });
+    expect(record.files).toEqual([
+      {
+        name: 'fresh.bin',
+        size: bytes.length,
+        mime: 'application/octet-stream',
+        lastModified: file.lastModified,
+      },
+    ]);
+    // ...and was removed after verified success.
+    await expect(store.list()).resolves.toEqual([]);
+  });
+
+  it('resumes an interrupted send over a matching source, refreshing and then removing the record', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(13));
+    const bytes = new Uint8Array(50 * 1024).map((_, i) => (i * 17) & 0xff);
+    const file = new File([bytes], 'resume.bin', { type: 'application/octet-stream' });
+    const id = 'dd'.repeat(16);
+    const store = memorySenderRecordStore();
+    await store.put(await recordForFile(file, id));
+
+    const sendPort = new FakePort();
+    const recvPort = new FakePort();
+    const sink = new MemorySink();
+    let atFirstFrame: Promise<SenderRecordLoad[]> | undefined;
+    recvPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') {
+        if (atFirstFrame === undefined) atFirstFrame = store.list();
+        sendPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+      }
+    };
+    sendPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') recvPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+    };
+    const recvP = runTransferCore(recvPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => sink,
+      fileSource: blobFileSource,
+    });
+    const sendP = runTransferCore(sendPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no source');
+      },
+      fileSource: blobFileSource,
+      senderRecords: store,
+    });
+
+    recvPort.toWorker({
+      kind: 'start-recv',
+      destination: { kind: 'auto' },
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounter: 1,
+      recvCounter: 1,
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      files: [file],
+      transferId: id,
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+      blockSize: 64 * 1024,
+      frameSize: 16 * 1024,
+    });
+    await Promise.all([recvP, sendP]);
+
+    const seen = await atFirstFrame!;
+    expect(seen).toHaveLength(1);
+    const record = (seen[0] as { kind: 'ok'; record: SenderRecord }).record;
+    // The interrupted id was reused (not re-minted) and the record refreshed...
+    expect(record.transferId).toBe(id);
+    expect(record.updatedAt).toBeGreaterThan(1_000);
+    // ...and removed after verified success.
+    await expect(store.list()).resolves.toEqual([]);
+  });
+
+  it('rejects a resume whose source changed before any frame is sent, keeping the record', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(17));
+    const original = new File([new Uint8Array(10)], 'same.bin');
+    const id = 'ee'.repeat(16);
+    const store = memorySenderRecordStore();
+    await store.put(await recordForFile(original, id));
+
+    const sendPort = new FakePort();
+    let frames = 0;
+    sendPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') frames++;
+    };
+    const sendP = runTransferCore(sendPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: blobFileSource,
+      senderRecords: store,
+    });
+    // Same name, different content: the fingerprint check must refuse the resume.
+    const changed = new File([new Uint8Array(11)], 'same.bin');
+    sendPort.toWorker({
+      kind: 'start-send',
+      files: [changed],
+      transferId: id,
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+    });
+    await expect(sendP).rejects.toThrow(/does not match interrupted transfer/);
+    expect(frames).toBe(0);
+    await expect(store.load(id)).resolves.toMatchObject({ kind: 'ok' });
+  });
+
+  it('fails closed when the prior sender record is corrupt', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(19));
+    const file = new File([new Uint8Array(10)], 'x.bin');
+    const id = 'aa'.repeat(16);
+    const corrupt: SenderRecordStore = {
+      load: async () => ({ kind: 'corrupt', transferId: id, error: 'tampered record' }),
+      list: async () => [],
+      put: async () => {},
+      remove: async () => {},
+    };
+    const sendPort = new FakePort();
+    const sendP = runTransferCore(sendPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: blobFileSource,
+      senderRecords: corrupt,
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      files: [file],
+      transferId: id,
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+    });
+    await expect(sendP).rejects.toThrow(/corrupt/);
+  });
+
+  it('fails closed when a supplied transfer id has no sender record', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(21));
+    const file = new File([new Uint8Array(10)], 'x.bin');
+    const id = 'bc'.repeat(16);
+    const sendPort = new FakePort();
+    const sendP = runTransferCore(sendPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: blobFileSource,
+      senderRecords: memorySenderRecordStore(),
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      files: [file],
+      transferId: id,
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+    });
+    await expect(sendP).rejects.toThrow(/no sender record/);
   });
 });

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -17,6 +17,7 @@ import {
   type Destination,
   type FileEntry,
   type FileSource,
+  type Manifest,
   type Sink,
 } from '@sendbeam/protocol';
 import type {
@@ -28,6 +29,7 @@ import type {
   WorkerToHost,
 } from './wire.js';
 import type { BrowserDestination } from './sink.js';
+import { newSenderRecord, refreshSenderRecord, type SenderRecordStore } from './sender-record.js';
 
 export interface TransferCoreDeps {
   /** Fresh streaming whole-file hasher (matches `sha256sum`). One live digest per call. */
@@ -38,6 +40,11 @@ export interface TransferCoreDeps {
   createDestination?(spec: ReceiveDestinationSpec): BrowserDestination;
   /** Adapt the sender's File into a re-callable byte source. */
   fileSource(file: File): FileSource;
+  /**
+   * Sender metadata store (V13-PR04). Absent when the platform cannot persist records
+   * (no IndexedDB): the send proceeds but offers no restart/reopen capability.
+   */
+  senderRecords?: SenderRecordStore;
 }
 
 type Port = DuplexPort<HostToWorker, WorkerToHost>;
@@ -142,6 +149,7 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
       try {
         const sources = msg.files.map((file) => deps.fileSource(file));
         let manifestFiles: FileEntry[] = [];
+        let transferId = msg.transferId ?? '';
         const sender = new TransferSender({
           files: sources,
           send,
@@ -151,11 +159,22 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           recvCounterStart: msg.recvCounter,
           createDigest: deps.createDigest,
           // Mint a stable transfer id so the manifest opts into resumption and a crashed
-          // receiver can journal and resume this exact transfer (V13-PR03).
-          newTransferId: () => mintTransferId(),
+          // receiver can journal and resume this exact transfer (V13-PR03). A restart
+          // reuses the caller's id instead (V13-PR04).
+          newTransferId: () => {
+            transferId = mintTransferId();
+            return transferId;
+          },
+          ...(msg.transferId !== undefined ? { transferId: msg.transferId } : {}),
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
-          onManifest: (manifest) => {
+          onManifest: async (manifest) => {
             manifestFiles = manifest.files;
+            const store = deps.senderRecords;
+            if (!store) return;
+            // Persist or verify the sender record strictly before the manifest frame goes
+            // out: the stable id + canonical source identity are durable before the id is
+            // advertised, and a changed source aborts the send with nothing transmitted.
+            await persistSenderRecord(store, msg, manifest);
           },
           onStateChange: (state) => post({ kind: 'state', state }),
           ...(msg.blockSize !== undefined ? { blockSize: msg.blockSize } : {}),
@@ -164,6 +183,12 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
         });
         bind(sender);
         const digest = await sender.run();
+        // Verified success: the transfer settled, so the sender record is spent. Removal
+        // is post-success cleanup, so a failure here must not fail the transfer — the
+        // lingering record only offers a harmless (receiver-verified) re-send.
+        if (transferId !== '' && deps.senderRecords) {
+          await deps.senderRecords.remove(transferId).catch(() => {});
+        }
         post({
           kind: 'done',
           files: manifestFiles.map((file) => ({
@@ -287,4 +312,51 @@ function mintTransferId(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
   return bytesToHex(bytes);
+}
+
+/**
+ * The V13-PR04 sender seam, run strictly before the manifest frame is transmitted:
+ *
+ *  - Fresh send (no caller-supplied id): persist a new record binding the minted id to the
+ *    canonical source identity. A persist failure aborts the send — the id is never
+ *    advertised unless a durable record backs it.
+ *  - Restart (caller-supplied id): the record must exist and be valid, and its canonical
+ *    fingerprint must match the manifest about to be advertised. Any mismatch (or a
+ *    missing/corrupt record) fails closed with nothing transmitted, so a changed source is
+ *    never advertised under the old id.
+ */
+async function persistSenderRecord(
+  store: SenderRecordStore,
+  msg: StartSendMsg,
+  manifest: Manifest,
+): Promise<void> {
+  if (manifest.transferId === undefined) {
+    throw new TransferError('integrity', 'sender record requires a manifest with a transfer id');
+  }
+  const prior = await store.load(manifest.transferId);
+  if (prior.kind === 'corrupt') {
+    throw new TransferError(
+      'integrity',
+      `the sender record for transfer ${manifest.transferId} is corrupt and cannot verify ` +
+        'the source; forget it and start a new transfer',
+    );
+  }
+  if (prior.kind === 'none') {
+    if (msg.transferId !== undefined) {
+      throw new TransferError(
+        'integrity',
+        `no sender record for transfer ${msg.transferId}; the record was lost, so the ` +
+          'source cannot be verified — start a new transfer',
+      );
+    }
+    const record = await newSenderRecord(
+      manifest,
+      msg.reattachment ?? { kind: 'reselection' },
+      Date.now(),
+    );
+    await store.put(record);
+    return;
+  }
+  const refreshed = await refreshSenderRecord(prior.record, manifest, msg.reattachment, Date.now());
+  await store.put(refreshed);
 }

--- a/apps/web/src/lib/transfer/transfer.worker.ts
+++ b/apps/web/src/lib/transfer/transfer.worker.ts
@@ -13,6 +13,7 @@ import { runTransferCore } from './transfer-core.js';
 import { createSha256DigestFactory } from './digest.js';
 import { blobFileSource } from './file-source.js';
 import { createBrowserDestination } from './sink.js';
+import { senderRecordStoreWhenAvailable } from './sender-record.js';
 import type { DuplexPort, HostToWorker, WorkerToHost } from './wire.js';
 
 /** The slice of the worker global we touch, typed narrowly to avoid the DOM/WebWorker lib clash. */
@@ -32,6 +33,7 @@ const port: DuplexPort<HostToWorker, WorkerToHost> = {
 
 async function main(): Promise<void> {
   const createDigest = await createSha256DigestFactory();
+  const senderRecords = senderRecordStoreWhenAvailable();
   post({ kind: 'ready' });
   await runTransferCore(port, {
     createDigest,
@@ -40,6 +42,9 @@ async function main(): Promise<void> {
     },
     createDestination: (spec) => createBrowserDestination(spec, createDigest),
     fileSource: (file) => blobFileSource(file),
+    // Sender metadata (V13-PR04): degraded (no restart support) when IndexedDB is
+    // unavailable; any store failure still fails the send before the manifest frame.
+    ...(senderRecords ? { senderRecords } : {}),
   });
 }
 

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ControlOp, DirectionalKey, TransferRunState } from '@sendbeam/protocol';
+import type { SenderReattachment } from './sender-record.js';
 
 /** Session crypto state handed to the worker at start — counters continue, never reset. */
 export interface SessionCrypto {
@@ -18,6 +19,14 @@ export interface SessionCrypto {
 export interface StartSendMsg extends SessionCrypto {
   kind: 'start-send';
   files: File[];
+  /** Reuse a stable transfer id from an interrupted send (worker re-verifies the source). */
+  transferId?: string;
+  /**
+   * How this send's source can be reopened after an interruption. Persisted by the
+   * worker's `onManifest` hook with the sender record; the handle crosses postMessage
+   * via structured clone (Chromium supports serializing FileSystemHandles).
+   */
+  reattachment?: SenderReattachment;
   blockSize?: number;
   frameSize?: number;
   window?: number;

--- a/docs/sender-reattachment.md
+++ b/docs/sender-reattachment.md
@@ -36,7 +36,7 @@ content digest. Any difference means a different source — that is the whole po
 
 ### Platform-specific identity claims
 
-The record's file set is platform-identical; only *how a restart locates the source*
+The record's file set is platform-identical; only _how a restart locates the source_
 differs, and that is local state, never on the wire:
 
 - **CLI** (`apps/cli/internal/transfer/sender_state.go`): the record adds
@@ -69,6 +69,7 @@ manifest frame is transmitted, and a rejection aborts the send with nothing sent
    resumable.
 
 Storage and integrity:
+
 - CLI: `os.UserConfigDir()/sendbeam/sender/<transferId>.json` (env override
   `SENDBEAM_SENDER_STATE`), mode 0600, atomic replace (temp + fsync + rename + directory
   sync). Decode is strict fail-closed: exact schema version, unknown fields rejected, no
@@ -85,6 +86,7 @@ Storage and integrity:
 ## Reopen behavior
 
 **CLI** — `sendbeam send` re-runs with the same arguments:
+
 1. The store `Lookup`s the record by the canonical path key. No record → fresh send with
    a minted id. Corrupt → fail closed with discard guidance.
 2. Cheap pre-check: the freshly statted source (count, and per-file name/size/mime/mtime
@@ -96,6 +98,7 @@ Storage and integrity:
 
 **Browser** — the offerer's pick screen lists "Interrupted sends" (records are loaded
 from IndexedDB; corrupt ones are surfaced with a Forget action):
+
 1. **Handle records** ("Send again"): the persisted handle is reopened (read permission
    queried/requested; revocation or a dead handle falls back to reselection), the files
    are re-materialized with their canonical relative names, and the send restarts under

--- a/docs/sender-reattachment.md
+++ b/docs/sender-reattachment.md
@@ -1,0 +1,138 @@
+# Sender source reattachment (v1.3 PR04)
+
+Senders keep a per-transfer record — the stable `transferId` plus the canonical source
+identity — durably persisted **before** the manifest frame is transmitted. If a send is
+interrupted (cancel, crash, reload), the sender can be reopened against the exact source
+and resumed under the same `transferId`: the receiver keeps its journal and partials
+(PR02/PR03), and the sender proves the source is unchanged before the id is re-advertised.
+A changed source is never resumed under an old id: the send fails closed before a single
+byte goes out.
+
+This page documents the record schema, the durability ordering, the identity definition,
+the reopen behavior of both implementations, and the limits deferred to later PRs.
+
+## The record
+
+Both implementations persist one record per transfer, schema-v1, carrying the same core:
+
+```
+schemaVersion       1
+transferId          32 lowercase hex   (the id advertised in the manifest)
+manifestFingerprint 64 lowercase hex   (canonical SHA-256 of the validated manifest)
+protocolVersion     'sendbeam/1'
+createdAt           unix ms
+updatedAt           unix ms
+files[]             name, size, mime, lastModified — canonical order
+checksum            SHA-256 (hex) over the canonical JSON of every field above
+```
+
+### Canonical source identity
+
+`manifestFingerprint` is the exact bytes the receiver's durable journal binds its
+checkpoints to (the same `wire.ManifestFingerprint` / `journal.manifestFingerprint`
+used by PR02/PR03): the canonical JSON of the validated manifest, covering the
+`transferId`, the block geometry, and every file's name, size, mime, timestamp, and
+content digest. Any difference means a different source — that is the whole point.
+
+### Platform-specific identity claims
+
+The record's file set is platform-identical; only *how a restart locates the source*
+differs, and that is local state, never on the wire:
+
+- **CLI** (`apps/cli/internal/transfer/sender_state.go`): the record adds
+  `paths` — the canonical sorted absolute source paths. The store keys records on
+  disk as `<transferId>.json` and finds them by `PathKey`, the SHA-256 of the
+  NUL-joined canonical sorted paths (domain prefix `sendbeam/sender-paths\x00`).
+  A re-run of the same command needs no extra information: it derives the key from
+  the arguments and finds the record.
+- **Browser** (`apps/web/src/lib/transfer/sender-record.ts`): the record adds a
+  `reattachment` claim — `{ kind: 'reselection' }` (a plain picker selection must be
+  re-picked) or `{ kind: 'handle'; handleKind; handle }` (a persisted File System
+  Access handle that reopens the source directly). Records are keyed by
+  `transferId` in IndexedDB (`sendbeam-sender` → `records`).
+
+## Durability ordering
+
+The seam is the wire `onManifest` hook, identical on both twins: it fires with the
+validated manifest (after every whole-file digest is computed) **strictly before** the
+manifest frame is transmitted, and a rejection aborts the send with nothing sent.
+
+1. **Fresh send**: a transfer id is minted, the record is created from the manifest and
+   persisted. A persist failure aborts before the manifest — the id is never advertised
+   unless a durable record backs it.
+2. **Restart**: the prior record must exist and be valid, and its `manifestFingerprint`
+   must equal the fingerprint of the manifest about to be advertised. Any mismatch — or
+   a corrupt or missing record — fails closed before the manifest frame. On success the
+   record's `updatedAt` is refreshed (and the browser's `reattachment` claim updated to
+   the freshest one).
+3. **Verified success**: the record is discarded. A failure keeps it, so the send stays
+   resumable.
+
+Storage and integrity:
+- CLI: `os.UserConfigDir()/sendbeam/sender/<transferId>.json` (env override
+  `SENDBEAM_SENDER_STATE`), mode 0600, atomic replace (temp + fsync + rename + directory
+  sync). Decode is strict fail-closed: exact schema version, unknown fields rejected, no
+  trailing data, checksum verified, and the `manifestFingerprint` recomputed from the
+  stored `transferId` + files. A corrupt record is surfaced (list/discard) but never
+  treated as absent.
+- Browser: records are structured-clone objects in IndexedDB because the handle cannot
+  be JSON-encoded. Integrity comes from strict shape validation (exact key sets at every
+  level) plus the checksum over the canonical JSON core; the opaque handle is excluded
+  from the checksum and fails at reopen time (permission revoked, handle dead), falling
+  back to reselection. Browsers without IndexedDB degrade: sends proceed without
+  restart/reopen support.
+
+## Reopen behavior
+
+**CLI** — `sendbeam send` re-runs with the same arguments:
+1. The store `Lookup`s the record by the canonical path key. No record → fresh send with
+   a minted id. Corrupt → fail closed with discard guidance.
+2. Cheap pre-check: the freshly statted source (count, and per-file name/size/mime/mtime
+   in canonical order) must match the record, or the send refuses before dialing.
+3. `PrepareSender` returns the stored `transferId` and a verify hook; the hook re-checks
+   the fingerprint against the manifest before it is sent.
+4. `sendbeam transfers list` shows "Interrupted sends" (id, files, bytes, updated,
+   paths); `sendbeam transfers discard <id>` / `--all` removes sender records too.
+
+**Browser** — the offerer's pick screen lists "Interrupted sends" (records are loaded
+from IndexedDB; corrupt ones are surfaced with a Forget action):
+1. **Handle records** ("Send again"): the persisted handle is reopened (read permission
+   queried/requested; revocation or a dead handle falls back to reselection), the files
+   are re-materialized with their canonical relative names, and the send restarts under
+   the record's `transferId` with the reattachment re-verified in the worker.
+2. **Reselection records** ("Send again"): the user re-picks the original source; a
+   cheap pre-check (count, names, sizes, timestamps) gives a friendly refusal on an
+   obvious mismatch, and the worker's fingerprint check is authoritative.
+3. **Reopenable folders**: a feature-detected "Send folder (reopenable)" button uses
+   `showDirectoryPicker` (File System Access) so fresh sends persist a handle and can be
+   reopened later instead of re-picked. The existing plain pickers are unchanged.
+4. **Forget** removes the record (nothing on the wire or at the receiver depends on it).
+
+In the browser the picked file order is canonicalized (stable sort by relative name)
+before sending, the analog of the CLI's sorted canonical paths: re-picking the same
+folder in any order produces the same manifest, so fingerprints stay comparable.
+
+## Changed-source rejection
+
+A same-size, same-mtime edit is the hard case: the cheap pre-check passes, the
+fingerprint check does not — the manifest about to be advertised is refused at the hook,
+before its frame, so the receiver never sees an inconsistent id. Nothing was sent.
+
+## Limits (deferred)
+
+- **Cross-session authenticated resume (PR05+)**: today a restart re-uses the same
+  rendezvous; resuming across new rooms/sessions with authentication is future work.
+- Browser restarts depend on the same browser + origin (the handle and record are
+  origin-scoped); there is no cross-device resume.
+- The record keeps the last successful manifest; it does not archive earlier versions,
+  and there is no quota management beyond the per-record removal.
+
+## CLI storage contract
+
+```
+os.UserConfigDir()/sendbeam/sender/
+  <transferId>.json          # schema-v1 record, mode 0600
+```
+
+Every load is fail-closed: corrupt or unsupported records are reported with discard
+guidance and never treated as absent.

--- a/packages/protocol/src/transfer-sender.test.ts
+++ b/packages/protocol/src/transfer-sender.test.ts
@@ -475,4 +475,109 @@ describe('TransferSender', () => {
     // fail with retry_exhausted instead of hanging.
     await expect(runP).rejects.toThrow(/retry_exhausted/);
   });
+
+  it('awaits onManifest before the manifest frame is emitted, with the validated manifest', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array(20).map((_, i) => i);
+    const outbound: Uint8Array[] = [];
+    let hookDone = false;
+    let firstFrameHookDone = false;
+    let seenFirst = false;
+    let received: { transferId: string; files: { name: string; size: number }[] } | undefined;
+
+    const sender = new TransferSender({
+      file: bytesSource(data, { name: 'f', size: 20, mime: '', lastModified: 0 }),
+      send: (f) => {
+        if (!seenFirst) {
+          seenFirst = true;
+          firstFrameHookDone = hookDone;
+        }
+        outbound.push(f);
+      },
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 8,
+      frameSize: 4,
+      window: 1,
+      transferId: '0123456789abcdef0123456789abcdef',
+      onManifest: async (manifest) => {
+        await Promise.resolve(); // persist asynchronously; the sender must await this
+        received = {
+          transferId: manifest.transferId,
+          files: manifest.files.map((f) => ({ name: f.name, size: f.size })),
+        };
+        hookDone = true;
+      },
+    });
+
+    const runP = sender.run();
+    await waitFor(() => outbound.length >= 1);
+    expect(seenFirst).toBe(true);
+    expect(firstFrameHookDone).toBe(true);
+    expect(received?.transferId).toBe('0123456789abcdef0123456789abcdef');
+    expect(received?.files).toEqual([{ name: 'f', size: 20 }]);
+
+    // Drain the window (block=8 → 3 blocks) and send done so the run settles. With a
+    // transferId the sender first waits for the receiver's resume_state (fresh: all zero).
+    let ackCtr = 0;
+    const send = async (type: FrameType, payload: Uint8Array, fileIdx = 0, blockIdx = 0) => {
+      const frame = await seal(
+        keys.j2o,
+        ackCtr++,
+        {
+          version: FRAME_VERSION,
+          type,
+          flags: 0,
+          fileIdx,
+          blockIdx,
+          frameOff: 0,
+        },
+        payload,
+      );
+      sender.handle(frame);
+      await new Promise((r) => setTimeout(r, 10));
+    };
+    await send(
+      FrameType.ResumeState,
+      encodeControl({
+        type: FrameType.ResumeState,
+        transferId: '0123456789abcdef0123456789abcdef',
+        files: [{ idx: 0, haveBlocks: 0 }],
+      }),
+    );
+    for (const b of [0, 1, 2]) {
+      await send(FrameType.Ack, encodeControl({ type: FrameType.Ack, fileIdx: 0, blockIdx: b }));
+    }
+    await send(FrameType.Done, encodeControl({ type: FrameType.Done }));
+    await runP;
+  });
+
+  it('rejects run when onManifest rejects, before any frame is emitted', async () => {
+    const keys = await deriveTransferKeys(master);
+    const outbound: Uint8Array[] = [];
+
+    const sender = new TransferSender({
+      file: bytesSource(new Uint8Array(20), { name: 'f', size: 20, mime: '', lastModified: 0 }),
+      send: (f) => void outbound.push(f),
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      blockSize: 8,
+      frameSize: 4,
+      window: 1,
+      transferId: '0123456789abcdef0123456789abcdef',
+      onManifest: async () => {
+        await Promise.resolve();
+        throw new Error('sender-state write failed');
+      },
+    });
+
+    await expect(sender.run()).rejects.toThrow(/sender-state write failed/);
+    expect(outbound.length).toBe(0);
+  });
 });

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -72,7 +72,14 @@ export interface TransferSenderOptions {
   onProgress?(acknowledgedBytes: number): void;
   /** Reports verified progress for the active file plus aggregate acknowledged bytes. */
   onFileProgress?(fileIdx: number, fileBytes: number, acknowledgedBytes: number): void;
-  onManifest?(manifest: Manifest): void;
+  /**
+   * Called with the validated manifest immediately before its frame is transmitted — the
+   * seam the caller uses to make sender-side state durable (stable transfer id + canonical
+   * source identity) strictly before the id is advertised. May be async; a rejection
+   * aborts the send without transmitting the manifest. Local API only: nothing on the
+   * wire changes.
+   */
+  onManifest?(manifest: Manifest): void | Promise<void>;
   onStateChange?(state: TransferRunState): void;
 }
 
@@ -262,7 +269,11 @@ export class TransferSender {
       totalSize,
     });
     const transferDigest = await completionDigest(manifest.files);
-    this.o.onManifest?.(manifest);
+    // The onManifest hook runs after every whole-file digest is computed and the manifest
+    // validated, strictly before its frame is transmitted: sender-side records (stable
+    // transfer id + canonical source identity) are durable before the id is advertised,
+    // and a rejection means the manifest never reaches the wire.
+    await this.o.onManifest?.(manifest);
     await this.sendControl(FrameType.Manifest, manifest);
     this.manifest = manifest;
 

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -66,6 +66,14 @@ type SenderOptions struct {
 	OnProgress     func(acknowledgedBytes int64)
 	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
 	OnStateChange  func(TransferState)
+	// OnManifest, when set, is called with the validated manifest immediately before its
+	// frame is transmitted. It lets the caller make sender-side state durable — the stable
+	// transfer id and canonical source identity — strictly before the manifest can
+	// advertise that id, so a crash after this call can be resumed with the same id and a
+	// changed source can be refused before it is ever advertised. Returning an error
+	// aborts the send without transmitting the manifest. Local API only: nothing on the
+	// wire changes.
+	OnManifest func(manifest Manifest) error
 }
 
 type inflightBlock struct {
@@ -229,6 +237,16 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 		return "", err
 	}
 	transferDigest := CompletionDigest(manifest.Files)
+	// The OnManifest hook runs after every whole-file digest is computed and the manifest
+	// validated, strictly before its frame is transmitted: sender-side records (stable
+	// transfer id + canonical source identity) are durable before the id is advertised,
+	// and a hook error means the manifest never reaches the wire.
+	if s.o.OnManifest != nil {
+		if err := s.o.OnManifest(manifest); err != nil {
+			s.fail(err)
+			return "", err
+		}
+	}
 	if err := s.sendControl(&manifest); err != nil {
 		s.fail(err)
 		return "", err

--- a/packages/wire/transfer_sender_test.go
+++ b/packages/wire/transfer_sender_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -445,5 +447,127 @@ func TestSenderFailsOnDoneBeforeComplete(t *testing.T) {
 	s.Handle(frame)
 	if runErr := <-res; runErr == nil {
 		t.Fatal("Run succeeded on Done before Complete was sent")
+	}
+}
+
+func TestSenderOnManifestRunsBeforeFirstFrame(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := seq(20) // block=8 → blocks 0,1 full, block 2 = 4 bytes
+	var out outbox
+	hookDone := make(chan *Manifest, 1)
+	var hookRan atomic.Bool
+	firstFrameHookRan := false
+	seenFirst := false
+	s := NewSender(SenderOptions{
+		File:       BytesSource(data, FileMeta{Name: "f", Size: 20}, 0),
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		Window:     1,
+		TransferID: "0123456789abcdef0123456789abcdef",
+		OnManifest: func(m Manifest) error {
+			hookRan.Store(true)
+			hookDone <- &m
+			return nil
+		},
+	})
+	// The hook must have completed before the very first frame (the manifest) is emitted:
+	// the sender's own goroutine runs the hook, then Send; capturing order proves the
+	// record would be durable before the id is advertised.
+	origSend := out.push
+	s.o.Send = func(f []byte) error {
+		if !seenFirst {
+			seenFirst = true
+			firstFrameHookRan = hookRan.Load()
+		}
+		return origSend(f)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	res := make(chan error, 1)
+	go func() { _, runErr := s.Run(ctx); res <- runErr }()
+
+	select {
+	case m := <-hookDone:
+		if m.TransferID != "0123456789abcdef0123456789abcdef" {
+			t.Fatalf("hook manifest transferId = %q", m.TransferID)
+		}
+		if len(m.Files) != 1 || m.Files[0].Name != "f" || m.Files[0].Size != 20 {
+			t.Fatalf("hook manifest files = %#v", m.Files)
+		}
+		sum := sha256.Sum256(data)
+		if m.Files[0].FileDigest != hex.EncodeToString(sum[:]) {
+			t.Fatalf("hook manifest digest = %s", m.Files[0].FileDigest)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnManifest never called")
+	}
+
+	cancel()
+	if err := <-res; err == nil {
+		t.Fatalf("Run unexpectedly succeeded after cancellation")
+	}
+	if !seenFirst {
+		t.Fatal("no frame was ever sent")
+	}
+	if !firstFrameHookRan {
+		t.Fatal("the manifest frame was emitted before OnManifest completed")
+	}
+	if out.len() == 0 {
+		t.Fatal("manifest frame missing after hook")
+	}
+	opened, err := Open(keys.O2J, 0, out.snapshot()[0])
+	if err != nil {
+		t.Fatalf("open first frame: %v", err)
+	}
+	if opened.Header.Type != FrameManifest {
+		t.Fatalf("first frame type = %d, want manifest", opened.Header.Type)
+	}
+	msg, err := DecodeControl(opened.Plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := msg.(*Manifest)
+	if !ok || m.TransferID != "0123456789abcdef0123456789abcdef" {
+		t.Fatalf("first frame manifest = %#v", msg)
+	}
+}
+
+func TestSenderOnManifestErrorAbortsBeforeManifestSent(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		File:       BytesSource(seq(20), FileMeta{Name: "f", Size: 20}, 0),
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		TransferID: "0123456789abcdef0123456789abcdef",
+		OnManifest: func(Manifest) error {
+			return errors.New("sender-state write failed")
+		},
+	})
+	res := make(chan error, 1)
+	go func() { _, runErr := s.Run(context.Background()); res <- runErr }()
+	select {
+	case runErr := <-res:
+		if runErr == nil || !strings.Contains(runErr.Error(), "sender-state write failed") {
+			t.Fatalf("Run error = %v, want the hook failure", runErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after hook failure")
+	}
+	if out.len() != 0 {
+		t.Fatalf("hook failure still emitted %d frames; the manifest must never reach the wire", out.len())
 	}
 }


### PR DESCRIPTION
Senders persist a per-transfer record — the stable transferId and the canonical manifest fingerprint — before the manifest frame is transmitted. An interrupted send can be reopened against the exact source and resumed under the same id, with a changed source failing closed before anything is sent.

- wire: OnManifest / onManifest sender seam runs before the manifest frame, aborting on error
- CLI: sender record store (schema-v1, 0600, atomic), prepare/verify hooks, re-run-to-resume, transfers list/discard
- browser: IndexedDB sender records, reopenable folder picker, Send again / Forget on interrupted sends, fingerprint re-verification in the worker
- docs: sender-reattachment.md