### PR TITLE
fix: isolate resumable browser digest state

### DIFF
--- a/apps/web/src/lib/transfer/digest-vector.test.ts
+++ b/apps/web/src/lib/transfer/digest-vector.test.ts
@@ -44,7 +44,7 @@ describe('digest-checkpoint vector (V13-PR05)', () => {
       const live = make();
       live.update(prefix);
       const state = (live as unknown as DigestState).saveState();
-      const restored = (await createSha256DigestFactory(state))();
+      const restored = make.restore(state);
       restored.update(suffix);
       expect(await restored.hexDigest(), `${s.name} restored continuation`).toBe(s.fullDigest);
     }

--- a/apps/web/src/lib/transfer/digest.test.ts
+++ b/apps/web/src/lib/transfer/digest.test.ts
@@ -48,14 +48,14 @@ describe('createSha256DigestFactory', () => {
     live.update(suffix);
     const oneShot = new Uint8Array([...prefix, ...suffix]);
 
-    const restored = (await createSha256DigestFactory(state))();
+    const restored = make.restore(state);
     restored.update(suffix);
     const restoredHex = await restored.hexDigest(); // hash-wasm digest() is one-shot
     expect(restoredHex).toBe(await live.hexDigest());
     expect(restoredHex).toBe(await ref(oneShot));
     // A restored digest covering a different prefix differs — only whole-file
     // verification can vouch for the final digest.
-    const other = (await createSha256DigestFactory(state))();
+    const other = make.restore(state);
     other.update(prefix); // double-fed: same state, extra prefix
     other.update(suffix);
     expect(await other.hexDigest()).not.toBe(await ref(oneShot));
@@ -66,15 +66,39 @@ describe('createSha256DigestFactory', () => {
     // A state from a different runtime: the 4-byte wasm prefix is mangled, so load()
     // must throw (never guess) and a fresh digest must still work.
     const bogus = new Uint8Array([1, 2, 3, 4, ...new Uint8Array(112)]);
-    const bogusFactory = await createSha256DigestFactory(bogus);
-    expect(() => bogusFactory().update(new Uint8Array([1]))).toThrow();
+    expect(() => make.restore(bogus).update(new Uint8Array([1]))).toThrow();
     // Truncated state is rejected too.
     const fresh = make();
     fresh.update(new Uint8Array([5]));
     const state = (fresh as unknown as DigestState).saveState();
-    const truncatedFactory = await createSha256DigestFactory(state.subarray(0, 20));
-    expect(() => truncatedFactory().update(new Uint8Array([1]))).toThrow();
+    expect(() => make.restore(state.subarray(0, 20)).update(new Uint8Array([1]))).toThrow();
     // An untouched factory still yields a working digest after all the failed loads.
     expect(await make().hexDigest()).toBe(await ref(new Uint8Array()));
+  });
+
+  it('keeps simultaneously-live digests isolated over one scratch hasher (V13-PR05)', async () => {
+    const make = await createSha256DigestFactory();
+    const a = new Uint8Array([1, 2, 3]);
+    const b = new Uint8Array([4, 5, 6, 7]);
+    const d1 = make();
+    const d2 = make();
+    d1.update(a);
+    d2.update(b);
+    // Interleaved updates must not alias: each digest covers exactly its own bytes.
+    expect(await d1.hexDigest()).toBe(await ref(a));
+    expect(await d2.hexDigest()).toBe(await ref(b));
+    // Digesting d1 deinitializes the shared scratch hasher; d2 must still finish.
+    expect(await d1.hexDigest()).toBe(await ref(a));
+    expect(await d2.hexDigest()).toBe(await ref(b));
+    // saveState of one digest must not alter the other.
+    const s1 = (d1 as unknown as DigestState).saveState();
+    expect(await d2.hexDigest()).toBe(await ref(b));
+    const restored = make.restore(s1);
+    expect(await restored.hexDigest()).toBe(await ref(a));
+    // Interleaving a restored digest with a live one stays independent.
+    restored.update(new Uint8Array([8]));
+    d2.update(new Uint8Array([9]));
+    expect(await restored.hexDigest()).toBe(await ref(new Uint8Array([1, 2, 3, 8])));
+    expect(await d2.hexDigest()).toBe(await ref(new Uint8Array([4, 5, 6, 7, 9])));
   });
 });

--- a/apps/web/src/lib/transfer/digest.ts
+++ b/apps/web/src/lib/transfer/digest.ts
@@ -2,47 +2,78 @@
  * Streaming whole-file SHA-256 for the transfer worker. `hash-wasm` produces a
  * `sha256sum`-identical hex string and hashes synchronously per `update`, so it runs inside
  * the worker (never on the main thread). `createSHA256()` is async — we pay that once, then
- * `init()` a fresh hasher per digest. Loading the wasm requires `'wasm-unsafe-eval'` in the CSP.
+ * share a single scratch hasher. Loading the wasm requires `'wasm-unsafe-eval'` in the CSP.
+ *
+ * Digest isolation (V13-PR05 stabilization): a live `IHasher` is mutable — `init()` wipes
+ * prior input and `digest()` deinitializes it, so a single hasher can never serve two
+ * simultaneously-live digests (a multi-file resume keeps every seed digest live until the
+ * whole transfer verifies). Instead, one factory owns ONE scratch hasher plus a captured
+ * fresh-init snapshot, and every wrapper digest is an independent byte snapshot of the
+ * internal state (~116 B). Each operation is scratch.load(state) → mutate → save(), all
+ * synchronous, so interleaved digests never alias and memory stays bounded: 1 wasm instance
+ * + ~116 B per live digest.
  */
-
 import { createSHA256, type IHasher } from 'hash-wasm';
 import type { Digest, DigestState } from '@sendbeam/protocol';
 
 /**
+ * A digest factory that additionally restores an independent digest from a serialized
+ * state snapshot (V13-PR05). All digests from one factory share its scratch hasher and
+ * can be live simultaneously; the wasm rejects incompatible restore states by throwing,
+ * so a restored digest either covers exactly the checkpointed bytes or fails closed.
+ */
+export interface Sha256DigestFactory {
+  (): Digest;
+  restore(state: Uint8Array): Digest;
+}
+
+/**
  * Resolve once the SHA-256 wasm is instantiated, returning a factory that yields a fresh,
  * initialised {@link Digest} per call. The engine calls the factory once per transfer.
- * When `restoreState` is given, a digest resumed from that serialized state is produced
- * instead of a fresh one (V13-PR05); the state must have been produced by this exact
- * hash-wasm build (`save()`), and the wasm rejects incompatible state by throwing.
  */
-export async function createSha256DigestFactory(restoreState?: Uint8Array): Promise<() => Digest> {
-  const hasher: IHasher = await createSHA256();
-  return () => (restoreState ? new WasmDigest(hasher, restoreState) : new WasmDigest(hasher));
+export async function createSha256DigestFactory(): Promise<Sha256DigestFactory> {
+  const scratch: IHasher = await createSHA256();
+  const fresh = scratch.save();
+  const make = (restoreState?: Uint8Array): Digest => new WasmDigest(scratch, fresh, restoreState);
+  const factory = ((): Digest => make()) as Sha256DigestFactory;
+  factory.restore = (state: Uint8Array): Digest => make(state);
+  return factory;
 }
 
 class WasmDigest implements Digest, DigestState {
+  private state: Uint8Array;
   constructor(
-    private readonly hasher: IHasher,
+    private readonly scratch: IHasher,
+    private readonly fresh: Uint8Array,
     restoreState?: Uint8Array,
   ) {
-    if (restoreState) {
-      this.hasher.load(restoreState);
+    if (restoreState === undefined) {
+      // fresh is a read-only snapshot (load() never mutates its input), so all fresh
+      // digests may share it until their first update replaces it with their own state.
+      this.state = fresh;
     } else {
-      this.hasher.init();
+      // load() throws on foreign/truncated state before mutating the scratch hasher —
+      // a restored digest either covers exactly the checkpointed bytes or fails closed.
+      this.scratch.load(restoreState);
+      this.state = this.scratch.save();
     }
   }
   update(bytes: Uint8Array): void {
-    this.hasher.update(bytes);
+    this.scratch.load(this.state);
+    this.scratch.update(bytes);
+    this.state = this.scratch.save();
   }
   hexDigest(): string {
-    return this.hasher.digest('hex');
+    this.scratch.load(this.state);
+    return this.scratch.digest('hex');
   }
   /**
    * Serialized snapshot of the internal state covering exactly the bytes fed so far
-   * (V13-PR05). The hasher remains usable afterwards. The bytes are only meaningful to
+   * (V13-PR05). The digest remains usable afterwards. The bytes are only meaningful to
    * this hash-wasm build; the storage layer tags them with DIGEST_CHECKPOINT_FORMAT_HASH_WASM.
    */
   saveState(): Uint8Array {
-    return this.hasher.save();
+    this.scratch.load(this.state);
+    return this.scratch.save();
   }
 }

--- a/apps/web/src/lib/transfer/durable-destination.test.ts
+++ b/apps/web/src/lib/transfer/durable-destination.test.ts
@@ -5,22 +5,28 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   DIGEST_CHECKPOINT_FORMAT_HASH_WASM,
+  FRAME_VERSION,
   FrameType,
   TransferError,
+  TransferReceiver,
   bytesToHex,
   commitBlocks as advanceJournal,
   decodeJournal,
+  deriveTransferKeys,
+  encodeControl,
   encodeJournal,
   newJournal,
+  seal,
   sha256,
   type Digest,
   type DigestState,
   type DigestStateSink,
   type DurableJournal,
+  type FrameHeaderInput,
   type JournalDigestCheckpoint,
   type Manifest,
 } from '@sendbeam/protocol';
-import { createSha256DigestFactory } from './digest.js';
+import { createSha256DigestFactory, type Sha256DigestFactory } from './digest.js';
 import { DurableDestination } from './durable-destination.js';
 import {
   DURABLE_LEASE_TTL_MS,
@@ -305,7 +311,7 @@ interface Harness {
   store: MemoryStore;
   files: MemoryFiles;
   makeDestination: (overrides?: Partial<{ now: () => number }>) => DurableDestination;
-  digest: () => Digest;
+  digest: Sha256DigestFactory;
   advance: (ms: number) => void;
 }
 
@@ -318,7 +324,7 @@ async function harness(): Promise<Harness> {
   const now = () => clock;
   const makeDestination = (overrides: Partial<{ now: () => number }> = {}): DurableDestination =>
     new DurableDestination({
-      createDigest: () => digestFactory(),
+      createDigest: digestFactory,
       files,
       store,
       now,
@@ -330,7 +336,7 @@ async function harness(): Promise<Harness> {
     store,
     files,
     makeDestination,
-    digest: () => digestFactory(),
+    digest: digestFactory,
     advance: (ms) => {
       clock += ms;
     },
@@ -355,11 +361,12 @@ async function journalFor(
   files: MemoryFiles,
   names: Array<[string, number]>,
   committedPerFile: number[],
+  m: Manifest = manifest(names),
 ): Promise<DurableJournal> {
   // The destination binds journals to the browser storage location; journals the tests
   // fabricate must carry the same claim or prepare rejects them as foreign.
   const destination = await webDestinationIdentity('web');
-  return newJournal(TRANSFER_ID, manifest(names), IDENTITY, destination, 1_000).then(async (j) => {
+  return newJournal(TRANSFER_ID, m, IDENTITY, destination, 1_000).then(async (j) => {
     for (let i = 0; i < names.length; i++) {
       const f = j.files[i]!;
       const rel = names[i]![0];
@@ -620,6 +627,325 @@ describe('DurableDestination', () => {
     );
   });
 
+  it('multi-file resume: fallback seeds from one factory stay isolated while live (V13-PR05)', async () => {
+    const h = await harness();
+    // Old v1 journal: no digest checkpoints anywhere — every seed must be re-hashed.
+    await journalFor(
+      h.store,
+      h.files,
+      [
+        ['a.bin', 24],
+        ['b.bin', 16],
+      ],
+      [2, 1],
+    );
+    // Distinct persisted content for the second file (journalFor's default pattern is shared).
+    const bPrefix = new Uint8Array(8).map((_, k) => (k + 101) & 0xff);
+    h.files.data.set('b.bin', bPrefix);
+
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d = h.makeDestination();
+    await d.prepare(
+      manifest([
+        ['a.bin', 24],
+        ['b.bin', 16],
+      ]),
+    );
+    const files = d.resumeStateFor()!.files;
+    const a = files.get(0)!.seedDigest;
+    const b = files.get(1)!.seedDigest;
+
+    // The receiver feeds files interleaved while every seed stays live; each digest
+    // must cover exactly its own prefix. (Before the fix, a shared hasher aliased them.)
+    a.update(new Uint8Array([17, 18, 19, 20, 21, 22, 23, 24]));
+    b.update(new Uint8Array([109, 110, 111, 112, 113, 114, 115, 116]));
+    expect(await a.hexDigest()).toBe(
+      bytesToHex(await sha256(new Uint8Array(24).map((_, k) => (k + 1) & 0xff))),
+    );
+    expect(await b.hexDigest()).toBe(
+      bytesToHex(
+        await sha256(new Uint8Array([...bPrefix, 109, 110, 111, 112, 113, 114, 115, 116])),
+      ),
+    );
+    // Digesting one must not deinitialize the other's stream.
+    expect(await a.hexDigest()).toBe(
+      bytesToHex(await sha256(new Uint8Array(24).map((_, k) => (k + 1) & 0xff))),
+    );
+    expect(await b.hexDigest()).toBe(
+      bytesToHex(
+        await sha256(new Uint8Array([...bPrefix, 109, 110, 111, 112, 113, 114, 115, 116])),
+      ),
+    );
+  });
+
+  it('multi-file resume: a restored checkpoint and a fallback seed stay isolated (V13-PR05)', async () => {
+    const h = await harness();
+    const j = await journalFor(
+      h.store,
+      h.files,
+      [
+        ['a.bin', 24],
+        ['b.bin', 24],
+      ],
+      [2, 1],
+    );
+    const aBytes = new Uint8Array(16).map((_, k) => (k + 1) & 0xff);
+    await journalWithCheckpoint(h.store, j, {
+      format: DIGEST_CHECKPOINT_FORMAT_HASH_WASM,
+      committedBlocks: 2,
+      committedBytes: 16,
+      state: bytesToHex(digestStateFor(h, aBytes)),
+    });
+    // Corrupt a.bin on disk: the restored seed must ignore it (restore skips the re-hash).
+    h.files.data.set('a.bin', new Uint8Array(16).fill(0xff));
+
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d = h.makeDestination();
+    await d.prepare(
+      manifest([
+        ['a.bin', 24],
+        ['b.bin', 24],
+      ]),
+    );
+    const files = d.resumeStateFor()!.files;
+    const a = files.get(0)!.seedDigest;
+    const b = files.get(1)!.seedDigest;
+    expect(await a.hexDigest()).toBe(bytesToHex(await sha256(aBytes)));
+    expect(await b.hexDigest()).toBe(
+      bytesToHex(await sha256(new Uint8Array(8).map((_, k) => (k + 1) & 0xff))),
+    );
+    // Interleaved continuation of both remains independent.
+    a.update(new Uint8Array([17, 18, 19, 20, 21, 22, 23, 24]));
+    b.update(new Uint8Array([9, 10, 11, 12, 13, 14, 15, 16]));
+    b.update(new Uint8Array([17, 18, 19, 20, 21, 22, 23, 24]));
+    expect(await a.hexDigest()).toBe(
+      bytesToHex(await sha256(new Uint8Array(24).map((_, k) => (k + 1) & 0xff))),
+    );
+    expect(await b.hexDigest()).toBe(
+      bytesToHex(await sha256(new Uint8Array(24).map((_, k) => (k + 1) & 0xff))),
+    );
+  });
+
+  it('multi-file resume: foreign-format checkpoint falls back alongside a plain rehash (V13-PR05)', async () => {
+    const h = await harness();
+    const j = await journalFor(
+      h.store,
+      h.files,
+      [
+        ['a.bin', 24],
+        ['b.bin', 24],
+      ],
+      [2, 1],
+    );
+    await journalWithCheckpoint(h.store, j, {
+      format: 'sha256-go-v1',
+      committedBlocks: 2,
+      committedBytes: 16,
+      state: '00'.repeat(108),
+    });
+
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d = h.makeDestination();
+    await d.prepare(
+      manifest([
+        ['a.bin', 24],
+        ['b.bin', 24],
+      ]),
+    );
+    const files = d.resumeStateFor()!.files;
+    const a = files.get(0)!.seedDigest;
+    const b = files.get(1)!.seedDigest;
+    // Both re-hash from the persisted prefix, but stay independent while live.
+    const aBytes = new Uint8Array(16).map((_, k) => (k + 1) & 0xff);
+    const bBytes = new Uint8Array(8).map((_, k) => (k + 1) & 0xff);
+    expect(await a.hexDigest()).toBe(bytesToHex(await sha256(aBytes)));
+    expect(await b.hexDigest()).toBe(bytesToHex(await sha256(bBytes)));
+    a.update(new Uint8Array([17, 18, 19, 20, 21, 22, 23, 24]));
+    b.update(new Uint8Array([9, 10, 11, 12, 13, 14, 15, 16]));
+    b.update(new Uint8Array([17, 18, 19, 20, 21, 22, 23, 24]));
+    expect(await a.hexDigest()).toBe(
+      bytesToHex(await sha256(new Uint8Array(24).map((_, k) => (k + 1) & 0xff))),
+    );
+    expect(await b.hexDigest()).toBe(
+      bytesToHex(await sha256(new Uint8Array(24).map((_, k) => (k + 1) & 0xff))),
+    );
+  });
+
+  it('resume covers fully committed files and skips seeds for not-yet-started ones (matches the Go driver)', async () => {
+    const h = await harness();
+    // a.bin fully committed (3/3), b.bin not started (0/3), c.bin partially committed (1/3).
+    await journalFor(
+      h.store,
+      h.files,
+      [
+        ['a.bin', 24],
+        ['b.bin', 24],
+        ['c.bin', 24],
+      ],
+      [3, 0, 1],
+    );
+
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d = h.makeDestination();
+    await d.prepare(
+      manifest([
+        ['a.bin', 24],
+        ['b.bin', 24],
+        ['c.bin', 24],
+      ]),
+    );
+    const files = d.resumeStateFor()!.files;
+    // Fully committed: the seed covers the whole file (verified at finish). Not started:
+    // no seed — the receiver starts the file fresh, exactly like the Go driver.
+    expect(files.get(0)!.haveBlocks).toBe(3);
+    expect(await files.get(0)!.seedDigest.hexDigest()).toBe(
+      bytesToHex(await sha256(new Uint8Array(24).map((_, k) => (k + 1) & 0xff))),
+    );
+    expect(files.has(1)).toBe(false);
+    expect(files.get(2)!.haveBlocks).toBe(1);
+  });
+
+  it('final resumed transfer streams only missing blocks and verifies every file (V13-PR05)', async () => {
+    const h = await harness();
+    const whole = new Uint8Array(24).map((_, k) => (k + 1) & 0xff);
+    const small = new Uint8Array(8).map((_, k) => (k + 1) & 0xff);
+    const files = [
+      { name: 'a.bin', size: 24, data: whole },
+      { name: 'b.bin', size: 24, data: whole },
+      { name: 'c.bin', size: 24, data: whole },
+      { name: 'd.bin', size: 8, data: small },
+    ];
+    const digests = await Promise.all(files.map(async (f) => bytesToHex(await sha256(f.data))));
+    const m: Manifest = {
+      type: FrameType.Manifest,
+      transferId: TRANSFER_ID,
+      files: files.map((f, idx) => ({
+        idx,
+        name: f.name,
+        size: f.size,
+        mime: 'application/octet-stream',
+        lastModified: 0,
+        blockSize: 8,
+        blocks: Math.ceil(f.size / 8),
+        fileDigest: digests[idx]!,
+      })),
+      totalSize: files.reduce((total, f) => total + f.size, 0),
+    };
+    const j = await journalFor(
+      h.store,
+      h.files,
+      files.map((f) => [f.name, f.size]),
+      [3, 2, 1, 0],
+      m,
+    );
+    // a.bin: valid wasm checkpoint (restored). b.bin: foreign-format checkpoint (rehash).
+    // c.bin: old journal, no checkpoint (rehash). d.bin: not started (no seed).
+    let advanced = advanceJournal(j, 0, 3, 3_000, {
+      format: DIGEST_CHECKPOINT_FORMAT_HASH_WASM,
+      committedBlocks: 3,
+      committedBytes: 24,
+      state: bytesToHex(digestStateFor(h, whole)),
+    });
+    advanced = advanceJournal(advanced, 1, 2, 3_000, {
+      format: 'sha256-go-v1',
+      committedBlocks: 2,
+      committedBytes: 16,
+      state: '00'.repeat(108),
+    });
+    h.store.journals.set(TRANSFER_ID, await encodeJournal(advanced));
+
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const d = h.makeDestination();
+
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(7));
+    const frames: Uint8Array[] = [];
+    let ctr = 0;
+    const push = async (header: FrameHeaderInput, payload: Uint8Array) => {
+      frames.push(await seal(keys.o2j, ctr++, header, payload));
+    };
+    const ctrl = (type: FrameType, msg: Parameters<typeof encodeControl>[0]) =>
+      push(
+        { version: FRAME_VERSION, type, flags: 0, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+        encodeControl(msg),
+      );
+    await ctrl(FrameType.Manifest, m);
+    // The sender learned the high-water marks from the ResumeState control: it sends only
+    // the blocks the receiver lacks, in file order — b.bin 2, c.bin 1..2, d.bin 0.
+    // a.bin streams nothing.
+    for (const [fileIdx, startBlock] of [
+      [1, 2],
+      [2, 1],
+      [3, 0],
+    ] as Array<[number, number]>) {
+      const f = files[fileIdx]!;
+      for (let blk = startBlock; blk * 8 < f.size; blk++) {
+        const start = blk * 8;
+        const end = Math.min(start + 8, f.size);
+        const block = f.data.subarray(start, end);
+        for (let off = 0; off < block.length; off += 4) {
+          const frag = block.subarray(off, Math.min(off + 4, block.length));
+          const last = off + frag.length === block.length;
+          await push(
+            {
+              version: FRAME_VERSION,
+              type: FrameType.BlockData,
+              flags: last ? 1 : 0,
+              fileIdx,
+              blockIdx: blk,
+              frameOff: off,
+            },
+            frag,
+          );
+        }
+        await ctrl(FrameType.BlockHash, {
+          type: FrameType.BlockHash,
+          fileIdx,
+          blockIdx: blk,
+          sha256: bytesToHex(await sha256(block)),
+        });
+      }
+    }
+    // One-shot terminal Complete carrying the canonical file-set completion digest.
+    await ctrl(FrameType.Complete, {
+      type: FrameType.Complete,
+      fileDigest: bytesToHex(await sha256(new TextEncoder().encode(digests.join('\n')))),
+    });
+
+    const receiverOpts: ConstructorParameters<typeof TransferReceiver>[0] = {
+      send: () => void Promise.resolve(),
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: h.digest,
+      destination: d,
+      onManifestSet: async () => {
+        const state = d.resumeStateFor();
+        if (state) receiverOpts.resume = state;
+      },
+    };
+    const receiver = new TransferReceiver(receiverOpts);
+    for (const f of frames) receiver.handle(f);
+    const result = await receiver.done;
+
+    // Every file verified end-to-end; the durable store finalized (journal + lease gone).
+    expect(result.digests).toEqual(digests);
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
+    const zipBytes = h.files.outputs.get(`sendbeam/durable/${TRANSFER_ID}/__receive.zip`);
+    expect(zipBytes).toBeDefined();
+    const dir = mkdtempSync(join(tmpdir(), 'sendbeam-durable-resume-'));
+    try {
+      const path = join(dir, 'resume.zip');
+      writeFileSync(path, zipBytes!);
+      expect(execFileSync('unzip', ['-t', path], { encoding: 'utf8' })).toContain('No errors');
+      for (const f of files) {
+        expect(execFileSync('unzip', ['-p', path, f.name])).toEqual(Buffer.from(f.data));
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('stale tail beyond the checkpoint is truncated and re-transferred on resume', async () => {
     const h = await harness();
     await journalFor(h.store, h.files, [['a.bin', 24]], [1]);
@@ -718,7 +1044,7 @@ describe('DurableDestination', () => {
     const m = manifest([['a.bin', 16]]);
 
     const low = new DurableDestination({
-      createDigest: () => h.digest(),
+      createDigest: h.digest,
       files: h.files,
       store: h.store,
       now: () => 1_000,

--- a/apps/web/src/lib/transfer/durable-destination.ts
+++ b/apps/web/src/lib/transfer/durable-destination.ts
@@ -42,7 +42,7 @@ import type {
   WritableFileLike,
 } from './durable-store.js';
 import { webDestinationIdentity } from './durable-store.js';
-import { createSha256DigestFactory } from './digest.js';
+import type { Sha256DigestFactory } from './digest.js';
 import {
   centralHeader,
   crc32Update,
@@ -62,7 +62,7 @@ export interface DurableMeta {
 }
 
 export interface DurableDestinationOptions {
-  createDigest(): Digest;
+  createDigest: Sha256DigestFactory;
   files: DurableFiles;
   store: DurableJournalStore;
   /** Injectable clock (unix ms); tests use a fixed clock with no sleeps. */
@@ -78,7 +78,7 @@ const DURABLE_LEASE_RENEW_MS = 30_000;
 const STORAGE_NAMESPACE = 'sendbeam';
 
 export class DurableDestination implements BrowserDestination {
-  private readonly createDigest: () => Digest;
+  private readonly createDigest: Sha256DigestFactory;
   private readonly files: DurableFiles;
   private readonly store: DurableJournalStore;
   private readonly now: () => number;
@@ -391,14 +391,16 @@ export class DurableDestination implements BrowserDestination {
             `journal ${this.transferId} file ${state.name}: partial data missing or truncated; refusing to resume — discard it`,
           );
         }
+      } else {
+        // Nothing persisted: the receiver starts fresh, no seed needed.
+        continue;
       }
       let digest: Digest;
       let restored = false;
       const cp = state.digestCheckpoint;
       if (cp && cp.format === DIGEST_CHECKPOINT_FORMAT_HASH_WASM) {
         try {
-          const factory = await createSha256DigestFactory(hexToBytes(cp.state));
-          digest = factory();
+          digest = this.createDigest.restore(hexToBytes(cp.state));
           restored = true;
         } catch {
           digest = this.createDigest();

--- a/apps/web/src/lib/transfer/durable-store.test.ts
+++ b/apps/web/src/lib/transfer/durable-store.test.ts
@@ -626,7 +626,7 @@ describe('sync partial writer short writes', () => {
     const store = indexedDbDurableStore();
     const digestFactory = await createSha256DigestFactory();
     const d = new DurableDestination({
-      createDigest: () => digestFactory(),
+      createDigest: digestFactory,
       files: durableOpfsFiles(),
       store,
       now: () => 1_000,

--- a/apps/web/src/lib/transfer/sink.ts
+++ b/apps/web/src/lib/transfer/sink.ts
@@ -1,7 +1,6 @@
 import {
   TransferError,
   normalizeTransferPath,
-  type Digest,
   type Destination,
   type FileEntry,
   type Manifest,
@@ -19,6 +18,7 @@ import {
   type ZipEntry,
 } from './zip.js';
 import type { ReceiveDestinationSpec } from './wire.js';
+import type { Sha256DigestFactory } from './digest.js';
 
 export type DestinationOutput =
   { kind: 'opfs'; key: string; name: string; mime: string } | { kind: 'direct' };
@@ -38,7 +38,7 @@ export interface BrowserDestination extends Destination {
  */
 export function createBrowserDestination(
   spec: ReceiveDestinationSpec,
-  createDigest?: () => Digest,
+  createDigest?: Sha256DigestFactory,
 ): BrowserDestination {
   let inner: BrowserDestination | undefined;
   const get = (): BrowserDestination => {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -92,6 +92,34 @@ never preempted once a server-reflexive hint appears. Symmetric NAT remains boun
 connectivity-check failure (~11s) because its unusable server-reflexive candidate is
 indistinguishable from a slow-but-healthy direct path.
 
+## Digest-checkpoint (V13-PR05)
+
+A resumed receive can either restore the serialized digest state — O(1), ~5 µs — or
+re-hash the whole persisted prefix through SHA-256. These benchmarks quantify that
+trade-off. Build-tagged (`-tags benchmark`), so normal test runs never execute them;
+run one at a time:
+
+```sh
+cd packages/wire
+SENDBEAM_BENCH_PREFIX_GIB=4 go test -tags benchmark -bench DigestCheckpoint -benchtime=1x -benchmem ./...
+```
+
+The target prefix size is parameterized with `SENDBEAM_BENCH_PREFIX_GIB` (default 4) and
+is always streamed in 1 MiB chunks, so the working set stays small at any size. Every
+row below is a measured run — numbers are never extrapolated from another size.
+
+| Machine | Prefix | Rehash (fallback) | Restore (checkpointed) |
+| ------- | -----: | ----------------: | ---------------------: |
+| i5-6200U @ 2.30 GHz, Linux, go1.24 | 4 GiB | ~17.0 s @ ~253 MB/s | ~5.1 µs |
+| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 | 10 GiB | 6.77 s @ 1,586 MB/s | 5.13 µs |
+| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 | 100 GiB | 67.7 s @ 1,586 MB/s | 4.97 µs |
+| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 | 256 GiB | 173.2 s @ 1,587 MB/s | 6.58 µs |
+
+Rehash cost is linear in the prefix (1,586 MB/s on the runner at every size — a
+consistent measurement, not an extrapolation); restore is a constant ~5 µs regardless
+of prefix size. At 256 GiB that is roughly 26 million times faster than re-hashing, and
+the restore cost does not grow with transfer size.
+
 ## CPU
 
 Crypto is the only CPU-heavy step: ~12.5 µs per 16 KiB frame, or ~0.8 s of one core per

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -108,12 +108,12 @@ The target prefix size is parameterized with `SENDBEAM_BENCH_PREFIX_GIB` (defaul
 is always streamed in 1 MiB chunks, so the working set stays small at any size. Every
 row below is a measured run — numbers are never extrapolated from another size.
 
-| Machine | Prefix | Rehash (fallback) | Restore (checkpointed) |
-| ------- | -----: | ----------------: | ---------------------: |
-| i5-6200U @ 2.30 GHz, Linux, go1.24 | 4 GiB | ~17.0 s @ ~253 MB/s | ~5.1 µs |
-| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 | 10 GiB | 6.77 s @ 1,586 MB/s | 5.13 µs |
-| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 | 100 GiB | 67.7 s @ 1,586 MB/s | 4.97 µs |
-| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 | 256 GiB | 173.2 s @ 1,587 MB/s | 6.58 µs |
+| Machine                                                   |  Prefix |    Rehash (fallback) | Restore (checkpointed) |
+| --------------------------------------------------------- | ------: | -------------------: | ---------------------: |
+| i5-6200U @ 2.30 GHz, Linux, go1.24                        |   4 GiB |  ~17.0 s @ ~253 MB/s |                ~5.1 µs |
+| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 |  10 GiB |  6.77 s @ 1,586 MB/s |                5.13 µs |
+| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 | 100 GiB |  67.7 s @ 1,586 MB/s |                4.97 µs |
+| GitHub-hosted ubuntu-latest, 4 vCPU AMD EPYC 7763, go1.25 | 256 GiB | 173.2 s @ 1,587 MB/s |                6.58 µs |
 
 Rehash cost is linear in the prefix (1,586 MB/s on the runner at every size — a
 consistent measurement, not an extrapolation); restore is a constant ~5 µs regardless

--- a/packages/protocol/src/transfer-receiver.test.ts
+++ b/packages/protocol/src/transfer-receiver.test.ts
@@ -7,12 +7,56 @@ import { FRAME_VERSION } from './constants.js';
 import { sha256 } from './webcrypto.js';
 import { bytesToHex } from './bytes.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
-import { MemorySink, type Digest, type Sink } from './transfer-ports.js';
+import {
+  MemorySink,
+  type Digest,
+  type DigestState,
+  type DigestStateSink,
+  type Sink,
+} from './transfer-ports.js';
 import { TransferReceiver } from './transfer-receiver.js';
 
 function nodeDigest(): Digest {
   const h = createHash('sha256');
   return { update: (b) => void h.update(b), hexDigest: () => h.digest('hex') };
+}
+
+/** Digest whose optional state serialization always fails (V13-PR05 regression). */
+class StateFailDigest implements Digest, DigestState {
+  private readonly h = createHash('sha256');
+  update(bytes: Uint8Array): void {
+    this.h.update(bytes);
+  }
+  hexDigest(): string {
+    return this.h.digest('hex');
+  }
+  saveState(): Uint8Array {
+    throw new Error('serialization failed');
+  }
+}
+
+/** Sink with the optional DigestStateSink seam, recording every state it was handed. */
+class StateRecordSink implements Sink, DigestStateSink {
+  states: Array<Uint8Array | null> = [];
+  chunks: Uint8Array[] = [];
+  write(_offset: number, bytes: Uint8Array): void {
+    this.chunks.push(bytes);
+  }
+  close(): void {}
+  abort(): void {}
+  setDigestState(state: Uint8Array | null): void {
+    this.states.push(state);
+  }
+}
+
+/** Sink whose state persistence (the journal write) genuinely fails. */
+class FailingStateSink implements Sink, DigestStateSink {
+  write(): void {}
+  close(): void {}
+  abort(): void {}
+  setDigestState(): void {
+    throw new Error('journal write failed');
+  }
 }
 const master = new Uint8Array(32).fill(9);
 
@@ -106,6 +150,121 @@ describe('TransferReceiver', () => {
     const backTypes: number[] = [];
     for (const f of backChannel) backTypes.push((await open(keys.j2o, c++, f)).header.type);
     expect(backTypes).toEqual([FrameType.Ack, FrameType.Ack, FrameType.Ack, FrameType.Done]);
+  });
+
+  it('a digest whose saveState throws omits the checkpoint but the receive completes (V13-PR05)', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array(16).map((_, i) => i);
+    const fileDigest = createHash('sha256').update(data).digest('hex');
+    const b = await build(keys);
+    await b.ctrl(FrameType.Manifest, {
+      type: FrameType.Manifest,
+      files: [
+        {
+          idx: 0,
+          name: 'f',
+          size: 16,
+          mime: '',
+          lastModified: 0,
+          blockSize: 8,
+          blocks: 2,
+          fileDigest,
+        },
+      ],
+      totalSize: 16,
+    });
+    for (let blk = 0; blk * 8 < data.length; blk++) {
+      const block = data.subarray(blk * 8, Math.min(blk * 8 + 8, data.length));
+      await b.push(
+        {
+          version: FRAME_VERSION,
+          type: FrameType.BlockData,
+          flags: 1,
+          fileIdx: 0,
+          blockIdx: blk,
+          frameOff: 0,
+        },
+        block,
+      );
+      await b.ctrl(FrameType.BlockHash, {
+        type: FrameType.BlockHash,
+        fileIdx: 0,
+        blockIdx: blk,
+        sha256: bytesToHex(await sha256(block)),
+      });
+    }
+    await b.ctrl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
+
+    // Serialization of the optimization state fails: the sink must be handed null (the
+    // durable host journals a checkpoint without digest state and resume re-hashes).
+    const sink = new StateRecordSink();
+    const receiver = new TransferReceiver({
+      send: () => void Promise.resolve(),
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: () => new StateFailDigest(),
+      sink,
+    });
+    for (const f of b.frames) receiver.handle(f);
+    const result = await receiver.done;
+    expect(result.digest).toBe(fileDigest);
+    expect(sink.states).toEqual([null, null]);
+    expect(sink.chunks.flatMap((c) => [...c])).toEqual([...data]);
+  });
+
+  it('a failing setDigestState still fails the receive (genuine journal failure, V13-PR05)', async () => {
+    const keys = await deriveTransferKeys(master);
+    const data = new Uint8Array(8).map((_, i) => i);
+    const fileDigest = createHash('sha256').update(data).digest('hex');
+    const b = await build(keys);
+    await b.ctrl(FrameType.Manifest, {
+      type: FrameType.Manifest,
+      files: [
+        {
+          idx: 0,
+          name: 'f',
+          size: 8,
+          mime: '',
+          lastModified: 0,
+          blockSize: 8,
+          blocks: 1,
+          fileDigest,
+        },
+      ],
+      totalSize: 8,
+    });
+    await b.push(
+      {
+        version: FRAME_VERSION,
+        type: FrameType.BlockData,
+        flags: 1,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      },
+      data,
+    );
+    await b.ctrl(FrameType.BlockHash, {
+      type: FrameType.BlockHash,
+      fileIdx: 0,
+      blockIdx: 0,
+      sha256: bytesToHex(await sha256(data)),
+    });
+    await b.ctrl(FrameType.Complete, { type: FrameType.Complete, fileDigest });
+
+    const receiver = new TransferReceiver({
+      send: () => void Promise.resolve(),
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounterStart: 0,
+      recvCounterStart: 0,
+      createDigest: nodeDigest,
+      sink: new FailingStateSink(),
+    });
+    for (const f of b.frames) receiver.handle(f);
+    await expect(receiver.done).rejects.toThrow(/sink_error/);
   });
 
   it('ignores pre-manifest data and identical duplicate manifests (cutover recovery)', async () => {

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -469,7 +469,15 @@ export class TransferReceiver {
   private async attachDigestState(sink: Sink, digest: Digest): Promise<void> {
     const stateSink = sink as Sink & Partial<DigestStateSink>;
     if (typeof stateSink.setDigestState !== 'function') return;
-    const state = (digest as Digest & Partial<DigestState>).saveState?.() ?? null;
+    let state: Uint8Array | null = null;
+    try {
+      state = (digest as Digest & Partial<DigestState>).saveState?.() ?? null;
+    } catch {
+      // Digest checkpoints are an optimization: serialization failure omits the state
+      // (the sink journals a checkpoint without it, and resume re-hashes the persisted
+      // prefix). Genuine journal/sink failures below must still propagate.
+      state = null;
+    }
     await stateSink.setDigestState(state);
   }
 

--- a/packages/wire/benchmark_digest_checkpoint_test.go
+++ b/packages/wire/benchmark_digest_checkpoint_test.go
@@ -3,17 +3,22 @@
 package wire
 
 import (
+	"os"
+	"strconv"
 	"testing"
 )
 
 // Benchmarks for the V13-PR05 digest-checkpoint seam (packages/wire/transfer_ports.go):
 // a resumed receive can either restore the serialized digest state (O(1)) or re-hash the
-// persisted prefix. Run one at a time (laptop rule):
+// persisted prefix. Run one at a time (laptop rule) — never several in parallel:
 //
 //	go test -tags benchmark -bench DigestCheckpoint -benchmem ./...
 //
-// 4 GiB is streamed in 1 MiB chunks, so the working set stays small and no giant
-// allocation dominates the measurement.
+// The target prefix size is parameterized via SENDBEAM_BENCH_PREFIX_GIB (default 4).
+// Any size is streamed in 1 MiB chunks, so the working set stays small and no giant
+// file or allocation dominates the measurement. Large sizes hash in real time (e.g.
+// 100 GiB is ~1-2 minutes on one core); use -benchtime=1x so each benchmark runs exactly
+// one op, and never extrapolate a measurement to a size that was not run.
 
 func benchChunk1MiB() []byte {
 	chunk := make([]byte, 1<<20)
@@ -23,17 +28,28 @@ func benchChunk1MiB() []byte {
 	return chunk
 }
 
-const digestCheckpointBenchTotal = 4 << 30 // 4 GiB per op
+// benchTotal returns the target prefix size in bytes: SENDBEAM_BENCH_PREFIX_GIB GiB,
+// defaulting to 4 GiB when the variable is unset or invalid.
+func benchTotal() int64 {
+	if raw := os.Getenv("SENDBEAM_BENCH_PREFIX_GIB"); raw != "" {
+		if gib, err := strconv.ParseInt(raw, 10, 64); err == nil && gib > 0 {
+			return gib << 30
+		}
+	}
+	return 4 << 30
+}
 
 // BenchmarkDigestCheckpointResumeRehash is the fallback path: stream the whole persisted
 // prefix through a fresh digest. Throughput is the SHA-256 rate.
 func BenchmarkDigestCheckpointResumeRehash(b *testing.B) {
 	chunk := benchChunk1MiB()
-	b.SetBytes(digestCheckpointBenchTotal)
+	total := benchTotal()
+	b.Logf("prefix %d GiB", total>>30)
+	b.SetBytes(total)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		d := NewSHA256Digest()
-		for n := 0; n < digestCheckpointBenchTotal; n += len(chunk) {
+		for n := int64(0); n < total; n += int64(len(chunk)) {
 			d.Update(chunk)
 		}
 		_ = d.HexDigest()
@@ -41,13 +57,16 @@ func BenchmarkDigestCheckpointResumeRehash(b *testing.B) {
 }
 
 // BenchmarkDigestCheckpointResumeRestore is the checkpointed path: restore the state
-// covering the 4 GiB prefix once, then hash only the tail. Restore itself is O(1); the
+// covering the full prefix once, then hash only the tail. Restore itself is O(1); the
 // timed loop feeds a tiny tail (64 bytes) so the restore cost — not hashing — is what is
-// measured. State creation (a one-off 4 GiB pass) happens before ResetTimer.
+// measured. State creation (a one-off pass over the full prefix) happens before
+// ResetTimer and is not part of the measured restore cost.
 func BenchmarkDigestCheckpointResumeRestore(b *testing.B) {
 	chunk := benchChunk1MiB()
+	total := benchTotal()
+	b.Logf("prefix %d GiB", total>>30)
 	live := NewSHA256Digest()
-	for n := 0; n < digestCheckpointBenchTotal; n += len(chunk) {
+	for n := int64(0); n < total; n += int64(len(chunk)) {
 		live.Update(chunk)
 	}
 	state, err := live.(DigestState).MarshalState()

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -520,10 +520,17 @@ func (r *Receiver) attachDigestState() error {
 		var err error
 		state, err = ds.MarshalState()
 		if err != nil {
-			return asTransferError(err, FailSinkError)
+			// Digest checkpoints are an optimization: serialization failure omits the
+			// state (the sink journals a checkpoint without it, and resume re-hashes
+			// the persisted prefix). Genuine journal/sink failures below must still
+			// propagate.
+			state = nil
 		}
 	}
-	return sink.SetDigestState(state)
+	if err := sink.SetDigestState(state); err != nil {
+		return asTransferError(err, FailSinkError)
+	}
+	return nil
 }
 
 func (r *Receiver) requestMissing() error {

--- a/packages/wire/transfer_receiver_test.go
+++ b/packages/wire/transfer_receiver_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -345,6 +346,102 @@ type plainDigest struct{ d Digest }
 
 func (d *plainDigest) Update(b []byte)   { d.d.Update(b) }
 func (d *plainDigest) HexDigest() string { return d.d.HexDigest() }
+
+// marshalFailDigest is a Digest WITH the optional DigestState capability whose
+// serialization always fails, to prove the seam degrades to a nil state.
+type marshalFailDigest struct {
+	d      Digest
+	events *[]string
+}
+
+func (d *marshalFailDigest) Update(b []byte) {
+	*d.events = append(*d.events, "update")
+	d.d.Update(b)
+}
+func (d *marshalFailDigest) HexDigest() string { return d.d.HexDigest() }
+func (d *marshalFailDigest) MarshalState() ([]byte, error) {
+	return nil, errors.New("serialization failed")
+}
+
+// failingStateSink records writes like seamSink but its SetDigestState (the journal
+// write) genuinely fails and must fail the receive.
+type failingStateSink struct {
+	seamSink
+}
+
+func (s *failingStateSink) SetDigestState([]byte) error { return errors.New("journal write failed") }
+
+func TestReceiverDigestMarshalStateFailureFallsBack(t *testing.T) {
+	// The digest's state serialization fails: the checkpoint is an optimization, so the
+	// sink must be handed a nil state and the receive must complete (resume re-hashes).
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := seq(16)
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(NewManifest([]FileEntry{{
+		Idx: 0, Name: "f", Size: 16, BlockSize: 8, Blocks: 2, FileDigest: hexSHA256(data),
+	}}, 16))
+	sf.blockData(data, 8, 8)
+	sf.ctrl(NewComplete(hexSHA256(data)))
+
+	var events []string
+	sink := &seamSink{events: &events}
+	var back outbox
+	r := NewReceiver(ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+		CreateDigest: func() Digest { return &marshalFailDigest{d: NewSHA256Digest(), events: &events} },
+	})
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	if _, err := r.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if len(sink.states) != 2 || sink.states[0] != nil || sink.states[1] != nil {
+		t.Fatalf("failing serialization must hand the sink nil states, got %v", sink.states)
+	}
+	wantEvents := []string{
+		"update", "setState", "write",
+		"update", "setState", "write",
+	}
+	for i, e := range wantEvents {
+		if events[i] != e {
+			t.Fatalf("event %d = %q, want %q", i, events[i], e)
+		}
+	}
+}
+
+func TestReceiverDigestSetStateFailurePropagates(t *testing.T) {
+	// A genuine journal/sink failure while persisting digest state must fail the receive
+	// (only serialization of the optional state is degraded, never the sink write).
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := seq(8)
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(NewManifest([]FileEntry{{
+		Idx: 0, Name: "f", Size: 8, BlockSize: 8, Blocks: 1, FileDigest: hexSHA256(data),
+	}}, 8))
+	sf.push(FrameHeaderInput{Version: FrameVersion, Type: FrameBlockData, Flags: FrameFlagLastInBlock}, data)
+	sf.ctrl(NewBlockHash(0, 0, hexSHA256(data)))
+	sf.ctrl(NewComplete(hexSHA256(data)))
+
+	sink := &failingStateSink{}
+	var back outbox
+	r := NewReceiver(ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+	})
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	_, err = r.Wait(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "sink_error") {
+		t.Fatalf("Wait error = %v, want one mentioning sink_error", err)
+	}
+}
 
 // recordingSink records the order of its calls so a test can assert onManifest ran first.
 type recordingSink struct{ events *[]string }


### PR DESCRIPTION
Multiple browser digest seeds are live simultaneously during a multi-file resume, but every WasmDigest wrapper previously shared one mutable hash-wasm hasher — interleaved updates aliased and digesting one seed broke the others. Each digest now owns an independent state snapshot (~116 B) over a single shared scratch hasher per factory: one wasm instance, bounded memory, sync streaming updates and O(1) checkpoint restore preserved, and the factory's restore() replaces the per-file factory allocation in buildResumeState.

Also: a checkpoint's serialization failure now omits the checkpoint instead of aborting the receive (Go + TS aligned), while genuine journal/sink failures still propagate, and the benchmark harness takes the prefix size from SENDBEAM_BENCH_PREFIX_GIB.