### PR TITLE
fix: validate durable resume state

### DIFF
--- a/apps/cli/internal/transfer/durable.go
+++ b/apps/cli/internal/transfer/durable.go
@@ -747,7 +747,11 @@ func (d *DurableDestination) ResumeStateFor(manifest wire.Manifest) (*wire.Recei
 		return nil, wire.Errorf(wire.CodeStorage,
 			"transfer: journal %s does not match the authenticated manifest; refusing to resume", journal.TransferID)
 	}
-	resume := &wire.ReceiverResume{TransferID: journal.TransferID, Files: make(map[int]wire.ResumeFileProgress)}
+	resume := &wire.ReceiverResume{
+		TransferID:          journal.TransferID,
+		ManifestFingerprint: journal.ManifestFingerprint,
+		Files:               make(map[int]wire.ResumeFileProgress),
+	}
 	for i, f := range journal.Files {
 		committed, err := journal.CommittedBytes(i)
 		if err != nil {

--- a/apps/web/src/lib/transfer/durable-destination.test.ts
+++ b/apps/web/src/lib/transfer/durable-destination.test.ts
@@ -795,14 +795,17 @@ describe('DurableDestination', () => {
       ]),
     );
     const files = d.resumeStateFor()!.files;
-    // Fully committed: the seed covers the whole file (verified at finish). Not started:
-    // no seed — the receiver starts the file fresh, exactly like the Go driver.
+    // Fully committed: the seed covers the whole file (verified at finish). Not started: the
+    // seed still covers it at haveBlocks 0 (complete coverage, V13-PR06) so the receiver's
+    // exact file-set validation passes and the file restarts fresh — like the Go driver.
     expect(files.get(0)!.haveBlocks).toBe(3);
     expect(await files.get(0)!.seedDigest.hexDigest()).toBe(
       bytesToHex(await sha256(new Uint8Array(24).map((_, k) => (k + 1) & 0xff))),
     );
-    expect(files.has(1)).toBe(false);
+    expect(files.get(1)!.haveBlocks).toBe(0);
     expect(files.get(2)!.haveBlocks).toBe(1);
+    // Every manifest file is covered.
+    expect(files.size).toBe(3);
   });
 
   it('final resumed transfer streams only missing blocks and verifies every file (V13-PR05)', async () => {

--- a/apps/web/src/lib/transfer/durable-destination.ts
+++ b/apps/web/src/lib/transfer/durable-destination.ts
@@ -418,7 +418,13 @@ export class DurableDestination implements BrowserDestination {
       }
       files.set(i, { haveBlocks: state.committedBlocks, seedDigest: digest });
     }
-    this.resumeState = { transferId: this.transferId, files };
+    this.resumeState = {
+      transferId: this.transferId,
+      // The wire receiver re-binds the seed against the authenticated manifest's canonical
+      // fingerprint before advertising any of it (V13-PR06).
+      manifestFingerprint: journal.manifestFingerprint,
+      files,
+    };
   }
 
   private async buildZip(): Promise<{ key: string; name: string }> {

--- a/apps/web/src/lib/transfer/durable-destination.ts
+++ b/apps/web/src/lib/transfer/durable-destination.ts
@@ -380,20 +380,18 @@ export class DurableDestination implements BrowserDestination {
     for (let i = 0; i < journal.files.length; i++) {
       const state = journal.files[i]!;
       const committed = Math.min(state.committedBlocks * state.blockSize, state.size);
-      if (state.committedBlocks > 0) {
-        const size = await this.files.partialSize(
-          this.transferId,
-          normalizeTransferPath(state.name),
-        );
-        if (size === undefined || size < committed) {
-          throw new TransferError(
-            'sink_error',
-            `journal ${this.transferId} file ${state.name}: partial data missing or truncated; refusing to resume — discard it`,
-          );
-        }
-      } else {
-        // Nothing persisted: the receiver starts fresh, no seed needed.
+      if (state.committedBlocks === 0) {
+        // Nothing persisted: the file restarts from zero. The seed still includes an entry
+        // so the receiver's exact file-set validation (V13-PR06) sees complete coverage.
+        files.set(i, { haveBlocks: 0, seedDigest: this.createDigest() });
         continue;
+      }
+      const size = await this.files.partialSize(this.transferId, normalizeTransferPath(state.name));
+      if (size === undefined || size < committed) {
+        throw new TransferError(
+          'sink_error',
+          `journal ${this.transferId} file ${state.name}: partial data missing or truncated; refusing to resume — discard it`,
+        );
       }
       let digest: Digest;
       let restored = false;

--- a/docs/adr/0004-durable-journal.md
+++ b/docs/adr/0004-durable-journal.md
@@ -81,6 +81,11 @@ The journal is local, user-editable on-disk state. It is **claims, not proof**:
   is handled by the storage layer per §8 and by resume validation per PR06, not by
   guessing.
 
+Implemented by V13-PR06: the receiver binds every restored seed to the authenticated
+manifest's canonical fingerprint (identical algorithm to the journal's `manifestFingerprint`),
+fails closed on any violation, and advertises only validated `haveBlocks` in the (additive,
+fingerprint-bound) `resume_state`. See `docs/protocol.md` § Transfer → Resume.
+
 ## 4. Schema
 
 The versioned schema lives in two twin modules that must serialize, validate, fingerprint,

--- a/docs/durable-receive.md
+++ b/docs/durable-receive.md
@@ -166,7 +166,9 @@ and the authenticated manifest matches an existing journal, the receiver:
    digest is restored from the journal's `digestCheckpoint` state when the format matches
    this runtime and the state decodes; otherwise the persisted prefix is re-hashed
    (correctness-first). A restored or re-hashed seed never bypasses the final whole-file
-   verification.
+   verification. The seed carries the journal's `manifestFingerprint`, and the receiver
+   re-binds the whole seed against the authenticated manifest before advertising any of it
+   (PR06): an impossible or mismatched claim fails closed rather than being clamped.
 4. Streams only the missing blocks from the sender.
 
 Resume is **same-session** recovery: the sender must still be connected in the room the
@@ -207,4 +209,5 @@ sendbeam transfers discard  <id>... [--out DIR] [--all] [--yes]
 - Cross-session authenticated resume with fresh traffic keys without a live sender is
   PR07 (the `resumeSecret` envelope exists in the schema but is unused by PR02).
 - Resume validation against authenticated peer identity (beyond the manifest fingerprint
-  and destination location) is PR06/PR07.
+  and destination location) is PR07. PR06 already binds every seed to the authenticated
+  manifest's fingerprint and geometry.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -271,7 +271,7 @@ above; relayed payloads are the same AEAD frames, never re-encrypted or inspecte
    otherwise the sender fails the transfer closed.
 
    Resume state is a **claim, not a trust anchor**. A receiver only applies a locally restored
-   seed after it validates the seed against the *authenticated* manifest: the fingerprint must
+   seed after it validates the seed against the _authenticated_ manifest: the fingerprint must
    match (binding the exact file set and block geometry), the file coverage must be exact and
    complete, and every `haveBlocks` must lie within `[0, blocks]`. Any violation fails the
    receive closed (`sink_error`) before any of the seed is advertised — a claim is never

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -261,10 +261,33 @@ above; relayed payloads are the same AEAD frames, never re-encrypted or inspecte
    ignoring any `resume_state` that does not match the manifest. A transfer with no prior
    state reports all-zero marks.
 
+   The `ResumeState` message is **additive** (key order pinned: `type`, `transferId`,
+   `manifestFingerprint`, `files`). The optional `manifestFingerprint` field carries the
+   canonical fingerprint of the exact manifest the checkpoints belong to (identical algorithm
+   to the durable journal's `manifestFingerprint`; see ADR 0004). It is **not** required for
+   wire compatibility: a peer that predates the binding answers without the field, and the
+   sender accepts that under the structural rules `sendbeam/1` always applied. When the field
+   is present it must be 64 lowercase hex and equal the sender's canonical manifest fingerprint,
+   otherwise the sender fails the transfer closed.
+
+   Resume state is a **claim, not a trust anchor**. A receiver only applies a locally restored
+   seed after it validates the seed against the *authenticated* manifest: the fingerprint must
+   match (binding the exact file set and block geometry), the file coverage must be exact and
+   complete, and every `haveBlocks` must lie within `[0, blocks]`. Any violation fails the
+   receive closed (`sink_error`) before any of the seed is advertised — a claim is never
+   clamped into range. A seed whose `transferId` does not match the manifest belongs to a
+   different transfer and is ignored, starting a fresh receive.
+
+   Settlement is idempotent and cutover-safe: an identical duplicate `resume_state` (a path
+   cutover can deliver the receiver's answer twice) is a no-op, while a conflicting duplicate
+   fails; and when a cutover retransmits the manifest, the receiver re-answers with the exact
+   same fingerprint-bound `ResumeState` so the negotiation converges instead of stalling.
+
 Durable resumption across process/session boundaries additionally relies on a **local
 durable-transfer journal** — a versioned on-device persistence contract (schema, checksum,
 fingerprint, fail-closed loading) defined in `docs/adr/0004-durable-journal.md` and
 implemented by the Go `packages/wire/journal.go` and TypeScript
 `packages/protocol/src/journal.ts` twins. The journal is **not** wire state: it is never
 transmitted between peers, is not part of `sendbeam/1`, and carries no wire-version
-implication. The wire `resume_state` message is unchanged.
+implication. The wire `resume_state` message gains only the additive, optional
+`manifestFingerprint` field described above; old peers ignore it and new peers validate it.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -78,8 +78,14 @@ clients honour via the 15-minute runtime-ICE-config TTL (`HOSTING.md`).
 AES-256-GCM with a per-direction monotonic nonce counter; the frame header is the GCM AAD,
 binding each frame to its position (file, block, offset, length). A reused counter is
 refused rather than risk nonce reuse. Any tampering fails the GCM auth tag; a bad per-block
-SHA-256 escalates to abort (no blind retry). Resume state is integrity-checked: a
-`resume_state` that does not match the authenticated manifest is rejected.
+SHA-256 escalates to abort (no blind retry). Resume state is a claim, not a trust anchor: a
+receiver only applies a locally restored seed after binding it to the authenticated
+manifest's canonical fingerprint (exact file set and block geometry) and failing closed on
+any violation, never clamping an out-of-range claim; the sender likewise rejects any
+`resume_state` that does not match its own manifest (unknown, duplicate, or missing file
+entries, out-of-range `haveBlocks`, a fingerprint mismatch, or a conflicting duplicate), so a
+malicious or stale peer cannot steer a resumed transfer into writing the wrong bytes or
+skipping unverified data.
 
 ### Code leakage
 
@@ -139,7 +145,9 @@ invite words, filenames, plaintext, or keys.
 Negative crypto tests are part of the suite: a wrong invite code fails closed; a tampered
 `pake` element aborts; a tampered or replayed SDP MAC is rejected; a reused GCM nonce is
 rejected; a bad block hash aborts without retry; two sessions sharing the same code derive
-different master keys (ephemeral SPAKE2 freshness); a forged `resume_state` is rejected.
+different master keys (ephemeral SPAKE2 freshness); a forged `resume_state` is rejected (bad
+transfer id, mismatched or malformed manifest fingerprint, unknown/duplicate/missing file
+entries, or out-of-range `haveBlocks` all fail closed on both the sender and receiver).
 Cross-language vector tests keep the TypeScript and Go implementations byte-identical, and
 the test-vector suite (KATs + a full transfer vector) is published under
 `docs/test-vectors/` for independent reimplementation. Before public release the crypto

--- a/packages/protocol/src/transfer-loopback.test.ts
+++ b/packages/protocol/src/transfer-loopback.test.ts
@@ -6,6 +6,7 @@ import { FrameType } from './transfer.js';
 import type { FileEntry, Manifest } from './transfer.js';
 import { TransferSender } from './transfer-sender.js';
 import { TransferReceiver } from './transfer-receiver.js';
+import { manifestFingerprint } from './journal.js';
 
 function nodeDigest(): Digest {
   const h = createHash('sha256');
@@ -246,6 +247,25 @@ describe('transfer loopback (no browser)', () => {
     sink.write(0, data.subarray(0, prefixLen));
     const seed = nodeDigest();
     seed.update(data.subarray(0, prefixLen));
+    // The seed must bind to the canonical fingerprint of the manifest the sender is about
+    // to stream (V13-PR06); recompute it from the same parameters.
+    const fingerprint = await manifestFingerprint({
+      type: FrameType.Manifest,
+      transferId,
+      files: [
+        {
+          idx: 0,
+          name: 'f',
+          size: data.length,
+          mime: '',
+          lastModified: 1,
+          blockSize,
+          blocks,
+          fileDigest: createHash('sha256').update(data).digest('hex'),
+        },
+      ],
+      totalSize: data.length,
+    });
 
     let commits = 0;
     const box: { receiver?: TransferReceiver } = {};
@@ -270,7 +290,11 @@ describe('transfer loopback (no browser)', () => {
       recvCounterStart: 0,
       createDigest: nodeDigest,
       sink,
-      resume: { transferId, files: new Map([[0, { haveBlocks: stop, seedDigest: seed }]]) },
+      resume: {
+        transferId,
+        manifestFingerprint: fingerprint,
+        files: new Map([[0, { haveBlocks: stop, seedDigest: seed }]]),
+      },
       onProgress: () => void commits++,
     });
     box.receiver = receiver;

--- a/packages/protocol/src/transfer-messages.test.ts
+++ b/packages/protocol/src/transfer-messages.test.ts
@@ -64,6 +64,25 @@ describe('control-message codec', () => {
     expect(decodeControl(wire)).toEqual(msg);
   });
 
+  it('round-trips a resume_state carrying the manifest fingerprint', () => {
+    const fp = '0123456789abcdef'.repeat(4);
+    const msg = {
+      type: FrameType.ResumeState,
+      transferId: '0123456789abcdef0123456789abcdef',
+      manifestFingerprint: fp,
+      files: [
+        { idx: 0, haveBlocks: 3 },
+        { idx: 1, haveBlocks: 0 },
+      ],
+    } as const;
+    const wire = encodeControl(msg);
+    // Key order is pinned: type, transferId, manifestFingerprint, then files.
+    expect(new TextDecoder().decode(wire)).toBe(
+      `{"type":12,"transferId":"0123456789abcdef0123456789abcdef","manifestFingerprint":"${fp}","files":[{"idx":0,"haveBlocks":3},{"idx":1,"haveBlocks":0}]}`,
+    );
+    expect(decodeControl(wire)).toEqual(msg);
+  });
+
   it('round-trips block and terminal messages', () => {
     const msgs = [
       { type: FrameType.BlockHash, fileIdx: 0, blockIdx: 1, sha256: 'ff' },
@@ -114,5 +133,15 @@ describe('control-message codec', () => {
         } as never),
       ),
     ).toThrow(); // resume file missing haveBlocks
+    expect(() =>
+      decodeControl(
+        encodeControl({
+          type: FrameType.ResumeState,
+          transferId: 'x',
+          manifestFingerprint: 'nope',
+          files: [{ idx: 0, haveBlocks: 0 }],
+        } as never),
+      ),
+    ).toThrow(); // malformed manifest fingerprint
   });
 });

--- a/packages/protocol/src/transfer-messages.ts
+++ b/packages/protocol/src/transfer-messages.ts
@@ -147,7 +147,15 @@ function asComplete(m: Record<string, unknown>): Complete {
 function asResumeFileState(v: unknown): ResumeFileState {
   if (typeof v !== 'object' || v === null) throw new Error('control frame: bad resume file state');
   const f = v as Record<string, unknown>;
-  return { idx: num(f, 'idx'), haveBlocks: num(f, 'haveBlocks') };
+  const idx = num(f, 'idx');
+  const haveBlocks = num(f, 'haveBlocks');
+  // The Go decoder's int fields already reject fractional/non-integral values at
+  // decode time; mirror that so both implementations fail the same malformed
+  // resume_state identically instead of only at semantic validation.
+  if (!Number.isSafeInteger(idx) || !Number.isSafeInteger(haveBlocks)) {
+    throw new Error('control frame: resume file state is not an integer');
+  }
+  return { idx, haveBlocks };
 }
 function asResumeState(m: Record<string, unknown>): ResumeState {
   if (!Array.isArray(m.files) || m.files.length === 0)
@@ -156,9 +164,19 @@ function asResumeState(m: Record<string, unknown>): ResumeState {
     throw new Error(
       `control frame: resume_state has ${m.files.length} files, maximum is ${MAX_TRANSFER_FILES}`,
     );
+  // manifestFingerprint is optional and keeps its position between transferId and files so
+  // the re-encoded wire bytes match the original key ordering.
+  const manifestFingerprint =
+    m.manifestFingerprint === undefined ? undefined : str(m, 'manifestFingerprint');
+  if (manifestFingerprint !== undefined && !/^[0-9a-f]{64}$/.test(manifestFingerprint)) {
+    throw new Error(
+      'control frame: resume_state.manifestFingerprint must be 64 lowercase hex characters',
+    );
+  }
   return {
     type: FrameType.ResumeState,
     transferId: str(m, 'transferId'),
+    ...(manifestFingerprint !== undefined ? { manifestFingerprint } : {}),
     files: m.files.map(asResumeFileState),
   };
 }

--- a/packages/protocol/src/transfer-receiver-resume.test.ts
+++ b/packages/protocol/src/transfer-receiver-resume.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { deriveTransferKeys } from './keyschedule.js';
+import { open, seal, type FrameHeaderInput } from './aead.js';
+import { FrameType, type Manifest } from './transfer.js';
+import { FRAME_VERSION } from './constants.js';
+import { decodeControl, encodeControl } from './transfer-messages.js';
+import { bytesToHex } from './bytes.js';
+import { sha256 } from './webcrypto.js';
+import { MemorySink, type Digest } from './transfer-ports.js';
+import { TransferReceiver, type ReceiverResumeState } from './transfer-receiver.js';
+import { manifestFingerprint } from './journal.js';
+
+function nodeDigest(): Digest {
+  const h = createHash('sha256');
+  return { update: (b) => void h.update(b), hexDigest: () => h.digest('hex') };
+}
+const master = new Uint8Array(32).fill(9);
+const ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+async function build(keys: Awaited<ReturnType<typeof deriveTransferKeys>>) {
+  let ctr = 0;
+  const frames: Uint8Array[] = [];
+  const push = async (header: FrameHeaderInput, payload: Uint8Array) => {
+    frames.push(await seal(keys.o2j, ctr++, header, payload));
+  };
+  const ctrl = (type: FrameType, msg: Parameters<typeof encodeControl>[0]) =>
+    push(
+      { version: FRAME_VERSION, type, flags: 0, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+      encodeControl(msg),
+    );
+  return { frames, push, ctrl };
+}
+
+async function expectedManifest(): Promise<Manifest> {
+  return {
+    type: FrameType.Manifest,
+    transferId: ID,
+    files: [
+      {
+        idx: 0,
+        name: 'f',
+        size: 20,
+        mime: '',
+        lastModified: 0,
+        blockSize: 8,
+        blocks: 3,
+        fileDigest: createHash('sha256').update(new Uint8Array(20)).digest('hex'),
+      },
+    ],
+    totalSize: 20,
+  };
+}
+
+async function streamFile(b: Awaited<ReturnType<typeof build>>, data: Uint8Array): Promise<void> {
+  for (let blk = 0; blk * 8 < data.length; blk++) {
+    const start = blk * 8;
+    const end = Math.min(start + 8, data.length);
+    const block = data.subarray(start, end);
+    for (let off = 0; off < block.length; off += 4) {
+      const frag = block.subarray(off, Math.min(off + 4, block.length));
+      const last = off + frag.length === block.length;
+      await b.push(
+        {
+          version: FRAME_VERSION,
+          type: FrameType.BlockData,
+          flags: last ? 1 : 0,
+          fileIdx: 0,
+          blockIdx: blk,
+          frameOff: off,
+        },
+        frag,
+      );
+    }
+    await b.ctrl(FrameType.BlockHash, {
+      type: FrameType.BlockHash,
+      fileIdx: 0,
+      blockIdx: blk,
+      sha256: bytesToHex(await sha256(block)),
+    });
+  }
+}
+
+async function runReceiver(
+  manifest: Manifest,
+  stream: boolean,
+  resume: ReceiverResumeState | undefined,
+  complete = true,
+): Promise<{
+  result: Awaited<ReturnType<TransferReceiver['done']['then']>> | undefined;
+  err: unknown;
+  back: Parameters<typeof decodeControl>[0][];
+}> {
+  const keys = await deriveTransferKeys(master);
+  const b = await build(keys);
+  await b.ctrl(FrameType.Manifest, manifest);
+  if (stream) {
+    await streamFile(b, new Uint8Array(20));
+  }
+  if (complete) {
+    await b.ctrl(FrameType.Complete, {
+      type: FrameType.Complete,
+      fileDigest: manifest.files[0]!.fileDigest,
+    });
+  }
+  const sink = new MemorySink();
+  const backChannel: Uint8Array[] = [];
+  const receiver = new TransferReceiver({
+    send: (f) => void backChannel.push(f),
+    sendDir: keys.j2o,
+    recvDir: keys.o2j,
+    sendCounterStart: 0,
+    recvCounterStart: 0,
+    createDigest: nodeDigest,
+    sink,
+    resume,
+  });
+  for (const f of b.frames) receiver.handle(f);
+  let result: Awaited<ReturnType<TransferReceiver['done']['then']>> | undefined;
+  let err: unknown;
+  try {
+    result = await receiver.done;
+  } catch (e) {
+    err = e;
+  }
+  const back: Parameters<typeof decodeControl>[0][] = [];
+  let c = 0;
+  for (const f of backChannel) {
+    const o = await open(keys.j2o, c++, f);
+    back.push(decodeControl(o.plaintext));
+  }
+  return { result, err, back };
+}
+
+describe('TransferReceiver resume validation (V13-PR06)', () => {
+  it('fails closed on bad resume seeds without advertising any resume_state', async () => {
+    const manifest = await expectedManifest();
+    const fp = await manifestFingerprint(manifest);
+    const base = (mutate: (r: ReceiverResumeState) => void): ReceiverResumeState => {
+      const r: ReceiverResumeState = {
+        transferId: ID,
+        manifestFingerprint: fp,
+        files: new Map([[0, { haveBlocks: 0, seedDigest: nodeDigest() }]]),
+      };
+      mutate(r);
+      return r;
+    };
+    const cases: { name: string; resume: ReceiverResumeState; want: RegExp }[] = [
+      {
+        name: 'uppercase fingerprint',
+        resume: base((r) => (r.manifestFingerprint = r.manifestFingerprint.toUpperCase())),
+        want: /resume seed manifestFingerprint must be 64 lowercase hex characters/,
+      },
+      {
+        name: 'short fingerprint',
+        resume: base((r) => (r.manifestFingerprint = fp.slice(0, 10))),
+        want: /resume seed manifestFingerprint must be 64 lowercase hex characters/,
+      },
+      {
+        name: 'wrong fingerprint',
+        resume: base((r) => (r.manifestFingerprint = '0'.repeat(64))),
+        want: /resume seed manifest fingerprint does not match the authenticated manifest/,
+      },
+      {
+        name: 'empty file set',
+        resume: base((r) => (r.files = new Map())),
+        want: /resume seed covers 0 files, manifest has 1/,
+      },
+      {
+        name: 'haveBlocks above blocks',
+        resume: base(
+          (r) => (r.files = new Map([[0, { haveBlocks: 4, seedDigest: nodeDigest() }]])),
+        ),
+        want: /resume seed haveBlocks 4 out of range for file 0 \(blocks 3\)/,
+      },
+    ];
+    for (const c of cases) {
+      const { err, back } = await runReceiver(manifest, false, c.resume);
+      expect(err, c.name).toBeInstanceOf(Error);
+      expect(String((err as Error).message), c.name).toMatch(c.want);
+      expect((err as Error).message).toMatch(/sink_error/);
+      // The only back-channel frame is the terminal fail; no resume_state was advertised.
+      expect(back.length, c.name).toBe(1);
+      expect(back[0]!.type, c.name).toBe(FrameType.Fail);
+    }
+  });
+
+  it('advertises a fingerprint-bound resume_state and streams only the missing blocks', async () => {
+    const manifest = await expectedManifest();
+    const fp = await manifestFingerprint(manifest);
+    const prefix = new Uint8Array(16);
+    const seed = nodeDigest();
+    seed.update(prefix);
+    const { err, back } = await runReceiver(manifest, true, {
+      transferId: ID,
+      manifestFingerprint: fp,
+      files: new Map([[0, { haveBlocks: 2, seedDigest: seed }]]),
+    });
+    expect(err).toBeUndefined();
+    expect(back.length).toBe(5); // resume_state, ack ×3, done
+    const rs = back[0] as Extract<(typeof back)[number], { type: FrameType.ResumeState }>;
+    expect(rs.type).toBe(FrameType.ResumeState);
+    expect(rs.manifestFingerprint).toBe(fp);
+    expect(rs.files).toEqual([{ idx: 0, haveBlocks: 2 }]);
+    expect(back[back.length - 1]!.type).toBe(FrameType.Done);
+  });
+
+  it('ignores a resume seed for a different transfer (fresh all-zero resume_state)', async () => {
+    const manifest = await expectedManifest();
+    const staleSeed = nodeDigest();
+    staleSeed.update(new Uint8Array(8));
+    const { err, back } = await runReceiver(manifest, true, {
+      transferId: 'b'.repeat(32),
+      manifestFingerprint: '0'.repeat(64),
+      files: new Map([[0, { haveBlocks: 2, seedDigest: staleSeed }]]),
+    });
+    expect(err).toBeUndefined();
+    const rs = back[0] as Extract<(typeof back)[number], { type: FrameType.ResumeState }>;
+    expect(rs.files).toEqual([{ idx: 0, haveBlocks: 0 }]);
+  });
+
+  it('re-answers an identical resume_state on a duplicate manifest and rejects a different one', async () => {
+    const manifest = await expectedManifest();
+    const fp = await manifestFingerprint(manifest);
+    const seed = nodeDigest();
+    seed.update(new Uint8Array(8));
+
+    // Identical duplicate manifest → identical resume_state both times.
+    {
+      const keys = await deriveTransferKeys(master);
+      const b = await build(keys);
+      await b.ctrl(FrameType.Manifest, manifest);
+      await b.ctrl(FrameType.Manifest, manifest);
+      await streamFile(b, new Uint8Array(20));
+      await b.ctrl(FrameType.Complete, {
+        type: FrameType.Complete,
+        fileDigest: manifest.files[0]!.fileDigest,
+      });
+      const sink = new MemorySink();
+      const backChannel: Uint8Array[] = [];
+      const receiver = new TransferReceiver({
+        send: (f) => void backChannel.push(f),
+        sendDir: keys.j2o,
+        recvDir: keys.o2j,
+        sendCounterStart: 0,
+        recvCounterStart: 0,
+        createDigest: nodeDigest,
+        sink,
+        resume: {
+          transferId: ID,
+          manifestFingerprint: fp,
+          files: new Map([[0, { haveBlocks: 1, seedDigest: seed }]]),
+        },
+      });
+      for (const f of b.frames) receiver.handle(f);
+      await receiver.done;
+      const backs: Parameters<typeof decodeControl>[0][] = [];
+      let c = 0;
+      for (const f of backChannel)
+        backs.push(decodeControl((await open(keys.j2o, c++, f)).plaintext));
+      const first = backs[0] as Extract<(typeof backs)[number], { type: FrameType.ResumeState }>;
+      const second = backs[1] as Extract<(typeof backs)[number], { type: FrameType.ResumeState }>;
+      expect(first.type).toBe(FrameType.ResumeState);
+      expect(second).toEqual(first);
+    }
+
+    // A different manifest after the first was applied is a protocol violation.
+    {
+      const other: Manifest = {
+        ...manifest,
+        files: [
+          {
+            ...manifest.files[0]!,
+            size: 40,
+            blocks: 5,
+            fileDigest: createHash('sha256').update(new Uint8Array(40)).digest('hex'),
+          },
+        ],
+        totalSize: 40,
+      };
+      const keys = await deriveTransferKeys(master);
+      const b = await build(keys);
+      await b.ctrl(FrameType.Manifest, manifest);
+      await b.ctrl(FrameType.Manifest, other);
+      const sink = new MemorySink();
+      const backChannel: Uint8Array[] = [];
+      const receiver = new TransferReceiver({
+        send: (f) => void backChannel.push(f),
+        sendDir: keys.j2o,
+        recvDir: keys.o2j,
+        sendCounterStart: 0,
+        recvCounterStart: 0,
+        createDigest: nodeDigest,
+        sink,
+        resume: {
+          transferId: ID,
+          manifestFingerprint: fp,
+          files: new Map([[0, { haveBlocks: 1, seedDigest: seed }]]),
+        },
+      });
+      for (const f of b.frames) receiver.handle(f);
+      await expect(receiver.done).rejects.toThrow(/duplicate manifest/);
+    }
+  });
+
+  it('settles immediately when the seed already holds the whole file', async () => {
+    const manifest = await expectedManifest();
+    const fp = await manifestFingerprint(manifest);
+    const seed = nodeDigest();
+    seed.update(new Uint8Array(20));
+    const { err, back } = await runReceiver(manifest, false, {
+      transferId: ID,
+      manifestFingerprint: fp,
+      files: new Map([[0, { haveBlocks: 3, seedDigest: seed }]]),
+    });
+    expect(err).toBeUndefined();
+    expect(back.length).toBe(2); // resume_state, done
+    const rs = back[0] as Extract<(typeof back)[number], { type: FrameType.ResumeState }>;
+    expect(rs.files).toEqual([{ idx: 0, haveBlocks: 3 }]);
+    expect(back[1]!.type).toBe(FrameType.Done);
+  });
+});

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -23,6 +23,7 @@ import {
   type Sink,
 } from './transfer-ports.js';
 import { decodeControl, encodeControl } from './transfer-messages.js';
+import { manifestFingerprint } from './journal.js';
 import type { TransferRunState } from './transfer-sender.js';
 import { validateManifest, MAX_MANIFEST_BLOCK_BYTES } from './safe-path.js';
 import { completionDigest } from './transfer-set.js';
@@ -55,6 +56,14 @@ export interface ReceiverResumeState {
    * file set, so the persisted offsets are ignored and a fresh receive starts.
    */
   transferId: string;
+  /**
+   * The canonical fingerprint of the exact manifest these checkpoints belong to (identical
+   * algorithm to the durable journal's `manifestFingerprint`). The receiver revalidates the
+   * whole seed against the authenticated manifest before advertising any of it: a claim that
+   * cannot be bound to the authenticated manifest fails closed rather than being clamped or
+   * silently dropped.
+   */
+  manifestFingerprint: string;
   files: ReadonlyMap<number, ReceiverResumeFile>;
 }
 
@@ -106,8 +115,20 @@ export class TransferReceiver {
   private readonly seenAhead = new Set<number>();
   private nackOutstanding: number | undefined;
   private paused = false;
-  /** The caller's resume seed, kept only once its transferId matches the arriving manifest. */
+  /** The caller's resume seed, kept only once its transferId matches the arriving manifest
+   *  and its claims validated against the authenticated manifest. */
   private activeResume: ReceiverResumeState | undefined;
+  /** The exact resume_state advertised on the first manifest, kept so an identical duplicate
+   *  manifest (a cutover retransmission) can re-answer with the same claims instead of the
+   *  sender waiting forever for a lost message. */
+  private resumeStateMessage:
+    | {
+        type: FrameType.ResumeState;
+        transferId: string;
+        manifestFingerprint: string;
+        files: Array<{ idx: number; haveBlocks: number }>;
+      }
+    | undefined;
 
   private resolveDone!: (r: ReceiveResult) => void;
   private rejectDone!: (e: Error) => void;
@@ -243,7 +264,17 @@ export class TransferReceiver {
       // A path cutover can retransmit the manifest while the original is still
       // being processed. An identical copy is harmless; a different one is a
       // protocol violation (mirrors the Go wire receiver).
-      if (manifestsEqual(manifest, this.manifest)) return;
+      if (manifestsEqual(manifest, this.manifest)) {
+        // The sender retransmits the manifest when a cutover lost its first copy —
+        // possibly before the receiver's resume_state ever reached it. Re-answer
+        // with the identical resume_state so the negotiation converges instead of
+        // the sender waiting forever for a lost message; the sender treats an
+        // identical duplicate as idempotent.
+        if (manifest.transferId !== undefined && this.resumeStateMessage !== undefined) {
+          await this.sendControl(FrameType.ResumeState, this.resumeStateMessage);
+        }
+        return;
+      }
       throw new TransferError('integrity', 'duplicate manifest');
     }
     try {
@@ -261,26 +292,91 @@ export class TransferReceiver {
     this.awaitingRestart = true;
     if (manifest.transferId !== undefined) {
       // The sender opted into resumption. Apply persisted offsets only when they belong to this
-      // exact transfer, then report each file's high-water mark so the sender skips held blocks.
-      this.activeResume =
-        this.o.resume && this.o.resume.transferId === manifest.transferId
-          ? this.o.resume
-          : undefined;
+      // exact transfer — and only after the seed validates against the authenticated manifest:
+      // a host-provided seed is a claim, not a trust anchor, and an impossible claim must fail
+      // closed before any of it is advertised (never clamped into range).
+      if (this.o.resume && this.o.resume.transferId === manifest.transferId) {
+        await this.validateResumeSeed(manifest, this.o.resume);
+        this.activeResume = this.o.resume;
+      }
       await this.sendResumeState(manifest);
     }
     await this.openNextFile();
   }
 
+  /**
+   * Bind a host-provided resume seed against the authenticated manifest (V13-PR06). Every check
+   * is reject, never repair: a seed that fails any rule is refused entirely so no claim without
+   * durable backing can ever be advertised to the sender. The seed's fingerprint already binds
+   * block geometry and the exact file set, so per-file bounds complete the validation.
+   */
+  private async validateResumeSeed(manifest: Manifest, resume: ReceiverResumeState): Promise<void> {
+    if (!/^[0-9a-f]{32}$/.test(resume.transferId)) {
+      throw new TransferError(
+        'sink_error',
+        'resume seed transferId must be 32 lowercase hex characters',
+      );
+    }
+    if (!/^[0-9a-f]{64}$/.test(resume.manifestFingerprint)) {
+      throw new TransferError(
+        'sink_error',
+        'resume seed manifestFingerprint must be 64 lowercase hex characters',
+      );
+    }
+    const fingerprint = await manifestFingerprint(manifest);
+    if (resume.manifestFingerprint !== fingerprint) {
+      throw new TransferError(
+        'sink_error',
+        'resume seed manifest fingerprint does not match the authenticated manifest',
+      );
+    }
+    if (resume.files.size !== manifest.files.length) {
+      throw new TransferError(
+        'sink_error',
+        `resume seed covers ${resume.files.size} files, manifest has ${manifest.files.length}`,
+      );
+    }
+    for (const file of manifest.files) {
+      const progress = resume.files.get(file.idx);
+      if (progress === undefined) {
+        throw new TransferError('sink_error', `resume seed is missing file ${file.idx}`);
+      }
+      if (
+        !Number.isSafeInteger(progress.haveBlocks) ||
+        progress.haveBlocks < 0 ||
+        progress.haveBlocks > file.blocks
+      ) {
+        throw new TransferError(
+          'sink_error',
+          `resume seed haveBlocks ${progress.haveBlocks} out of range for file ${file.idx} (blocks ${file.blocks})`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Advertise the receiver's durable high-water marks. The first call builds the message
+   * (bound to the authenticated manifest's canonical fingerprint) and snapshots it; later
+   * calls — a cutover's identical duplicate manifest — re-answer with that exact snapshot so
+   * the sender's idempotent duplicate handling converges the negotiation.
+   */
   private async sendResumeState(manifest: Manifest): Promise<void> {
+    if (this.resumeStateMessage !== undefined) {
+      await this.sendControl(FrameType.ResumeState, this.resumeStateMessage);
+      return;
+    }
     const files = manifest.files.map((file) => ({
       idx: file.idx,
-      haveBlocks: Math.min(this.activeResume?.files.get(file.idx)?.haveBlocks ?? 0, file.blocks),
+      haveBlocks: this.activeResume?.files.get(file.idx)?.haveBlocks ?? 0,
     }));
-    await this.sendControl(FrameType.ResumeState, {
+    const msg = {
       type: FrameType.ResumeState,
       transferId: manifest.transferId!,
+      manifestFingerprint: await manifestFingerprint(manifest),
       files,
-    });
+    } as const;
+    this.resumeStateMessage = msg;
+    await this.sendControl(FrameType.ResumeState, msg);
   }
 
   /** Open the next file and immediately verify/close consecutive empty files. */
@@ -291,7 +387,9 @@ export class TransferReceiver {
       const file = manifest.files[this.fileIdx]!;
       this.file = file;
       const rf = this.activeResume?.files.get(file.idx);
-      this.nextBlock = rf ? Math.min(rf.haveBlocks, file.blocks) : 0;
+      // The seed was validated against the authenticated manifest, so the high-water mark
+      // is already within [0, blocks]; it is never clamped.
+      this.nextBlock = rf ? rf.haveBlocks : 0;
       this.seenAhead.clear();
       this.nackOutstanding = undefined;
       // The seed digest already holds the persisted prefix; the streamed remainder appends to it.

--- a/packages/protocol/src/transfer-sender-resume.test.ts
+++ b/packages/protocol/src/transfer-sender-resume.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { deriveTransferKeys } from './keyschedule.js';
+import { seal, open } from './aead.js';
+import { FrameType, type Manifest } from './transfer.js';
+import { FRAME_VERSION } from './constants.js';
+import { encodeControl } from './transfer-messages.js';
+import { bytesSource, type Digest } from './transfer-ports.js';
+import { TransferSender } from './transfer-sender.js';
+import { manifestFingerprint } from './journal.js';
+
+function nodeDigest(): Digest {
+  const h = createHash('sha256');
+  return { update: (b) => void h.update(b), hexDigest: () => h.digest('hex') };
+}
+const master = new Uint8Array(32).fill(9);
+const ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const data = new Uint8Array(20).map((_, i) => i); // block=8 → blocks 0,1 full, block 2 = 4B
+
+async function waitFor(check: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error('timed out waiting for sender state');
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+/** The canonical manifest the sender will stream, for computing the fingerprint binding. */
+async function expectedManifest(): Promise<Manifest> {
+  return {
+    type: FrameType.Manifest,
+    transferId: ID,
+    files: [
+      {
+        idx: 0,
+        name: 'f',
+        size: data.length,
+        mime: '',
+        lastModified: 0,
+        blockSize: 8,
+        blocks: 3,
+        fileDigest: createHash('sha256').update(data).digest('hex'),
+      },
+    ],
+    totalSize: data.length,
+  };
+}
+
+/** Build a sender in resume mode and capture its outbound frames. */
+function resumeSender(keys: Awaited<ReturnType<typeof deriveTransferKeys>>) {
+  const outbound: Uint8Array[] = [];
+  const sender = new TransferSender({
+    file: bytesSource(data, { name: 'f', size: data.length, mime: '', lastModified: 0 }),
+    send: (f) => void outbound.push(f),
+    sendDir: keys.o2j,
+    recvDir: keys.j2o,
+    sendCounterStart: 0,
+    recvCounterStart: 0,
+    createDigest: nodeDigest,
+    blockSize: 8,
+    frameSize: 4,
+    window: 1,
+    transferId: ID,
+  });
+  return { sender, outbound };
+}
+
+async function sealInbound(
+  keys: Awaited<ReturnType<typeof deriveTransferKeys>>,
+  counter: number,
+  type: FrameType,
+  payload: Uint8Array,
+): Promise<Uint8Array> {
+  return seal(
+    keys.j2o,
+    counter,
+    { version: FRAME_VERSION, type, flags: 0, fileIdx: 0, blockIdx: 0, frameOff: 0 },
+    payload,
+  );
+}
+
+/** Ack the blocks above the high-water mark, then send done; the caller awaits sender.run(). */
+async function settleResume(
+  sender: TransferSender,
+  keys: Awaited<ReturnType<typeof deriveTransferKeys>>,
+  outbound: Uint8Array[],
+  haveBlocks: number,
+  startCounter: number,
+): Promise<void> {
+  await waitFor(() => outbound.length >= 1 + 2 * (3 - haveBlocks));
+  let ctr = startCounter;
+  for (let b = haveBlocks; b < 3; b++) {
+    const ack = await sealInbound(
+      keys,
+      ctr++,
+      FrameType.Ack,
+      encodeControl({ type: FrameType.Ack, fileIdx: 0, blockIdx: b }),
+    );
+    sender.handle(ack);
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  const done = await sealInbound(
+    keys,
+    ctr++,
+    FrameType.Done,
+    encodeControl({ type: FrameType.Done }),
+  );
+  sender.handle(done);
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+describe('TransferSender resume validation (V13-PR06)', () => {
+  it('rejects a resume_state before the manifest was validated', async () => {
+    const keys = await deriveTransferKeys(master);
+    const { sender } = resumeSender(keys);
+    // Deliver the resume_state before run() validates the manifest: there is no binding yet.
+    await sender.handle(
+      await sealInbound(
+        keys,
+        0,
+        FrameType.ResumeState,
+        encodeControl({
+          type: FrameType.ResumeState,
+          transferId: ID,
+          files: [{ idx: 0, haveBlocks: 0 }],
+        }),
+      ),
+    );
+    await expect(sender.run()).rejects.toThrow(/unexpected resume_state/);
+  });
+
+  it('rejects a resume_state for another transfer', async () => {
+    const keys = await deriveTransferKeys(master);
+    const { sender, outbound } = resumeSender(keys);
+    const runP = sender.run();
+    await waitFor(() => outbound.length >= 1);
+    await sender.handle(
+      await sealInbound(
+        keys,
+        0,
+        FrameType.ResumeState,
+        encodeControl({
+          type: FrameType.ResumeState,
+          transferId: 'b'.repeat(32),
+          files: [{ idx: 0, haveBlocks: 0 }],
+        }),
+      ),
+    );
+    await expect(runP).rejects.toThrow(/resume_state transfer id mismatch/);
+  });
+
+  it('rejects a resume_state bound to a different manifest fingerprint', async () => {
+    const keys = await deriveTransferKeys(master);
+    const { sender, outbound } = resumeSender(keys);
+    const runP = sender.run();
+    await waitFor(() => outbound.length >= 1);
+    await sender.handle(
+      await sealInbound(
+        keys,
+        0,
+        FrameType.ResumeState,
+        encodeControl({
+          type: FrameType.ResumeState,
+          transferId: ID,
+          manifestFingerprint: '0'.repeat(64),
+          files: [{ idx: 0, haveBlocks: 0 }],
+        }),
+      ),
+    );
+    await expect(runP).rejects.toThrow(/resume_state manifest fingerprint mismatch/);
+  });
+
+  it('rejects malformed claims: unknown file, duplicate file, out-of-range haveBlocks, missing entry', async () => {
+    const manifest = await expectedManifest();
+    const fp = await manifestFingerprint(manifest);
+    const cases: { name: string; files: { idx: number; haveBlocks: number }[]; want: RegExp }[] = [
+      {
+        name: 'unknown file',
+        files: [{ idx: 3, haveBlocks: 0 }],
+        want: /resume_state references an unknown file/,
+      },
+      {
+        name: 'duplicate file',
+        files: [
+          { idx: 0, haveBlocks: 0 },
+          { idx: 0, haveBlocks: 0 },
+        ],
+        want: /resume_state references a file more than once/,
+      },
+      {
+        name: 'haveBlocks above blocks',
+        files: [{ idx: 0, haveBlocks: 4 }],
+        want: /resume_state haveBlocks out of range/,
+      },
+    ];
+    for (const c of cases) {
+      const keys = await deriveTransferKeys(master);
+      const { sender, outbound } = resumeSender(keys);
+      const runP = sender.run();
+      await waitFor(() => outbound.length >= 1);
+      await sender.handle(
+        await sealInbound(
+          keys,
+          0,
+          FrameType.ResumeState,
+          encodeControl({
+            type: FrameType.ResumeState,
+            transferId: ID,
+            manifestFingerprint: fp,
+            files: c.files,
+          }),
+        ),
+      );
+      await expect(runP, c.name).rejects.toThrow(c.want);
+    }
+  });
+
+  it('resumes from a fingerprint-bound high-water mark, streaming only missing blocks', async () => {
+    const keys = await deriveTransferKeys(master);
+    const { sender, outbound } = resumeSender(keys);
+    const runP = sender.run();
+    await waitFor(() => outbound.length >= 1);
+    const manifest = await expectedManifest();
+    const fp = await manifestFingerprint(manifest);
+    await sender.handle(
+      await sealInbound(
+        keys,
+        0,
+        FrameType.ResumeState,
+        encodeControl({
+          type: FrameType.ResumeState,
+          transferId: ID,
+          manifestFingerprint: fp,
+          files: [{ idx: 0, haveBlocks: 2 }],
+        }),
+      ),
+    );
+    await settleResume(sender, keys, outbound, 2, 1);
+
+    // manifest + block 2 data + block 2 hash + complete: the held prefix is never sent.
+    await waitFor(() => outbound.length >= 4);
+    let dataFrames = 0;
+    for (let i = 0; i < outbound.length; i++) {
+      const o = await open(keys.o2j, i, outbound[i]!);
+      if (o.header.type === FrameType.BlockData) dataFrames++;
+    }
+    expect(dataFrames).toBe(1);
+    await runP;
+  });
+
+  it('accepts a legacy resume_state without the fingerprint field (structural rules still apply)', async () => {
+    const keys = await deriveTransferKeys(master);
+    const { sender, outbound } = resumeSender(keys);
+    const runP = sender.run();
+    await waitFor(() => outbound.length >= 1);
+    await sender.handle(
+      await sealInbound(
+        keys,
+        0,
+        FrameType.ResumeState,
+        encodeControl({
+          type: FrameType.ResumeState,
+          transferId: ID,
+          files: [{ idx: 0, haveBlocks: 2 }],
+        }),
+      ),
+    );
+    await settleResume(sender, keys, outbound, 2, 1);
+    await runP;
+  });
+
+  it('treats an identical duplicate resume_state as idempotent and a conflicting one as fatal', async () => {
+    const manifest = await expectedManifest();
+    const fp = await manifestFingerprint(manifest);
+
+    // Identical duplicate: the resumed stream proceeds exactly as with a single answer.
+    {
+      const keys = await deriveTransferKeys(master);
+      const { sender, outbound } = resumeSender(keys);
+      const runP = sender.run();
+      await waitFor(() => outbound.length >= 1);
+      const payload = encodeControl({
+        type: FrameType.ResumeState,
+        transferId: ID,
+        manifestFingerprint: fp,
+        files: [{ idx: 0, haveBlocks: 2 }],
+      });
+      await sender.handle(await sealInbound(keys, 0, FrameType.ResumeState, payload));
+      await sender.handle(await sealInbound(keys, 1, FrameType.ResumeState, payload));
+      await settleResume(sender, keys, outbound, 2, 2);
+      await runP;
+    }
+
+    // Conflicting duplicate: the second answer claims a different high-water mark.
+    {
+      const keys = await deriveTransferKeys(master);
+      const { sender, outbound } = resumeSender(keys);
+      const runP = sender.run();
+      await waitFor(() => outbound.length >= 1);
+      const first = encodeControl({
+        type: FrameType.ResumeState,
+        transferId: ID,
+        manifestFingerprint: fp,
+        files: [{ idx: 0, haveBlocks: 2 }],
+      });
+      const conflicting = encodeControl({
+        type: FrameType.ResumeState,
+        transferId: ID,
+        manifestFingerprint: fp,
+        files: [{ idx: 0, haveBlocks: 3 }],
+      });
+      await sender.handle(await sealInbound(keys, 0, FrameType.ResumeState, first));
+      await sender.handle(await sealInbound(keys, 1, FrameType.ResumeState, conflicting));
+      await expect(runP).rejects.toThrow(/conflicting duplicate resume_state/);
+    }
+  });
+});

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -9,7 +9,14 @@
 
 import { FrameReplayError, openSequenced, seal, type FrameHeaderInput } from './aead.js';
 import type { DirectionalKey } from './keyschedule.js';
-import { FrameType, type ControlOp, type Fail, type Manifest } from './transfer.js';
+import {
+  FrameType,
+  type ControlOp,
+  type Fail,
+  type Manifest,
+  type ResumeState,
+} from './transfer.js';
+import { manifestFingerprint } from './journal.js';
 import {
   DEFAULT_BLOCK_BYTES,
   DEFAULT_FRAME_BYTES,
@@ -94,6 +101,23 @@ const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_DONE_TIMEOUT_MS = 30_000;
 const DEFAULT_COMPLETE_INTERVAL_MS = 500;
 
+/** Reports whether two resume_state messages carry the same claims. */
+function resumeStatesEqual(a: ResumeState | undefined, b: ResumeState | undefined): boolean {
+  if (
+    !a ||
+    !b ||
+    a.transferId !== b.transferId ||
+    a.manifestFingerprint !== b.manifestFingerprint ||
+    a.files.length !== b.files.length
+  ) {
+    return false;
+  }
+  return a.files.every((f, i) => {
+    const other = b.files[i];
+    return !!other && f.idx === other.idx && f.haveBlocks === other.haveBlocks;
+  });
+}
+
 export class TransferSender {
   private readonly o: TransferSenderOptions;
   private readonly blockSize: number;
@@ -115,11 +139,18 @@ export class TransferSender {
   private activeFileAcknowledged = 0;
   /** The validated manifest, kept so a path change before any acknowledgment can retransmit it. */
   private manifest: Manifest | undefined;
+  /** Canonical fingerprint of {@link manifest}, computed before its frame is transmitted so an
+   *  early resume_state is never validated against an unset binding (V13-PR06). */
+  private manifestFingerprint = '';
 
   /** Set when a transfer id is advertised: the manifest carries it and a resume handshake runs. */
   private readonly transferId: string | undefined;
   /** Per-file high-water marks the receiver reported; each file restarts at its value. */
-  private readonly resumePlan = new Map<number, number>();
+  private resumePlan = new Map<number, number>();
+  /** The exact resume_state message that produced {@link resumePlan}, kept so a path cutover
+   *  that duplicates it is recognized as an idempotent re-answer while a conflicting duplicate
+   *  fails closed. */
+  private appliedResume: ResumeState | undefined;
   /** Resolves when the receiver's `resume_state` has been validated (resume mode only). */
   private resolveResumeReady!: () => void;
   private rejectResumeReady!: (e: Error) => void;
@@ -274,8 +305,13 @@ export class TransferSender {
     // transfer id + canonical source identity) are durable before the id is advertised,
     // and a rejection means the manifest never reaches the wire.
     await this.o.onManifest?.(manifest);
-    await this.sendControl(FrameType.Manifest, manifest);
+    // The fingerprint binding is registered before the manifest frame is transmitted: the
+    // receiver can answer a resume_state the moment it authenticates the manifest, possibly
+    // before drive reaches the wait, and that answer must never be validated against an
+    // unset binding.
+    this.manifestFingerprint = await manifestFingerprint(manifest);
     this.manifest = manifest;
+    await this.sendControl(FrameType.Manifest, manifest);
 
     // A transfer id opts into resumption: the receiver answers the manifest with a resume_state
     // carrying each file's high-water mark (all zero on a first attempt). Wait for it before
@@ -287,7 +323,10 @@ export class TransferSender {
     for (const [fileIdx, source] of this.files.entries()) {
       this.activeFileIdx = fileIdx;
       const file = manifest.files[fileIdx]!;
-      const haveBlocks = Math.min(this.resumePlan.get(fileIdx) ?? 0, file.blocks);
+      // resumePlan is only ever populated from a fully-validated resume_state whose claims
+      // were already bounded to the manifest geometry (see the ResumeState handler); a
+      // missing file here means fresh mode, restart at zero.
+      const haveBlocks = this.resumePlan.get(fileIdx) ?? 0;
       // Bytes the receiver already holds count as acknowledged up front so progress is continuous
       // across a resume. Only the final block may be partial, so a full prefix is haveBlocks blocks.
       const committed = haveBlocks >= file.blocks ? file.size : haveBlocks * this.blockSize;
@@ -396,26 +435,53 @@ export class TransferSender {
         this.queueRetry(msg.blockIdx);
         return;
       case FrameType.ResumeState: {
-        if (this.transferId === undefined) {
+        if (this.transferId === undefined || this.manifest === undefined) {
           throw new TransferError('integrity', 'unexpected resume_state');
-        }
-        if (this.resumeSettled) {
-          throw new TransferError('integrity', 'duplicate resume_state');
         }
         if (msg.transferId !== this.transferId) {
           throw new TransferError('integrity', 'resume_state transfer id mismatch');
         }
+        if (
+          msg.manifestFingerprint !== undefined &&
+          msg.manifestFingerprint !== this.manifestFingerprint
+        ) {
+          throw new TransferError('integrity', 'resume_state manifest fingerprint mismatch');
+        }
+        if (this.resumeSettled) {
+          // A path cutover can deliver the receiver's answer twice: an identical duplicate
+          // is an idempotent no-op, anything different fails closed.
+          if (resumeStatesEqual(msg, this.appliedResume)) return;
+          throw new TransferError('integrity', 'conflicting duplicate resume_state');
+        }
+        // Build the complete validated plan first; it is committed only after the whole
+        // message passes, so a bad claim can never leave a partially-applied resume plan.
+        const plan = new Map<number, number>();
         for (const entry of msg.files) {
-          const file = this.files[entry.idx];
-          const blocks = file ? Math.ceil(file.meta.size / this.blockSize) : -1;
-          if (blocks < 0 || this.resumePlan.has(entry.idx)) {
+          if (
+            !Number.isSafeInteger(entry.idx) ||
+            entry.idx < 0 ||
+            entry.idx >= this.manifest.files.length
+          ) {
             throw new TransferError('integrity', 'resume_state references an unknown file');
           }
-          if (entry.haveBlocks < 0 || entry.haveBlocks > blocks) {
+          if (plan.has(entry.idx)) {
+            throw new TransferError('integrity', 'resume_state references a file more than once');
+          }
+          const blocks = this.manifest.files[entry.idx]!.blocks;
+          if (
+            !Number.isSafeInteger(entry.haveBlocks) ||
+            entry.haveBlocks < 0 ||
+            entry.haveBlocks > blocks
+          ) {
             throw new TransferError('integrity', 'resume_state haveBlocks out of range');
           }
-          this.resumePlan.set(entry.idx, entry.haveBlocks);
+          plan.set(entry.idx, entry.haveBlocks);
         }
+        if (plan.size !== this.manifest.files.length) {
+          throw new TransferError('integrity', 'resume_state is missing a file entry');
+        }
+        this.resumePlan = plan;
+        this.appliedResume = msg;
         this.resumeSettled = true;
         this.resolveResumeReady();
         return;

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -140,10 +140,18 @@ export interface ResumeFileState {
  * fresh session: "I already hold blocks `[0, haveBlocks)` of each file — restart there." The
  * sender validates it against its own manifest (same `transferId`, `haveBlocks ≤ file.blocks`)
  * and streams only the missing blocks; a mismatch fails the transfer closed.
+ *
+ * `manifestFingerprint` is the optional canonical manifest fingerprint (additive since V13-PR06,
+ * identical algorithm to the durable journal's `manifestFingerprint`). Receivers that understand
+ * it include it so the sender can prove the claims are for exactly the manifest being streamed
+ * before skipping any source block. It is omitted when the receiver predates the binding: an old
+ * sender ignores it, and a new sender treats absence as legacy negotiation (the structural
+ * validation that always applied still runs; a present-but-wrong fingerprint fails closed).
  */
 export interface ResumeState {
   type: FrameType.ResumeState;
   transferId: string;
+  manifestFingerprint?: string;
   files: ResumeFileState[];
 }
 

--- a/packages/wire/faults_test.go
+++ b/packages/wire/faults_test.go
@@ -549,6 +549,27 @@ func TestFaultDuplicateResumeStateIsIdempotent(t *testing.T) {
 	_ = sink.Write(0, data[:prefix])
 	seed := NewSHA256Digest()
 	seed.Update(data[:prefix])
+	// The seed must bind to the canonical fingerprint of the manifest the sender is about
+	// to stream (V13-PR06); recompute it from the same parameters.
+	sum := sha256.Sum256(data)
+	blocks := 0
+	if len(data) > 0 {
+		blocks = (len(data)-1)/1024 + 1
+	}
+	resumeManifest := Manifest{
+		Type:       FrameManifest,
+		TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Files: []FileEntry{{
+			Idx: 0, Name: "f", Size: int64(len(data)), Mime: "application/octet-stream",
+			LastModified: 1, BlockSize: 1024, Blocks: blocks,
+			FileDigest: hex.EncodeToString(sum[:]),
+		}},
+		TotalSize: int64(len(data)),
+	}
+	resumeFingerprint, err := ManifestFingerprint(resumeManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
 	sender := NewSender(SenderOptions{
 		File:        BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
 		Send:        func(f []byte) error { return link.send(dirS2R, f) },
@@ -568,8 +589,9 @@ func TestFaultDuplicateResumeStateIsIdempotent(t *testing.T) {
 		RecvDir: keys.O2J,
 		Sink:    sink,
 		Resume: &ReceiverResume{
-			TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			Files:      map[int]ResumeFileProgress{0: {HaveBlocks: 5, SeedDigest: seed}},
+			TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			ManifestFingerprint: resumeFingerprint,
+			Files:               map[int]ResumeFileProgress{0: {HaveBlocks: 5, SeedDigest: seed}},
 		},
 	})
 	go func() {

--- a/packages/wire/transfer_loopback_test.go
+++ b/packages/wire/transfer_loopback_test.go
@@ -166,16 +166,42 @@ func runResumeLoopback(t *testing.T, data []byte, blockSize, haveBlocks int, sen
 		TransferID: senderID,
 	})
 	var commits int
+	resume := &ReceiverResume{}
+	if resumeID == senderID {
+		// The seed must bind to the canonical fingerprint of the manifest the sender
+		// is about to stream (V13-PR06); recompute it from the same parameters.
+		sum := sha256.Sum256(data)
+		blocks := 0
+		if len(data) > 0 {
+			blocks = (len(data)-1)/blockSize + 1
+		}
+		manifest := Manifest{
+			Type:       FrameManifest,
+			TransferID: senderID,
+			Files: []FileEntry{{
+				Idx: 0, Name: "f", Size: int64(len(data)), Mime: "application/octet-stream",
+				LastModified: 1, BlockSize: blockSize, Blocks: blocks,
+				FileDigest: hex.EncodeToString(sum[:]),
+			}},
+			TotalSize: int64(len(data)),
+		}
+		fingerprint, err := ManifestFingerprint(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resume = &ReceiverResume{
+			TransferID:          resumeID,
+			ManifestFingerprint: fingerprint,
+			Files:               map[int]ResumeFileProgress{0: {HaveBlocks: haveBlocks, SeedDigest: seed}},
+		}
+	}
 	receiver := NewReceiver(ReceiverOptions{
 		Send:       func(f []byte) error { r2s <- cp(f); return nil },
 		SendDir:    keys.J2O,
 		RecvDir:    keys.O2J,
 		Sink:       sink,
 		OnProgress: func(int64) { commits++ },
-		Resume: &ReceiverResume{
-			TransferID: resumeID,
-			Files:      map[int]ResumeFileProgress{0: {HaveBlocks: haveBlocks, SeedDigest: seed}},
-		},
+		Resume:     resume,
 	})
 
 	go func() {

--- a/packages/wire/transfer_messages.go
+++ b/packages/wire/transfer_messages.go
@@ -127,10 +127,19 @@ type ResumeFileState struct {
 // ResumeState tells the sender where to restart each file after the receiver reloaded and
 // re-handshaked. The sender validates it against its manifest (same TransferID, HaveBlocks
 // within bounds) and streams only the missing blocks.
+//
+// ManifestFingerprint is the optional canonical manifest fingerprint (additive since PR06;
+// see ManifestFingerprint). A receiver that understands it includes it so the sender can
+// prove the claims are for exactly the manifest being streamed before skipping any source
+// block. The field is omitted when the receiver predates the binding: an old decoder
+// ignores it, and a new sender treats its absence as legacy negotiation (the same
+// structural validation that always applied still runs, and a present-but-wrong
+// fingerprint fails closed). Field order matches the TypeScript twin byte-for-byte.
 type ResumeState struct {
-	Type       uint8             `json:"type"`
-	TransferID string            `json:"transferId"`
-	Files      []ResumeFileState `json:"files"`
+	Type                uint8             `json:"type"`
+	TransferID          string            `json:"transferId"`
+	ManifestFingerprint string            `json:"manifestFingerprint,omitempty"`
+	Files               []ResumeFileState `json:"files"`
 }
 
 // FrameType returns the frame-header tag for each message; the JSON "type" field carries the
@@ -204,7 +213,7 @@ func NewDone() *Done { return &Done{Type: FrameDone} }
 func NewFail(reason FailReason) *Fail { return &Fail{Type: FrameFail, Reason: reason} }
 
 // NewResumeState builds a resume_state message carrying the transfer id and per-file high-water
-// marks.
+// marks. Set ManifestFingerprint on the result to bind the claims to the canonical manifest.
 func NewResumeState(transferID string, files []ResumeFileState) *ResumeState {
 	return &ResumeState{Type: FrameResumeState, TransferID: transferID, Files: files}
 }
@@ -437,14 +446,18 @@ type rawResumeFileState struct {
 
 func decodeResumeState(payload []byte) (ControlMsg, error) {
 	var raw struct {
-		TransferID *string              `json:"transferId"`
-		Files      []rawResumeFileState `json:"files"`
+		TransferID          *string              `json:"transferId"`
+		ManifestFingerprint *string              `json:"manifestFingerprint"`
+		Files               []rawResumeFileState `json:"files"`
 	}
 	if err := json.Unmarshal(payload, &raw); err != nil {
 		return nil, errors.New("control frame: invalid resume_state")
 	}
 	if raw.TransferID == nil {
 		return nil, errors.New("control frame: resume_state.transferId missing")
+	}
+	if raw.ManifestFingerprint != nil && !isLowerHex(*raw.ManifestFingerprint, 64) {
+		return nil, errors.New("control frame: resume_state.manifestFingerprint must be 64 lowercase hex characters")
 	}
 	if len(raw.Files) == 0 {
 		return nil, errors.New("control frame: resume_state.files empty")
@@ -459,5 +472,9 @@ func decodeResumeState(payload []byte) (ControlMsg, error) {
 		}
 		files[i] = ResumeFileState{Idx: *rf.Idx, HaveBlocks: *rf.HaveBlocks}
 	}
-	return &ResumeState{Type: FrameResumeState, TransferID: *raw.TransferID, Files: files}, nil
+	rs := &ResumeState{Type: FrameResumeState, TransferID: *raw.TransferID, Files: files}
+	if raw.ManifestFingerprint != nil {
+		rs.ManifestFingerprint = *raw.ManifestFingerprint
+	}
+	return rs, nil
 }

--- a/packages/wire/transfer_messages_test.go
+++ b/packages/wire/transfer_messages_test.go
@@ -1,6 +1,9 @@
 package wire
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // The exact JSON byte strings JavaScript's JSON.stringify produces for these shapes. Go must
 // match them byte-for-byte (key order, no HTML escaping, no spaces) or a browser peer and a
@@ -44,6 +47,15 @@ func TestEncodeControlWireBytes(t *testing.T) {
 			"resume_state",
 			NewResumeState("0123456789abcdef0123456789abcdef", []ResumeFileState{{Idx: 0, HaveBlocks: 3}, {Idx: 1, HaveBlocks: 0}}),
 			`{"type":12,"transferId":"0123456789abcdef0123456789abcdef","files":[{"idx":0,"haveBlocks":3},{"idx":1,"haveBlocks":0}]}`,
+		},
+		{
+			"resume_state with manifest fingerprint",
+			&ResumeState{
+				Type: FrameResumeState, TransferID: "0123456789abcdef0123456789abcdef",
+				ManifestFingerprint: strings.Repeat("0123456789abcdef", 4),
+				Files:               []ResumeFileState{{Idx: 0, HaveBlocks: 3}, {Idx: 1, HaveBlocks: 0}},
+			},
+			`{"type":12,"transferId":"0123456789abcdef0123456789abcdef","manifestFingerprint":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","files":[{"idx":0,"haveBlocks":3},{"idx":1,"haveBlocks":0}]}`,
 		},
 	}
 	for _, c := range cases {
@@ -132,8 +144,22 @@ func TestDecodeControlFromTSShapes(t *testing.T) {
 	}
 	rs, ok := m.(*ResumeState)
 	if !ok || rs.TransferID != "abc123" || len(rs.Files) != 2 ||
-		rs.Files[0] != (ResumeFileState{Idx: 0, HaveBlocks: 5}) || rs.Files[1] != (ResumeFileState{Idx: 1, HaveBlocks: 0}) {
+		rs.Files[0] != (ResumeFileState{Idx: 0, HaveBlocks: 5}) || rs.Files[1] != (ResumeFileState{Idx: 1, HaveBlocks: 0}) ||
+		rs.ManifestFingerprint != "" {
 		t.Fatalf("decoded resume_state = %#v", m)
+	}
+
+	// A resume_state carrying the optional manifest fingerprint decodes with it preserved
+	// (a new receiver → legacy sender shape).
+	m, err = DecodeControl([]byte(`{"type":12,"transferId":"abc123","manifestFingerprint":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","files":[{"idx":0,"haveBlocks":5}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs, ok = m.(*ResumeState)
+	if !ok || rs.TransferID != "abc123" ||
+		rs.ManifestFingerprint != "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" ||
+		len(rs.Files) != 1 || rs.Files[0] != (ResumeFileState{Idx: 0, HaveBlocks: 5}) {
+		t.Fatalf("decoded fingerprint resume_state = %#v", m)
 	}
 
 	// A manifest carrying a transferId decodes with the id preserved.
@@ -150,17 +176,20 @@ func TestDecodeControlRejectsMalformed(t *testing.T) {
 	bad := []string{
 		`{{`,           // invalid JSON
 		`{"type":999}`, // out-of-range type
-		`{"type":263,"fileIdx":0,"blockIdx":1,"reason":"missing"}`, // must not wrap to nack
-		`{"type":11,"reason":"nope"}`,                              // bad fail reason
-		`{"type":7,"fileIdx":0,"blockIdx":1,"reason":"bad"}`,       // bad nack reason
-		`{"type":8,"op":"stop"}`,                                   // bad control operation
-		`{"type":9}`,                                               // complete missing fileDigest
-		`{"type":2,"files":[],"totalSize":0}`,                      // empty manifest files
-		`{"type":4,"fileIdx":0}`,                                   // block_hash missing sha256/blockIdx
-		`{"type":12,"files":[{"idx":0,"haveBlocks":0}]}`,           // resume_state missing transferId
-		`{"type":12,"transferId":"x","files":[]}`,                  // resume_state empty files
-		`{"type":12,"transferId":"x","files":[{"idx":0}]}`,         // resume file missing haveBlocks
-		`{"fileIdx":0}`,                                            // missing type
+		`{"type":263,"fileIdx":0,"blockIdx":1,"reason":"missing"}`,                                     // must not wrap to nack
+		`{"type":11,"reason":"nope"}`,                                                                  // bad fail reason
+		`{"type":7,"fileIdx":0,"blockIdx":1,"reason":"bad"}`,                                           // bad nack reason
+		`{"type":8,"op":"stop"}`,                                                                       // bad control operation
+		`{"type":9}`,                                                                                   // complete missing fileDigest
+		`{"type":2,"files":[],"totalSize":0}`,                                                          // empty manifest files
+		`{"type":4,"fileIdx":0}`,                                                                       // block_hash missing sha256/blockIdx
+		`{"type":12,"files":[{"idx":0,"haveBlocks":0}]}`,                                               // resume_state missing transferId
+		`{"type":12,"transferId":"x","files":[]}`,                                                      // resume_state empty files
+		`{"type":12,"transferId":"x","files":[{"idx":0}]}`,                                             // resume file missing haveBlocks
+		`{"type":12,"transferId":"x","files":[{"idx":0.5,"haveBlocks":0}]}`,                            // fractional idx (Go int decode)
+		`{"type":12,"transferId":"x","files":[{"idx":0,"haveBlocks":1.5}]}`,                            // fractional haveBlocks (Go int decode)
+		`{"type":12,"transferId":"x","manifestFingerprint":"nope","files":[{"idx":0,"haveBlocks":0}]}`, // malformed fingerprint
+		`{"fileIdx":0}`, // missing type
 	}
 	for _, s := range bad {
 		if _, err := DecodeControl([]byte(s)); err == nil {

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -34,9 +34,15 @@ type ResumeFileProgress struct {
 // ReceiverResume is the state a reloaded receiver restores to resume a transfer in place. It is
 // applied only when TransferID equals the arriving manifest's; a mismatch means the room was
 // reused for a different file set, so the offsets are ignored and a fresh receive starts.
+//
+// ManifestFingerprint is the canonical fingerprint of the exact manifest these checkpoints
+// belong to (see ManifestFingerprint). The receiver revalidates the whole seed against the
+// authenticated manifest before advertising any of it: a claim that cannot be bound to the
+// authenticated manifest fails closed rather than being clamped or silently dropped.
 type ReceiverResume struct {
-	TransferID string
-	Files      map[int]ResumeFileProgress
+	TransferID          string
+	ManifestFingerprint string
+	Files               map[int]ResumeFileProgress
 }
 
 // ReceiverOptions configures a Receiver.
@@ -87,8 +93,13 @@ type Receiver struct {
 	awaitingRestart bool
 	seenAhead       map[int]bool
 	nackOutstanding int
-	// activeResume is the caller's seed, kept only once its TransferID matches the manifest.
+	// activeResume is the caller's seed, kept only once its TransferID matches the manifest
+	// and its claims validated against the authenticated manifest.
 	activeResume *ReceiverResume
+	// resumeState is the exact resume_state message advertised on the first manifest, kept
+	// so an identical duplicate manifest (a cutover retransmission) can re-answer with the
+	// same claims instead of the sender waiting forever for a lost message.
+	resumeState *ResumeState
 
 	mu      sync.Mutex
 	done    chan struct{}
@@ -242,6 +253,14 @@ func (r *Receiver) applyManifest(payload []byte) error {
 		// being processed. An identical copy is harmless; a different one is a
 		// protocol violation.
 		if manifestsEqual(&validated, r.manifest) {
+			// The sender retransmits the manifest when a cutover lost its first
+			// copy — possibly before the receiver's resume_state ever reached it.
+			// Re-answer with the identical resume_state so the negotiation
+			// converges instead of the sender waiting forever for a lost message;
+			// the sender treats an identical duplicate as idempotent.
+			if validated.TransferID != "" && r.resumeState != nil {
+				return r.sendControl(r.resumeState)
+			}
 			return nil
 		}
 		return NewTransferError(FailIntegrity, "duplicate manifest")
@@ -265,8 +284,13 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	r.awaitingRestart = true
 	if validated.TransferID != "" {
 		// The sender opted into resumption. Apply persisted offsets only when they belong to this
-		// exact transfer, then report each file's high-water mark so the sender skips held blocks.
+		// exact transfer — and only after the seed validates against the authenticated manifest:
+		// a host-provided seed is a claim, not a trust anchor, and an impossible claim must fail
+		// closed before any of it is advertised (never clamped into range).
 		if r.o.Resume != nil && r.o.Resume.TransferID == validated.TransferID {
+			if err := validateResumeSeed(&validated, r.o.Resume); err != nil {
+				return NewTransferError(FailSinkError, err.Error())
+			}
 			r.activeResume = r.o.Resume
 		}
 		if err := r.sendResumeState(&validated); err != nil {
@@ -276,7 +300,50 @@ func (r *Receiver) applyManifest(payload []byte) error {
 	return r.openNextFile()
 }
 
+// validateResumeSeed binds a host-provided resume seed against the authenticated manifest
+// (V13-PR06). Every check is reject, never repair: a seed that fails any rule is refused
+// entirely so no claim without durable backing can ever be advertised to the sender. The
+// seed's fingerprint already binds block geometry and the exact file set, so per-file
+// bounds complete the validation.
+func validateResumeSeed(manifest *Manifest, resume *ReceiverResume) error {
+	if !isLowerHex(resume.TransferID, 32) {
+		return errors.New("resume seed transferId must be 32 lowercase hex characters")
+	}
+	if !isLowerHex(resume.ManifestFingerprint, 64) {
+		return errors.New("resume seed manifestFingerprint must be 64 lowercase hex characters")
+	}
+	fingerprint, err := ManifestFingerprint(*manifest)
+	if err != nil {
+		return err
+	}
+	if resume.ManifestFingerprint != fingerprint {
+		return errors.New("resume seed manifest fingerprint does not match the authenticated manifest")
+	}
+	if len(resume.Files) != len(manifest.Files) {
+		return fmt.Errorf("resume seed covers %d files, manifest has %d",
+			len(resume.Files), len(manifest.Files))
+	}
+	for _, file := range manifest.Files {
+		progress, ok := resume.Files[file.Idx]
+		if !ok {
+			return fmt.Errorf("resume seed is missing file %d", file.Idx)
+		}
+		if progress.HaveBlocks < 0 || progress.HaveBlocks > file.Blocks {
+			return fmt.Errorf("resume seed haveBlocks %d out of range for file %d (blocks %d)",
+				progress.HaveBlocks, file.Idx, file.Blocks)
+		}
+	}
+	return nil
+}
+
+// sendResumeState advertises the receiver's durable high-water marks. The first call builds
+// the message (bound to the authenticated manifest's canonical fingerprint) and snapshots it;
+// later calls — a cutover's identical duplicate manifest — re-answer with that exact snapshot
+// so the sender's idempotent duplicate handling converges the negotiation.
 func (r *Receiver) sendResumeState(manifest *Manifest) error {
+	if r.resumeState != nil {
+		return r.sendControl(r.resumeState)
+	}
 	files := make([]ResumeFileState, len(manifest.Files))
 	for i, file := range manifest.Files {
 		have := 0
@@ -285,12 +352,16 @@ func (r *Receiver) sendResumeState(manifest *Manifest) error {
 				have = p.HaveBlocks
 			}
 		}
-		if have > file.Blocks {
-			have = file.Blocks
-		}
 		files[i] = ResumeFileState{Idx: file.Idx, HaveBlocks: have}
 	}
-	return r.sendControl(NewResumeState(manifest.TransferID, files))
+	fingerprint, err := ManifestFingerprint(*manifest)
+	if err != nil {
+		return err
+	}
+	rs := NewResumeState(manifest.TransferID, files)
+	rs.ManifestFingerprint = fingerprint
+	r.resumeState = rs
+	return r.sendControl(rs)
 }
 
 func (r *Receiver) openNextFile() error {
@@ -304,10 +375,9 @@ func (r *Receiver) openNextFile() error {
 		r.digest = r.o.CreateDigest()
 		if r.activeResume != nil {
 			if p, ok := r.activeResume.Files[file.Idx]; ok {
+				// The seed was validated against the authenticated manifest, so the
+				// high-water mark is already within [0, Blocks]; it is never clamped.
 				r.nextBlock = p.HaveBlocks
-				if r.nextBlock > file.Blocks {
-					r.nextBlock = file.Blocks
-				}
 				if p.SeedDigest != nil {
 					// The seed digest already holds the persisted prefix; the remainder appends.
 					r.digest = p.SeedDigest

--- a/packages/wire/transfer_receiver_resume_test.go
+++ b/packages/wire/transfer_receiver_resume_test.go
@@ -43,7 +43,7 @@ func mustDigest(t *testing.T, prefix []byte) Digest {
 
 // runReceiverWithSeed drives a receiver whose seed is the given claim and returns the Wait
 // outcome plus the decoded back-channel frames.
-func runReceiverWithSeed(t *testing.T, manifest Manifest, seed *ReceiverResume) (ReceiveResult, error, []ControlMsg) {
+func runReceiverWithSeed(t *testing.T, manifest Manifest, seed *ReceiverResume) (ReceiveResult, []ControlMsg, error) {
 	t.Helper()
 	keys, err := DeriveTransferKeys(senderMaster())
 	if err != nil {
@@ -83,7 +83,7 @@ func runReceiverWithSeed(t *testing.T, manifest Manifest, seed *ReceiverResume) 
 		}
 		msgs = append(msgs, m)
 	}
-	return res, waitErr, msgs
+	return res, msgs, waitErr
 }
 
 // TestReceiverRejectsBadResumeSeeds: a host-provided seed is a claim, not a trust anchor.
@@ -123,7 +123,7 @@ func TestReceiverRejectsBadResumeSeeds(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			_, err, msgs := runReceiverWithSeed(t, manifest, c.rs)
+			_, msgs, err := runReceiverWithSeed(t, manifest, c.rs)
 			if err == nil || !strings.Contains(err.Error(), c.want) {
 				t.Fatalf("Wait error = %v, want one mentioning %q", err, c.want)
 			}
@@ -149,7 +149,7 @@ func TestReceiverAdvertisesFingerprintBoundResumeState(t *testing.T) {
 		ManifestFingerprint: fp,
 		Files:               map[int]ResumeFileProgress{0: {HaveBlocks: 2, SeedDigest: seedDigest}},
 	}
-	_, err, msgs := runReceiverWithSeed(t, manifest, seed)
+	_, msgs, err := runReceiverWithSeed(t, manifest, seed)
 	if err != nil {
 		t.Fatalf("Wait: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestReceiverIgnoresSeedForDifferentTransfer(t *testing.T) {
 		ManifestFingerprint: strings.Repeat("0", 64),
 		Files:               map[int]ResumeFileProgress{0: {HaveBlocks: 2, SeedDigest: staleSeed}},
 	}
-	_, err, msgs := runReceiverWithSeed(t, manifest, seed)
+	_, msgs, err := runReceiverWithSeed(t, manifest, seed)
 	if err != nil {
 		t.Fatalf("Wait: %v", err)
 	}

--- a/packages/wire/transfer_receiver_resume_test.go
+++ b/packages/wire/transfer_receiver_resume_test.go
@@ -1,0 +1,345 @@
+package wire
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// resumeManifest builds the manifest the senderFrames will stream, with the canonical
+// fingerprint the seed must bind to (V13-PR06).
+func resumeManifest(t *testing.T, id string, data []byte, blockSize int) (Manifest, string) {
+	t.Helper()
+	sum := sha256.Sum256(data)
+	blocks := 0
+	if len(data) > 0 {
+		blocks = (len(data)-1)/blockSize + 1
+	}
+	raw := NewManifest([]FileEntry{{
+		Idx: 0, Name: "f", Size: int64(len(data)), Mime: "application/octet-stream",
+		LastModified: 1, BlockSize: blockSize, Blocks: blocks, FileDigest: hex.EncodeToString(sum[:]),
+	}}, int64(len(data)))
+	raw.TransferID = id
+	validated, err := ValidateManifest(*raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp, err := ManifestFingerprint(validated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return validated, fp
+}
+
+// mustDigest feeds the given prefix into a fresh digest, mirroring a persisted high-water mark.
+func mustDigest(t *testing.T, prefix []byte) Digest {
+	t.Helper()
+	d := NewSHA256Digest()
+	d.Update(prefix)
+	return d
+}
+
+// runReceiverWithSeed drives a receiver whose seed is the given claim and returns the Wait
+// outcome plus the decoded back-channel frames.
+func runReceiverWithSeed(t *testing.T, manifest Manifest, seed *ReceiverResume) (ReceiveResult, error, []ControlMsg) {
+	t.Helper()
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(&manifest)
+	if manifest.Files[0].Blocks > 0 {
+		// Stream the whole file so a fresh receive completes; a resumed one ignores the held prefix.
+		data := make([]byte, manifest.Files[0].Size)
+		sf.blockData(data, manifest.Files[0].BlockSize, manifest.Files[0].BlockSize)
+		sf.ctrl(NewComplete(CompletionDigest(manifest.Files)))
+	}
+	sink := &MemorySink{}
+	var back outbox
+	opts := ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink,
+	}
+	if seed != nil {
+		opts.Resume = seed
+	}
+	r := NewReceiver(opts)
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	res, waitErr := r.Wait(context.Background())
+
+	var msgs []ControlMsg
+	for i, f := range back.snapshot() {
+		o, err := Open(keys.J2O, uint64(i), f)
+		if err != nil {
+			t.Fatalf("open back frame %d: %v", i, err)
+		}
+		m, err := DecodeControl(o.Plaintext)
+		if err != nil {
+			t.Fatalf("decode back frame %d: %v", i, err)
+		}
+		msgs = append(msgs, m)
+	}
+	return res, waitErr, msgs
+}
+
+// TestReceiverRejectsBadResumeSeeds: a host-provided seed is a claim, not a trust anchor.
+// Every impossible claim fails the receive closed before any of it is advertised.
+func TestReceiverRejectsBadResumeSeeds(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = keys
+	data := make([]byte, 20)
+	manifest, fp := resumeManifest(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", data, 8)
+
+	seed := func(mutate func(*ReceiverResume)) *ReceiverResume {
+		s := &ReceiverResume{
+			TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			ManifestFingerprint: fp,
+			Files:               map[int]ResumeFileProgress{0: {HaveBlocks: 0}},
+		}
+		mutate(s)
+		return s
+	}
+
+	cases := []struct {
+		name string
+		rs   *ReceiverResume
+		want string
+	}{
+		{"uppercase fingerprint", seed(func(s *ReceiverResume) { s.ManifestFingerprint = strings.ToUpper(s.ManifestFingerprint) }), "resume seed manifestFingerprint must be 64 lowercase hex characters"},
+		{"short fingerprint", seed(func(s *ReceiverResume) { s.ManifestFingerprint = fp[:10] }), "resume seed manifestFingerprint must be 64 lowercase hex characters"},
+		{"wrong manifest fingerprint", seed(func(s *ReceiverResume) { s.ManifestFingerprint = strings.Repeat("0", 64) }), "resume seed manifest fingerprint does not match the authenticated manifest"},
+		{"empty file set", seed(func(s *ReceiverResume) { s.Files = map[int]ResumeFileProgress{} }), "resume seed covers 0 files, manifest has 1"},
+		{"missing file entry", seed(func(s *ReceiverResume) { s.Files = map[int]ResumeFileProgress{} }), "resume seed covers 0 files, manifest has 1"},
+		{"haveBlocks above blocks", seed(func(s *ReceiverResume) { s.Files = map[int]ResumeFileProgress{0: {HaveBlocks: 4}} }), "resume seed haveBlocks 4 out of range for file 0 (blocks 3)"},
+		{"haveBlocks negative", seed(func(s *ReceiverResume) { s.Files = map[int]ResumeFileProgress{0: {HaveBlocks: -1}} }), "resume seed haveBlocks -1 out of range for file 0 (blocks 3)"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			_, err, msgs := runReceiverWithSeed(t, manifest, c.rs)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("Wait error = %v, want one mentioning %q", err, c.want)
+			}
+			// The failure must be a sink_error fail frame; no resume_state may ever be advertised.
+			if len(msgs) != 1 || msgs[0].FrameType() != FrameFail {
+				t.Fatalf("back-channel = %#v, want a single fail frame", msgs)
+			}
+		})
+	}
+}
+
+// TestReceiverAdvertisesFingerprintBoundResumeState: a valid seed is advertised only bound to
+// the authenticated manifest's canonical fingerprint, and only the missing suffix is streamed.
+func TestReceiverAdvertisesFingerprintBoundResumeState(t *testing.T) {
+	data := make([]byte, 20)
+	manifest, fp := resumeManifest(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", data, 8)
+
+	prefix := 2 * 8
+	seedDigest := NewSHA256Digest()
+	seedDigest.Update(data[:prefix])
+	seed := &ReceiverResume{
+		TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ManifestFingerprint: fp,
+		Files:               map[int]ResumeFileProgress{0: {HaveBlocks: 2, SeedDigest: seedDigest}},
+	}
+	_, err, msgs := runReceiverWithSeed(t, manifest, seed)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	// resume_state, then an ack for every block the test streamed (the held 0-1 are acked
+	// from the resumed high-water mark; block 2 is verified normally), then done.
+	if len(msgs) != 5 {
+		t.Fatalf("back-channel has %d frames, want 5 (resume_state, ack ×3, done)", len(msgs))
+	}
+	rs, ok := msgs[0].(*ResumeState)
+	if !ok {
+		t.Fatalf("first back frame = %T, want resume_state", msgs[0])
+	}
+	if rs.ManifestFingerprint != fp {
+		t.Fatalf("advertised fingerprint = %q, want %q", rs.ManifestFingerprint, fp)
+	}
+	if len(rs.Files) != 1 || rs.Files[0].HaveBlocks != 2 {
+		t.Fatalf("advertised resume_state = %#v, want haveBlocks 2", rs)
+	}
+	for i := 1; i <= 3; i++ {
+		ack, ok := msgs[i].(*Ack)
+		if !ok || ack.BlockIdx != i-1 {
+			t.Fatalf("back frame %d = %#v, want ack for block %d", i, msgs[i], i-1)
+		}
+	}
+	if msgs[4].FrameType() != FrameDone {
+		t.Fatalf("last back frame = %T, want done", msgs[4])
+	}
+}
+
+// TestReceiverIgnoresSeedForDifferentTransfer: a seed bound to another transfer is a different
+// receive; the receiver starts fresh and advertises an all-zero resume_state for this one.
+func TestReceiverIgnoresSeedForDifferentTransfer(t *testing.T) {
+	data := make([]byte, 20)
+	manifest, _ := resumeManifest(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", data, 8)
+	staleSeed := NewSHA256Digest()
+	staleSeed.Update(make([]byte, 8))
+	seed := &ReceiverResume{
+		TransferID:          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		ManifestFingerprint: strings.Repeat("0", 64),
+		Files:               map[int]ResumeFileProgress{0: {HaveBlocks: 2, SeedDigest: staleSeed}},
+	}
+	_, err, msgs := runReceiverWithSeed(t, manifest, seed)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	rs, ok := msgs[0].(*ResumeState)
+	if !ok {
+		t.Fatalf("first back frame = %T, want resume_state", msgs[0])
+	}
+	if len(rs.Files) != 1 || rs.Files[0].HaveBlocks != 0 {
+		t.Fatalf("advertised resume_state = %#v, want an all-zero high-water mark", rs)
+	}
+}
+
+// TestReceiverReanswersIdenticalResumeStateOnDuplicateManifest: a cutover can deliver the
+// manifest twice; the identical duplicate is re-answered with the exact same resume_state
+// (never a re-validated one), while a different manifest is a protocol violation.
+func TestReceiverReanswersIdenticalResumeStateOnDuplicateManifest(t *testing.T) {
+	data := make([]byte, 20)
+	manifest, fp := resumeManifest(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", data, 8)
+	seed := &ReceiverResume{
+		TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ManifestFingerprint: fp,
+		Files: map[int]ResumeFileProgress{
+			0: {HaveBlocks: 1, SeedDigest: mustDigest(t, data[:8])},
+		},
+	}
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(&manifest)
+	sf.ctrl(&manifest)
+	sf.blockData(data, 8, 8)
+	sf.ctrl(NewComplete(CompletionDigest(manifest.Files)))
+
+	sink := &MemorySink{}
+	var back outbox
+	r := NewReceiver(ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink, Resume: seed,
+	})
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	if _, err := r.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	var msgs []ControlMsg
+	for i, f := range back.snapshot() {
+		o, err := Open(keys.J2O, uint64(i), f)
+		if err != nil {
+			t.Fatalf("open back frame %d: %v", i, err)
+		}
+		m, err := DecodeControl(o.Plaintext)
+		if err != nil {
+			t.Fatalf("decode back frame %d: %v", i, err)
+		}
+		msgs = append(msgs, m)
+	}
+	if len(msgs) != 6 {
+		t.Fatalf("back-channel has %d frames, want 6 (resume_state ×2, ack ×3, done)", len(msgs))
+	}
+	first, ok1 := msgs[0].(*ResumeState)
+	second, ok2 := msgs[1].(*ResumeState)
+	if !ok1 || !ok2 || !resumeStatesEqual(first, second) {
+		t.Fatalf("duplicate manifest answers = %#v / %#v, want identical resume_state messages", msgs[0], msgs[1])
+	}
+	if msgs[5].FrameType() != FrameDone {
+		t.Fatalf("last back frame = %T, want done", msgs[5])
+	}
+
+	// A *different* manifest arriving after the first was applied is a violation: the seed
+	// already validated against the first manifest, and the second is not that transfer.
+	other, _ := resumeManifest(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", make([]byte, 40), 8)
+	sf2 := newSenderFrames(t, keys)
+	sf2.ctrl(&manifest)
+	sf2.ctrl(&other)
+	sink2 := &MemorySink{}
+	var back2 outbox
+	r2 := NewReceiver(ReceiverOptions{
+		Send: back2.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink2, Resume: seed,
+	})
+	for _, f := range sf2.frames {
+		r2.Handle(f)
+	}
+	_, err = r2.Wait(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "duplicate manifest") {
+		t.Fatalf("Wait error = %v, want duplicate manifest", err)
+	}
+}
+
+// TestReceiverAllCompleteSeedSettles: a seed whose high-water mark already covers the whole
+// file needs no data; the receiver advertises it and settles on the terminal Complete.
+func TestReceiverAllCompleteSeedSettles(t *testing.T) {
+	data := make([]byte, 20)
+	manifest, fp := resumeManifest(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", data, 8)
+	seedDigest := NewSHA256Digest()
+	seedDigest.Update(data)
+	seed := &ReceiverResume{
+		TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ManifestFingerprint: fp,
+		Files:               map[int]ResumeFileProgress{0: {HaveBlocks: 3, SeedDigest: seedDigest}},
+	}
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sf := newSenderFrames(t, keys)
+	sf.ctrl(&manifest)
+	sf.ctrl(NewComplete(CompletionDigest(manifest.Files)))
+
+	sink := &MemorySink{}
+	var back outbox
+	r := NewReceiver(ReceiverOptions{
+		Send: back.push, SendDir: keys.J2O, RecvDir: keys.O2J, Sink: sink, Resume: seed,
+	})
+	for _, f := range sf.frames {
+		r.Handle(f)
+	}
+	res, err := r.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if res.Digest != hexSHA256(data) {
+		t.Fatalf("digest = %s, want %s", res.Digest, hexSHA256(data))
+	}
+	if !sink.IsClosed() {
+		t.Fatal("sink not closed on done")
+	}
+	var msgs []ControlMsg
+	for i, f := range back.snapshot() {
+		o, err := Open(keys.J2O, uint64(i), f)
+		if err != nil {
+			t.Fatalf("open back frame %d: %v", i, err)
+		}
+		m, err := DecodeControl(o.Plaintext)
+		if err != nil {
+			t.Fatalf("decode back frame %d: %v", i, err)
+		}
+		msgs = append(msgs, m)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("back-channel has %d frames, want 2 (resume_state, done)", len(msgs))
+	}
+	rs, ok := msgs[0].(*ResumeState)
+	if !ok || rs.Files[0].HaveBlocks != 3 {
+		t.Fatalf("first back frame = %#v, want resume_state with haveBlocks 3", msgs[0])
+	}
+	if msgs[1].FrameType() != FrameDone {
+		t.Fatalf("second back frame = %T, want done", msgs[1])
+	}
+}

--- a/packages/wire/transfer_resume_cutover_test.go
+++ b/packages/wire/transfer_resume_cutover_test.go
@@ -1,0 +1,158 @@
+package wire
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// runResumeFaultLoopback wires a resumable sender to a reloaded receiver (seeded like a
+// durable reload) over a fault link, drives a cutover, and returns both sides' outcomes.
+func runResumeFaultLoopback(t *testing.T, data []byte, blockSize int, haveBlocks int, script faultScript, cutoverAfter func(link *faultLink, sender *Sender)) (error, error) {
+	t.Helper()
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := newFaultLink(script, nil)
+	sink := &MemorySink{}
+	prefix := haveBlocks * blockSize
+	if prefix > len(data) {
+		prefix = len(data)
+	}
+	seed := NewSHA256Digest()
+	if prefix > 0 {
+		_ = sink.Write(0, data[:prefix])
+		seed.Update(data[:prefix])
+	}
+	fp, err := ManifestFingerprint(Manifest{
+		Type:       FrameManifest,
+		TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Files: []FileEntry{{
+			Idx: 0, Name: "f", Size: int64(len(data)), Mime: "application/octet-stream",
+			LastModified: 1, BlockSize: blockSize, Blocks: (len(data)-1)/blockSize + 1,
+			FileDigest: hexSHA256(data),
+		}},
+		TotalSize: int64(len(data)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sender := NewSender(SenderOptions{
+		File:        BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:        func(f []byte) error { return link.send(dirS2R, f) },
+		SendDir:     keys.O2J,
+		RecvDir:     keys.J2O,
+		BlockSize:   blockSize,
+		FrameSize:   256,
+		Window:      4,
+		AckTimeout:  250 * time.Millisecond,
+		MaxRetries:  5,
+		DoneTimeout: 2 * time.Second,
+		TransferID:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	receiver := NewReceiver(ReceiverOptions{
+		Send:    func(f []byte) error { return link.send(dirR2S, f) },
+		SendDir: keys.J2O,
+		RecvDir: keys.O2J,
+		Sink:    sink,
+		Resume: &ReceiverResume{
+			TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			ManifestFingerprint: fp,
+			Files:               map[int]ResumeFileProgress{0: {HaveBlocks: haveBlocks, SeedDigest: seed}},
+		},
+	})
+
+	go func() {
+		for !link.isClosed() {
+			f, ok := <-link.s2r
+			if !ok {
+				return
+			}
+			receiver.Handle(f)
+		}
+	}()
+	go func() {
+		for !link.isClosed() {
+			f, ok := <-link.r2s
+			if !ok {
+				return
+			}
+			sender.Handle(f)
+		}
+	}()
+
+	var cutoverOnce atomic.Bool
+	go func() {
+		for !link.isClosed() {
+			if cutoverAfter != nil && !cutoverOnce.Swap(true) {
+				cutoverAfter(link, sender)
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	runErrCh := make(chan error, 1)
+	go func() {
+		_, e := sender.Run(runCtx)
+		runErrCh <- e
+	}()
+	_, recvErr := receiver.Wait(runCtx)
+	var runErr error
+	select {
+	case runErr = <-runErrCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sender.Run did not return after cutover")
+	}
+	return runErr, recvErr
+}
+
+// TestResumeNegotiationConvergesAfterCutover pins the recovery this PR exists for: the
+// receiver's one-shot resume_state is lost at the moment of a direct→relay cutover, so the
+// sender waits in resume negotiation forever. On cutover the sender retransmits the
+// manifest; the receiver re-answers with the exact same fingerprint-bound resume_state, and
+// the sender's idempotent duplicate handling lets the resumed stream proceed.
+func TestResumeNegotiationConvergesAfterCutover(t *testing.T) {
+	data := testData(64_000, 61)
+	script := faultScript{}.at(dirR2S, FrameResumeState, fDrop)
+	cutoverAfter := func(link *faultLink, sender *Sender) {
+		for !link.manifestSeen() && !link.isClosed() {
+			time.Sleep(2 * time.Millisecond)
+		}
+		sender.TransportChanged()
+	}
+	runErr, recvErr := runResumeFaultLoopback(t, data, 1024, 5, script, cutoverAfter)
+	if runErr != nil {
+		t.Fatalf("sender: %v", runErr)
+	}
+	if recvErr != nil {
+		t.Fatalf("receiver: %v", recvErr)
+	}
+}
+
+// TestAllCompleteResumeWithLostDone pins settlement when the resume seed already holds the
+// whole file: nothing is streamed, and if the receiver's Done is lost at the cutover moment,
+// the sender's Complete retransmission must draw a fresh Done from the settled receiver.
+func TestAllCompleteResumeWithLostDone(t *testing.T) {
+	data := testData(8_000, 3)
+	blocks := (len(data)-1)/1024 + 1
+	script := faultScript{}.at(dirR2S, FrameDone, fDrop)
+	cutoverAfter := func(link *faultLink, sender *Sender) {
+		for !link.completeSeen() && !link.isClosed() {
+			time.Sleep(2 * time.Millisecond)
+		}
+		sender.TransportChanged()
+	}
+	runErr, recvErr := runResumeFaultLoopback(t, data, 1024, blocks, script, cutoverAfter)
+	if runErr != nil {
+		t.Fatalf("sender: %v", runErr)
+	}
+	if recvErr != nil {
+		t.Fatalf("receiver: %v", recvErr)
+	}
+}

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -100,8 +100,12 @@ type Sender struct {
 	// manifest is the validated manifest sent on the first path, kept so a
 	// TransportChanged before any acknowledgment can retransmit it (a cutover
 	// can lose it, and it is outside the block retransmit window).
-	manifest     *Manifest
-	manifestSent bool
+	manifest *Manifest
+	// manifestFingerprint is the canonical fingerprint of manifest (V13-PR06). It is
+	// computed before the manifest frame is transmitted so an early resume_state is
+	// never accepted without the binding available.
+	manifestFingerprint string
+	manifestSent        bool
 
 	mu                     sync.Mutex
 	cond                   *sync.Cond
@@ -122,6 +126,10 @@ type Sender struct {
 	handleMu sync.Mutex
 	// resumePlan maps file index to the receiver's high-water mark; each file restarts there.
 	resumePlan map[int]int
+	// appliedResume is the exact resume_state message that produced resumePlan, kept so a
+	// path cutover that duplicates it can be recognized as an idempotent re-answer while a
+	// conflicting duplicate fails closed.
+	appliedResume *ResumeState
 	// resumeReceived is set once a valid resume_state has been applied (resume mode only).
 	resumeReceived bool
 }
@@ -247,14 +255,24 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 			return "", err
 		}
 	}
-	if err := s.sendControl(&manifest); err != nil {
+	// The fingerprint binding is registered before the manifest frame is transmitted:
+	// the receiver can answer a resume_state the moment it authenticates the manifest,
+	// possibly before Run reaches the wait, and that answer must never be validated
+	// against an unset binding.
+	fingerprint, err := ManifestFingerprint(manifest)
+	if err != nil {
 		s.fail(err)
 		return "", err
 	}
 	s.mu.Lock()
 	s.manifest = &manifest
+	s.manifestFingerprint = fingerprint
 	s.manifestSent = true
 	s.mu.Unlock()
+	if err := s.sendControl(&manifest); err != nil {
+		s.fail(err)
+		return "", err
+	}
 
 	// A transfer id opts into resumption: wait for the receiver's resume_state (all zero on a
 	// first attempt) before streaming so blocks it already holds are never sent. Fresh transfers
@@ -268,10 +286,10 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 	for fileIdx, source := range s.files {
 		s.mu.Lock()
 		s.activeFileIdx = fileIdx
+		// resumePlan is only ever populated from a fully-validated resume_state whose
+		// claims were already bounded to the manifest geometry (see
+		// buildResumePlanLocked); a missing file here means fresh mode, restart at zero.
 		haveBlocks := s.resumePlan[fileIdx]
-		if haveBlocks > entries[fileIdx].Blocks {
-			haveBlocks = entries[fileIdx].Blocks
-		}
 		// Bytes the receiver already holds count as acknowledged up front so progress is continuous
 		// across a resume. Only a file's final block may be partial, so a full prefix is N blocks.
 		committed := int64(haveBlocks) * int64(s.blockSize)
@@ -545,11 +563,14 @@ func (s *Sender) waitResume() error {
 
 // onResumeState validates the receiver's resume_state against the manifest and records each
 // file's high-water mark, then unblocks the driver. Any inconsistency fails the transfer closed.
+// The plan is only committed once the entire message validates; an identical duplicate
+// (retransmitted after a path cutover lost the first answer) is idempotent.
 func (s *Sender) onResumeState(m *ResumeState) {
 	s.mu.Lock()
 	plan, failErr := s.buildResumePlanLocked(m)
 	if failErr == nil {
 		s.resumePlan = plan
+		s.appliedResume = m
 		s.resumeReceived = true
 		s.cond.Broadcast()
 	}
@@ -559,34 +580,71 @@ func (s *Sender) onResumeState(m *ResumeState) {
 	}
 }
 
+// buildResumePlanLocked fully validates one resume_state against the sender's own manifest and
+// returns the complete per-file plan, or fails the message closed. It never mutates sender
+// state: the caller commits the returned plan only after the entire message passed, so a bad
+// claim can never leave a partially-applied resume plan behind. Validation rules (V13-PR06):
+//
+//   - the message may only arrive after the manifest was validated (resume mode only);
+//   - transferId must equal the sender's;
+//   - manifestFingerprint, when present, must equal the sender's canonical manifest
+//     fingerprint (an absent field is a legacy peer that predates the binding and is
+//     accepted under the structural rules sendbeam/1 always applied);
+//   - exactly one entry per manifest file: unknown indexes, duplicates, and missing files
+//     are all rejected;
+//   - haveBlocks must be within [0, manifest blocks] using the sender's manifest geometry;
+//   - a duplicate message identical to the one already applied is an idempotent no-op (a
+//     cutover can deliver the receiver's answer twice); any different duplicate fails.
 func (s *Sender) buildResumePlanLocked(m *ResumeState) (map[int]int, *TransferError) {
-	if s.transferID == "" {
+	if s.transferID == "" || s.manifest == nil {
 		return nil, NewTransferError(FailIntegrity, "unexpected resume_state")
-	}
-	if s.resumeReceived {
-		return nil, NewTransferError(FailIntegrity, "duplicate resume_state")
 	}
 	if m.TransferID != s.transferID {
 		return nil, NewTransferError(FailIntegrity, "resume_state transfer id mismatch")
 	}
+	if m.ManifestFingerprint != "" {
+		if m.ManifestFingerprint != s.manifestFingerprint {
+			return nil, NewTransferError(FailIntegrity, "resume_state manifest fingerprint mismatch")
+		}
+	}
+	if s.resumeReceived {
+		if s.appliedResume != nil && resumeStatesEqual(m, s.appliedResume) {
+			return s.resumePlan, nil
+		}
+		return nil, NewTransferError(FailIntegrity, "conflicting duplicate resume_state")
+	}
 	plan := make(map[int]int, len(m.Files))
 	for _, f := range m.Files {
-		if f.Idx < 0 || f.Idx >= len(s.files) {
+		if f.Idx < 0 || f.Idx >= len(s.manifest.Files) {
 			return nil, NewTransferError(FailIntegrity, "resume_state references an unknown file")
 		}
 		if _, dup := plan[f.Idx]; dup {
-			return nil, NewTransferError(FailIntegrity, "resume_state references an unknown file")
+			return nil, NewTransferError(FailIntegrity, "resume_state references a file more than once")
 		}
-		blocks := 0
-		if size := s.files[f.Idx].Meta().Size; size > 0 {
-			blocks = int((size-1)/int64(s.blockSize) + 1)
-		}
+		blocks := s.manifest.Files[f.Idx].Blocks
 		if f.HaveBlocks < 0 || f.HaveBlocks > blocks {
 			return nil, NewTransferError(FailIntegrity, "resume_state haveBlocks out of range")
 		}
 		plan[f.Idx] = f.HaveBlocks
 	}
+	if len(plan) != len(s.manifest.Files) {
+		return nil, NewTransferError(FailIntegrity, "resume_state is missing a file entry")
+	}
 	return plan, nil
+}
+
+// resumeStatesEqual reports whether two resume_state messages carry the same claims.
+func resumeStatesEqual(a, b *ResumeState) bool {
+	if a == nil || b == nil || a.TransferID != b.TransferID ||
+		a.ManifestFingerprint != b.ManifestFingerprint || len(a.Files) != len(b.Files) {
+		return false
+	}
+	for i := range a.Files {
+		if a.Files[i] != b.Files[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Sender) applyRemoteControl(op ControlOp) {

--- a/packages/wire/transfer_sender_resume_test.go
+++ b/packages/wire/transfer_sender_resume_test.go
@@ -1,0 +1,482 @@
+package wire
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+)
+
+// sealResumeIn seals one resume_state under the sender's inbound counter so tests can
+// hand it to Handle exactly like a frame from the receiver.
+func sealResumeIn(t *testing.T, keys TransferKeys, counter uint64, rs *ResumeState) []byte {
+	t.Helper()
+	payload, err := EncodeControl(rs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame, err := Seal(keys.J2O, counter, FrameHeaderInput{Version: FrameVersion, Type: FrameResumeState}, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return frame
+}
+
+// runSenderWithResume starts a sender that waits for one resume_state, injects it, then
+// drives the resumed stream to completion. It returns the sender error (nil on success),
+// the outbox snapshot, and the number of frames whose block data was transmitted.
+func runSenderWithResume(t *testing.T, data []byte, rs *ResumeState) (error, *outbox, int) {
+	t.Helper()
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		File:      BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:      out.push,
+		SendDir:   keys.O2J,
+		RecvDir:   keys.J2O,
+		BlockSize: 8,
+		FrameSize: 4,
+		Window:    1,
+		TransferID: func() string {
+			if rs != nil {
+				return rs.TransferID
+			}
+			return "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		}(),
+	})
+
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run(context.Background())
+		res <- err
+	}()
+
+	if rs != nil {
+		// Wait for the manifest, then answer with the resume_state.
+		waitStable(t, &out, 1)
+		s.Handle(sealResumeIn(t, keys, 0, rs))
+	} else {
+		// Inject the resume_state before the manifest was ever validated.
+		s.Handle(sealResumeIn(t, keys, 0, NewResumeState("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", []ResumeFileState{{Idx: 0, HaveBlocks: 0}})))
+		return waitSenderResult(t, res), &out, -1
+	}
+
+	// With window=1 the resumed stream stalls after the manifest plus the frames of the
+	// first block above the high-water mark; settle it block by block.
+	blocks := (len(data)-1)/8 + 1
+	have := 0
+	if len(rs.Files) == 1 {
+		have = rs.Files[0].HaveBlocks
+	}
+	counter := uint64(1)
+	for b := have; b < blocks; b++ {
+		waitStable(t, &out, 1+2*(b-have+1))
+		payload, err := EncodeControl(NewAck(0, b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		frame, err := Seal(keys.J2O, counter, FrameHeaderInput{Version: FrameVersion, Type: FrameAck}, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		counter++
+		s.Handle(frame)
+	}
+	waitStable(t, &out, 1+2*(blocks-have)+1)
+	donePayload, err := EncodeControl(NewDone())
+	if err != nil {
+		t.Fatal(err)
+	}
+	doneFrame, err := Seal(keys.J2O, counter, FrameHeaderInput{Version: FrameVersion, Type: FrameDone}, donePayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Handle(doneFrame)
+
+	runErr := waitSenderResult(t, res)
+	frames := out.snapshot()
+	transmitted := 0
+	for i, f := range frames {
+		o, err := Open(keys.O2J, uint64(i), f)
+		if err != nil {
+			t.Fatalf("open frame %d: %v", i, err)
+		}
+		if o.Header.Type == FrameBlockData {
+			transmitted++
+		}
+	}
+	return runErr, &out, transmitted
+}
+
+func waitSenderResult(t *testing.T, res chan error) error {
+	t.Helper()
+	select {
+	case err := <-res:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("sender.Run did not return")
+		return nil
+	}
+}
+
+func fp(t *testing.T, data []byte, transferID string) string {
+	t.Helper()
+	sum := sha256.Sum256(data)
+	blocks := (len(data)-1)/8 + 1
+	manifest := Manifest{
+		Type:       FrameManifest,
+		TransferID: transferID,
+		Files: []FileEntry{{
+			Idx: 0, Name: "f", Size: int64(len(data)), Mime: "application/octet-stream",
+			LastModified: 1, BlockSize: 8, Blocks: blocks, FileDigest: hex.EncodeToString(sum[:]),
+		}},
+		TotalSize: int64(len(data)),
+	}
+	f, err := ManifestFingerprint(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+// TestSenderRejectsResumeStateBeforeManifest: a resume_state must never be accepted before
+// the sender validated its own manifest — there is no binding to check it against.
+func TestSenderRejectsResumeStateBeforeManifest(t *testing.T) {
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewSender(SenderOptions{
+		File:      BytesSource([]byte{1, 2, 3}, FileMeta{Name: "f", Size: 3}, 0),
+		Send:      func([]byte) error { return nil },
+		SendDir:   keys.O2J,
+		RecvDir:   keys.J2O,
+		BlockSize: 8,
+		FrameSize: 4,
+	})
+	s.Handle(sealResumeIn(t, keys, 0, NewResumeState("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", []ResumeFileState{{Idx: 0, HaveBlocks: 0}})))
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run(context.Background())
+		res <- err
+	}()
+	err = waitSenderResult(t, res)
+	if err == nil || !strings.Contains(err.Error(), "unexpected resume_state") {
+		t.Fatalf("Run error = %v, want one mentioning unexpected resume_state", err)
+	}
+}
+
+// TestSenderRejectsResumeTransferIDMismatch: a resume_state bound to another transfer is a
+// different receive; the sender must fail closed rather than trust its claims.
+func TestSenderRejectsResumeTransferIDMismatch(t *testing.T) {
+	data := seq(20)
+	var out outbox
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewSender(SenderOptions{
+		File:       BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		Window:     1,
+		TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run(context.Background())
+		res <- err
+	}()
+	waitStable(t, &out, 1)
+	s.Handle(sealResumeIn(t, keys, 0, NewResumeState("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", []ResumeFileState{{Idx: 0, HaveBlocks: 0}})))
+	err = waitSenderResult(t, res)
+	if err == nil || !strings.Contains(err.Error(), "resume_state transfer id mismatch") {
+		t.Fatalf("Run error = %v, want resume_state transfer id mismatch", err)
+	}
+}
+
+// TestSenderRejectsResumeFingerprintMismatch: a resume_state claiming a manifest the sender
+// is not streaming must fail closed even when every other claim is plausible.
+func TestSenderRejectsResumeFingerprintMismatch(t *testing.T) {
+	data := seq(20)
+	fpA := fp(t, data, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		File:       BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		Window:     1,
+		TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run(context.Background())
+		res <- err
+	}()
+	waitStable(t, &out, 1)
+	stale := NewResumeState("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", []ResumeFileState{{Idx: 0, HaveBlocks: 1}})
+	stale.ManifestFingerprint = strings.Repeat("0", 64)
+	if stale.ManifestFingerprint == fpA {
+		t.Fatal("test fingerprint collision with the real manifest fingerprint")
+	}
+	s.Handle(sealResumeIn(t, keys, 0, stale))
+	err = waitSenderResult(t, res)
+	if err == nil || !strings.Contains(err.Error(), "resume_state manifest fingerprint mismatch") {
+		t.Fatalf("Run error = %v, want resume_state manifest fingerprint mismatch", err)
+	}
+}
+
+// TestSenderRejectsMalformedResumeClaims: every impossible claim — unknown file, duplicated
+// file, out-of-range haveBlocks, missing file entry — fails the send closed.
+func TestSenderRejectsMalformedResumeClaims(t *testing.T) {
+	data := seq(20) // block=8 → blocks 0,1 full, block 2 = 4 bytes
+	id := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cases := []struct {
+		name string
+		rs   *ResumeState
+		want string
+	}{
+		{"unknown file", NewResumeState(id, []ResumeFileState{{Idx: 3, HaveBlocks: 0}}), "resume_state references an unknown file"},
+		{"negative file", NewResumeState(id, []ResumeFileState{{Idx: -1, HaveBlocks: 0}}), "resume_state references an unknown file"},
+		{"duplicate file", NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 0}, {Idx: 0, HaveBlocks: 0}}), "resume_state references a file more than once"},
+		{"haveBlocks above blocks", NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 4}}), "resume_state haveBlocks out of range"},
+		{"haveBlocks negative", NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: -1}}), "resume_state haveBlocks out of range"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			keys, err := DeriveTransferKeys(senderMaster())
+			if err != nil {
+				t.Fatal(err)
+			}
+			var out outbox
+			s := NewSender(SenderOptions{
+				File:       BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+				Send:       out.push,
+				SendDir:    keys.O2J,
+				RecvDir:    keys.J2O,
+				BlockSize:  8,
+				FrameSize:  4,
+				Window:     1,
+				TransferID: id,
+			})
+			res := make(chan error, 1)
+			go func() {
+				_, err := s.Run(context.Background())
+				res <- err
+			}()
+			waitStable(t, &out, 1)
+			s.Handle(sealResumeIn(t, keys, 0, c.rs))
+			err = waitSenderResult(t, res)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("Run error = %v, want one mentioning %s", err, c.want)
+			}
+			if frames := out.snapshot(); frames[len(frames)-1][9] == FrameComplete {
+				t.Fatal("complete was sent despite a rejected resume_state")
+			}
+		})
+	}
+}
+
+// TestSenderRejectsResumeMissingFileEntry: a claim covering only one of two manifest files
+// must fail closed, not silently restart the uncovered file from zero.
+func TestSenderRejectsResumeMissingFileEntry(t *testing.T) {
+	id := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataA := seq(20)
+	dataB := seq(30)
+	meta := func(name string, size int) FileMeta {
+		return FileMeta{Name: name, Size: int64(size), Mime: "application/octet-stream", LastModified: 1}
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		Files: []FileSource{
+			BytesSource(dataA, meta("a", len(dataA)), 0),
+			BytesSource(dataB, meta("b", len(dataB)), 0),
+		},
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		Window:     1,
+		TransferID: id,
+	})
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run(context.Background())
+		res <- err
+	}()
+	waitStable(t, &out, 1)
+	s.Handle(sealResumeIn(t, keys, 0, NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 1}})))
+	err = waitSenderResult(t, res)
+	if err == nil || !strings.Contains(err.Error(), "resume_state is missing a file entry") {
+		t.Fatalf("Run error = %v, want resume_state is missing a file entry", err)
+	}
+}
+
+// TestSenderResumeStreamsOnlyMissingBlocks: a valid resume_state (with fingerprint) skips the
+// held prefix entirely and transmits only the blocks above the high-water mark.
+func TestSenderResumeStreamsOnlyMissingBlocks(t *testing.T) {
+	data := seq(20) // blocks 0,1 full, block 2 = 4 bytes
+	id := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	rs := NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 2}})
+	rs.ManifestFingerprint = fp(t, data, id)
+	err, out, transmitted := runSenderWithResume(t, data, rs)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if transmitted != 1 {
+		t.Fatalf("transmitted %d data frames, want 1 (only block 2)", transmitted)
+	}
+	// manifest + block2 data + block2 hash + complete
+	if n := out.len(); n != 4 {
+		t.Fatalf("outbox has %d frames, want 4 (manifest, block 2 data, hash, complete)", n)
+	}
+}
+
+// TestSenderAcceptsLegacyResumeStateWithoutFingerprint: a peer predating the fingerprint
+// binding answers without the field; structural validation still applies and the resume works.
+func TestSenderAcceptsLegacyResumeStateWithoutFingerprint(t *testing.T) {
+	data := seq(20)
+	rs := NewResumeState("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", []ResumeFileState{{Idx: 0, HaveBlocks: 2}})
+	err, out, transmitted := runSenderWithResume(t, data, rs)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if transmitted != 1 {
+		t.Fatalf("transmitted %d data frames, want 1", transmitted)
+	}
+	if n := out.len(); n != 4 {
+		t.Fatalf("outbox has %d frames, want 4", n)
+	}
+}
+
+// TestSenderRejectsConflictingDuplicateResumeState: the receiver's answer retransmitted
+// identically after a path cutover is an idempotent no-op; a different second answer means
+// one of the two peers is not this transfer and the send must fail closed.
+func TestSenderRejectsConflictingDuplicateResumeState(t *testing.T) {
+	data := seq(20)
+	id := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		File:       BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		Window:     1,
+		TransferID: id,
+	})
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run(context.Background())
+		res <- err
+	}()
+	waitStable(t, &out, 1)
+	first := NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 2}})
+	first.ManifestFingerprint = fp(t, data, id)
+	s.Handle(sealResumeIn(t, keys, 0, first))
+	// A different second answer (raised high-water mark out of nowhere) is a conflict.
+	conflicting := NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 3}})
+	conflicting.ManifestFingerprint = first.ManifestFingerprint
+	s.Handle(sealResumeIn(t, keys, 1, conflicting))
+	err = waitSenderResult(t, res)
+	if err == nil || !strings.Contains(err.Error(), "conflicting duplicate resume_state") {
+		t.Fatalf("Run error = %v, want conflicting duplicate resume_state", err)
+	}
+}
+
+// TestSenderDuplicateResumeStateIsIdempotent: an identical retransmitted answer (the cutover
+// case the receiver's manifest retransmission triggers) must not disturb the resumed stream.
+func TestSenderDuplicateResumeStateIsIdempotent(t *testing.T) {
+	data := seq(20)
+	id := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	s := NewSender(SenderOptions{
+		File:       BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send:       out.push,
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  8,
+		FrameSize:  4,
+		Window:     1,
+		TransferID: id,
+	})
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run(context.Background())
+		res <- err
+	}()
+	waitStable(t, &out, 1)
+	rs := NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 2}})
+	rs.ManifestFingerprint = fp(t, data, id)
+	s.Handle(sealResumeIn(t, keys, 0, rs))
+	s.Handle(sealResumeIn(t, keys, 1, rs))
+
+	// Wait for the resumed stream (manifest + block 2 data + hash) before acking:
+	// an ack for a file the sender has not started streaming is "ack for unknown file".
+	waitStable(t, &out, 3)
+	payload, err := EncodeControl(NewAck(0, 2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ackFrame, err := Seal(keys.J2O, 2, FrameHeaderInput{Version: FrameVersion, Type: FrameAck}, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Handle(ackFrame)
+	waitStable(t, &out, 4)
+	donePayload, err := EncodeControl(NewDone())
+	if err != nil {
+		t.Fatal(err)
+	}
+	doneFrame, err := Seal(keys.J2O, 3, FrameHeaderInput{Version: FrameVersion, Type: FrameDone}, donePayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Handle(doneFrame)
+	if err := waitSenderResult(t, res); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	transmitted := 0
+	for i, f := range out.snapshot() {
+		o, err := Open(keys.O2J, uint64(i), f)
+		if err != nil {
+			t.Fatalf("open frame %d: %v", i, err)
+		}
+		if o.Header.Type == FrameBlockData {
+			transmitted++
+		}
+	}
+	if transmitted != 1 {
+		t.Fatalf("transmitted %d data frames, want 1", transmitted)
+	}
+}

--- a/packages/wire/transfer_sender_resume_test.go
+++ b/packages/wire/transfer_sender_resume_test.go
@@ -27,7 +27,7 @@ func sealResumeIn(t *testing.T, keys TransferKeys, counter uint64, rs *ResumeSta
 // runSenderWithResume starts a sender that waits for one resume_state, injects it, then
 // drives the resumed stream to completion. It returns the sender error (nil on success),
 // the outbox snapshot, and the number of frames whose block data was transmitted.
-func runSenderWithResume(t *testing.T, data []byte, rs *ResumeState) (error, *outbox, int) {
+func runSenderWithResume(t *testing.T, data []byte, rs *ResumeState) (*outbox, int, error) {
 	t.Helper()
 	keys, err := DeriveTransferKeys(senderMaster())
 	if err != nil {
@@ -63,7 +63,7 @@ func runSenderWithResume(t *testing.T, data []byte, rs *ResumeState) (error, *ou
 	} else {
 		// Inject the resume_state before the manifest was ever validated.
 		s.Handle(sealResumeIn(t, keys, 0, NewResumeState("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", []ResumeFileState{{Idx: 0, HaveBlocks: 0}})))
-		return waitSenderResult(t, res), &out, -1
+		return &out, -1, waitSenderResult(t, res)
 	}
 
 	// With window=1 the resumed stream stalls after the manifest plus the frames of the
@@ -110,7 +110,7 @@ func runSenderWithResume(t *testing.T, data []byte, rs *ResumeState) (error, *ou
 			transmitted++
 		}
 	}
-	return runErr, &out, transmitted
+	return &out, transmitted, runErr
 }
 
 func waitSenderResult(t *testing.T, res chan error) error {
@@ -340,7 +340,7 @@ func TestSenderResumeStreamsOnlyMissingBlocks(t *testing.T) {
 	id := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	rs := NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 2}})
 	rs.ManifestFingerprint = fp(t, data, id)
-	err, out, transmitted := runSenderWithResume(t, data, rs)
+	out, transmitted, err := runSenderWithResume(t, data, rs)
 	if err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
@@ -358,7 +358,7 @@ func TestSenderResumeStreamsOnlyMissingBlocks(t *testing.T) {
 func TestSenderAcceptsLegacyResumeStateWithoutFingerprint(t *testing.T) {
 	data := seq(20)
 	rs := NewResumeState("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", []ResumeFileState{{Idx: 0, HaveBlocks: 2}})
-	err, out, transmitted := runSenderWithResume(t, data, rs)
+	out, transmitted, err := runSenderWithResume(t, data, rs)
 	if err != nil {
 		t.Fatalf("Run error = %v", err)
 	}

--- a/packages/wire/transfer_sender_test.go
+++ b/packages/wire/transfer_sender_test.go
@@ -508,6 +508,10 @@ func TestSenderOnManifestRunsBeforeFirstFrame(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("OnManifest never called")
 	}
+	// The manifest frame must be on the wire before canceling: the cancellation sends its
+	// own control frame, and racing it against the manifest send makes the "first frame is
+	// the manifest" assertion below nondeterministic.
+	waitStable(t, &out, 1)
 
 	cancel()
 	if err := <-res; err == nil {


### PR DESCRIPTION
## Summary

- **Manifest-fingerprint-bound resume state.** `resume_state` gains an additive, optional `manifestFingerprint` (canonical fingerprint of the exact manifest the checkpoints belong to). Old peers ignore it; new peers validate it; the key order stays byte-identical for `sendbeam/1`.
- **Exact sender/receiver validation, never clamped.** Both sides reject any resume claim that cannot be bound to the authenticated manifest — wrong/stale fingerprint, unknown/duplicate/missing file entries, out-of-range or non-integer `haveBlocks` — failing closed instead of repairing. A seed whose `transferId` does not match is treated as a different transfer (fresh receive).
- **Idempotent same-session recovery across path changes.** An identical duplicate `resume_state` is a no-op, a conflicting duplicate fails, and a path cutover that retransmits the manifest is re-answered with the exact same fingerprint-bound `resume_state`, so negotiation converges instead of stalling.
- **Go/TypeScript parity.** The wire message, both validation paths, error messages, and the receiver's fingerprint-bound advertisement are mirrored byte-for-byte and semantically equivalent across `packages/wire` and `packages/protocol`.

Includes new Go and TypeScript test coverage: malformed/stale claim matrices, all-complete resume, and cutover recovery (lost `resume_state`, lost `Done`, `Complete` retransmission). A pre-existing flaky test race (`TestSenderOnManifestRunsBeforeFirstFrame`) was stabilized so the `-race` gate is deterministic.
