### PR TITLE
feat: resume interrupted transfers securely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,27 @@ jobs:
           version: v2.12.2
           working-directory: ${{ matrix.module }}
 
+  campaign:
+    # V13-PR08 heavyweight validation: the >= 100 GiB streamed resume campaign proves a very
+    # large logical transfer resumes from a deep durable checkpoint with bounded memory and no
+    # full-file staging. Owned by CI, never the laptop (hashing 100+ GiB takes minutes).
+    name: campaign (100 GiB streamed resume)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: packages/wire/go.sum
+
+      - name: Run 100 GiB campaign
+        working-directory: packages/wire
+        # go test's default 10-minute timeout killed the stream mid-run; the campaign needs
+        # the job's full budget (hashing 100+ GiB takes tens of minutes), so raise it.
+        run: go test -tags campaign -timeout 90m -run 'TestCampaign' -v ./...
+
   branding:
     name: branding (no stale SendArc references)
     runs-on: ubuntu-latest

--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -125,9 +125,54 @@ func runSend(args []string) int {
 		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
 		return 1
 	}
+	// V13-PR08 cross-session resume: a reused record resumes only through authenticated
+	// resume-auth (a fresh invite code authenticates the NEW session only). A record
+	// without a transfer-scoped credential is legacy pre-PR07 state: the id must never be
+	// reused, so the send refuses with explicit restart/discard guidance. With a
+	// credential, this send advertises resume-auth-v1 and authenticates with the original
+	// receiver before any verified progress is reused.
+	session := rendezvous.Options{
+		Role:      rendezvous.RoleOfferer,
+		WordCount: *words,
+		OnCode:    codePrinter(*server),
+		OnPhase:   phasePrinter(rendezvous.RoleOfferer),
+	}
+	var resumeCtx *transfer.ResumeContext
 	if reused {
+		srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(positionals))
+		if lookupErr != nil {
+			fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", lookupErr)
+			return 1
+		}
+		if !ok {
+			fmt.Fprintf(os.Stderr, "sendbeam send: the sender record for the interrupted transfer vanished; the source cannot be verified — nothing was sent. Start fresh or discard any receiver-side state.\n")
+			return 1
+		}
+		if srec.ResumeSecret == nil {
+			// Legacy pre-PR07 record: no transfer-scoped credential, so authenticated
+			// cross-session resume is unavailable and the id must not be reused (the
+			// receiver would otherwise silently trust old progress).
+			fmt.Fprintf(os.Stderr, "sendbeam send: the sender record for transfer %s carries no resume credential (legacy pre-PR07 state); authenticated cross-session resume is unavailable and the transfer id cannot be reused — nothing was sent. Discard the record with %q and send fresh, or resume with a pre-PR07-compatible receiver.\n",
+				srec.TransferID, "sendbeam transfers discard "+srec.TransferID)
+			return 1
+		}
+		secret, err := wire.DecodeResumeSecretEnvelope(srec.ResumeSecret)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "sendbeam send: sender record %s has a corrupt resume credential (%v); refusing to reuse the id — discard the record with %q\n",
+				srec.TransferID, err, "sendbeam transfers discard "+srec.TransferID)
+			return 1
+		}
+		resumeCtx = &transfer.ResumeContext{
+			TransferID:          srec.TransferID,
+			ManifestFingerprint: srec.ManifestFingerprint,
+			Role:                wire.RoleOfferer,
+			ResumeSecret:        secret,
+		}
+		caps := rendezvous.DefaultCaps()
+		caps.Features = append(caps.Features, wire.ResumeAuthCapability)
+		session.LocalCaps = &caps
 		s := newStyle(os.Stderr)
-		fmt.Fprintln(os.Stderr, s.dim("Continuing interrupted transfer "+transferID+" — the source must be unchanged."))
+		fmt.Fprintln(os.Stderr, s.dim("Interrupted transfer "+transferID+" — resuming requires authenticating with the original receiver before any verified progress is reused."))
 	}
 	progressFiles := make([]progressFile, len(sources))
 	for i, source := range sources {
@@ -153,12 +198,7 @@ func runSend(args []string) int {
 	progress := newProgress(totalSize)
 	progress.setFiles(progressFiles)
 	out, err := transfer.Run(ctx, client, transfer.Spec{
-		Session: rendezvous.Options{
-			Role:      rendezvous.RoleOfferer,
-			WordCount: *words,
-			OnCode:    codePrinter(*server),
-			OnPhase:   phasePrinter(rendezvous.RoleOfferer),
-		},
+		Session:        session,
 		Sources:        sources,
 		TransferID:     transferID,
 		OnSendManifest: onSendManifest,
@@ -170,6 +210,15 @@ func runSend(args []string) int {
 		// without one — never fabricated from a later session master).
 		OnResumeCredential: func(manifest wire.Manifest, resumeRoot []byte) error {
 			return senderStore.AttachResumeSecret(manifest, resumeRoot, !reused)
+		},
+		Resume: resumeCtx,
+		OnResume: func(r transfer.ResumeResult) {
+			s := newStyle(os.Stderr)
+			if r.Authenticated {
+				fmt.Fprintln(os.Stderr, s.check("Authenticated with the original receiver — resuming from the verified checkpoint with fresh keys."))
+			} else if r.Attempted {
+				fmt.Fprintln(os.Stderr, s.cyan("Authenticating the interrupted transfer with the receiver …"))
+			}
 		},
 		ForceRelay:     *relayOnly,
 		ICEServers:     ice,

--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -151,8 +151,11 @@ func runSend(args []string) int {
 		if srec.ResumeSecret == nil {
 			// Legacy pre-PR07 record: no transfer-scoped credential, so authenticated
 			// cross-session resume is unavailable and the id must not be reused (the
-			// receiver would otherwise silently trust old progress).
-			fmt.Fprintf(os.Stderr, "sendbeam send: the sender record for transfer %s carries no resume credential (legacy pre-PR07 state); authenticated cross-session resume is unavailable and the transfer id cannot be reused — nothing was sent. Discard the record with %q and send fresh, or resume with a pre-PR07-compatible receiver.\n",
+			// receiver would otherwise silently trust old progress). No downgrade path is
+			// offered: an old receiver/binary/protocol is never recommended as a
+			// workaround. The only actions are discard/forget the record and start a
+			// fresh transfer.
+			fmt.Fprintf(os.Stderr, "sendbeam send: the sender record for transfer %s carries no resume credential (legacy pre-PR07 state); authenticated cross-session resume is unavailable and the transfer id cannot be reused — nothing was sent. Discard the record with %q and send fresh.\n",
 				srec.TransferID, "sendbeam transfers discard "+srec.TransferID)
 			return 1
 		}

--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -220,13 +220,14 @@ func runSend(args []string) int {
 				fmt.Fprintln(os.Stderr, s.cyan("Authenticating the interrupted transfer with the receiver …"))
 			}
 		},
-		ForceRelay:     *relayOnly,
-		ICEServers:     ice,
-		OnTransport:    transportPrinter,
-		OnConnect:      connectPrinter(fmt.Sprintf("Sending %s (%s) …", label, humanBytes(totalSize))),
-		OnFileProgress: progress.reportFile,
-		OnControls:     terminalControls(),
-		OnStateChange:  progress.setState,
+		ForceRelay:       *relayOnly,
+		ICEServers:       ice,
+		OnTransport:      transportPrinter,
+		OnConnect:        connectPrinter(fmt.Sprintf("Sending %s (%s) …", label, humanBytes(totalSize))),
+		OnFileProgress:   progress.reportFile,
+		OnResumeProgress: progress.setReused,
+		OnControls:       terminalControls(),
+		OnStateChange:    progress.setState,
 	})
 	progress.finish()
 	s := newStyle(os.Stderr)
@@ -327,9 +328,10 @@ func runReceive(args []string) int {
 			}
 			connectPrinter(fmt.Sprintf("Receiving %s (%s) …", label, humanBytes(manifest.TotalSize)))()
 		},
-		OnFileProgress: progress.reportFile,
-		OnControls:     terminalControls(),
-		OnStateChange:  progress.setState,
+		OnFileProgress:   progress.reportFile,
+		OnResumeProgress: progress.setReused,
+		OnControls:       terminalControls(),
+		OnStateChange:    progress.setState,
 	})
 	progress.finish()
 	if err != nil {

--- a/apps/cli/cmd/sendbeam/progress.go
+++ b/apps/cli/cmd/sendbeam/progress.go
@@ -24,11 +24,17 @@ type progressFile struct {
 }
 
 // progress renders acknowledged bytes, a five-second rolling rate, and ETA on stderr,
-// with a live percentage bar when the total is known.
+// with a live percentage bar when the total is known. On an authenticated resume
+// (V13-PR08) the verified checkpoint is surfaced immediately and reused bytes are tracked
+// separately: sessionBytes = verified - reused, and the rate/ETA measure only session
+// advancement so the reused jump is never counted as transferred.
 type progress struct {
-	mu        sync.Mutex
-	total     int64
-	bytes     int64
+	mu    sync.Mutex
+	total int64
+	bytes int64
+	// reused is the verified baseline backed by the authenticated durable checkpoint at
+	// resume start; bytes = reused + sessionBytes (never less).
+	reused    int64
 	lastPct   int
 	reported  bool
 	paused    bool
@@ -58,6 +64,17 @@ func (p *progress) setFiles(files []progressFile) {
 	p.mu.Lock()
 	p.files = append([]progressFile(nil), files...)
 	p.mu.Unlock()
+}
+
+// setReused anchors the verified baseline reused from the authenticated durable checkpoint
+// (V13-PR08). It fires BEFORE the first new block is acknowledged, so the first rate sample
+// sits exactly on the checkpoint and the reused jump is never counted as transferred bytes.
+func (p *progress) setReused(n int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.reused = n
+	// Surface the checkpoint immediately: the reused bytes ARE verified progress.
+	p.reportLocked(n)
 }
 
 func (p *progress) reportFile(fileIdx int, fileBytes, acknowledgedBytes int64) {
@@ -112,7 +129,19 @@ func (p *progress) reportLocked(n int64) {
 		file := p.files[p.fileIdx]
 		detail = fmt.Sprintf("%s · %s / %s", p.st.dim(file.name), humanBytes(p.fileBytes), humanBytes(file.size)) + " · " + detail
 	}
-	fmt.Fprintf(os.Stderr, "\r  %s %s  %s", bar(pct, 18), p.st.cyan(fmt.Sprintf("%d%%", pct)), detail)
+	label := fmt.Sprintf("%d%%", pct)
+	if p.reused > 0 {
+		// Resumed session: verified = reused + session, and the rate/ETA measure only the
+		// session's advancement.
+		session := n - p.reused
+		if session < 0 {
+			session = 0
+		}
+		label = fmt.Sprintf("%d%% verified", pct)
+		detail = fmt.Sprintf("%s reused · %s this session",
+			humanBytes(p.reused), humanBytes(session)) + " · " + detail
+	}
+	fmt.Fprintf(os.Stderr, "\r  %s %s  %s", bar(pct, 18), p.st.cyan(label), detail)
 }
 
 func (p *progress) recordSample() {

--- a/apps/cli/cmd/sendbeam/progress_test.go
+++ b/apps/cli/cmd/sendbeam/progress_test.go
@@ -25,6 +25,31 @@ func TestProgressRateAndETAStabilizeWithinFiveSeconds(t *testing.T) {
 	}
 }
 
+func TestProgressSetReusedAnchorsSessionRate(t *testing.T) {
+	now := time.Unix(0, 0)
+	p := newProgressWithClock(100_000, func() time.Time { return now })
+	// The engine reports the verified baseline reused from the authenticated checkpoint
+	// BEFORE the first new block is acknowledged (V13-PR08).
+	p.setReused(68_000)
+	now = now.Add(time.Second)
+	p.report(69_000) // one block durably ACKed this session
+	p.mu.Lock()
+	rate, eta := p.rateAndETA()
+	reused := p.reused
+	p.mu.Unlock()
+	if reused != 68_000 {
+		t.Fatalf("reused = %d, want 68000", reused)
+	}
+	// 1000 bytes over 1s: the reused jump (68000) is NOT counted as transferred bytes.
+	if math.Abs(rate-1000) > 0.01 {
+		t.Fatalf("rate = %f, want 1000 (session advancement only)", rate)
+	}
+	// ETA uses remaining verified bytes and the current-session rate.
+	if eta != 31*time.Second {
+		t.Fatalf("eta = %s, want 31s", eta)
+	}
+}
+
 func TestProgressNeverRegresses(t *testing.T) {
 	p := newProgressWithClock(100, time.Now)
 	p.report(50)

--- a/apps/cli/cmd/sendbeam/transfers.go
+++ b/apps/cli/cmd/sendbeam/transfers.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
+	"github.com/sendbeam/cli/internal/rendezvous"
 	clitransfer "github.com/sendbeam/cli/internal/transfer"
+	"github.com/sendbeam/wire"
 )
 
 // transfersUsage prints the management-command help.
@@ -15,20 +20,29 @@ func transfersUsage(w *os.File) {
 	_, _ = fmt.Fprintln(w, "Usage:")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam transfers list")+" [--out DIR]")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam transfers inspect")+" <id> [--out DIR]")
-	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam transfers resume")+" <id> [--out DIR]")
+	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam transfers resume")+" <id> --code <code> [--out DIR]")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam transfers discard")+" <id>... [--out DIR] [--all] [--yes]")
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, s.dim("Manage durable receive state kept under DIR/.sendbeam (default .):"))
 	_, _ = fmt.Fprintln(w, "  list     show every journal, unreadable journal, and orphaned partial tree")
 	_, _ = fmt.Fprintln(w, "  inspect  validate one journal against its partial data (never deletes)")
-	_, _ = fmt.Fprintln(w, "  resume   verify a journal is resumable and how to resume it")
+	_, _ = fmt.Fprintln(w, "  resume   resume an interrupted transfer: join the sender's fresh rendezvous")
+	_, _ = fmt.Fprintln(w, "           with --code and authenticate the original sender (PR07 resume-auth)")
+	_, _ = fmt.Fprintln(w, "           before any verified progress is reused (fresh keys every attempt)")
 	_, _ = fmt.Fprintln(w, "  discard  explicitly delete a journal and its partials (idempotent)")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, s.dim("Session classes (used consistently in list statuses):"))
+	_, _ = fmt.Fprintln(w, "  reconnect      same live transfer; transport direct<->relay / outage recovery")
+	_, _ = fmt.Fprintln(w, "  durable resume  process/session died; both peers authenticate via resume-auth,")
+	_, _ = fmt.Fprintln(w, "                 then continue from the verified checkpoint with fresh keys")
+	_, _ = fmt.Fprintln(w, "  restart        no compatible credential; start from zero, old state kept")
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, s.dim("Sender records (kept under the user config dir):"))
 	_, _ = fmt.Fprintln(w, "  list     also shows interrupted sends and their source paths")
 	_, _ = fmt.Fprintln(w, "  discard  also removes the matching sender record (idempotent)")
 	_, _ = fmt.Fprintln(w)
-	_, _ = fmt.Fprintln(w, s.dim("Discard flags:"))
+	_, _ = fmt.Fprintln(w, s.dim("Resume/other flags:"))
+	_, _ = fmt.Fprintln(w, "  --code   fresh invite code from the sender's re-run (resume)")
 	_, _ = fmt.Fprintln(w, "  --all    discard every journal and orphaned partial tree in the store")
 	_, _ = fmt.Fprintln(w, "  --yes    confirm --all without prompting")
 }
@@ -110,10 +124,12 @@ func transfersList(args []string) int {
 			if entry.Files > 1 {
 				label = fmt.Sprintf("%s (%d files)", label, entry.Files)
 			}
+			status := durableStatus(entry)
 			fmt.Fprintf(os.Stderr, "  %s  %s committed / %s total · updated %s\n",
 				s.cyan(label),
 				humanBytes(entry.CommittedBytes), humanBytes(entry.TotalSize),
 				formatTime(entry.UpdatedAt))
+			fmt.Fprintf(os.Stderr, "      %s\n", s.dim(status+" · run: sendbeam transfers "+resumeHint(entry)))
 		}
 	}
 	// Interrupted sends: the sender-side records of transfers whose manifest was
@@ -144,6 +160,10 @@ func transfersList(args []string) int {
 		fmt.Fprintf(os.Stderr, "  %s  %d file(s) · %s · updated %s\n",
 			s.cyan(entry.TransferID), entry.Files, humanBytes(entry.TotalSize),
 			formatTime(entry.UpdatedAt))
+		status := senderStatus(entry)
+		if status != "" {
+			fmt.Fprintf(os.Stderr, "      %s\n", s.dim(status))
+		}
 		for _, p := range entry.Paths {
 			fmt.Fprintf(os.Stderr, "      %s\n", s.dim(p))
 		}
@@ -202,12 +222,60 @@ func transfersInspect(args []string) int {
 	return 0
 }
 
+// durableStatus renders the receiver-side session class for one journal (V13-PR08).
+func durableStatus(entry clitransfer.DurableEntry) string {
+	switch {
+	case !entry.PartialOK:
+		return "Partial data missing — inspect/discard"
+	case !entry.HasResumeSecret:
+		return "Legacy — restart required"
+	default:
+		return "Ready to resume"
+	}
+}
+
+// resumeHint renders the management command for one journal's next step.
+func resumeHint(entry clitransfer.DurableEntry) string {
+	switch {
+	case !entry.PartialOK:
+		return "inspect " + entry.TransferID + ""
+	case !entry.HasResumeSecret:
+		return "discard " + entry.TransferID + ""
+	default:
+		return "resume " + entry.TransferID + " --code <code>"
+	}
+}
+
+// senderStatus renders the sender-side session class for one record (V13-PR08).
+func senderStatus(entry clitransfer.SenderEntry) string {
+	if !entry.HasResumeSecret {
+		return "Legacy — restart required (no resume credential; discard to send fresh)"
+	}
+	return "Ready to resume (re-run the same send command, then resume on the receiver)"
+}
+
+// transfersResume resumes an interrupted transfer (V13-PR08): the user pre-selected the
+// interrupted journal locally, joins the sender's FRESH rendezvous with --code, and the
+// two peers authenticate continuity via resume-auth before any verified progress is reused.
+// Verified progress is advertised only after mutual authentication; the transfer then runs
+// under a fresh key epoch with fresh counters.
 func transfersResume(args []string) int {
 	fs := flag.NewFlagSet("transfers resume", flag.ExitOnError)
 	outDir := fs.String("out", ".", "directory whose .sendbeam store to resume from")
+	code := fs.String("code", "", "fresh invite code from the sender's re-run of `sendbeam send`")
+	server := fs.String("server", defaultServer, "signaling server URL")
+	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
+	relayOnly := fs.Bool("relay-only", false, "force the encrypted WebSocket relay")
+	var iceServer iceServerList
+	fs.Var(&iceServer, "ice-server", "STUN server URL for direct-path candidates (repeatable; default stun:stun.l.google.com:19302)")
 	positionals := parseArgs(fs, args)
 	if len(positionals) != 1 {
 		fmt.Fprintln(os.Stderr, "sendbeam transfers resume: exactly one transfer id is required")
+		return 2
+	}
+	if *code == "" {
+		s0 := newStyle(os.Stderr)
+		fmt.Fprintln(os.Stderr, "sendbeam transfers resume: --code is required — the sender re-runs "+s0.bold("sendbeam send")+" (same paths) and shares the fresh invite code")
 		return 2
 	}
 	id := positionals[0]
@@ -216,12 +284,13 @@ func transfersResume(args []string) int {
 		fmt.Fprintf(os.Stderr, "sendbeam transfers resume: %s\n", err)
 		return 1
 	}
+	s := newStyle(os.Stderr)
 	ins, err := store.Inspect(id)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "sendbeam transfers resume: %s\n", err)
+		fmt.Fprintf(os.Stderr, "  %s\n", s.dim("nothing was deleted; discard the state explicitly to remove it"))
 		return 1
 	}
-	s := newStyle(os.Stderr)
 	if !ins.Resumable {
 		fmt.Fprintln(os.Stderr, s.cross("Transfer "+id+" is not resumable:"))
 		for _, problem := range ins.Problems {
@@ -230,13 +299,105 @@ func transfersResume(args []string) int {
 		fmt.Fprintln(os.Stderr, s.dim("Nothing was deleted. Discard the state to start a fresh receive."))
 		return 1
 	}
-	fmt.Fprintln(os.Stderr, s.check(fmt.Sprintf("Transfer %s is resumable at %s committed.", id, humanBytes(ins.Committed))))
-	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, s.dim("To resume: re-run "+s.bold("sendbeam receive <code>")+" in the same room where the sender is still connected."))
-	fmt.Fprintln(os.Stderr, s.dim("The receiver detects the matching journal from the authenticated manifest and continues from its checkpoint automatically."))
-	fmt.Fprintln(os.Stderr, s.dim("The invite code is never stored, so a standalone resume without the sender is not possible yet."))
-	fmt.Fprintln(os.Stderr, s.dim("Cross-session authenticated resume with fresh traffic keys is a later milestone; until then every resume re-derives a fresh key from a new handshake."))
+	j := ins.Journal
+	if j.ResumeSecret == nil {
+		fmt.Fprintln(os.Stderr, s.cross("Transfer "+id+" has no resume credential (legacy pre-PR07 state); authenticated cross-session resume is unavailable."))
+		fmt.Fprintf(os.Stderr, "  %s\n", s.dim("The verified partial data is kept; restart from zero explicitly with: sendbeam transfers discard "+id+" --out "+*outDir))
+		return 1
+	}
+	// The journal is strictly validated on load (version + exact 64-hex value), so this
+	// decode is a belt-and-braces re-check before the secret enters the handshake.
+	secret, err := wire.DecodeResumeSecretEnvelope(&wire.ResumeSecretEnvelope{
+		Version: j.ResumeSecret.Version,
+		Value:   j.ResumeSecret.Value,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sendbeam transfers resume: transfer %s has a corrupt resume credential (%v); refusing to reuse its progress — nothing was deleted\n", id, err)
+		return 1
+	}
+	ice, err := iceServers(iceServer)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sendbeam transfers resume: %s\n", err)
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	client, err := dial(ctx, *server, *insecure)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n%s\n", s.cross("Failed: "+handshakeError(err)))
+		return 1
+	}
+	defer client.Close()
+
+	fmt.Fprintf(os.Stderr, "%s\n", s.dim("Resuming transfer "+id+" — joining the sender's fresh rendezvous "+normalizeCodeArg(*code)+" …"))
+	progress := newProgress(0)
+	caps := rendezvous.DefaultCaps()
+	caps.Features = append(caps.Features, wire.ResumeAuthCapability)
+	resumeCtx := &clitransfer.ResumeContext{
+		TransferID:          j.TransferID,
+		ManifestFingerprint: j.ManifestFingerprint,
+		Role:                wire.RoleJoiner,
+		ResumeSecret:        secret,
+	}
+	out, err := clitransfer.Run(ctx, client, clitransfer.Spec{
+		Session: rendezvous.Options{
+			Role:      rendezvous.RoleJoiner,
+			Code:      normalizeCodeArg(*code),
+			LocalCaps: &caps,
+			OnPhase:   phasePrinter(rendezvous.RoleJoiner),
+		},
+		DestDir:    *outDir,
+		ForceRelay: *relayOnly,
+		ICEServers: ice,
+		Resume:     resumeCtx,
+		OnResume: func(r clitransfer.ResumeResult) {
+			if r.Authenticated {
+				fmt.Fprintf(os.Stderr, "%s\n", s.check(fmt.Sprintf("Authenticated with the original sender — resuming %s from %s verified; %s remains to transfer.",
+					id, humanBytes(ins.Committed), humanBytes(ins.Total-ins.Committed))))
+			} else if r.Attempted {
+				fmt.Fprintln(os.Stderr, s.cyan("Authenticating the interrupted transfer with the sender …"))
+			} else if r.Skipped {
+				fmt.Fprintf(os.Stderr, "%s\n", s.yellow("The sender did not authenticate a resume; receiving a fresh transfer. Your interrupted state for "+id+" was kept."))
+			}
+		},
+		OnTransport: transportPrinter,
+		OnManifestSet: func(manifest wire.Manifest) {
+			progress.setTotal(manifest.TotalSize)
+			files := make([]progressFile, len(manifest.Files))
+			for i, file := range manifest.Files {
+				files[i] = progressFile{name: file.Name, size: file.Size}
+			}
+			progress.setFiles(files)
+			connectPrinter(fmt.Sprintf("Receiving %s (%s) …", labelFor(manifest), humanBytes(manifest.TotalSize)))()
+		},
+		OnFileProgress: progress.reportFile,
+		OnControls:     terminalControls(),
+		OnStateChange:  progress.setState,
+	})
+	progress.finish()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n%s\n", s.cross("Failed: "+handshakeError(err)))
+		fmt.Fprintf(os.Stderr, "%s\n", s.dim("The interrupted state for "+id+" was kept; the sender record and partial data were not deleted."))
+		return 1
+	}
+	fmt.Println()
+	if len(out.Files) == 1 {
+		fmt.Println(s.check("Received " + s.bold(out.Name) + " (" + humanBytes(out.Size) + ") → " + out.Path + "."))
+	} else {
+		fmt.Println(s.check("Received " + s.bold(fmt.Sprintf("%d files", len(out.Files))) + " (" + humanBytes(out.Size) + ") → " + *outDir + "."))
+	}
+	fmt.Printf("  %s  %s\n", s.grey("SHA-256:"), out.Digest)
 	return 0
+}
+
+// labelFor names the manifest's first file or file count for progress headers.
+func labelFor(manifest wire.Manifest) string {
+	if len(manifest.Files) == 1 {
+		return manifest.Files[0].Name
+	}
+	return fmt.Sprintf("%d files", len(manifest.Files))
 }
 
 func transfersDiscard(args []string) int {

--- a/apps/cli/cmd/sendbeam/transfers.go
+++ b/apps/cli/cmd/sendbeam/transfers.go
@@ -372,9 +372,10 @@ func transfersResume(args []string) int {
 			progress.setFiles(files)
 			connectPrinter(fmt.Sprintf("Receiving %s (%s) …", labelFor(manifest), humanBytes(manifest.TotalSize)))()
 		},
-		OnFileProgress: progress.reportFile,
-		OnControls:     terminalControls(),
-		OnStateChange:  progress.setState,
+		OnFileProgress:   progress.reportFile,
+		OnResumeProgress: progress.setReused,
+		OnControls:       terminalControls(),
+		OnStateChange:    progress.setState,
 	})
 	progress.finish()
 	if err != nil {

--- a/apps/cli/cmd/sendbeam/transfers_test.go
+++ b/apps/cli/cmd/sendbeam/transfers_test.go
@@ -249,3 +249,77 @@ func TestTransfersStorePathIsBoundedToOutDir(t *testing.T) {
 		t.Fatalf("storage escaped the out dir: %v", entries)
 	}
 }
+
+// TestSendLegacyRecordNeverRecommendsDowngrade pins the V13-PR08 security-UX rule: a
+// pre-PR07 sender record with NO resume credential must refuse with restart/discard
+// guidance only — never a suggestion to use an old receiver/binary/protocol as a
+// workaround. The refusal happens before dialing, so no server is needed.
+func TestSendLegacyRecordNeverRecommendsDowngrade(t *testing.T) {
+	t.Setenv("SENDBEAM_SENDER_STATE", t.TempDir())
+	srcDir := t.TempDir()
+	content := []byte("legacy source bytes")
+	srcPath := filepath.Join(srcDir, "legacy.bin")
+	if err := os.WriteFile(srcPath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := clitransfer.OpenSenderStore(os.Getenv("SENDBEAM_SENDER_STATE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp, err := wire.ManifestFingerprint(wire.Manifest{
+		TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Files: []wire.FileEntry{{
+			Idx: 0, Name: filepath.Base(srcPath), Size: int64(len(content)),
+			Mime: "application/octet-stream", LastModified: info.ModTime().UnixMilli(),
+			BlockSize: 1024, Blocks: 1, FileDigest: strings.Repeat("0", 64),
+		}},
+		TotalSize: int64(len(content)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Legacy pre-PR07 record: schema v2 shape but NO resume secret (exactly what a
+	// pre-PR07 record decodes to).
+	if err := store.Save(clitransfer.SenderRecord{
+		SchemaVersion:       2,
+		TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ManifestFingerprint: fp,
+		ProtocolVersion:     wire.ProtocolVersion,
+		CreatedAt:           1_700_000_000_000,
+		UpdatedAt:           1_700_000_000_000,
+		Paths:               []string{srcPath},
+		Files: []clitransfer.SenderFileState{{
+			Idx: 0, Name: filepath.Base(srcPath), Size: int64(len(content)),
+			Mime: "application/octet-stream", LastModified: info.ModTime().UnixMilli(),
+			BlockSize: 1024, Blocks: 1, FileDigest: strings.Repeat("0", 64),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := captureStderr(t, func() int { return runSend([]string{srcPath}) })
+	if code != 1 {
+		t.Fatalf("legacy send: code=%d out=%q", code, out)
+	}
+	if !strings.Contains(out, "no resume credential") {
+		t.Fatalf("legacy send must name the missing credential: %q", out)
+	}
+	if !strings.Contains(out, "cannot be reused") {
+		t.Fatalf("legacy send must refuse the old transfer id: %q", out)
+	}
+	// No downgrade guidance: an old receiver/binary/protocol must never be offered.
+	for _, banned := range []string{"pre-PR07-compatible", "old receiver", "old binary", "downgrade"} {
+		if strings.Contains(out, banned) {
+			t.Fatalf("legacy send must not recommend downgrade %q: %q", banned, out)
+		}
+	}
+	// The record is preserved for explicit discard; nothing was deleted.
+	if _, ok, err := store.Lookup(clitransfer.PathKey([]string{srcPath})); err != nil || !ok {
+		t.Fatalf("legacy record must be preserved: ok=%v err=%v", ok, err)
+	}
+}

--- a/apps/cli/cmd/sendbeam/transfers_test.go
+++ b/apps/cli/cmd/sendbeam/transfers_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +14,22 @@ import (
 	clitransfer "github.com/sendbeam/cli/internal/transfer"
 	"github.com/sendbeam/wire"
 )
+
+// attachSeedSecret attaches a valid resume-secret envelope to the journal for id so the
+// management list classifies it as ready to resume (V13-PR08).
+func attachSeedSecret(t *testing.T, store *clitransfer.DurableStore, id string) error {
+	t.Helper()
+	j, ok, err := store.LoadJournal(id)
+	if err != nil || !ok {
+		return fmt.Errorf("load journal: ok=%v err=%v", ok, err)
+	}
+	env, err := wire.EncodeResumeSecretEnvelope(bytes.Repeat([]byte{0x5A}, 32))
+	if err != nil {
+		return err
+	}
+	j.ResumeSecret = &wire.JournalResumeSecret{Version: env.Version, Value: env.Value}
+	return store.SaveJournal(j)
+}
 
 // captureStderr runs fn with os.Stderr redirected to a pipe and returns its exit code
 // and captured output.
@@ -81,6 +99,10 @@ func TestTransfersListInspectResumeDiscard(t *testing.T) {
 	if code != 0 || !strings.Contains(out, id) || !strings.Contains(out, "committed") {
 		t.Fatalf("list: code=%d out=%q", code, out)
 	}
+	// The seeded journal has no resume credential: the list must classify it honestly.
+	if !strings.Contains(out, "Legacy — restart required") {
+		t.Fatalf("list status: missing legacy classification in %q", out)
+	}
 
 	code, out = captureStderr(t, func() int {
 		return runTransfers([]string{"inspect", id, "--out", dir})
@@ -89,11 +111,33 @@ func TestTransfersListInspectResumeDiscard(t *testing.T) {
 		t.Fatalf("inspect: code=%d out=%q", code, out)
 	}
 
+	// V13-PR08: resume requires the fresh invite code from the sender's re-run.
 	code, out = captureStderr(t, func() int {
 		return runTransfers([]string{"resume", id, "--out", dir})
 	})
-	if code != 0 || !strings.Contains(out, "resumable") || !strings.Contains(out, "sendbeam receive") {
-		t.Fatalf("resume: code=%d out=%q", code, out)
+	if code != 2 || !strings.Contains(out, "--code") {
+		t.Fatalf("resume without --code: code=%d out=%q", code, out)
+	}
+	// A legacy no-secret journal cannot authenticate a cross-session resume.
+	code, out = captureStderr(t, func() int {
+		return runTransfers([]string{"resume", id, "--code", "7-alpha-bravo", "--out", dir})
+	})
+	if code != 1 || !strings.Contains(out, "no resume credential") {
+		t.Fatalf("resume legacy: code=%d out=%q", code, out)
+	}
+	// Once the credential is attached, the journal is classified as ready to resume.
+	store, err := clitransfer.OpenStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := attachSeedSecret(t, store, id); err != nil {
+		t.Fatal(err)
+	}
+	code, out = captureStderr(t, func() int {
+		return runTransfers([]string{"list", "--out", dir})
+	})
+	if code != 0 || !strings.Contains(out, "Ready to resume") || !strings.Contains(out, "resume "+id+" --code <code>") {
+		t.Fatalf("list after credential: code=%d out=%q", code, out)
 	}
 
 	code, out = captureStderr(t, func() int {
@@ -170,7 +214,7 @@ func TestTransfersInspectAndResumeFailClosedOnInconsistency(t *testing.T) {
 		t.Fatalf("inspect inconsistent: code=%d out=%q", code, out)
 	}
 	code, out = captureStderr(t, func() int {
-		return runTransfers([]string{"resume", id, "--out", dir})
+		return runTransfers([]string{"resume", id, "--code", "7-alpha-bravo", "--out", dir})
 	})
 	if code != 1 || !strings.Contains(out, "not resumable") {
 		t.Fatalf("resume inconsistent: code=%d out=%q", code, out)

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -96,6 +96,10 @@ type Spec struct {
 	// OnProgress reports cumulative bytes acknowledged after verify-and-sink.
 	OnProgress     func(int64)
 	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
+	// OnResumeProgress reports the verified baseline reused from the authenticated durable
+	// checkpoint at resume start, once, before the first new block is acknowledged. The host
+	// anchors its session rate on it: sessionBytes = verified - reused (V13-PR08).
+	OnResumeProgress func(int64)
 	// OnControls receives the live engine after the channel opens, before bytes begin moving.
 	OnControls func(Controls)
 	// OnStateChange reports pause, resume, and remote cancellation.
@@ -590,6 +594,15 @@ func (d *driver) prepareResumePreamble(conn dataConn, res *rendezvous.Result, se
 	if d.spec.Resume == nil {
 		return nil, nil
 	}
+	// Role binding (V13-PR08 review): the persisted/host resume role MUST equal the actual
+	// rendezvous role of this session. A mismatched role is a hard failure — never silently
+	// ignored — because the resume-auth transcript binds the role, and a wrong claim can
+	// only come from misusing local interrupted state across a different session shape.
+	if d.spec.Resume.Role != res.Role {
+		return nil, wire.Errorf(wire.CodeProtocol,
+			"transfer: resume role mismatch: the interrupted %s state cannot resume in this %s session; nothing was sent or received — restart the resume with the matching side",
+			d.spec.Resume.Role, res.Role)
+	}
 	if !wire.NegotiateResumeAuth([]string{wire.ResumeAuthCapability}, res.RemoteCaps.Features) {
 		if res.Role == wire.RoleOfferer {
 			return nil, wire.Errorf(wire.CodeCompat,
@@ -765,6 +778,7 @@ func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervi
 		},
 		OnProgress:     d.spec.OnProgress,
 		OnFileProgress: d.spec.OnFileProgress,
+		OnResume:       d.spec.OnResumeProgress,
 		OnStateChange:  d.spec.OnStateChange,
 	})
 	if sv != nil {
@@ -846,6 +860,7 @@ func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supe
 		Resume:           &sharedResume,
 		OnProgress:       d.spec.OnProgress,
 		OnFileProgress:   d.spec.OnFileProgress,
+		OnResume:         d.spec.OnResumeProgress,
 		OnStateChange:    d.spec.OnStateChange,
 		OnManifestSet: func(manifest wire.Manifest) error {
 			if d.spec.OnManifestSet != nil {

--- a/apps/cli/internal/transfer/driver.go
+++ b/apps/cli/internal/transfer/driver.go
@@ -71,6 +71,15 @@ type Spec struct {
 	// the manifest frame is transmitted; a restart's already-persisted credential is never
 	// replaced.
 	OnResumeCredential func(manifest wire.Manifest, resumeRoot []byte) error
+	// Resume carries the local cross-session resume context (V13-PR08). It is set ONLY on a
+	// peer that can actually authenticate a resume for this attempt: the sender re-using an
+	// interrupted record that holds a credential, or the receiver whose user pre-selected an
+	// interrupted journal holding one. Its presence makes the peer advertise resume-auth-v1;
+	// durable progress from the previous session is reused only after the mutual
+	// resume-auth preamble succeeds and the transfer runs under a fresh key epoch.
+	Resume *ResumeContext
+	// OnResume reports the cross-session resume decision (attempted/authenticated) for UX.
+	OnResume func(ResumeResult)
 	// ICEServers overrides rtc.DefaultICEServers. An explicit empty slice uses host candidates
 	// only (loopback tests); nil takes the default STUN server.
 	ICEServers []webrtc.ICEServer
@@ -96,6 +105,31 @@ type Spec struct {
 	// breakDirectRecovery simulates the peer's recovery-failure hook firing (direct recovery
 	// failed) so the driver falls back to the relay. Test-only.
 	breakDirectRecovery <-chan struct{}
+}
+
+// ResumeContext is the local resume context of an interrupted transfer (V13-PR08). It is
+// local state only — the transfer id, the canonical manifest fingerprint, the stable role,
+// and the decoded transfer-scoped credential — and is NEVER transmitted: the resume-auth
+// transcript binds these values on both peers, so a mismatch fails closed without leaking
+// any of them. The credential is never printed, logged, or exposed.
+type ResumeContext struct {
+	TransferID          string
+	ManifestFingerprint string
+	Role                wire.Role
+	ResumeSecret        []byte
+}
+
+// ResumeResult reports the cross-session resume decision to the host for UX (V13-PR08).
+// Attempted is true when both peers advertised resume-auth-v1 and the preamble ran;
+// Authenticated is true only when mutual authentication completed and the transfer runs
+// under a fresh resumed key epoch — the only state in which old durable progress may be
+// reused. Skipped is true when the peer could not authenticate a resume (e.g. a fresh
+// sender for a receiver that pre-selected a journal) and the transfer proceeds fresh with
+// the local interrupted state untouched.
+type ResumeResult struct {
+	Attempted     bool
+	Authenticated bool
+	Skipped       bool
 }
 
 // Outcome is the result of a completed transfer.
@@ -527,15 +561,133 @@ func (d *driver) reportRecovering(rec bool) {
 // receives one. Counters continue from the handshake so the AES-GCM nonce is never reused, and
 // block/frame sizes are the min of the two peers' announced caps. Canceling ctx aborts the
 // in-flight transfer.
+//
+// V13-PR08: when both peers can authenticate a cross-session resume, the resume preamble
+// runs over the sealed session channel strictly before the engine starts — the engine is
+// then constructed with the FRESH resumed key epoch (new keys, new salts, counters 0), so
+// no Manifest/ResumeState/BlockData/Complete can flow before mutual resume authentication.
 func (d *driver) transfer(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result) (*Outcome, error) {
 	sendDir, recvDir := directionalKeys(res)
-	if res.Role == wire.RoleOfferer {
-		return d.send(ctx, conn, sv, res, sendDir, recvDir)
+	preamble, err := d.prepareResumePreamble(conn, res, sendDir, recvDir)
+	if err != nil {
+		return nil, err
 	}
-	return d.receive(ctx, conn, sv, res, sendDir, recvDir)
+	sendStart, recvStart := res.SendCounter, res.RecvCounter
+	if res.Role == wire.RoleOfferer {
+		return d.send(ctx, conn, sv, res, sendDir, recvDir, sendStart, recvStart, preamble)
+	}
+	return d.receive(ctx, conn, sv, res, sendDir, recvDir, sendStart, recvStart, preamble)
 }
 
-func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+// prepareResumePreamble decides whether this session performs an authenticated cross-session
+// resume (V13-PR08). It returns a preamble to run when BOTH the local peer has resume
+// context (Spec.Resume) and the remote peer advertised resume-auth-v1. The security
+// invariant: capability absent/stripped/untrusted ⇒ the interrupted transfer id is never
+// reused — the offerer fails closed before anything is sent, and a receiver whose
+// pre-selected resume does not materialize proceeds as a fresh receive with its journal
+// untouched.
+func (d *driver) prepareResumePreamble(conn dataConn, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*wire.ResumePreamble, error) {
+	if d.spec.Resume == nil {
+		return nil, nil
+	}
+	if !wire.NegotiateResumeAuth([]string{wire.ResumeAuthCapability}, res.RemoteCaps.Features) {
+		if res.Role == wire.RoleOfferer {
+			return nil, wire.Errorf(wire.CodeCompat,
+				"transfer: the receiver did not advertise authenticated resume (resume-auth-v1); the interrupted transfer id %s cannot be reused without it — nothing was sent. Have the receiver join with %q, or discard the sender record to send fresh",
+				d.spec.Resume.TransferID, "sendbeam transfers resume <id> --code <fresh-code>")
+		}
+		// The sender started a fresh transfer (no resume context): the receiver's
+		// pre-selected journal stays untouched and the receive proceeds fresh.
+		if d.spec.OnResume != nil {
+			d.spec.OnResume(ResumeResult{Skipped: true})
+		}
+		return nil, nil
+	}
+	if d.spec.OnResume != nil {
+		d.spec.OnResume(ResumeResult{Attempted: true})
+	}
+	preamble, err := wire.NewResumePreamble(wire.ResumePreambleOptions{
+		Role:         res.Role,
+		TransferID:   d.spec.Resume.TransferID,
+		Fingerprint:  d.spec.Resume.ManifestFingerprint,
+		ResumeSecret: d.spec.Resume.ResumeSecret,
+		Send:         conn.Send,
+		SendDir:      sendDir,
+		RecvDir:      recvDir,
+		SendCounter:  res.SendCounter,
+		RecvCounter:  res.RecvCounter,
+	})
+	if err != nil {
+		return nil, wire.Errorf(wire.CodeAuth, "transfer: prepare resume preamble: %v", err)
+	}
+	return preamble, nil
+}
+
+// runPreamble drives the resume preamble to completion (bounded by ctx), returning the
+// fresh resumed key epoch. It is called with the inbound router already wired to the
+// preamble, so responses flow while we wait. A failed handshake aborts the transfer before
+// the manifest.
+func runPreamble(ctx context.Context, preamble *wire.ResumePreamble) (*wire.ResumeAuthResult, error) {
+	if preamble == nil {
+		return nil, nil
+	}
+	if err := preamble.Start(); err != nil {
+		return nil, err
+	}
+	select {
+	case <-preamble.Done():
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return preamble.Result()
+}
+
+// engineRouter hands inbound frames to the resume preamble while it is in flight, then to
+// the transfer engine. Frames arriving between the preamble settling and the engine being
+// installed (the peer may send its manifest the moment its own preamble settles) are
+// queued and replayed in order, so no frame is ever dropped or misrouted.
+type engineRouter struct {
+	mu      sync.Mutex
+	pending [][]byte
+	engine  func([]byte)
+}
+
+func (r *engineRouter) route(preamble *wire.ResumePreamble, frame []byte) {
+	if preamble != nil && !preamble.Settled() {
+		preamble.Handle(frame)
+		return
+	}
+	r.mu.Lock()
+	if r.engine == nil {
+		r.pending = append(r.pending, frame)
+		r.mu.Unlock()
+		return
+	}
+	engine := r.engine
+	r.mu.Unlock()
+	engine(frame)
+}
+
+func (r *engineRouter) install(engine func([]byte)) {
+	r.mu.Lock()
+	r.engine = engine
+	pending := r.pending
+	r.pending = nil
+	r.mu.Unlock()
+	for _, frame := range pending {
+		engine(frame)
+	}
+}
+
+// resumedDirs selects the directional keys of a fresh resumed key epoch for this role.
+func resumedDirs(role wire.Role, result *wire.ResumeAuthResult) (send, recv wire.DirectionalKey) {
+	if role == wire.RoleOfferer {
+		return result.Keys.O2J, result.Keys.J2O
+	}
+	return result.Keys.J2O, result.Keys.O2J
+}
+
+func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey, sendStart, recvStart uint64, preamble *wire.ResumePreamble) (*Outcome, error) {
 	if (d.spec.Source == nil) == (len(d.spec.Sources) == 0) {
 		return nil, errors.New("transfer: exactly one of Source or Sources is required to send")
 	}
@@ -562,13 +714,34 @@ func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervi
 	}
 	onManifest := d.spec.OnSendManifest
 	onResumeCredential := d.spec.OnResumeCredential
+	// V13-PR08: the resume preamble runs strictly before the manifest may go out. The inbound
+	// router is wired to the preamble FIRST (so challenge/ready responses flow while we
+	// wait); the engine is constructed only AFTER mutual authentication, using the fresh
+	// resumed key epoch when one was derived (never the session keys for the transfer).
+	router := &engineRouter{}
+	if sv != nil {
+		sv.OnData(func(frame []byte) { router.route(preamble, frame) })
+	} else {
+		conn.OnData(func(frame []byte) { router.route(preamble, frame) })
+	}
+	if preamble != nil {
+		result, err := runPreamble(ctx, preamble)
+		if err != nil {
+			return nil, err
+		}
+		sendDir, recvDir = resumedDirs(res.Role, result)
+		sendStart, recvStart = result.SendCounter, result.RecvCounter
+		if d.spec.OnResume != nil {
+			d.spec.OnResume(ResumeResult{Attempted: true, Authenticated: true})
+		}
+	}
 	sender := wire.NewSender(wire.SenderOptions{
 		Files:            sources,
 		Send:             conn.Send,
 		SendDir:          sendDir,
 		RecvDir:          recvDir,
-		SendCounterStart: res.SendCounter,
-		RecvCounterStart: res.RecvCounter,
+		SendCounterStart: sendStart,
+		RecvCounterStart: recvStart,
 		BlockSize:        negotiate(res.LocalCaps.BlockSize, res.RemoteCaps.BlockSize, wire.DefaultBlockBytes),
 		FrameSize:        negotiate(res.LocalCaps.MaxFrame, res.RemoteCaps.MaxFrame, wire.DefaultFrameBytes),
 		// Advertise a stable random id in the manifest so a receiver that crashes mid-file
@@ -596,10 +769,8 @@ func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervi
 	})
 	if sv != nil {
 		sv.SetOnSwitch(sender.TransportChanged)
-		sv.OnData(sender.Handle)
-	} else {
-		conn.OnData(sender.Handle)
 	}
+	router.install(sender.Handle)
 	if d.spec.OnControls != nil {
 		d.spec.OnControls(sender)
 	}
@@ -626,10 +797,38 @@ func containsString(values []string, want string) bool {
 	return false
 }
 
-func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey) (*Outcome, error) {
+func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey, sendStart, recvStart uint64, preamble *wire.ResumePreamble) (*Outcome, error) {
 	destination, err := NewDurableDestination(d.spec.DestDir)
 	if err != nil {
 		return nil, wire.NewTransferError(wire.FailSinkError, err.Error())
+	}
+	// V13-PR08: an explicit resume attempt pre-selects its interrupted journal locally; its
+	// verified progress is reused only after resume-auth succeeds in this session.
+	if d.spec.Resume != nil {
+		destination.ExpectResume(d.spec.Resume.TransferID)
+	}
+	// The inbound router is wired BEFORE the preamble runs: the offerer's resume_init may
+	// arrive the moment its own preamble starts, and the transport buffers it until a
+	// handler is registered. Frames arriving between the preamble settling and the engine
+	// being installed (the manifest, sent once the offerer's own preamble settled) are
+	// queued by the router in order.
+	router := &engineRouter{}
+	if sv != nil {
+		sv.OnData(func(frame []byte) { router.route(preamble, frame) })
+	} else {
+		conn.OnData(func(frame []byte) { router.route(preamble, frame) })
+	}
+	if preamble != nil {
+		result, err := runPreamble(ctx, preamble)
+		if err != nil {
+			return nil, err
+		}
+		destination.SetResumeAuthorized()
+		sendDir, recvDir = resumedDirs(res.Role, result)
+		sendStart, recvStart = result.SendCounter, result.RecvCounter
+		if d.spec.OnResume != nil {
+			d.spec.OnResume(ResumeResult{Attempted: true, Authenticated: true})
+		}
 	}
 	// sharedResume is filled from OnManifestSet, before the wire layer applies the resume
 	// seed: when the authenticated manifest matches a durable journal, the driver rebuilds
@@ -641,8 +840,8 @@ func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supe
 		Send:             conn.Send,
 		SendDir:          sendDir,
 		RecvDir:          recvDir,
-		SendCounterStart: res.SendCounter,
-		RecvCounterStart: res.RecvCounter,
+		SendCounterStart: sendStart,
+		RecvCounterStart: recvStart,
 		Destination:      destination,
 		Resume:           &sharedResume,
 		OnProgress:       d.spec.OnProgress,
@@ -684,10 +883,8 @@ func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supe
 	})
 	if sv != nil {
 		sv.SetOnSwitch(receiver.TransportChanged)
-		sv.OnData(receiver.Handle)
-	} else {
-		conn.OnData(receiver.Handle)
 	}
+	router.install(receiver.Handle)
 	if d.spec.OnControls != nil {
 		d.spec.OnControls(receiver)
 	}

--- a/apps/cli/internal/transfer/driver_test.go
+++ b/apps/cli/internal/transfer/driver_test.go
@@ -494,12 +494,13 @@ func TestDriverArmsReconnectableSignal(t *testing.T) {
 	}
 }
 
-// TestDriverSenderRestartResumesDurableReceive drives the full V13-PR04 restart loop
-// through the real driver and the real durable destination: the sender persists a record
-// before the manifest is advertised, the transfer is interrupted mid-file, and re-running
-// the same send reuses the recorded id and completes byte-identical against the receiver's
-// durable journal.
-func TestDriverSenderRestartResumesDurableReceive(t *testing.T) {
+// TestDriverAuthenticatedCrossSessionResume drives the full V13-PR08 cross-session resume
+// loop through the real driver and the real durable destination: leg 1 persists the sender
+// record and the receiver journal (each carrying the transfer-scoped resume credential)
+// and is interrupted mid-file; leg 2 is a FRESH rendezvous where both peers run mutual
+// resume-auth BEFORE any verified progress is reused, then continue under a fresh key
+// epoch and complete byte-identical.
+func TestDriverAuthenticatedCrossSessionResume(t *testing.T) {
 	senderStore := testSenderStore(t)
 	outDir := t.TempDir()
 	srcDir := t.TempDir()
@@ -512,14 +513,19 @@ func TestDriverSenderRestartResumesDurableReceive(t *testing.T) {
 		t.Fatal(err)
 	}
 	args := []string{srcPath}
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	type result struct {
 		out *Outcome
 		err error
 	}
-	runLeg := func(idempotent string, interrupt bool) (send, recv result, id string, reused bool) {
+	capsResume := func() *rendezvous.Caps {
+		c := rendezvous.DefaultCaps()
+		c.Features = append(c.Features, wire.ResumeAuthCapability)
+		return &c
+	}
+	runLeg := func(interrupt bool, sendResume, recvResume *ResumeContext, sendCaps, recvCaps *rendezvous.Caps) (send, recv result, id string, reused bool) {
 		hub := newRelay()
 		sources, _, err := NewOSFileSources(args)
 		if err != nil {
@@ -547,18 +553,23 @@ func TestDriverSenderRestartResumesDurableReceive(t *testing.T) {
 		recvDone := make(chan result, 1)
 		go func() {
 			out, err := Run(legCtx, hub.off, Spec{
-				Session:        rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo"},
+				Session:        rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo", LocalCaps: sendCaps},
 				Sources:        sources,
 				TransferID:     id,
 				OnSendManifest: hook,
-				ICEServers:     []webrtc.ICEServer{},
+				OnResumeCredential: func(manifest wire.Manifest, resumeRoot []byte) error {
+					return senderStore.AttachResumeSecret(manifest, resumeRoot, !reused)
+				},
+				Resume:     sendResume,
+				ICEServers: []webrtc.ICEServer{},
 			})
 			sendDone <- result{out, err}
 		}()
 		go func() {
 			out, err := Run(legCtx, hub.join, Spec{
-				Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo"},
+				Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo", LocalCaps: recvCaps},
 				DestDir:    outDir,
+				Resume:     recvResume,
 				ICEServers: []webrtc.ICEServer{},
 				OnProgress: func(int64) {
 					if interrupt {
@@ -570,12 +581,12 @@ func TestDriverSenderRestartResumesDurableReceive(t *testing.T) {
 		}()
 		send = <-sendDone
 		recv = <-recvDone
-		_ = idempotent
 		return send, recv, id, reused
 	}
 
-	// Leg 1: interrupt the transfer after the first committed block.
-	send1, recv1, _, _ := runLeg("interrupt", true)
+	// Leg 1: interrupt the transfer after the first committed block. Both peers persist the
+	// transfer-scoped resume credential derived from the ORIGINAL session master.
+	send1, recv1, id1, _ := runLeg(true, nil, nil, capsResume(), capsResume())
 	if send1.err == nil || recv1.err == nil {
 		t.Fatalf("interrupted leg unexpectedly succeeded: send=%v recv=%v", send1.err, recv1.err)
 	}
@@ -594,9 +605,35 @@ func TestDriverSenderRestartResumesDurableReceive(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("sender record not persisted after interruption: ok=%v err=%v", ok, err)
 	}
+	// Leg 1 minted a fresh id (the record carries it); the journal is keyed by it.
+	j, ok, err := recvStore.LoadJournal(srec.TransferID)
+	if err != nil || !ok {
+		t.Fatalf("receiver journal not persisted: ok=%v err=%v", ok, err)
+	}
+	_ = id1
+	if srec.ResumeSecret == nil || j.ResumeSecret == nil {
+		t.Fatalf("resume credentials not persisted after leg 1: record=%v journal=%v", srec.ResumeSecret != nil, j.ResumeSecret != nil)
+	}
+	secret, err := wire.DecodeResumeSecretEnvelope(srec.ResumeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jSecret, err := wire.DecodeResumeSecretEnvelope(&wire.ResumeSecretEnvelope{Version: j.ResumeSecret.Version, Value: j.ResumeSecret.Value})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(secret, jSecret) {
+		t.Fatal("both peers must derive the same transfer-scoped credential")
+	}
 
-	// Leg 2: restart the same send — the id is reused and the source identity verified.
-	send2, recv2, id2, reused := runLeg("resume", false)
+	// Leg 2: a FRESH rendezvous with authenticated cross-session resume. The sender reuses
+	// its record (source identity re-verified) and the receiver pre-selects its journal;
+	// both advertise resume-auth-v1, run the preamble BEFORE the manifest, then continue
+	// under a fresh key epoch.
+	send2, recv2, id2, reused := runLeg(false,
+		&ResumeContext{TransferID: srec.TransferID, ManifestFingerprint: srec.ManifestFingerprint, Role: wire.RoleOfferer, ResumeSecret: secret},
+		&ResumeContext{TransferID: j.TransferID, ManifestFingerprint: j.ManifestFingerprint, Role: wire.RoleJoiner, ResumeSecret: jSecret},
+		capsResume(), capsResume())
 	if send2.err != nil || recv2.err != nil {
 		t.Fatalf("restart leg: send=%v recv=%v", send2.err, recv2.err)
 	}

--- a/apps/cli/internal/transfer/durable.go
+++ b/apps/cli/internal/transfer/durable.go
@@ -578,23 +578,44 @@ func (d *DurableDestination) Prepare(manifest wire.Manifest) error {
 			"transfer: journal %s does not match the authenticated manifest (fingerprint mismatch); refusing to guess — run \"sendbeam transfers inspect %s\" or discard it",
 			validated.TransferID, validated.TransferID)
 	}
-	// V13-PR08: an interrupted journal's verified progress may be reused ONLY after
-	// successful resume-auth in this session. A fresh rendezvous authenticates the NEW
-	// session only; it does not prove continuity with the original transfer peer. Failing
-	// closed here is what makes a fresh session unable to skip old blocks merely because
-	// the transfer id + fingerprint match.
-	if !d.resumeAuthorized {
-		// The pre-selected-journal branch fires only when the incoming manifest IS the
-		// interrupted journal the user chose; a different id means a fresh sender and is
-		// handled by the generic branch below (its journal, if any, still fails closed).
-		if d.expectResume != "" && d.expectResume == validated.TransferID {
+	// V13-PR08 (review Blocker 2): an interrupted journal's verified progress may be reused
+	// ONLY for the journal THIS session authenticated a resume for. The authorization is
+	// bound to the locally selected interrupted transfer: successful auth for A must never
+	// authorize an existing journal B, and authorization with no selected journal
+	// authorizes nothing. The strict predicate requires the expected resume id to equal
+	// BOTH the loaded journal's id AND the authenticated manifest's id. A fresh
+	// rendezvous authenticates the NEW session only; it does not prove continuity with
+	// the original transfer peer. Failing closed here is what makes a fresh session unable
+	// to skip old blocks merely because the transfer id + fingerprint match.
+	authorizedForThisJournal := d.resumeAuthorized &&
+		d.expectResume != "" &&
+		d.expectResume == existing.TransferID &&
+		d.expectResume == validated.TransferID
+	if !authorizedForThisJournal {
+		switch {
+		case d.expectResume != "" && d.expectResume == validated.TransferID:
+			// The user pre-selected THIS journal and the incoming manifest is it, but
+			// resume-auth never completed in this session.
 			return wire.Errorf(wire.CodeStorage,
 				"transfer: resume of %s was not authenticated in this session; refusing to reuse its verified progress — nothing was received or deleted. Re-run \"sendbeam transfers resume %s --code <fresh code>\" so both peers authenticate first",
 				validated.TransferID, validated.TransferID)
+		case d.resumeAuthorized && d.expectResume != "":
+			// The session authenticated for a DIFFERENT interrupted transfer; this
+			// journal's verified progress is not covered by that authorization.
+			return wire.Errorf(wire.CodeStorage,
+				"transfer: this session authenticated resume for %s, not %s; refusing to reuse %s's verified progress — nothing was received or deleted. Run \"sendbeam transfers resume %s --code <fresh code>\" for that transfer, or discard its state",
+				d.expectResume, validated.TransferID, validated.TransferID, validated.TransferID)
+		case d.resumeAuthorized:
+			// Authorization with no selected journal covers nothing.
+			return wire.Errorf(wire.CodeStorage,
+				"transfer: this session authorized resume without selecting an interrupted journal; refusing to reuse %s's verified progress — nothing was received or deleted",
+				validated.TransferID)
+		default:
+			// A plain fresh receive met an interrupted journal.
+			return wire.Errorf(wire.CodeStorage,
+				"transfer: transfer %s has verified partial data kept from an interrupted transfer; resuming it requires authenticated resume. Run \"sendbeam transfers resume %s --code <fresh code>\" (the sender re-runs its send for a fresh code), or discard the state with \"sendbeam transfers discard %s --out %s\" to receive fresh — nothing was received or deleted",
+				validated.TransferID, validated.TransferID, validated.TransferID, d.outRoot)
 		}
-		return wire.Errorf(wire.CodeStorage,
-			"transfer: transfer %s has verified partial data kept from an interrupted transfer; resuming it requires authenticated resume. Run \"sendbeam transfers resume %s --code <fresh code>\" (the sender re-runs its send for a fresh code), or discard the state with \"sendbeam transfers discard %s --out %s\" to receive fresh — nothing was received or deleted",
-			validated.TransferID, validated.TransferID, validated.TransferID, d.outRoot)
 	}
 	wantDest, err := destinationIdentity(d.outRoot)
 	if err != nil {
@@ -879,14 +900,29 @@ func (d *DurableDestination) ResumeStateFor(manifest wire.Manifest) (*wire.Recei
 	if journal == nil {
 		return nil, nil
 	}
-	// The gate protects the PRE-SELECTED interrupted journal only: a manifest whose id
-	// differs from the expected resume id is a genuinely fresh sender, and its fresh
-	// journal has no verified progress at risk. Expected must equal the journal's id for
-	// this to be the interrupted transfer the user chose.
-	if !authorized && expected != "" && expected == journal.TransferID {
+	// V13-PR08 (review Blocker 2): persisted haveBlocks may be advertised only for the
+	// journal THIS session authenticated a resume for. Successful auth for A must never
+	// advertise B's progress, and authorization with no selected journal advertises
+	// nothing. A fresh journal created during this session has zero committed progress and
+	// advertises a zero seed as an ordinary fresh receive.
+	hasProgress := false
+	for _, f := range journal.Files {
+		if f.CommittedBlocks > 0 {
+			hasProgress = true
+			break
+		}
+	}
+	authorizedForThis := authorized && expected != "" &&
+		expected == journal.TransferID && expected == manifest.TransferID
+	if hasProgress && !authorizedForThis {
+		if expected == "" {
+			return nil, wire.Errorf(wire.CodeStorage,
+				"transfer: refusing to advertise verified progress for %s: this session did not authenticate a resume for it",
+				journal.TransferID)
+		}
 		return nil, wire.Errorf(wire.CodeStorage,
-			"transfer: refusing to advertise verified progress for %s before resume authentication completed",
-			journal.TransferID)
+			"transfer: refusing to advertise verified progress for %s: this session authenticated resume for %s, not it",
+			journal.TransferID, expected)
 	}
 	fp, err := wire.ManifestFingerprint(manifest)
 	if err != nil {

--- a/apps/cli/internal/transfer/durable.go
+++ b/apps/cli/internal/transfer/durable.go
@@ -170,6 +170,25 @@ func (s *DurableStore) SaveJournal(j wire.DurableJournal) error {
 	return nil
 }
 
+// partialsBackCheckpoint reports whether every committed file's .part is present and at
+// least as long as its checkpoint claims (cheap Lstat; the authoritative check runs at
+// resume time in Inspect/Prepare).
+func (s *DurableStore) partialsBackCheckpoint(j *wire.DurableJournal) bool {
+	for i, f := range j.Files {
+		if f.CommittedBlocks == 0 {
+			continue
+		}
+		want, err := j.CommittedBytes(i)
+		if err != nil {
+			return false
+		}
+		if err := checkSafePartial(s.PartialPath(j.TransferID, f.Name), want); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
 // committedBytesTotal sums every file's durable byte claim (whole committed blocks,
 // final block capped at file size).
 func (s *DurableStore) committedBytesTotal(j *wire.DurableJournal) (int64, error) {
@@ -208,6 +227,13 @@ type DurableEntry struct {
 	Orphaned bool
 	// Fingerprint is the journal's manifest fingerprint ("" for orphans/unreadable).
 	Fingerprint string
+	// HasResumeSecret is true when the journal carries the transfer-scoped resume
+	// credential (V13-PR07); without it, authenticated cross-session resume is unavailable
+	// (legacy pre-PR07 state). Never printed as a value.
+	HasResumeSecret bool
+	// PartialOK is true when every committed file's .part backs its checkpoint (cheap
+	// Lstat check; the authoritative check runs on resume).
+	PartialOK bool
 	// Files / TotalSize / CommittedBytes / UpdatedAt summarize a valid journal.
 	Files          int
 	TotalSize      int64
@@ -248,13 +274,15 @@ func (s *DurableStore) List() ([]DurableEntry, error) {
 			total += f.Size
 		}
 		entries = append(entries, DurableEntry{
-			TransferID:     id,
-			JournalOK:      true,
-			Fingerprint:    j.ManifestFingerprint,
-			Files:          len(j.Files),
-			TotalSize:      total,
-			CommittedBytes: committed,
-			UpdatedAt:      j.UpdatedAt,
+			TransferID:      id,
+			JournalOK:       true,
+			Fingerprint:     j.ManifestFingerprint,
+			HasResumeSecret: j.ResumeSecret != nil,
+			PartialOK:       s.partialsBackCheckpoint(&j),
+			Files:           len(j.Files),
+			TotalSize:       total,
+			CommittedBytes:  committed,
+			UpdatedAt:       j.UpdatedAt,
 		})
 	}
 	// Orphaned partial trees: a partials/<name> directory with no journal. They are
@@ -418,6 +446,13 @@ type DurableDestination struct {
 	journal    *wire.DurableJournal
 	transferID string
 	resumed    bool
+	// expectResume is set by the driver when this receive is an explicit authenticated-resume
+	// attempt for a specific interrupted journal (V13-PR08: `sendbeam transfers resume`).
+	// Until resume-auth succeeds in THIS session, that journal's progress is never trusted.
+	expectResume string
+	// resumeAuthorized records that mutual resume-auth completed in this session; only then
+	// may a pre-existing journal's verified progress be reused.
+	resumeAuthorized bool
 	// sinks, finalPaths, partPaths key by manifest file index.
 	sinks      map[int]*DurableFileSink
 	finalPaths map[int]string
@@ -452,10 +487,34 @@ func NewDurableDestination(outDir string) (*DurableDestination, error) {
 // Store exposes the underlying storage area (management surfaces use it directly).
 func (d *DurableDestination) Store() *DurableStore { return d.store }
 
+// ExpectResume marks this receive as an explicit authenticated-resume attempt for the
+// interrupted journal `transferID` (the user pre-selected it locally). Until resume-auth
+// succeeds in this session, the journal's verified progress is never trusted.
+func (d *DurableDestination) ExpectResume(transferID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.expectResume = transferID
+}
+
+// SetResumeAuthorized records that mutual resume-auth completed in THIS session; only then
+// may the pre-selected interrupted journal's verified progress be reused (V13-PR08
+// invariant). A fresh receive without a pre-selected journal never needs it.
+func (d *DurableDestination) SetResumeAuthorized() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.resumeAuthorized = true
+}
+
 // Prepare validates the manifest and establishes the journal: it loads and revalidates an
 // existing journal for the manifest's transfer id (fail closed on corrupt, foreign, or
 // mismatched state), or creates a fresh one. Transfers whose manifest carries no transfer
 // id never opt into resumption and get no journal.
+//
+// V13-PR08 fail-closed gating: an existing journal's verified progress is reused ONLY when
+// this session authenticated a resume for it (ExpectResume + SetResumeAuthorized). A plain
+// receive that meets an interrupted journal — or an explicit resume attempt whose
+// authentication never completed — fails closed with guidance; nothing is deleted and
+// nothing is silently resumed.
 func (d *DurableDestination) Prepare(manifest wire.Manifest) error {
 	validated, err := wire.ValidateManifest(manifest)
 	if err != nil {
@@ -518,6 +577,24 @@ func (d *DurableDestination) Prepare(manifest wire.Manifest) error {
 		return wire.Errorf(wire.CodeStorage,
 			"transfer: journal %s does not match the authenticated manifest (fingerprint mismatch); refusing to guess — run \"sendbeam transfers inspect %s\" or discard it",
 			validated.TransferID, validated.TransferID)
+	}
+	// V13-PR08: an interrupted journal's verified progress may be reused ONLY after
+	// successful resume-auth in this session. A fresh rendezvous authenticates the NEW
+	// session only; it does not prove continuity with the original transfer peer. Failing
+	// closed here is what makes a fresh session unable to skip old blocks merely because
+	// the transfer id + fingerprint match.
+	if !d.resumeAuthorized {
+		// The pre-selected-journal branch fires only when the incoming manifest IS the
+		// interrupted journal the user chose; a different id means a fresh sender and is
+		// handled by the generic branch below (its journal, if any, still fails closed).
+		if d.expectResume != "" && d.expectResume == validated.TransferID {
+			return wire.Errorf(wire.CodeStorage,
+				"transfer: resume of %s was not authenticated in this session; refusing to reuse its verified progress — nothing was received or deleted. Re-run \"sendbeam transfers resume %s --code <fresh code>\" so both peers authenticate first",
+				validated.TransferID, validated.TransferID)
+		}
+		return wire.Errorf(wire.CodeStorage,
+			"transfer: transfer %s has verified partial data kept from an interrupted transfer; resuming it requires authenticated resume. Run \"sendbeam transfers resume %s --code <fresh code>\" (the sender re-runs its send for a fresh code), or discard the state with \"sendbeam transfers discard %s --out %s\" to receive fresh — nothing was received or deleted",
+			validated.TransferID, validated.TransferID, validated.TransferID, d.outRoot)
 	}
 	wantDest, err := destinationIdentity(d.outRoot)
 	if err != nil {
@@ -790,12 +867,26 @@ func (d *DurableDestination) AttachResumeSecret(manifest wire.Manifest, resumeRo
 // the wire receiver's resume seed: per-file high-water marks plus a digest re-hashed from
 // the persisted prefix. Missing or truncated partials fail closed (never guessed, never
 // deleted). Returns nil when the transfer is not resumable (no journal).
+//
+// V13-PR08: the seed may only be advertised after resume-auth succeeded in this session
+// (Prepare already fails closed otherwise; this is defense in depth).
 func (d *DurableDestination) ResumeStateFor(manifest wire.Manifest) (*wire.ReceiverResume, error) {
 	d.mu.Lock()
 	journal := d.journal
+	authorized := d.resumeAuthorized
+	expected := d.expectResume
 	d.mu.Unlock()
 	if journal == nil {
 		return nil, nil
+	}
+	// The gate protects the PRE-SELECTED interrupted journal only: a manifest whose id
+	// differs from the expected resume id is a genuinely fresh sender, and its fresh
+	// journal has no verified progress at risk. Expected must equal the journal's id for
+	// this to be the interrupted transfer the user chose.
+	if !authorized && expected != "" && expected == journal.TransferID {
+		return nil, wire.Errorf(wire.CodeStorage,
+			"transfer: refusing to advertise verified progress for %s before resume authentication completed",
+			journal.TransferID)
 	}
 	fp, err := wire.ManifestFingerprint(manifest)
 	if err != nil {
@@ -1022,7 +1113,11 @@ func (d *DurableDestination) Abort(reason string) error {
 	for _, sink := range sinks {
 		_ = sink.Abort(reason)
 	}
-	if journal == nil {
+	// Only a non-resumable transfer's OWN temp partial tree is removed. partialID is ""
+	// when the manifest never arrived (e.g. the sender died during resume auth): PartialDir("")
+	// would resolve to the shared partials ROOT, so removing it would destroy EVERY
+	// transfer's partial data. Never touch anything in that state.
+	if journal == nil && partialID != "" {
 		_ = os.RemoveAll(d.store.PartialDir(partialID))
 	}
 	return nil

--- a/apps/cli/internal/transfer/durable_test.go
+++ b/apps/cli/internal/transfer/durable_test.go
@@ -129,8 +129,22 @@ func durableLoopbackMaster() []byte {
 // The resume seed is applied through OnManifestSet exactly as the CLI driver does: the
 // authenticated manifest binds the journal, then per-file high-water marks and digest
 // prefixes are rebuilt from the persisted partials.
+// resumeAuthorizedDest marks a destination as an authenticated resume leg (V13-PR08): in
+// these direct/loopback tests there is no handshake, so the driver's ExpectResume +
+// SetResumeAuthorized are applied directly. The unauthenticated refusal is covered by the
+// dedicated fail-closed regression tests.
+func resumeAuthorizedDest(dest *DurableDestination) {
+	dest.ExpectResume(durableTestID)
+	dest.SetResumeAuthorized()
+}
+
 func runDurableLoopback(t *testing.T, dest *DurableDestination, blockSize int, contents map[string][]byte) (sendErr, recvErr error) {
 	t.Helper()
+	// V13-PR08: every resumed leg in these tests models the product flow where resume-auth
+	// already succeeded in this session (ExpectResume pre-selects the journal; the loopback
+	// has no handshake, so the driver's SetResumeAuthorized is applied directly). The
+	// unauthenticated variant is covered by the dedicated fail-closed regression tests.
+	resumeAuthorizedDest(dest)
 	keys, err := wire.DeriveTransferKeys(durableLoopbackMaster())
 	if err != nil {
 		t.Fatal(err)
@@ -244,11 +258,12 @@ func TestDurableDigestCheckpointPersistsAndResumes(t *testing.T) {
 		t.Fatalf("checkpoint state hex = %d chars, want %d (a 108-byte sha256 state)", len(cp.State), 2*108)
 	}
 
-	// A fresh process restores the digest from the checkpointed state.
+	// A fresh process restores the digest from the checkpointed state (authenticated leg).
 	resumed, err := NewDurableDestination(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
+	resumeAuthorizedDest(resumed)
 	if err := resumed.Prepare(manifest); err != nil {
 		t.Fatal(err)
 	}
@@ -292,13 +307,16 @@ func TestDurableUnusableCheckpointFallsBackToRehash(t *testing.T) {
 	manifest := durableTestManifest(t, durableTestID, blockSize, map[string][]byte{"f.bin": content})
 
 	// seedCheckpoint writes one committed block with a digest checkpoint, then mutates the
-	// checkpoint in the on-disk journal and re-saves it (recomputed checksum).
+	// checkpoint in the on-disk journal and re-saves it (recomputed checksum). The sub-tests
+	// share one dir, so a later seed may find the earlier journal: mark the leg authorized
+	// (V13-PR08) — this test exercises checkpoint restore, not the auth gate.
 	seedCheckpoint := func(t *testing.T, mutate func(cp *wire.JournalDigestCheckpoint)) {
 		t.Helper()
 		dest, err := NewDurableDestination(dir)
 		if err != nil {
 			t.Fatal(err)
 		}
+		resumeAuthorizedDest(dest)
 		if err := dest.Prepare(manifest); err != nil {
 			t.Fatal(err)
 		}
@@ -336,6 +354,7 @@ func TestDurableUnusableCheckpointFallsBackToRehash(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		resumeAuthorizedDest(resumed)
 		if err := resumed.Prepare(manifest); err != nil {
 			t.Fatal(err)
 		}
@@ -356,6 +375,7 @@ func TestDurableUnusableCheckpointFallsBackToRehash(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		resumeAuthorizedDest(resumed)
 		if err := resumed.Prepare(manifest); err != nil {
 			t.Fatal(err)
 		}
@@ -851,6 +871,10 @@ func TestDurableMissingOrTruncatedPartialFailsClosed(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			// V13-PR08: this leg models an authenticated resume (the loopback has no
+			// handshake; the dedicated regression tests cover the unauthenticated refusal).
+			resumed.ExpectResume(durableTestID)
+			resumed.SetResumeAuthorized()
 			if err := resumed.Prepare(manifest); err != nil {
 				t.Fatalf("Prepare with the matching journal must succeed: %v", err)
 			}
@@ -1152,6 +1176,9 @@ func TestDurablePathAndSymlinkSafety(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		// V13-PR08: this leg models an authenticated resume.
+		resumed.ExpectResume(durableTestID)
+		resumed.SetResumeAuthorized()
 		if err := resumed.Prepare(manifest); err != nil {
 			t.Fatal(err)
 		}
@@ -1571,10 +1598,13 @@ func TestDurableAttachResumeSecretResumedJournalNeverGetsFabricatedSecret(t *tes
 
 	// Session 2: a later receive loads the journal as existing/resumed state and attaches
 	// with a DIFFERENT session root. It must leave the journal without a credential.
+	// V13-PR08: the leg models an authenticated resume.
 	second, err := NewDurableDestination(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
+	second.ExpectResume(durableTestID)
+	second.SetResumeAuthorized()
 	if err := second.Prepare(manifest); err != nil {
 		t.Fatal(err)
 	}

--- a/apps/cli/internal/transfer/durable_test.go
+++ b/apps/cli/internal/transfer/durable_test.go
@@ -1822,3 +1822,227 @@ func TestDurableJournalIsLocalStateNotWireMaterial(t *testing.T) {
 		}
 	}
 }
+
+// --- V13-PR08 review Blocker 2: durable authorization is scoped to the SELECTED journal ---
+//
+// Successful resume-auth in this session proves continuity with the peer for the locally
+// selected interrupted transfer A ONLY. It must never authorize an existing journal B when
+// the peer later sends a manifest for B, and authorization with no selected journal
+// authorizes nothing. The strict predicate for pre-existing durable progress is:
+//
+//	authorizedForThisJournal := resumeAuthorized && expectResume != "" &&
+//	    expectResume == journal.TransferID && expectResume == validatedManifest.TransferID
+//
+// Anything else fails closed: zero old progress advertised, every journal/partial
+// preserved, never repaired/deleted/guessed. A genuinely fresh manifest with a DIFFERENT
+// transfer id and NO existing journal remains an ordinary fresh receive.
+
+// durableJournalFor seeds an existing journal (with committed partials) for a transfer.
+func durableJournalFor(t *testing.T, dir, transferID string, blockSize int, contents map[string][]byte) {
+	t.Helper()
+	dest, err := NewDurableDestination(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := durableTestManifest(t, transferID, blockSize, contents)
+	if err := dest.Prepare(manifest); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range sortedNames(contents) {
+		sink, err := dest.Open(manifestFileByName(manifest, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeDurableBlocks(t, sink, blockSize, contents[name])
+	}
+}
+
+func sortedNames(contents map[string][]byte) []string {
+	names := make([]string, 0, len(contents))
+	for name := range contents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func manifestFileByName(manifest wire.Manifest, name string) wire.FileEntry {
+	for _, f := range manifest.Files {
+		if f.Name == name {
+			return f
+		}
+	}
+	panic("file not in manifest: " + name)
+}
+
+// TestDurableAuthScopedToSelectedJournalA: selected A + auth success + manifest A +
+// journal A => resume allowed, its verified progress reused.
+func TestDurableAuthScopedToSelectedJournalA(t *testing.T) {
+	dir := t.TempDir()
+	blockSize := 1024
+	idA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	contentA := durableTestData(4 * blockSize)
+	durableJournalFor(t, dir, idA, blockSize, map[string][]byte{"a.bin": contentA})
+
+	dest, err := NewDurableDestination(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest.ExpectResume(idA)
+	dest.SetResumeAuthorized()
+	manifestA := durableTestManifest(t, idA, blockSize, map[string][]byte{"a.bin": contentA})
+	if err := dest.Prepare(manifestA); err != nil {
+		t.Fatalf("Prepare for the selected journal A must succeed: %v", err)
+	}
+	resume, err := dest.ResumeStateFor(manifestA)
+	if err != nil {
+		t.Fatalf("ResumeStateFor for A: %v", err)
+	}
+	if resume == nil || resume.Files[0].HaveBlocks != 4 {
+		t.Fatalf("resume must advertise A's checkpoint, got %+v", resume)
+	}
+}
+
+// TestDurableAuthForADoesNotAuthorizeJournalB: selected A + auth success + incoming
+// manifest B + EXISTING journal B => fail closed; B's progress never advertised; both
+// journals/partials preserved.
+func TestDurableAuthForADoesNotAuthorizeJournalB(t *testing.T) {
+	dir := t.TempDir()
+	blockSize := 1024
+	idA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	idB := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	contentA := durableTestData(2 * blockSize)
+	contentB := durableTestData(4 * blockSize)
+	durableJournalFor(t, dir, idA, blockSize, map[string][]byte{"a.bin": contentA})
+	durableJournalFor(t, dir, idB, blockSize, map[string][]byte{"b.bin": contentB})
+
+	dest, err := NewDurableDestination(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The user selected A locally and auth succeeded for A...
+	dest.ExpectResume(idA)
+	dest.SetResumeAuthorized()
+	// ...but the peer's manifest is B, which has its own existing journal.
+	manifestB := durableTestManifest(t, idB, blockSize, map[string][]byte{"b.bin": contentB})
+	err = dest.Prepare(manifestB)
+	if err == nil {
+		t.Fatal("Prepare must fail closed when auth covers A but the manifest is B with an existing journal")
+	}
+	if !strings.Contains(err.Error(), "not "+idB) || !strings.Contains(err.Error(), "authenticated resume for "+idA) {
+		t.Fatalf("error must name the authorized transfer and the refused journal: %v", err)
+	}
+	// Prepare already refused before any journal was bound, so ResumeStateFor must
+	// advertise NOTHING (no journal loaded) — B's progress never reaches the wire.
+	if resume, err := dest.ResumeStateFor(manifestB); err != nil || resume != nil {
+		t.Fatalf("ResumeStateFor after a failed Prepare must advertise nothing, got resume=%+v err=%v", resume, err)
+	}
+	// Both journals and their partials are preserved; nothing was deleted or repaired.
+	for _, id := range []string{idA, idB} {
+		if _, ok, err := dest.Store().LoadJournal(id); err != nil || !ok {
+			t.Fatalf("journal %s must be preserved: ok=%v err=%v", id, ok, err)
+		}
+	}
+	if size := partialSizeFor(t, dest, idB, "b.bin"); size != int64(len(contentB)) {
+		t.Fatalf("B's partial must be preserved, got %d bytes", size)
+	}
+	if size := partialSizeFor(t, dest, idA, "a.bin"); size != int64(len(contentA)) {
+		t.Fatalf("A's partial must be preserved, got %d bytes", size)
+	}
+}
+
+// TestDurableAuthForADoesNotBlockFreshTransferB: selected A + auth success + incoming
+// FRESH manifest B + NO journal B => ordinary fresh receive allowed, reused bytes = 0.
+func TestDurableAuthForADoesNotBlockFreshTransferB(t *testing.T) {
+	dir := t.TempDir()
+	blockSize := 1024
+	idA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	idB := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	contentA := durableTestData(2 * blockSize)
+	durableJournalFor(t, dir, idA, blockSize, map[string][]byte{"a.bin": contentA})
+
+	dest, err := NewDurableDestination(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest.ExpectResume(idA)
+	dest.SetResumeAuthorized()
+	contentB := durableTestData(3 * blockSize)
+	manifestB := durableTestManifest(t, idB, blockSize, map[string][]byte{"b.bin": contentB})
+	if err := dest.Prepare(manifestB); err != nil {
+		t.Fatalf("a genuinely fresh manifest B with no journal B must remain an ordinary receive: %v", err)
+	}
+	if dest.resumed {
+		t.Fatal("fresh transfer B must not be marked resumed")
+	}
+	resume, err := dest.ResumeStateFor(manifestB)
+	if err != nil {
+		t.Fatalf("ResumeStateFor for fresh B: %v", err)
+	}
+	if resume != nil && resume.Files[0].HaveBlocks != 0 {
+		t.Fatalf("fresh B must advertise zero old progress, got %+v", resume)
+	}
+}
+
+// TestDurableAuthRequiredForSelectedJournal: selected A + NO auth + journal A => fail
+// closed; A's progress never reused.
+func TestDurableAuthRequiredForSelectedJournal(t *testing.T) {
+	dir := t.TempDir()
+	blockSize := 1024
+	idA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	contentA := durableTestData(4 * blockSize)
+	durableJournalFor(t, dir, idA, blockSize, map[string][]byte{"a.bin": contentA})
+
+	dest, err := NewDurableDestination(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest.ExpectResume(idA) // selected, but resume-auth never ran in this session
+	manifestA := durableTestManifest(t, idA, blockSize, map[string][]byte{"a.bin": contentA})
+	if err := dest.Prepare(manifestA); err == nil {
+		t.Fatal("Prepare must fail closed without session authentication")
+	}
+	if _, ok, _ := dest.Store().LoadJournal(idA); !ok {
+		t.Fatal("journal A must be preserved on auth failure")
+	}
+}
+
+// TestDurableResumeStateForRejectsWrongJournal pins the defense-in-depth gate: even when
+// the destination holds authorization for A, ResumeStateFor must never advertise the
+// persisted progress of a loaded journal B.
+func TestDurableResumeStateForRejectsWrongJournal(t *testing.T) {
+	dir := t.TempDir()
+	blockSize := 1024
+	idA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	idB := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	contentB := durableTestData(4 * blockSize)
+	durableJournalFor(t, dir, idB, blockSize, map[string][]byte{"b.bin": contentB})
+
+	dest, err := NewDurableDestination(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Load B's journal as the destination's journal while the session authorized A only.
+	j, ok, err := dest.Store().LoadJournal(idB)
+	if err != nil || !ok {
+		t.Fatalf("load journal B: ok=%v err=%v", ok, err)
+	}
+	dest.journal = &j
+	dest.resumed = true
+	dest.ExpectResume(idA)
+	dest.SetResumeAuthorized()
+	manifestB := durableTestManifest(t, idB, blockSize, map[string][]byte{"b.bin": contentB})
+	if _, err := dest.ResumeStateFor(manifestB); err == nil {
+		t.Fatal("ResumeStateFor must fail closed for a journal not covered by this session's authorization")
+	}
+}
+
+// partialSizeFor returns the on-disk size of one transfer's .part.
+func partialSizeFor(t *testing.T, dest *DurableDestination, transferID, name string) int64 {
+	t.Helper()
+	info, err := os.Stat(dest.Store().PartialPath(transferID, name))
+	if err != nil {
+		t.Fatalf("stat partial %s for %s: %v", name, transferID, err)
+	}
+	return info.Size()
+}

--- a/apps/cli/internal/transfer/resume_driver_test.go
+++ b/apps/cli/internal/transfer/resume_driver_test.go
@@ -227,6 +227,25 @@ func TestDriverFreshSessionCannotSkipOldBlocksWithoutResumeAuth(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
+	// Variant C: the persisted resume role does NOT match the actual rendezvous role (the
+	// sender record was somehow armed on a session whose role is not offerer). The driver
+	// must fail closed on the role mismatch before anything is sent — never silently
+	// ignore a mismatched persisted/host role.
+	sendC, recvC, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		sendResume: &ResumeContext{
+			TransferID: srec.TransferID, ManifestFingerprint: srec.ManifestFingerprint,
+			Role: wire.RoleJoiner, ResumeSecret: decodeRecordSecret(t, srec.ResumeSecret),
+		},
+		sendCaps: resumeCaps(),
+		recvCaps: resumeCaps(),
+	})
+	if sendC.err == nil || !bytes.Contains([]byte(sendC.err.Error()), []byte("resume role mismatch")) {
+		t.Fatalf("sender must fail closed on a resume role mismatch, got %v", sendC.err)
+	}
+	if recvC.err == nil {
+		t.Fatal("receiver must not complete when the sender's role binding fails")
+	}
+
 	// Variant A: the sender reuses its record (Spec.Resume set, capability advertised) but
 	// the receiver joins as a plain fresh receive (no resume context, no capability). The
 	// sender must refuse to reuse the id before anything is sent. runResumeLeg cancels the

--- a/apps/cli/internal/transfer/resume_driver_test.go
+++ b/apps/cli/internal/transfer/resume_driver_test.go
@@ -1,0 +1,769 @@
+package transfer
+
+// V13-PR08 cross-session resume regression tests (driver level, deterministic).
+//
+// The critical invariant these tests pin: durable progress from a PREVIOUS authenticated
+// session may be reused ONLY after successful resume-auth-v1 continuity authentication.
+// A fresh invite/rendezvous code authenticates the NEW session; it does NOT by itself
+// prove continuity with the original transfer peer. Every fresh-session path that would
+// otherwise skip old blocks merely because transferId + fingerprint match must fail
+// closed.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/cli/internal/rendezvous"
+	"github.com/sendbeam/wire"
+)
+
+// result pairs a driver Run outcome with its error, mirroring the local helper type used
+// across the other driver test files.
+type result struct {
+	out *Outcome
+	err error
+}
+
+// resumeLegSpec configures one driver leg for the resume regression tests.
+type resumeLegSpec struct {
+	interrupt    bool
+	sendResume   *ResumeContext
+	recvResume   *ResumeContext
+	sendCaps     *rendezvous.Caps
+	recvCaps     *rendezvous.Caps
+	onSendResume func(ResumeResult)
+	onRecvResume func(ResumeResult)
+	// recvProgress counts acknowledged bytes on the receiver (0 for a zero-byte resume).
+	recvProgress func(int64)
+}
+
+// runResumeLeg runs one send+receive pair through the real driver.
+func runResumeLeg(ctx context.Context, t *testing.T, senderStore *SenderStore, outDir string, args []string, ls resumeLegSpec) (send, recv result, id string, reused bool) {
+	t.Helper()
+	hub := newRelay()
+	sources, _, err := NewOSFileSources(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hook func(wire.Manifest) error
+	id, hook, reused, err = PrepareSender(senderStore, args, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legCtx, legCancel := context.WithCancel(ctx)
+	defer legCancel()
+	firstProgress := make(chan struct{})
+	var once sync.Once
+	if ls.interrupt {
+		go func() {
+			select {
+			case <-firstProgress:
+				legCancel()
+			case <-legCtx.Done():
+			}
+		}()
+	}
+	sendDone := make(chan result, 1)
+	recvDone := make(chan result, 1)
+	go func() {
+		out, err := Run(legCtx, hub.off, Spec{
+			Session:        rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-bravo", LocalCaps: ls.sendCaps},
+			Sources:        sources,
+			TransferID:     id,
+			OnSendManifest: hook,
+			OnResumeCredential: func(manifest wire.Manifest, resumeRoot []byte) error {
+				return senderStore.AttachResumeSecret(manifest, resumeRoot, !reused)
+			},
+			Resume:     ls.sendResume,
+			OnResume:   ls.onSendResume,
+			ICEServers: []webrtc.ICEServer{},
+		})
+		sendDone <- result{out, err}
+	}()
+	go func() {
+		out, err := Run(legCtx, hub.join, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-bravo", LocalCaps: ls.recvCaps},
+			DestDir:    outDir,
+			Resume:     ls.recvResume,
+			OnResume:   ls.onRecvResume,
+			ICEServers: []webrtc.ICEServer{},
+			OnProgress: func(n int64) {
+				if ls.recvProgress != nil {
+					ls.recvProgress(n)
+				}
+				if ls.interrupt {
+					once.Do(func() { close(firstProgress) })
+				}
+			},
+		})
+		recvDone <- result{out, err}
+	}()
+	// Wait for whichever side settles first. When that side FAILED, the transfer can no
+	// longer succeed, so cancel the leg context to unblock the peer — this mirrors
+	// production, where a failing peer tears down its signaling socket and the surviving
+	// side's read loop surfaces the closure as a cancelled transfer. A successful first
+	// result needs no cancel: the peer completes on its own.
+	select {
+	case s := <-sendDone:
+		send = s
+		if s.err != nil {
+			legCancel()
+		}
+		recv = <-recvDone
+	case r := <-recvDone:
+		recv = r
+		if r.err != nil {
+			legCancel()
+		}
+		send = <-sendDone
+	}
+	return send, recv, id, reused
+}
+
+// seedInterruptedTransfer runs a real interrupted leg so BOTH peers persist the transfer
+// id, the manifest fingerprint, and the matching resume credential. It returns the sender
+// record and the receiver journal.
+func seedInterruptedTransfer(t *testing.T, senderStore *SenderStore, outDir string, args []string) (SenderRecord, wire.DurableJournal) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	send, recv, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		interrupt: true,
+		sendCaps:  resumeCaps(),
+		recvCaps:  resumeCaps(),
+	})
+	if send.err == nil || recv.err == nil {
+		t.Fatalf("seed leg unexpectedly succeeded: send=%v recv=%v", send.err, recv.err)
+	}
+	srec, ok, err := senderStore.Lookup(PathKey(args))
+	if err != nil || !ok {
+		t.Fatalf("sender record missing: ok=%v err=%v", ok, err)
+	}
+	if srec.ResumeSecret == nil {
+		t.Fatal("sender record must carry the resume credential")
+	}
+	recvStore, err := OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j, ok, err := recvStore.LoadJournal(srec.TransferID)
+	if err != nil || !ok {
+		t.Fatalf("receiver journal missing: ok=%v err=%v", ok, err)
+	}
+	if j.ResumeSecret == nil {
+		t.Fatal("receiver journal must carry the resume credential")
+	}
+	return srec, j
+}
+
+// resumeCaps advertises resume-auth-v1 (the CLI does this only on a peer that can
+// actually authenticate a resume).
+func resumeCaps() *rendezvous.Caps {
+	c := rendezvous.DefaultCaps()
+	c.Features = append(c.Features, wire.ResumeAuthCapability)
+	return &c
+}
+
+func plainCaps() *rendezvous.Caps {
+	c := rendezvous.DefaultCaps()
+	return &c
+}
+
+func decodeJournalSecret(t *testing.T, j *wire.JournalResumeSecret) []byte {
+	t.Helper()
+	secret, err := wire.DecodeResumeSecretEnvelope(&wire.ResumeSecretEnvelope{Version: j.Version, Value: j.Value})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return secret
+}
+
+func decodeRecordSecret(t *testing.T, e *wire.ResumeSecretEnvelope) []byte {
+	t.Helper()
+	secret, err := wire.DecodeResumeSecretEnvelope(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return secret
+}
+
+// TestDriverFreshSessionCannotSkipOldBlocksWithoutResumeAuth is the V13-PR08 critical
+// audit regression: a fresh rendezvous that reuses the transferId + matching fingerprint
+// MUST NOT skip old blocks when resume-auth was never performed. This holds even when the
+// sender (miswired or malicious) reuses the id without any resume context: the receiver
+// fails closed and nothing is transferred or deleted.
+func TestDriverFreshSessionCannotSkipOldBlocksWithoutResumeAuth(t *testing.T) {
+	senderStore := testSenderStore(t)
+	outDir := t.TempDir()
+	srcDir := t.TempDir()
+	payload := make([]byte, 8<<20)
+	for i := range payload {
+		payload[i] = byte(i*7 + 3)
+	}
+	srcPath := filepath.Join(srcDir, "payload.bin")
+	if err := os.WriteFile(srcPath, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{srcPath}
+	srec, j := seedInterruptedTransfer(t, senderStore, outDir, args)
+	recvStore, err := OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	committedBefore := before[0].CommittedBytes
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Variant A: the sender reuses its record (Spec.Resume set, capability advertised) but
+	// the receiver joins as a plain fresh receive (no resume context, no capability). The
+	// sender must refuse to reuse the id before anything is sent. runResumeLeg cancels the
+	// leg the moment the sender's refusal lands, unblocking the plain fresh receiver
+	// (production surfaces the same via the signaling socket close).
+	sendA, recvA, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		sendResume: &ResumeContext{
+			TransferID: srec.TransferID, ManifestFingerprint: srec.ManifestFingerprint,
+			Role: wire.RoleOfferer, ResumeSecret: decodeRecordSecret(t, srec.ResumeSecret),
+		},
+		sendCaps: resumeCaps(),
+		recvCaps: plainCaps(),
+	})
+	if sendA.err == nil || !bytes.Contains([]byte(sendA.err.Error()), []byte("resume-auth-v1")) {
+		t.Fatalf("sender must refuse to reuse the id without a capable peer, got %v", sendA.err)
+	}
+	if recvA.err == nil {
+		t.Fatal("receiver must not complete without resume auth")
+	}
+
+	// Variant B: the sender (miswired) reuses the id WITHOUT any resume context. The
+	// receiver still fails closed at its journal — a fresh session can never skip old
+	// blocks merely because transferId + fingerprint match.
+	sendB, recvB, idB, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		sendCaps: plainCaps(),
+		recvCaps: plainCaps(),
+	})
+	if idB != srec.TransferID {
+		t.Fatalf("sender did not reuse the id: %q != %q", idB, srec.TransferID)
+	}
+	if sendB.err == nil {
+		t.Fatal("variant B send must fail")
+	}
+	if recvB.err == nil || !bytes.Contains([]byte(recvB.err.Error()), []byte("authenticated resume")) {
+		t.Fatalf("receiver must fail closed with guidance, got %v", recvB.err)
+	}
+	if bytes.Contains([]byte(recvB.err.Error()), []byte("nothing was received or deleted")) == false {
+		t.Fatalf("receiver guidance must state nothing was transferred: %v", recvB.err)
+	}
+
+	// Fail closed means nothing moved and nothing was deleted.
+	after, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 1 || after[0].CommittedBytes != committedBefore {
+		t.Fatalf("journal changed across an unauthenticated fresh session: before=%d after=%#v", committedBefore, after)
+	}
+	if _, ok, err := senderStore.Lookup(PathKey(args)); err != nil || !ok {
+		t.Fatalf("sender record must be preserved: ok=%v err=%v", ok, err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "payload.bin")); err == nil {
+		t.Fatal("final file must not exist after an unauthenticated fresh session")
+	}
+	_ = j
+}
+
+// TestDriverReceiverResumeWithoutCapableSenderFallsBackFresh pins the receiver side of a
+// non-resume join: a receiver that pre-selected an interrupted journal but joins a sender
+// that started FRESH must receive fresh (a different transfer id) and leave its own
+// interrupted state untouched.
+func TestDriverReceiverResumeWithoutCapableSenderFallsBackFresh(t *testing.T) {
+	senderStore := testSenderStore(t)
+	outDir := t.TempDir()
+	srcDir := t.TempDir()
+	payload := make([]byte, 4<<20)
+	for i := range payload {
+		payload[i] = byte(i*3 + 1)
+	}
+	srcPath := filepath.Join(srcDir, "payload.bin")
+	if err := os.WriteFile(srcPath, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{srcPath}
+	srec, j := seedInterruptedTransfer(t, senderStore, outDir, args)
+	recvStore, err := OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	committedBefore := before[0].CommittedBytes
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	// The sender must be genuinely fresh: discard its record so PrepareSender mints a new
+	// id and the send path does not advertise resume-auth-v1 (no credential loaded).
+	if err := senderStore.Discard(srec.TransferID); err != nil {
+		t.Fatal(err)
+	}
+	var skipped bool
+	send2, recv2, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		recvResume: &ResumeContext{
+			TransferID: j.TransferID, ManifestFingerprint: j.ManifestFingerprint,
+			Role: wire.RoleJoiner, ResumeSecret: decodeJournalSecret(t, j.ResumeSecret),
+		},
+		recvCaps: resumeCaps(),
+		onRecvResume: func(r ResumeResult) {
+			if r.Skipped {
+				skipped = true
+			}
+		},
+		sendCaps: plainCaps(),
+	})
+	if send2.err != nil || recv2.err != nil {
+		t.Fatalf("fresh leg must complete: send=%v recv=%v", send2.err, recv2.err)
+	}
+	if !skipped {
+		t.Fatal("receiver must report the skipped resume (fresh sender)")
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "payload.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("fresh receive must deliver the whole file")
+	}
+	// The pre-selected interrupted journal is untouched (still resumable later).
+	after, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 1 || after[0].TransferID != j.TransferID || after[0].CommittedBytes != committedBefore {
+		t.Fatalf("pre-selected journal changed by a fresh receive: %#v", after)
+	}
+}
+
+// TestDriverResumeAuthFailurePreservesStateAndAllowsRetry pins the failure semantics:
+// a failed resume-auth (here: one peer's credential does not match) preserves the sender
+// record and the receiver journal exactly, and a LATER fresh attempt with the correct
+// credential and fresh nonces succeeds.
+func TestDriverResumeAuthFailurePreservesStateAndAllowsRetry(t *testing.T) {
+	senderStore := testSenderStore(t)
+	outDir := t.TempDir()
+	srcDir := t.TempDir()
+	payload := make([]byte, 8<<20)
+	for i := range payload {
+		payload[i] = byte(i*11 + 9)
+	}
+	srcPath := filepath.Join(srcDir, "payload.bin")
+	if err := os.WriteFile(srcPath, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{srcPath}
+	srec, j := seedInterruptedTransfer(t, senderStore, outDir, args)
+	recvStore, err := OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	committedBefore := before[0].CommittedBytes
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	// Attempt 1: the receiver's journal was tampered (a DIFFERENT secret). The handshake
+	// fails closed on both sides; nothing moves.
+	wrong := make([]byte, 32)
+	for i := range wrong {
+		wrong[i] = byte(i + 1)
+	}
+	send1, recv1, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		sendResume: &ResumeContext{
+			TransferID: srec.TransferID, ManifestFingerprint: srec.ManifestFingerprint,
+			Role: wire.RoleOfferer, ResumeSecret: decodeRecordSecret(t, srec.ResumeSecret),
+		},
+		recvResume: &ResumeContext{
+			TransferID: j.TransferID, ManifestFingerprint: j.ManifestFingerprint,
+			Role: wire.RoleJoiner, ResumeSecret: wrong,
+		},
+		sendCaps: resumeCaps(),
+		recvCaps: resumeCaps(),
+	})
+	if send1.err == nil || recv1.err == nil {
+		t.Fatalf("wrong-secret attempt must fail: send=%v recv=%v", send1.err, recv1.err)
+	}
+	after, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 1 || after[0].CommittedBytes != committedBefore {
+		t.Fatalf("failed auth changed the journal: before=%d after=%#v", committedBefore, after)
+	}
+	if _, ok, err := senderStore.Lookup(PathKey(args)); err != nil || !ok {
+		t.Fatalf("failed auth removed the sender record: ok=%v err=%v", ok, err)
+	}
+
+	// Attempt 2: the correct credential, fresh nonces (the driver uses crypto/rand). The
+	// failed attempt consumed nothing; this one completes.
+	send2, recv2, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		sendResume: &ResumeContext{
+			TransferID: srec.TransferID, ManifestFingerprint: srec.ManifestFingerprint,
+			Role: wire.RoleOfferer, ResumeSecret: decodeRecordSecret(t, srec.ResumeSecret),
+		},
+		recvResume: &ResumeContext{
+			TransferID: j.TransferID, ManifestFingerprint: j.ManifestFingerprint,
+			Role: wire.RoleJoiner, ResumeSecret: decodeJournalSecret(t, j.ResumeSecret),
+		},
+		sendCaps: resumeCaps(),
+		recvCaps: resumeCaps(),
+	})
+	if send2.err != nil || recv2.err != nil {
+		t.Fatalf("retry after failed auth: send=%v recv=%v", send2.err, recv2.err)
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "payload.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("resumed file differs from source")
+	}
+}
+
+// TestDriverResumeTransfersZeroBytesWhenAllCommitted pins the lost-final-Done behavior:
+// when every block was already durable before the restart, the authenticated resume sends
+// NO block data, whole-file verification still runs, and the receive finalizes.
+func TestDriverResumeTransfersZeroBytesWhenAllCommitted(t *testing.T) {
+	senderStore := testSenderStore(t)
+	outDir := t.TempDir()
+	srcDir := t.TempDir()
+	// The wire layer builds the manifest with the NEGOTIATED block size (both peers
+	// announce defaultBlockBytes = 1 MiB in these tests), and the record/journal
+	// fingerprints bind that geometry — so the seeded manifest must use the same size or
+	// the resume leg sees a fingerprint mismatch.
+	blockSize := 1024 * 1024
+	payload := make([]byte, 4*blockSize)
+	for i := range payload {
+		payload[i] = byte(i*17 + 2)
+	}
+	srcPath := filepath.Join(srcDir, "payload.bin")
+	if err := os.WriteFile(srcPath, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{srcPath}
+
+	// Seed the state: a sender record + a receiver journal whose checkpoint claims ALL
+	// blocks (the transfer was durable before the restart, but never finalized).
+	sources, _, err := NewOSFileSources(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, hook, reused, err := PrepareSender(senderStore, args, sources)
+	if err != nil || reused {
+		t.Fatalf("fresh PrepareSender: reused=%v err=%v", reused, err)
+	}
+	// The manifest must carry the REAL source meta: the resume leg's PrepareSender runs
+	// cheapSourceCheck against the live file and rejects a record whose mtime differs.
+	meta := sources[0].Meta()
+	manifest := wire.NewManifest([]wire.FileEntry{{
+		Idx: 0, Name: meta.Name, Size: meta.Size, Mime: meta.Mime,
+		LastModified: meta.LastModified, BlockSize: blockSize, Blocks: len(payload) / blockSize,
+		FileDigest: sha256Hex(payload),
+	}}, int64(len(payload)))
+	// The wire layer mints the transfer id exactly like this when a fresh record is
+	// created; the manifest is what binds the id to the record at persist time. The
+	// fingerprint binds the id too, so it must be computed AFTER the id is set.
+	id := newTransferID()
+	manifest.TransferID = id
+	validated, err := wire.ValidateManifest(*manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp, err := wire.ManifestFingerprint(validated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := hook(*manifest); err != nil {
+		t.Fatal(err)
+	}
+	// Attach the credential the way the ORIGINAL session would have (fresh record).
+	root, err := wire.ResumeRoot(bytes.Repeat([]byte{0x33}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := senderStore.AttachResumeSecret(*manifest, root, true); err != nil {
+		t.Fatal(err)
+	}
+	// Reload the record AFTER the credential attach — the pre-attach copy is stale.
+	srec, ok, err := senderStore.Lookup(PathKey(args))
+	if err != nil || !ok {
+		t.Fatalf("sender record missing: ok=%v err=%v", ok, err)
+	}
+	recvStore, err := OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest, err := NewDurableDestination(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.Prepare(*manifest); err != nil {
+		t.Fatal(err)
+	}
+	sink, err := dest.Open(validated.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for off := 0; off < len(payload); off += blockSize {
+		if err := sink.Write(int64(off), payload[off:off+blockSize]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Attach the matching credential to the journal (fresh session-created journal).
+	if err := dest.AttachResumeSecret(*manifest, root); err != nil {
+		t.Fatal(err)
+	}
+	j, ok, err := recvStore.LoadJournal(id)
+	if err != nil || !ok {
+		t.Fatalf("journal missing: ok=%v err=%v", ok, err)
+	}
+	if j.Files[0].CommittedBlocks != len(payload)/blockSize {
+		t.Fatalf("seeded checkpoint not full: %d blocks", j.Files[0].CommittedBlocks)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	recvProgressTotal := int64(0)
+	send, recv, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		sendResume: &ResumeContext{
+			TransferID: id, ManifestFingerprint: fp, Role: wire.RoleOfferer,
+			ResumeSecret: decodeRecordSecret(t, srec.ResumeSecret),
+		},
+		recvResume: &ResumeContext{
+			TransferID: id, ManifestFingerprint: fp, Role: wire.RoleJoiner,
+			ResumeSecret: decodeJournalSecret(t, j.ResumeSecret),
+		},
+		sendCaps: resumeCaps(),
+		recvCaps: resumeCaps(),
+		recvProgress: func(n int64) {
+			recvProgressTotal += n
+		},
+	})
+	if send.err != nil || recv.err != nil {
+		t.Fatalf("zero-byte resume: send=%v recv=%v", send.err, recv.err)
+	}
+	if recvProgressTotal != 0 {
+		t.Fatalf("zero-byte resume transferred %d new bytes, want 0", recvProgressTotal)
+	}
+	if send.out.Digest != recv.out.Digest {
+		t.Fatalf("digests differ after zero-byte resume: %s vs %s", send.out.Digest, recv.out.Digest)
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "payload.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("finalized file differs from source")
+	}
+	// Finalized: the journal is gone.
+	if entries, _ := recvStore.List(); len(entries) != 0 {
+		t.Fatalf("journal not removed after finalize: %#v", entries)
+	}
+}
+
+// TestDriverCrashAfterResumeAuthBeforeManifest pins the sender boundary "after resume-auth
+// success, before the resumed Manifest": the sender cancels the moment its preamble
+// completes, so the manifest never goes out; the receiver's journal is untouched and a
+// later attempt resumes normally.
+func TestDriverCrashAfterResumeAuthBeforeManifest(t *testing.T) {
+	senderStore := testSenderStore(t)
+	outDir := t.TempDir()
+	srcDir := t.TempDir()
+	payload := make([]byte, 8<<20)
+	for i := range payload {
+		payload[i] = byte(i*23 + 7)
+	}
+	srcPath := filepath.Join(srcDir, "payload.bin")
+	if err := os.WriteFile(srcPath, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{srcPath}
+	srec, j := seedInterruptedTransfer(t, senderStore, outDir, args)
+	recvStore, err := OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	committedBefore := before[0].CommittedBytes
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	crashCh := make(chan struct{})
+	legCtx, legCancel := context.WithCancel(ctx)
+	defer legCancel()
+	sendCtx, sendCancel := context.WithCancel(legCtx)
+	defer sendCancel()
+	_ = crashCh
+	// The sender's OnResume fires AFTER mutual auth completes and BEFORE the manifest is
+	// built/sent: cancelling there deterministically crashes at that boundary.
+	send, recv, _, _ := runResumeLeg(sendCtx, t, senderStore, outDir, args, resumeLegSpec{
+		sendResume: &ResumeContext{
+			TransferID: srec.TransferID, ManifestFingerprint: srec.ManifestFingerprint,
+			Role: wire.RoleOfferer, ResumeSecret: decodeRecordSecret(t, srec.ResumeSecret),
+		},
+		recvResume: &ResumeContext{
+			TransferID: j.TransferID, ManifestFingerprint: j.ManifestFingerprint,
+			Role: wire.RoleJoiner, ResumeSecret: decodeJournalSecret(t, j.ResumeSecret),
+		},
+		sendCaps: resumeCaps(),
+		recvCaps: resumeCaps(),
+		onSendResume: func(r ResumeResult) {
+			if r.Authenticated {
+				sendCancel()
+			}
+		},
+	})
+	if send.err == nil || recv.err == nil {
+		t.Fatalf("crash leg must fail: send=%v recv=%v", send.err, recv.err)
+	}
+	after, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 1 || after[0].CommittedBytes != committedBefore {
+		t.Fatalf("journal moved before the resumed manifest: before=%d after=%#v", committedBefore, after)
+	}
+
+	// A later attempt resumes normally from the preserved state.
+	send2, recv2, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		sendResume: &ResumeContext{
+			TransferID: srec.TransferID, ManifestFingerprint: srec.ManifestFingerprint,
+			Role: wire.RoleOfferer, ResumeSecret: decodeRecordSecret(t, srec.ResumeSecret),
+		},
+		recvResume: &ResumeContext{
+			TransferID: j.TransferID, ManifestFingerprint: j.ManifestFingerprint,
+			Role: wire.RoleJoiner, ResumeSecret: decodeJournalSecret(t, j.ResumeSecret),
+		},
+		sendCaps: resumeCaps(),
+		recvCaps: resumeCaps(),
+	})
+	if send2.err != nil || recv2.err != nil {
+		t.Fatalf("resume after the crash boundary: send=%v recv=%v", send2.err, recv2.err)
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "payload.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("resumed file differs from source")
+	}
+}
+
+// TestDriverCrashDuringResumedDataFlow pins a crash inside the RESUME leg (after
+// resume-auth, mid-data): the journal advances only for verified blocks, and a THIRD
+// fresh attempt re-authenticates and completes.
+func TestDriverCrashDuringResumedDataFlow(t *testing.T) {
+	senderStore := testSenderStore(t)
+	outDir := t.TempDir()
+	srcDir := t.TempDir()
+	payload := make([]byte, 16<<20)
+	for i := range payload {
+		payload[i] = byte(i*29 + 11)
+	}
+	srcPath := filepath.Join(srcDir, "payload.bin")
+	if err := os.WriteFile(srcPath, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{srcPath}
+	srec, j := seedInterruptedTransfer(t, senderStore, outDir, args)
+	recvStore, err := OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	committedBefore := before[0].CommittedBytes
+
+	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+	defer cancel()
+	resumeCtx := func() *ResumeContext {
+		return &ResumeContext{
+			TransferID: srec.TransferID, ManifestFingerprint: srec.ManifestFingerprint,
+			Role: wire.RoleOfferer, ResumeSecret: decodeRecordSecret(t, srec.ResumeSecret),
+		}
+	}
+	recvResumeCtx := func() *ResumeContext {
+		return &ResumeContext{
+			TransferID: j.TransferID, ManifestFingerprint: j.ManifestFingerprint,
+			Role: wire.RoleJoiner, ResumeSecret: decodeJournalSecret(t, j.ResumeSecret),
+		}
+	}
+
+	// Resume leg 1: crash after the first resumed block commits.
+	send1, recv1, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		interrupt:  true,
+		sendResume: resumeCtx(),
+		recvResume: recvResumeCtx(),
+		sendCaps:   resumeCaps(),
+		recvCaps:   resumeCaps(),
+	})
+	if send1.err == nil || recv1.err == nil {
+		t.Fatalf("resume leg 1 must be interrupted: send=%v recv=%v", send1.err, recv1.err)
+	}
+	mid, err := recvStore.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mid) != 1 || mid[0].CommittedBytes <= committedBefore || mid[0].CommittedBytes >= int64(len(payload)) {
+		t.Fatalf("resume leg 1 checkpoint must advance strictly: before=%d after=%#v", committedBefore, mid)
+	}
+
+	// Resume leg 2: re-authenticate (fresh nonces) and complete.
+	send2, recv2, _, _ := runResumeLeg(ctx, t, senderStore, outDir, args, resumeLegSpec{
+		sendResume: resumeCtx(),
+		recvResume: recvResumeCtx(),
+		sendCaps:   resumeCaps(),
+		recvCaps:   resumeCaps(),
+	})
+	if send2.err != nil || recv2.err != nil {
+		t.Fatalf("resume leg 2: send=%v recv=%v", send2.err, recv2.err)
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "payload.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("resumed file differs from source")
+	}
+	if entries, _ := recvStore.List(); len(entries) != 0 {
+		t.Fatalf("journal not removed after finalize: %#v", entries)
+	}
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/apps/cli/internal/transfer/sender_state.go
+++ b/apps/cli/internal/transfer/sender_state.go
@@ -95,6 +95,10 @@ type SenderEntry struct {
 	TotalSize   int64
 	CreatedAt   int64
 	UpdatedAt   int64
+	// HasResumeSecret is true when the record carries the transfer-scoped resume
+	// credential (V13-PR07); without it, authenticated cross-session resume is unavailable
+	// (legacy pre-PR07 state). Never printed as a value.
+	HasResumeSecret bool
 }
 
 // SenderStore owns the sender-state directory: record load/save with atomic replace,
@@ -235,14 +239,15 @@ func (s *SenderStore) List() ([]SenderEntry, error) {
 			total += f.Size
 		}
 		out = append(out, SenderEntry{
-			TransferID:  id,
-			RecordOK:    true,
-			Fingerprint: rec.ManifestFingerprint,
-			Paths:       rec.Paths,
-			Files:       len(rec.Files),
-			TotalSize:   total,
-			CreatedAt:   rec.CreatedAt,
-			UpdatedAt:   rec.UpdatedAt,
+			TransferID:      id,
+			RecordOK:        true,
+			Fingerprint:     rec.ManifestFingerprint,
+			Paths:           rec.Paths,
+			Files:           len(rec.Files),
+			TotalSize:       total,
+			CreatedAt:       rec.CreatedAt,
+			UpdatedAt:       rec.UpdatedAt,
+			HasResumeSecret: rec.ResumeSecret != nil,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].TransferID < out[j].TransferID })

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -402,30 +402,46 @@
   /**
    * V13-PR08 (Blocker 3): the ONE shared sender-resume construction used by both the
    * persistent-handle reopen and the manual re-selection paths, so authenticated
-   * cross-session resume behaves identically either way. The resumeAttempt carries exactly
-   * the stored transferId + fingerprint + offerer role + persisted credential envelope; a
-   * legacy record without a credential never reuses its old stable transferId under a
-   * fresh session (restart fresh instead).
+   * cross-session resume behaves identically either way.
+   *
+   * V13-PR08 review (Blocker 1): the capability gate lives HERE, at the shared boundary,
+   * so the persistent-handle reopen path cannot bypass it. The old transferId +
+   * resumeAttempt reach runSend only when ALL of these hold:
+   *   - this rendezvous exists (handshake/signaling adopted)
+   *   - the remote peer advertised resume-auth-v1 in THIS session
+   *   - the record actually holds a resume credential (armed interrupted sender record)
+   * On any refusal: runSend is never called, the old transferId never leaves the host,
+   * the worker never starts, and the sender record is preserved.
    */
   function beginSendResume(rec: SenderRecord, files: File[], reattachment: SenderReattachment) {
+    if (handshake === undefined || signaling === undefined) return;
+    if (rec.resumeSecret === undefined) {
+      // Legacy pre-PR07 record: authenticated resume is unavailable and the old stable id
+      // is never reused under a fresh session — forget and restart fresh.
+      errorText =
+        'This interrupted send has no resume credential (legacy state); authenticated resume is unavailable and the transfer id cannot be reused — nothing was sent. Forget the record and start a fresh transfer.';
+      screen = 'failed';
+      return;
+    }
+    if (!remoteSupportsResume()) {
+      errorText =
+        'The receiver did not advertise authenticated resume (resume-auth-v1); the interrupted transfer id cannot be reused without it — nothing was sent. Ask the receiver to resume, or forget the record and send fresh.';
+      screen = 'failed';
+      return;
+    }
     const ice = iceServers();
-    const resumeAttempt =
-      rec.resumeSecret === undefined
-        ? undefined
-        : {
-            transferId: rec.transferId,
-            manifestFingerprint: rec.manifestFingerprint,
-            role: 'offerer' as const,
-            envelope: rec.resumeSecret,
-          };
+    const resumeAttempt = {
+      transferId: rec.transferId,
+      manifestFingerprint: rec.manifestFingerprint,
+      role: 'offerer' as const,
+      envelope: rec.resumeSecret,
+    };
     beginTransfer(
-      runSend(handshake!, signaling!, {
+      runSend(handshake, signaling, {
         files,
-        // The old stable id is reused ONLY when this session will authenticate continuity
-        // with the original peer; otherwise the sender mints a fresh id.
-        ...(resumeAttempt !== undefined ? { transferId: rec.transferId } : {}),
+        transferId: rec.transferId,
         reattachment,
-        ...(resumeAttempt !== undefined ? { resumeAttempt } : {}),
+        resumeAttempt,
         ...(ice ? { iceServers: ice } : {}),
       }),
     );

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -89,6 +89,11 @@
   // let an interrupted send be reopened against its original source.
   let senderRecordList = $state.raw<SenderRecordListEntry[]>([]);
   let pendingResume = $state.raw<SenderRecord | undefined>(undefined);
+  // Final review blocker: the interrupted sender record this FRESH rendezvous was created
+  // FOR. Captured BEFORE offer() (only startSendResume sets it) and bound to the exact
+  // transfer id, so an ordinary rendezvous can never be retrofitted into a resume session
+  // and a rendezvous armed for record A can never resume record B. Cleared by reset().
+  let activeSendResumeTransferId = $state<string | undefined>(undefined);
   let resumeHint = $state('');
   let pickError = $state('');
   // Interrupted-receives surface (V13-PR08): locally kept receive journals with their
@@ -204,6 +209,10 @@
     }
     pickError = '';
     reset();
+    // Bind THIS rendezvous to THIS exact interrupted record BEFORE the offer is created:
+    // this is the proof the local resume-auth-v1 capability was advertised during caps
+    // negotiation, and it restricts resume eligibility to exactly this transfer.
+    activeSendResumeTransferId = rec.transferId;
     pendingResume = rec;
     resumeHint =
       'Authenticated resume armed — verified progress is reused only after the peer authenticates. Pick the original source.';
@@ -410,11 +419,30 @@
    *   - this rendezvous exists (handshake/signaling adopted)
    *   - the remote peer advertised resume-auth-v1 in THIS session
    *   - the record actually holds a resume credential (armed interrupted sender record)
+   *   - THIS rendezvous was itself armed for THIS exact interrupted record before the
+   *     offer (activeSendResumeTransferId === rec.transferId)
    * On any refusal: runSend is never called, the old transferId never leaves the host,
    * the worker never starts, and the sender record is preserved.
    */
   function beginSendResume(rec: SenderRecord, files: File[], reattachment: SenderReattachment) {
     if (handshake === undefined || signaling === undefined) return;
+    // Final review blocker: local resume intent must have been bound to THIS rendezvous
+    // before offer() (i.e. the user started it from the Resume action). pendingResume alone
+    // is not proof — the ordinary sendAgain() reselection flow can assign it after an
+    // ordinary rendezvous, and advertising generic resume-auth-v1 for a rendezvous armed
+    // for another record must not make every record eligible.
+    if (activeSendResumeTransferId === undefined) {
+      errorText =
+        'Authenticated resume was not armed before this rendezvous — nothing was sent. Start the interrupted transfer from the Resume action and share the fresh code.';
+      screen = 'failed';
+      return;
+    }
+    if (activeSendResumeTransferId !== rec.transferId) {
+      errorText =
+        'This rendezvous is armed to resume a different interrupted transfer — nothing was sent. Start resume for this record from the Resume action with a fresh code.';
+      screen = 'failed';
+      return;
+    }
     if (rec.resumeSecret === undefined) {
       // Legacy pre-PR07 record: authenticated resume is unavailable and the old stable id
       // is never reused under a fresh session — forget and restart fresh.
@@ -535,6 +563,7 @@
     durableDiscarded = false;
     senderRecordList = [];
     pendingResume = undefined;
+    activeSendResumeTransferId = undefined;
     resumeHint = '';
     pickError = '';
     receiveJournalList = [];

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -21,6 +21,7 @@
     senderRecordStoreWhenAvailable,
     type SenderRecord,
     type SenderRecordListEntry,
+    type SenderReattachment,
   } from './lib/transfer/sender-record.js';
   import { baseUrl, iceServers, loadConfig } from './lib/config.js';
   import { toJSON } from './lib/transfer/diagnostics.js';
@@ -47,6 +48,7 @@
     phaseLabel,
     progressLabel,
     progressPercent,
+    progressResumedLabel,
     rateLabel,
     etaLabel,
     humanBytes,
@@ -96,7 +98,15 @@
   // A journal selected for resume: joining a FRESH rendezvous carries this attempt so the
   // worker authenticates the original peer before reusing the verified checkpoint.
   let pendingReceiveResume = $state.raw<ReceiveJournalEntry | undefined>(undefined);
+  // V13-PR08 (Blocker 2): the ACTIVE receive-resume attempt for THIS fresh rendezvous/
+  // session — snapshotted from the pending selection at startReceive (before reset() clears
+  // it) and consumed by startTransferIfReady. Cleared only on reset (cancel / start over /
+  // terminal), never left armed for a later unrelated receive.
+  let activeReceiveResume = $state.raw<ReceiveJournalEntry | undefined>(undefined);
   let receiveResumeHint = $state('');
+  // V13-PR08: one-line in-flight resume note shown in the transfer block (what is reused,
+  // and only after authentication).
+  let resumeNote = $state('');
   let directoryPickerAvailable = $state(false);
   directoryPickerAvailable = typeof (window as PickerWindow).showDirectoryPicker === 'function';
 
@@ -112,6 +122,9 @@
   let transfer = $state.raw<TransferController | null>(null);
   let sentBytes = $state(0);
   let totalBytes = $state(0);
+  // V13-PR08: verified baseline reused from the authenticated checkpoint (sessionBytes =
+  // sentBytes - reusedBytes); zero on ordinary fresh transfers.
+  let reusedBytes = $state(0);
   let rateBps = $state(0);
   let etaSeconds = $state<number | undefined>(undefined);
   let transferState = $state<'running' | 'paused' | 'canceled'>('running');
@@ -134,7 +147,14 @@
     return typeof window === 'undefined' ? '' : codeFromHash(window.location.hash);
   }
 
-  function browserCaps(): Partial<CapsPayload> {
+  /**
+   * V13-PR08 (Blocker 4): resume-auth-v1 is advertised ONLY when THIS fresh rendezvous is
+   * actually participating in an interrupted-transfer resume (the user pre-selected it
+   * locally before creating the offer / joining). Ordinary sends and receives never
+   * announce it, so a peer can never infer resume intent from generic implementation
+   * support and one side cannot wait for a preamble the other side never intends to run.
+   */
+  function browserCaps(opts: { resume?: boolean } = {}): Partial<CapsPayload> {
     const pickerWindow = window as PickerWindow;
     const storage = navigator.storage as StorageManager | undefined;
     const hasOpfs = typeof storage?.getDirectory === 'function';
@@ -147,6 +167,7 @@
     }
     if (pickerWindow.showSaveFilePicker) sinkHints.push('direct-file');
     features.push('relay');
+    if (opts.resume === true) features.push('resume-auth-v1');
     return { features, sinkHints };
   }
 
@@ -155,7 +176,42 @@
     screen = 'sending';
     track(
       offer({
+        // An ordinary fresh send never advertises resume-auth-v1.
         localCaps: browserCaps(),
+        onPhase: (p) => (phase = p),
+        onCode: (c) => {
+          code = c;
+          link = inviteLinkFor(baseUrl(), c);
+        },
+      }),
+    );
+  }
+
+  /**
+   * V13-PR08 (Blocker 4): resume an interrupted send. The record is selected BEFORE the
+   * fresh offer is created, and the offer advertises resume-auth-v1 only because this
+   * rendezvous is participating in an authenticated resume. A legacy record without a
+   * credential cannot resume — restart fresh or forget it.
+   */
+  async function startSendResume(rec: SenderRecord) {
+    if (rec.resumeSecret === undefined) {
+      // Pre-PR07/legacy record: no credential, so authenticated cross-session resume is
+      // unavailable. Never reuse the old stable transferId under a fresh session.
+      resumeHint =
+        'This interrupted send has no resume credential — authenticated resume is unavailable. Forget it and start a fresh transfer (old data is never reused).';
+      await refreshSenderRecords();
+      return;
+    }
+    pickError = '';
+    reset();
+    pendingResume = rec;
+    resumeHint =
+      'Authenticated resume armed — verified progress is reused only after the peer authenticates. Pick the original source.';
+    resumeNote = 'Resuming the interrupted send — nothing is sent until both peers authenticate.';
+    screen = 'sending';
+    track(
+      offer({
+        localCaps: browserCaps({ resume: true }),
         onPhase: (p) => (phase = p),
         onCode: (c) => {
           code = c;
@@ -168,19 +224,31 @@
   async function startReceive() {
     const trimmed = codeInput.trim();
     if (trimmed === '') return;
+    // V13-PR08 (Blocker 2): snapshot the EXACT selected journal entry into active session
+    // state BEFORE reset(), which clears the pending selection; the attempt then survives
+    // the fresh rendezvous and reaches runReceive exactly once.
+    const resumeAttempt = pendingReceiveResume;
+    reset();
+    activeReceiveResume = resumeAttempt;
     let destination: ReceiveDestinationSpec = { kind: 'auto' };
     try {
-      const pickerWindow = window as PickerWindow;
-      if (receiveTarget === 'direct-file') {
-        if (!pickerWindow.showSaveFilePicker) throw new Error('Direct file saving is unavailable.');
-        destination = { kind: 'direct-file', handle: await pickerWindow.showSaveFilePicker() };
-      } else if (receiveTarget === 'direct-directory') {
-        if (!pickerWindow.showDirectoryPicker)
-          throw new Error('Direct folder saving is unavailable.');
-        destination = {
-          kind: 'direct-directory',
-          handle: await pickerWindow.showDirectoryPicker(),
-        };
+      // V13-PR08 (Blocker 7): an armed journal resume always targets the durable
+      // journal-backed destination — the kept partial data IS the destination. The
+      // ordinary save-to selector is never consulted for that attempt.
+      if (resumeAttempt === undefined) {
+        const pickerWindow = window as PickerWindow;
+        if (receiveTarget === 'direct-file') {
+          if (!pickerWindow.showSaveFilePicker)
+            throw new Error('Direct file saving is unavailable.');
+          destination = { kind: 'direct-file', handle: await pickerWindow.showSaveFilePicker() };
+        } else if (receiveTarget === 'direct-directory') {
+          if (!pickerWindow.showDirectoryPicker)
+            throw new Error('Direct folder saving is unavailable.');
+          destination = {
+            kind: 'direct-directory',
+            handle: await pickerWindow.showDirectoryPicker(),
+          };
+        }
       }
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
@@ -188,20 +256,19 @@
       screen = 'failed';
       return;
     }
-    // V13-PR08: joining a FRESH rendezvous while an interrupted receive is selected arms the
-    // authenticated-resume attempt — the worker runs resume-auth-v1 with the peer strictly
-    // before reusing the verified checkpoint, under a fresh key epoch.
-    const resumeAttempt = pendingReceiveResume;
-    reset();
     if (resumeAttempt !== undefined) {
-      receiveResumeHint = `Authenticated resume armed for ${resumeAttempt.label} — verified prior progress is reused only after the peer authenticates.`;
+      receiveResumeHint = `Authenticated resume armed for ${resumeAttempt.label} — verified prior progress (${humanBytes(resumeAttempt.committedBytes)}) is reused only after the peer authenticates.`;
+      resumeNote =
+        'Resuming the interrupted receive — the verified checkpoint is reused only after the peer authenticates.';
     }
     receiveDestination = destination;
     screen = 'receiving';
     track(
       join({
         code: trimmed,
-        localCaps: browserCaps(),
+        // V13-PR08 (Blocker 4): resume-auth-v1 is advertised only for this resume attempt;
+        // ordinary receives never announce it.
+        localCaps: browserCaps({ resume: resumeAttempt !== undefined }),
         onPhase: (p) => (phase = p),
       }),
     );
@@ -251,6 +318,15 @@
   }
 
   /**
+   * V13-PR08 (Blocker 4): the host checks the remote capability BEFORE the worker starts.
+   * A peer that did not advertise resume-auth-v1 in this rendezvous cannot participate in
+   * authenticated resume.
+   */
+  function remoteSupportsResume(): boolean {
+    return peerCaps?.features?.includes('resume-auth-v1') === true;
+  }
+
+  /**
    * Kick off the transfer once everything it needs is in hand. The joiner receives as soon as the
    * channel is adopted; the offerer waits until a file has been picked. Guarded so it runs once.
    */
@@ -260,37 +336,23 @@
     if (role === 'offerer') {
       if (pickedFiles.length === 0) return;
       if (pendingResume) {
-        // Resuming an interrupted send: the picked selection is cheap-checked against the
-        // record first (a friendly refusal beats a pointless transfer), then re-verified
-        // authoritatively by the worker before the manifest frame goes out.
+        // Resuming an interrupted send: the peer must have advertised resume-auth-v1, or
+        // the old transferId never reaches the transfer engine (fail closed, nothing sent).
+        if (!remoteSupportsResume()) {
+          errorText =
+            'The receiver did not advertise authenticated resume (resume-auth-v1); the interrupted transfer id cannot be reused without it — nothing was sent. Ask the receiver to resume, or forget the record and send fresh.';
+          screen = 'failed';
+          return;
+        }
+        // The picked selection is cheap-checked against the record first (a friendly
+        // refusal beats a pointless transfer), then re-verified authoritatively by the
+        // worker before the manifest frame goes out.
         const mismatch = cheapSourceCheck(pendingResume, pickedFiles);
         if (mismatch !== undefined) {
           pickError = `Resume refused — ${mismatch}`;
           return;
         }
-        beginTransfer(
-          runSend(handshake, signaling, {
-            files: pickedFiles,
-            transferId: pendingResume.transferId,
-            reattachment: { kind: 'reselection' },
-            // V13-PR08: the record's persisted credential (when present) arms an explicit
-            // cross-session resume — the worker runs resume-auth-v1 with the peer strictly
-            // before reusing any durable progress, under a fresh key epoch. A pre-PR07
-            // record without a credential resumes as an ordinary fresh send (the old
-            // partials are never silently trusted).
-            ...(pendingResume.resumeSecret !== undefined
-              ? {
-                  resumeAttempt: {
-                    transferId: pendingResume.transferId,
-                    manifestFingerprint: pendingResume.manifestFingerprint,
-                    role: 'offerer' as const,
-                    envelope: pendingResume.resumeSecret,
-                  },
-                }
-              : {}),
-            ...(ice ? { iceServers: ice } : {}),
-          }),
-        );
+        beginSendResume(pendingResume, pickedFiles, { kind: 'reselection' });
         pendingResume = undefined;
         resumeHint = '';
         return;
@@ -302,14 +364,27 @@
         }),
       );
     } else {
-      const resumeAttempt = pendingReceiveResume;
+      // V13-PR08 (Blocker 2): the attempt is the ACTIVE session state, snapshotted at
+      // startReceive — never the pending selection, which reset() cleared.
+      const resumeAttempt = activeReceiveResume;
+      const capable = remoteSupportsResume();
+      if (resumeAttempt !== undefined && !capable) {
+        // Authenticated resume is unavailable: the journal is preserved untouched and the
+        // receive proceeds as a genuinely fresh transfer. Its durable gate still refuses
+        // any progress reuse if the manifest happens to match the kept journal.
+        resumeNote =
+          'The sender did not advertise authenticated resume — kept partial data is preserved but is not reused; this transfer starts fresh.';
+      } else if (resumeAttempt !== undefined) {
+        resumeNote = 'Authenticated resume in progress — the verified checkpoint is reused.';
+      }
       beginTransfer(
         runReceive(handshake, signaling, receiveDestination, {
           ...(ice ? { iceServers: ice } : {}),
           // V13-PR08: the persisted credential envelope stays on the main thread; only
           // the decoded secret crosses into the worker, which authenticates the original
-          // peer before reusing any verified progress.
-          ...(resumeAttempt?.journal?.resumeSecret !== undefined
+          // peer before reusing any verified progress. Without the remote capability the
+          // attempt is NOT passed — the worker treats the transfer as fresh.
+          ...(resumeAttempt?.journal?.resumeSecret !== undefined && capable
             ? {
                 resumeAttempt: {
                   transferId: resumeAttempt.transferId,
@@ -324,11 +399,44 @@
     }
   }
 
+  /**
+   * V13-PR08 (Blocker 3): the ONE shared sender-resume construction used by both the
+   * persistent-handle reopen and the manual re-selection paths, so authenticated
+   * cross-session resume behaves identically either way. The resumeAttempt carries exactly
+   * the stored transferId + fingerprint + offerer role + persisted credential envelope; a
+   * legacy record without a credential never reuses its old stable transferId under a
+   * fresh session (restart fresh instead).
+   */
+  function beginSendResume(rec: SenderRecord, files: File[], reattachment: SenderReattachment) {
+    const ice = iceServers();
+    const resumeAttempt =
+      rec.resumeSecret === undefined
+        ? undefined
+        : {
+            transferId: rec.transferId,
+            manifestFingerprint: rec.manifestFingerprint,
+            role: 'offerer' as const,
+            envelope: rec.resumeSecret,
+          };
+    beginTransfer(
+      runSend(handshake!, signaling!, {
+        files,
+        // The old stable id is reused ONLY when this session will authenticate continuity
+        // with the original peer; otherwise the sender mints a fresh id.
+        ...(resumeAttempt !== undefined ? { transferId: rec.transferId } : {}),
+        reattachment,
+        ...(resumeAttempt !== undefined ? { resumeAttempt } : {}),
+        ...(ice ? { iceServers: ice } : {}),
+      }),
+    );
+  }
+
   /** Bind a running transfer's live progress and terminal outcome to the UI. */
   function beginTransfer(ctrl: TransferController) {
     transfer = ctrl;
     sentBytes = 0;
     totalBytes = ctrl.total() ?? 0;
+    reusedBytes = 0;
     rateBps = 0;
     etaSeconds = undefined;
     transferState = 'running';
@@ -336,6 +444,7 @@
       const snapshot = ctrl.snapshot();
       sentBytes = snapshot.bytes;
       totalBytes = snapshot.total ?? totalBytes;
+      reusedBytes = snapshot.reusedBytes;
       rateBps = snapshot.rateBps;
       etaSeconds = snapshot.etaSeconds;
       transferState = snapshot.state;
@@ -393,6 +502,7 @@
     receiveDestination = { kind: 'auto' };
     sentBytes = 0;
     totalBytes = 0;
+    reusedBytes = 0;
     rateBps = 0;
     etaSeconds = undefined;
     transferState = 'running';
@@ -413,7 +523,9 @@
     pickError = '';
     receiveJournalList = [];
     pendingReceiveResume = undefined;
+    activeReceiveResume = undefined;
     receiveResumeHint = '';
+    resumeNote = '';
   }
 
   async function discardDurable() {
@@ -504,11 +616,16 @@
     await refreshReceiveJournals();
   }
 
-  /** Resume an interrupted send from its record. */
+  /**
+   * Resume an interrupted send from its record. V13-PR08 (Blocker 3): BOTH paths — the
+   * persistent-handle reopen and the manual re-selection — share one resume construction
+   * (beginSendResume), so the authenticated resume attempt (stored transferId +
+   * fingerprint + offerer role + credential) reaches runSend regardless of how the source
+   * was reopened. A revoked permission or dead handle falls back to re-selection.
+   */
   async function sendAgain(rec: SenderRecord) {
     if (handshake === undefined || signaling === undefined) return;
     pickError = '';
-    const ice = iceServers();
     if (rec.reattachment.kind === 'handle') {
       // The persisted handle reopens the original source directly; a revoked permission or a
       // dead handle falls back to re-selection (the record keeps the transfer id either way).
@@ -517,14 +634,8 @@
         try {
           const files = await materializeHandle(rec.reattachment.handle);
           if (files.length === 0) throw new Error('the folder is empty');
-          beginTransfer(
-            runSend(handshake, signaling, {
-              files,
-              transferId: rec.transferId,
-              reattachment: rec.reattachment,
-              ...(ice ? { iceServers: ice } : {}),
-            }),
-          );
+          resumeNote = 'Authenticated resume in progress — the verified checkpoint is reused.';
+          beginSendResume(rec, files, rec.reattachment);
           return;
         } catch {
           // fall through to re-selection
@@ -581,9 +692,11 @@
     void refreshReceiveJournals();
   }
 
-  // Populate the interrupted-receives list once the app mounts.
+  // Populate the interrupted-receives AND interrupted-sends lists once the app mounts, so
+  // interrupted transfers are discoverable before a fresh rendezvous is created.
   if (typeof window !== 'undefined') {
     void refreshReceiveJournals();
+    void refreshSenderRecords();
   }
 </script>
 
@@ -620,6 +733,56 @@
           Send a file
         </button>
         <p class="hint">Files stay end-to-end encrypted with no server-side file storage.</p>
+        {#if senderRecordList.length > 0}
+          <!-- V13-PR08 (Blocker 4): interrupted sends are visible BEFORE a fresh offer, so
+            the user selects the record first and the offer advertises resume-auth-v1 only
+            for that rendezvous. -->
+          <div class="resume-zone">
+            <h3>Interrupted sends</h3>
+            {#each senderRecordList as entry (entry.transferId)}
+              <div class="resume-card">
+                {#if entry.kind === 'ok'}
+                  <p class="resume-name">
+                    {entry.record.files.length} file{entry.record.files.length === 1 ? '' : 's'}
+                    ({humanBytes(entry.record.files.reduce((total, f) => total + f.size, 0))})
+                  </p>
+                  <p class="muted">
+                    {entry.record.reattachment.kind === 'handle'
+                      ? 'Reopens the original folder'
+                      : 'Re-select the original source'}
+                    {#if entry.record.resumeSecret === undefined}
+                      {'\u00b7'} restart required (no credential)
+                    {/if}
+                    {'\u00b7'} interrupted {new Date(entry.record.updatedAt).toLocaleString()}
+                  </p>
+                  <div class="resume-actions">
+                    <button
+                      class="ghost"
+                      disabled={entry.record.resumeSecret === undefined}
+                      title={entry.record.resumeSecret === undefined
+                        ? 'No resume credential — authenticated resume is unavailable; start a fresh transfer instead'
+                        : undefined}
+                      onclick={() => startSendResume(entry.record)}
+                    >
+                      Resume
+                    </button>
+                    <button class="ghost" onclick={() => forgetSenderRecord(entry)}>Forget</button>
+                  </div>
+                {:else}
+                  <p class="resume-name">Corrupt sender record</p>
+                  <p class="muted">
+                    {entry.error} — nothing was sent; forget it to start a new transfer.
+                  </p>
+                  <div class="resume-actions">
+                    <button class="ghost" onclick={() => forgetSenderRecord(entry)}>
+                      Forget
+                    </button>
+                  </div>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
       </article>
 
       <article class="card receive-card">
@@ -650,11 +813,24 @@
             </button>
           </div>
           <label for="destination">Save to</label>
-          <select id="destination" bind:value={receiveTarget}>
+          <!-- V13-PR08 (Blocker 7): while an interrupted receive is armed for resume, the
+            journal + partial storage IS the destination; the ordinary selector is disabled
+            so a resume can never silently fall back to a fresh save. -->
+          <select
+            id="destination"
+            bind:value={receiveTarget}
+            disabled={pendingReceiveResume !== undefined}
+          >
             <option value="auto">Download when verified</option>
             <option value="direct-file">Save directly to one file</option>
             <option value="direct-directory">Save directly to a folder</option>
           </select>
+          {#if pendingReceiveResume !== undefined}
+            <p class="resume-hint">
+              Resuming into the kept partial data — verified progress is reused only after the peer
+              authenticates.
+            </p>
+          {/if}
         </form>
         {#if receiveResumeHint}
           <p class="resume-hint">{receiveResumeHint}</p>
@@ -839,7 +1015,16 @@
           <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100">
             <div class="bar-fill" style={`width:${progressPercent(sentBytes, totalBytes)}%`}></div>
           </div>
-          <p class="status" aria-live="polite">{progressLabel(sentBytes, totalBytes)}</p>
+          <p class="status" aria-live="polite">
+            {#if reusedBytes > 0}
+              {progressResumedLabel(sentBytes, reusedBytes, totalBytes)}
+            {:else}
+              {progressLabel(sentBytes, totalBytes)}
+            {/if}
+          </p>
+          {#if resumeNote}
+            <p class="resume-hint">{resumeNote}</p>
+          {/if}
           <div class="stats">
             <div class="stat">
               <span class="stat-label">Rate</span>
@@ -928,10 +1113,23 @@
                       {entry.record.reattachment.kind === 'handle'
                         ? 'Reopens the original folder'
                         : 'Re-select the original source'}
+                      {#if entry.record.resumeSecret === undefined}
+                        {'\u00b7'} restart required (no resume credential)
+                      {/if}
                       {'\u00b7'} interrupted {new Date(entry.record.updatedAt).toLocaleString()}
                     </p>
                     <div class="resume-actions">
-                      <button class="ghost" onclick={() => sendAgain(entry.record)}>
+                      <!-- V13-PR08 (Blocker 3): a legacy record without a credential cannot
+                        resume; never reuse its old stable transferId under a fresh session.
+                        Restart fresh (mint a new id) or forget it. -->
+                      <button
+                        class="ghost"
+                        disabled={entry.record.resumeSecret === undefined}
+                        title={entry.record.resumeSecret === undefined
+                          ? 'No resume credential — authenticated resume is unavailable; start a fresh transfer instead'
+                          : undefined}
+                        onclick={() => sendAgain(entry.record)}
+                      >
                         Send again
                       </button>
                       <button class="ghost" onclick={() => forgetSenderRecord(entry)}>

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import type { CapsPayload, RendezvousPhase, RendezvousResult, Role } from '@sendbeam/protocol';
+  import type {
+    CapsPayload,
+    DurableJournal,
+    RendezvousPhase,
+    RendezvousResult,
+    Role,
+  } from '@sendbeam/protocol';
   import { RendezvousError } from '@sendbeam/protocol';
 
   import { offer, join, type RendezvousController } from './lib/session/rendezvous.js';
@@ -18,6 +24,11 @@
   } from './lib/transfer/sender-record.js';
   import { baseUrl, iceServers, loadConfig } from './lib/config.js';
   import { toJSON } from './lib/transfer/diagnostics.js';
+  import {
+    discardDurableTransfer,
+    durableOpfsFiles,
+    indexedDbDurableStore,
+  } from './lib/transfer/durable-store.js';
   import QrCode from './lib/QrCode.svelte';
   import markUrl from './lib/assets/sendbeam-mark.svg';
 
@@ -45,6 +56,19 @@
 
   type Screen = 'home' | 'sending' | 'receiving' | 'done' | 'failed';
 
+  /** One locally kept interrupted receive (V13-PR08). Safe metadata only — never secrets. */
+  interface ReceiveJournalEntry {
+    transferId: string;
+    corrupt: boolean;
+    error?: string;
+    journal?: DurableJournal;
+    /** Total verified bytes across the checkpoint (durable truth). */
+    committedBytes: number;
+    totalBytes: number;
+    label: string;
+    updatedAt: number;
+  }
+
   let screen = $state<Screen>('home');
   let phase = $state<RendezvousPhase>('idle');
   let code = $state('');
@@ -65,6 +89,14 @@
   let pendingResume = $state.raw<SenderRecord | undefined>(undefined);
   let resumeHint = $state('');
   let pickError = $state('');
+  // Interrupted-receives surface (V13-PR08): locally kept receive journals with their
+  // verified checkpoint, so the user can explicitly resume (fresh rendezvous + resume-auth)
+  // or discard. Never server-side history — purely local durable state.
+  let receiveJournalList = $state.raw<ReceiveJournalEntry[]>([]);
+  // A journal selected for resume: joining a FRESH rendezvous carries this attempt so the
+  // worker authenticates the original peer before reusing the verified checkpoint.
+  let pendingReceiveResume = $state.raw<ReceiveJournalEntry | undefined>(undefined);
+  let receiveResumeHint = $state('');
   let directoryPickerAvailable = $state(false);
   directoryPickerAvailable = typeof (window as PickerWindow).showDirectoryPicker === 'function';
 
@@ -156,7 +188,14 @@
       screen = 'failed';
       return;
     }
+    // V13-PR08: joining a FRESH rendezvous while an interrupted receive is selected arms the
+    // authenticated-resume attempt — the worker runs resume-auth-v1 with the peer strictly
+    // before reusing the verified checkpoint, under a fresh key epoch.
+    const resumeAttempt = pendingReceiveResume;
     reset();
+    if (resumeAttempt !== undefined) {
+      receiveResumeHint = `Authenticated resume armed for ${resumeAttempt.label} — verified prior progress is reused only after the peer authenticates.`;
+    }
     receiveDestination = destination;
     screen = 'receiving';
     track(
@@ -234,6 +273,21 @@
             files: pickedFiles,
             transferId: pendingResume.transferId,
             reattachment: { kind: 'reselection' },
+            // V13-PR08: the record's persisted credential (when present) arms an explicit
+            // cross-session resume — the worker runs resume-auth-v1 with the peer strictly
+            // before reusing any durable progress, under a fresh key epoch. A pre-PR07
+            // record without a credential resumes as an ordinary fresh send (the old
+            // partials are never silently trusted).
+            ...(pendingResume.resumeSecret !== undefined
+              ? {
+                  resumeAttempt: {
+                    transferId: pendingResume.transferId,
+                    manifestFingerprint: pendingResume.manifestFingerprint,
+                    role: 'offerer' as const,
+                    envelope: pendingResume.resumeSecret,
+                  },
+                }
+              : {}),
             ...(ice ? { iceServers: ice } : {}),
           }),
         );
@@ -248,8 +302,24 @@
         }),
       );
     } else {
+      const resumeAttempt = pendingReceiveResume;
       beginTransfer(
-        runReceive(handshake, signaling, receiveDestination, ice ? { iceServers: ice } : {}),
+        runReceive(handshake, signaling, receiveDestination, {
+          ...(ice ? { iceServers: ice } : {}),
+          // V13-PR08: the persisted credential envelope stays on the main thread; only
+          // the decoded secret crosses into the worker, which authenticates the original
+          // peer before reusing any verified progress.
+          ...(resumeAttempt?.journal?.resumeSecret !== undefined
+            ? {
+                resumeAttempt: {
+                  transferId: resumeAttempt.transferId,
+                  manifestFingerprint: resumeAttempt.journal.manifestFingerprint,
+                  role: 'joiner' as const,
+                  envelope: resumeAttempt.journal.resumeSecret,
+                },
+              }
+            : {}),
+        }),
       );
     }
   }
@@ -341,6 +411,9 @@
     pendingResume = undefined;
     resumeHint = '';
     pickError = '';
+    receiveJournalList = [];
+    pendingReceiveResume = undefined;
+    receiveResumeHint = '';
   }
 
   async function discardDurable() {
@@ -356,6 +429,79 @@
   async function refreshSenderRecords() {
     const store = senderRecordStoreWhenAvailable();
     senderRecordList = store ? await store.list() : [];
+  }
+
+  /**
+   * Reload the locally kept interrupted-receive journals (V13-PR08). Pure local discovery —
+   * there is no server-side transfer directory or history.
+   */
+  async function refreshReceiveJournals() {
+    const store = indexedDbDurableStore();
+    let entries;
+    try {
+      entries = await store.listJournals();
+    } catch {
+      // Storage unavailable (private mode / unsupported browser): the interrupted-receives
+      // surface is a local convenience, not a critical path — hide it rather than fail.
+      receiveJournalList = [];
+      return;
+    }
+    receiveJournalList = entries.map((e) => {
+      const journal = e.journal;
+      if (e.kind !== 'ok' || journal === undefined) {
+        return {
+          transferId: e.transferId,
+          corrupt: true,
+          error: e.error ?? 'corrupt journal',
+          committedBytes: 0,
+          totalBytes: 0,
+          label: 'Unreadable interrupted receive',
+          updatedAt: 0,
+        };
+      }
+      const committed = journal.files.reduce(
+        (total, f) => total + Math.min(f.committedBlocks * f.blockSize, f.size),
+        0,
+      );
+      const total = journal.files.reduce((total, f) => total + f.size, 0);
+      return {
+        transferId: journal.transferId,
+        corrupt: false,
+        journal,
+        committedBytes: committed,
+        totalBytes: total,
+        label:
+          journal.files.length === 1
+            ? journal.files[0]!.name
+            : `${journal.files.length} files (${journal.files[0]!.name}…)`,
+        updatedAt: journal.updatedAt,
+      };
+    });
+  }
+
+  /** Resume an interrupted receive: join the peer's FRESH rendezvous carrying the attempt. */
+  function resumeReceive(entry: ReceiveJournalEntry) {
+    if (entry.corrupt || entry.journal === undefined || entry.journal.resumeSecret === undefined) {
+      receiveResumeHint =
+        'This interrupted receive has no resume credential — start a fresh transfer instead; the kept partial data was not deleted.';
+      return;
+    }
+    pendingReceiveResume = entry;
+    receiveResumeHint = `Resuming ${entry.label} — verified prior progress (${humanBytes(entry.committedBytes)}) is reused only after the peer authenticates. Ask the sender to resume and share their fresh code.`;
+  }
+
+  /** Explicitly discard one interrupted receive's journal + partials (keeps others). */
+  async function discardReceive(entry: ReceiveJournalEntry) {
+    const ownerId = crypto.randomUUID();
+    try {
+      await discardDurableTransfer(entry.transferId, ownerId, {
+        files: durableOpfsFiles(),
+        store: indexedDbDurableStore(),
+      });
+    } catch {
+      // Keep the entry visible; the data is still kept and the discard can be retried.
+    }
+    await refreshReceiveJournals();
   }
 
   /** Resume an interrupted send from its record. */
@@ -430,6 +576,14 @@
   function backHome() {
     reset();
     screen = 'home';
+    // Refresh both interrupted surfaces: local durable state may have changed.
+    void refreshSenderRecords();
+    void refreshReceiveJournals();
+  }
+
+  // Populate the interrupted-receives list once the app mounts.
+  if (typeof window !== 'undefined') {
+    void refreshReceiveJournals();
   }
 </script>
 
@@ -502,6 +656,49 @@
             <option value="direct-directory">Save directly to a folder</option>
           </select>
         </form>
+        {#if receiveResumeHint}
+          <p class="resume-hint">{receiveResumeHint}</p>
+        {/if}
+        {#if receiveJournalList.length > 0}
+          <div class="resume-zone">
+            <h3>Interrupted receives</h3>
+            {#each receiveJournalList as entry (entry.transferId)}
+              <div class="resume-card">
+                {#if entry.corrupt}
+                  <p class="resume-name">Unreadable interrupted receive</p>
+                  <p class="muted">
+                    {entry.error} — nothing was received; discard it to start a new transfer.
+                  </p>
+                  <div class="resume-actions">
+                    <button class="ghost" onclick={() => discardReceive(entry)}>Discard</button>
+                  </div>
+                {:else}
+                  <p class="resume-name">{entry.label}</p>
+                  <p class="muted">
+                    {#if entry.journal?.resumeSecret !== undefined}
+                      {humanBytes(entry.committedBytes)} of {humanBytes(entry.totalBytes)} verified
+                      {'\u00b7'} ready to resume
+                    {:else}
+                      {humanBytes(entry.committedBytes)} of {humanBytes(entry.totalBytes)} verified
+                      {'\u00b7'} restart required (no credential)
+                    {/if}
+                    {'\u00b7'} interrupted {new Date(entry.updatedAt).toLocaleString()}
+                  </p>
+                  <div class="resume-actions">
+                    <button
+                      class="ghost"
+                      disabled={entry.journal?.resumeSecret === undefined}
+                      onclick={() => resumeReceive(entry)}
+                    >
+                      Resume
+                    </button>
+                    <button class="ghost" onclick={() => discardReceive(entry)}>Discard</button>
+                  </div>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
       </article>
     </section>
   {:else if screen === 'sending'}

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -826,4 +826,189 @@ describe('App transfer completion', () => {
     const opts = mocks.runReceive.mock.calls[0]![3] as { resumeAttempt?: unknown };
     expect(opts.resumeAttempt).toBeUndefined();
   });
+
+  it('ordinary sender cannot retrofit resume after negotiation (final blocker test 1)', async () => {
+    // An interrupted send holds a credential + reopenable handle; the peer happens to be
+    // attempting a receive resume (so IT advertises resume-auth-v1), but THIS sender's
+    // rendezvous was an ORDINARY fresh send with no local resume intent.
+    const envelope = { format: 1, bytes: new Uint8Array([9, 9, 9]) };
+    const record = {
+      transferId: 'c'.repeat(32),
+      manifestFingerprint: 'd'.repeat(64),
+      files: [{ name: 'photo.bin', size: 8 }],
+      reattachment: { kind: 'handle', handleKind: 'directory', handle: {} },
+      resumeSecret: envelope,
+      updatedAt: 1_700_000_000_000,
+    };
+    mocks.listSenderRecords.mockResolvedValue([
+      { transferId: record.transferId, kind: 'ok', record },
+    ]);
+    mocks.senderRecordStoreWhenAvailable.mockReturnValue({
+      list: mocks.listSenderRecords,
+      remove: mocks.removeSenderRecord,
+    });
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.bin');
+    mocks.ensureReadPermission.mockResolvedValue(true);
+    mocks.materializeHandle.mockResolvedValue([file]);
+
+    const handshake = deferred<unknown>();
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
+    mocks.offer.mockReturnValue({
+      code: undefined,
+      phase: 'idle',
+      done: handshake.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    });
+
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    // An ORDINARY fresh send: local caps must NOT advertise resume-auth-v1.
+    const sendButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Send a file',
+    );
+    expect(sendButton).toBeDefined();
+    sendButton!.click();
+    await settle();
+    const offerOpts = mocks.offer.mock.calls[0]![0] as { localCaps: { features: string[] } };
+    expect(offerOpts.localCaps.features).not.toContain('resume-auth-v1');
+
+    // The receiver is attempting an interrupted receive resume, so ITS caps contain
+    // resume-auth-v1 even though this sender never armed local resume intent.
+    handshake.resolve({
+      master: new Uint8Array(32),
+      remoteCaps: {
+        version: 'sendbeam/1',
+        maxFrame: 16 * 1024,
+        blockSize: 1024 * 1024,
+        features: ['resume-auth-v1'],
+        sinkHints: ['opfs'],
+      },
+      role: 'offerer',
+    });
+    await settle();
+    await settle();
+
+    // "Send again" on the credentialed record: materialization may happen, but the worker
+    // must NEVER start — local resume intent was never bound to this rendezvous.
+    const sendAgainButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Send again',
+    );
+    expect(sendAgainButton).toBeDefined();
+    sendAgainButton!.click();
+    await settle();
+    await settle();
+    expect(mocks.materializeHandle).toHaveBeenCalledOnce();
+    expect(mocks.runSend).not.toHaveBeenCalled();
+    expect(mocks.removeSenderRecord).not.toHaveBeenCalled();
+    expect(target.textContent).toContain('was not armed before this rendezvous');
+    expect(target.textContent).toContain('nothing was sent');
+  });
+
+  it('resume rendezvous is bound to the exact record A, refusing record B (final blocker test 2)', async () => {
+    // Two interrupted sends: A (size 8) and B (size 16), both credentialed + reopenable.
+    const envelope = { format: 1, bytes: new Uint8Array([9, 9, 9]) };
+    const recordA = {
+      transferId: 'a'.repeat(32),
+      manifestFingerprint: 'd'.repeat(64),
+      files: [{ name: 'a.bin', size: 8 }],
+      reattachment: { kind: 'handle', handleKind: 'directory', handle: {} },
+      resumeSecret: envelope,
+      updatedAt: 1_700_000_000_000,
+    };
+    const recordB = {
+      transferId: 'b'.repeat(32),
+      manifestFingerprint: 'e'.repeat(64),
+      files: [{ name: 'b.bin', size: 16 }],
+      reattachment: { kind: 'handle', handleKind: 'directory', handle: {} },
+      resumeSecret: envelope,
+      updatedAt: 1_700_000_000_000,
+    };
+    mocks.listSenderRecords.mockResolvedValue([
+      { transferId: recordA.transferId, kind: 'ok', record: recordA },
+      { transferId: recordB.transferId, kind: 'ok', record: recordB },
+    ]);
+    mocks.senderRecordStoreWhenAvailable.mockReturnValue({
+      list: mocks.listSenderRecords,
+      remove: mocks.removeSenderRecord,
+    });
+    mocks.ensureReadPermission.mockResolvedValue(true);
+    mocks.materializeHandle.mockResolvedValue([new File([new Uint8Array([1, 2, 3])], 'b.bin')]);
+
+    const handshake = deferred<unknown>();
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
+    mocks.offer.mockReturnValue({
+      code: undefined,
+      phase: 'idle',
+      done: handshake.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    });
+
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    // Start resume for record A: the offer advertises resume-auth-v1 for THIS rendezvous.
+    const resumeButtons = [...target.querySelectorAll('button')].filter(
+      (button) => button.textContent?.trim() === 'Resume',
+    );
+    const resumeA = resumeButtons.find((b) =>
+      b.closest('.resume-card')?.textContent?.includes('8 B'),
+    );
+    expect(resumeA).toBeDefined();
+    resumeA!.click();
+    await settle();
+    const offerOpts = mocks.offer.mock.calls[0]![0] as { localCaps: { features: string[] } };
+    expect(offerOpts.localCaps.features).toContain('resume-auth-v1');
+
+    // The peer is capable and the rendezvous settles as the offerer.
+    handshake.resolve({
+      master: new Uint8Array(32),
+      remoteCaps: {
+        version: 'sendbeam/1',
+        maxFrame: 16 * 1024,
+        blockSize: 1024 * 1024,
+        features: ['resume-auth-v1'],
+        sinkHints: ['opfs'],
+      },
+      role: 'offerer',
+    });
+    await settle();
+    await settle();
+
+    // "Send again" for record B inside a rendezvous armed for A must be refused: generic
+    // resume-auth-v1 for this session does not make every local record eligible.
+    const sendAgainButtons = [...target.querySelectorAll('button')].filter(
+      (button) => button.textContent?.trim() === 'Send again',
+    );
+    const sendAgainB = sendAgainButtons.find((b) =>
+      b.closest('.resume-card')?.textContent?.includes('16 B'),
+    );
+    expect(sendAgainB).toBeDefined();
+    sendAgainB!.click();
+    await settle();
+    await settle();
+    expect(mocks.materializeHandle).toHaveBeenCalledOnce();
+    expect(mocks.runSend).not.toHaveBeenCalled();
+    expect(mocks.removeSenderRecord).not.toHaveBeenCalled();
+    expect(target.textContent).toContain('armed to resume a different interrupted transfer');
+    expect(target.textContent).toContain('nothing was sent');
+  });
 });

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -10,7 +10,54 @@ const mocks = vi.hoisted(() => ({
   join: vi.fn(),
   runSend: vi.fn(),
   runReceive: vi.fn(),
+  listJournals: vi.fn(),
+  discardDurableTransfer: vi.fn(),
+  durableOpfsFiles: vi.fn(),
+  indexedDbDurableStore: vi.fn(),
+  listSenderRecords: vi.fn(),
+  removeSenderRecord: vi.fn(),
+  senderRecordStoreWhenAvailable: vi.fn(),
+  ensureReadPermission: vi.fn(),
+  materializeHandle: vi.fn(),
+  canonicalizeFiles: vi.fn(),
+  cheapSourceCheck: vi.fn(),
 }));
+
+// V13-PR08 (Blocker 3/4): interrupted-sends surface + handle reattachment. The sender record
+// store and the File System Access helpers are mocked so the real App flow can be driven.
+vi.mock('./lib/transfer/sender-record.js', () => ({
+  senderRecordStoreWhenAvailable: mocks.senderRecordStoreWhenAvailable,
+}));
+
+vi.mock('./lib/transfer/sender-reattach.js', () => ({
+  canonicalizeFiles: mocks.canonicalizeFiles,
+  cheapSourceCheck: mocks.cheapSourceCheck,
+  ensureReadPermission: mocks.ensureReadPermission,
+  materializeHandle: mocks.materializeHandle,
+}));
+
+// V13-PR08 (Blocker 2): the interrupted-receives surface reads the durable store. Mock it
+// with a controllable journal list so the App component test can drive the real flow.
+vi.mock('./lib/transfer/durable-store.js', () => ({
+  discardDurableTransfer: mocks.discardDurableTransfer,
+  durableOpfsFiles: mocks.durableOpfsFiles,
+  indexedDbDurableStore: mocks.indexedDbDurableStore,
+}));
+
+/** A fake durable journal entry (safe metadata + credential envelope, never secrets). */
+function journalEntry(transferId: string, label: string): unknown {
+  return {
+    transferId,
+    kind: 'ok',
+    journal: {
+      transferId,
+      files: [{ name: label, size: 24, committedBlocks: 2, blockSize: 8 }],
+      manifestFingerprint: 'f'.repeat(64),
+      resumeSecret: { format: 1, bytes: new Uint8Array([1, 2, 3, 4]) },
+      updatedAt: 1_700_000_000_000,
+    },
+  };
+}
 
 vi.mock('./lib/session/rendezvous.js', () => ({
   offer: mocks.offer,
@@ -58,6 +105,24 @@ describe('App transfer completion', () => {
     mocks.join.mockReset();
     mocks.runSend.mockReset();
     mocks.runReceive.mockReset();
+    mocks.listJournals.mockReset();
+    mocks.discardDurableTransfer.mockReset();
+    mocks.durableOpfsFiles.mockReset();
+    mocks.indexedDbDurableStore.mockReset();
+    mocks.listSenderRecords.mockReset();
+    mocks.removeSenderRecord.mockReset();
+    mocks.senderRecordStoreWhenAvailable.mockReset();
+    mocks.ensureReadPermission.mockReset();
+    mocks.materializeHandle.mockReset();
+    mocks.canonicalizeFiles.mockReset();
+    mocks.cheapSourceCheck.mockReset();
+    // Default: no durable store (no journals), matching a fresh profile.
+    mocks.indexedDbDurableStore.mockReturnValue({ listJournals: mocks.listJournals });
+    mocks.listJournals.mockResolvedValue([]);
+    // Default: no sender-record store (no interrupted sends).
+    mocks.senderRecordStoreWhenAvailable.mockReturnValue(undefined);
+    mocks.canonicalizeFiles.mockImplementation((files: File[]) => [...files]);
+    mocks.cheapSourceCheck.mockReturnValue(undefined);
     target = document.createElement('div');
     document.body.append(target);
   });
@@ -147,5 +212,516 @@ describe('App transfer completion', () => {
     await settle();
 
     expect(target.textContent).toContain('Sent proof.bin — verified by the receiver.');
+  });
+
+  it('receives the exact selected journal attempt once (V13-PR08 Blocker 2)', async () => {
+    const entry = journalEntry('a'.repeat(32), 'archive.bin');
+    mocks.listJournals.mockResolvedValue([entry]);
+    const handshake = deferred<unknown>();
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
+    const rendezvous = {
+      code: undefined,
+      phase: 'idle',
+      done: handshake.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    };
+    const transfer = {
+      progress: vi.fn(() => 0),
+      total: vi.fn(() => undefined),
+      snapshot: vi.fn(() => ({
+        bytes: 0,
+        reusedBytes: 0,
+        sessionBytes: 0,
+        total: undefined,
+        rateBps: 0,
+        etaSeconds: undefined,
+        state: 'running' as const,
+      })),
+      transport: vi.fn(() => 'direct'),
+      done: deferred<unknown>().promise,
+      pause: vi.fn(),
+      resume: vi.fn(),
+      cancel: vi.fn(),
+    };
+    mocks.join.mockReturnValue(rendezvous);
+    mocks.runReceive.mockReturnValue(transfer);
+
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    // The interrupted receive is listed on the home screen.
+    const resumeButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Resume',
+    );
+    expect(resumeButton).toBeDefined();
+    resumeButton!.click();
+    await settle();
+
+    // The ordinary save-to selector is disabled while a resume is armed (Blocker 7).
+    const select = target.querySelector<HTMLSelectElement>('#destination');
+    expect(select?.disabled).toBe(true);
+
+    // Submit the fresh invite code.
+    const input = target.querySelector<HTMLInputElement>('#code');
+    expect(input).not.toBeNull();
+    input!.value = 'fresh-code-1234';
+    input!.dispatchEvent(new Event('input', { bubbles: true }));
+    await settle();
+    const receiveButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Receive',
+    );
+    receiveButton!.click();
+    await settle();
+
+    // The rendezvous advertises resume-auth-v1 ONLY for this armed attempt.
+    expect(mocks.join).toHaveBeenCalledOnce();
+    const joinOpts = mocks.join.mock.calls[0]![0] as {
+      code: string;
+      localCaps: { features: string[] };
+    };
+    expect(joinOpts.code).toBe('fresh-code-1234');
+    expect(joinOpts.localCaps.features).toContain('resume-auth-v1');
+
+    // Rendezvous completes as the joiner; the peer supports authenticated resume.
+    handshake.resolve({
+      master: new Uint8Array(32),
+      remoteCaps: {
+        version: 'sendbeam/1',
+        maxFrame: 16 * 1024,
+        blockSize: 1024 * 1024,
+        features: ['resume-auth-v1'],
+        sinkHints: ['opfs'],
+      },
+      role: 'joiner',
+    });
+    await settle();
+    await settle();
+
+    // runReceive receives entry A's exact transferId/fingerprint/credential EXACTLY once,
+    // and the destination is the forced durable auto spec (Blocker 7).
+    expect(mocks.runReceive).toHaveBeenCalledOnce();
+    const [rendezvousArg, , destination, opts] = mocks.runReceive.mock.calls[0]!;
+    // The receiver starts the worker with the settled rendezvous (the resolved value).
+    expect((rendezvousArg as { role: string }).role).toBe('joiner');
+    expect(destination).toEqual({ kind: 'auto' });
+    const attempt = (opts as { resumeAttempt?: unknown }).resumeAttempt;
+    expect(attempt).toEqual({
+      transferId: 'a'.repeat(32),
+      manifestFingerprint: 'f'.repeat(64),
+      role: 'joiner',
+      envelope: (entry as { journal: { resumeSecret: unknown } }).journal.resumeSecret,
+    });
+  });
+
+  it('cancel clears the armed resume; a later ordinary receive has no attempt (V13-PR08 Blocker 2)', async () => {
+    const entry = journalEntry('b'.repeat(32), 'notes.bin');
+    mocks.listJournals.mockResolvedValue([entry]);
+    const handshake = deferred<unknown>();
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
+    const rendezvous = {
+      code: undefined,
+      phase: 'idle',
+      done: handshake.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    };
+    const transfer = {
+      progress: vi.fn(() => 0),
+      total: vi.fn(() => undefined),
+      snapshot: vi.fn(() => ({
+        bytes: 0,
+        reusedBytes: 0,
+        sessionBytes: 0,
+        total: undefined,
+        rateBps: 0,
+        etaSeconds: undefined,
+        state: 'running' as const,
+      })),
+      transport: vi.fn(() => 'direct'),
+      done: deferred<unknown>().promise,
+      pause: vi.fn(),
+      resume: vi.fn(),
+      cancel: vi.fn(),
+    };
+    mocks.join.mockReturnValue(rendezvous);
+    mocks.runReceive.mockReturnValue(transfer);
+
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    const resumeButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Resume',
+    );
+    resumeButton!.click();
+    await settle();
+
+    // Submit the code and land on the receiving screen, then Cancel (back home).
+    const input = target.querySelector<HTMLInputElement>('#code');
+    input!.value = 'code-cancel';
+    input!.dispatchEvent(new Event('input', { bubbles: true }));
+    await settle();
+    const receiveButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Receive',
+    );
+    receiveButton!.click();
+    await settle();
+    const cancelButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Cancel',
+    );
+    cancelButton!.click();
+    await settle();
+    await settle();
+    // The armed resume is gone: the save-to selector is re-enabled and no attempt is armed.
+    const select = target.querySelector<HTMLSelectElement>('#destination');
+    expect(select?.disabled).toBe(false);
+
+    // A later ORDINARY receive (no resume selected) joins without resume-auth-v1 and passes
+    // no resumeAttempt to the worker.
+    mocks.listJournals.mockResolvedValue([]);
+    mocks.join.mockClear();
+    const handshake2 = deferred<unknown>();
+    const rendezvous2 = {
+      code: undefined,
+      phase: 'idle',
+      done: handshake2.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    };
+    mocks.join.mockReturnValue(rendezvous2);
+    // The home screen re-rendered after backHome: re-query the live code input.
+    const input2 = target.querySelector<HTMLInputElement>('#code');
+    expect(input2).not.toBeNull();
+    input2!.value = 'fresh-code-2';
+    input2!.dispatchEvent(new Event('input', { bubbles: true }));
+    await settle();
+    const receiveButton2 = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Receive',
+    );
+    receiveButton2!.click();
+    await settle();
+    const joinOpts = mocks.join.mock.calls[0]![0] as { localCaps: { features: string[] } };
+    expect(joinOpts.localCaps.features).not.toContain('resume-auth-v1');
+    handshake2.resolve({
+      master: new Uint8Array(32),
+      remoteCaps: {
+        version: 'sendbeam/1',
+        maxFrame: 16 * 1024,
+        blockSize: 1024 * 1024,
+        features: [],
+        sinkHints: ['opfs'],
+      },
+      role: 'joiner',
+    });
+    await settle();
+    await settle();
+    // The FIRST receive was canceled before its rendezvous resolved, so no worker started
+    // for it; the later ordinary receive is the only one that reached runReceive, and it
+    // carries no resume attempt.
+    expect(mocks.runReceive).toHaveBeenCalledOnce();
+    const opts = mocks.runReceive.mock.calls[0]![3] as { resumeAttempt?: unknown };
+    expect(opts.resumeAttempt).toBeUndefined();
+  });
+
+  it('persistent-handle sender resume runs the preamble (V13-PR08 Blocker 3)', async () => {
+    // The interrupted send holds a credential and a reopenable directory handle.
+    const envelope = { format: 1, bytes: new Uint8Array([9, 9, 9]) };
+    const record = {
+      transferId: 'c'.repeat(32),
+      manifestFingerprint: 'd'.repeat(64),
+      files: [{ name: 'photo.bin', size: 8 }],
+      reattachment: { kind: 'handle', handleKind: 'directory', handle: {} },
+      resumeSecret: envelope,
+      updatedAt: 1_700_000_000_000,
+    };
+    mocks.listSenderRecords.mockResolvedValue([
+      { transferId: record.transferId, kind: 'ok', record },
+    ]);
+    mocks.senderRecordStoreWhenAvailable.mockReturnValue({
+      list: mocks.listSenderRecords,
+      remove: mocks.removeSenderRecord,
+    });
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.bin');
+    mocks.ensureReadPermission.mockResolvedValue(true);
+    mocks.materializeHandle.mockResolvedValue([file]);
+
+    const handshake = deferred<unknown>();
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
+    const rendezvous = {
+      code: undefined,
+      phase: 'idle',
+      done: handshake.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    };
+    const transfer = {
+      progress: vi.fn(() => 0),
+      total: vi.fn(() => 8),
+      snapshot: vi.fn(() => ({
+        bytes: 0,
+        reusedBytes: 0,
+        sessionBytes: 0,
+        total: 8,
+        rateBps: 0,
+        etaSeconds: undefined,
+        state: 'running' as const,
+      })),
+      transport: vi.fn(() => 'direct'),
+      done: deferred<unknown>().promise,
+      pause: vi.fn(),
+      resume: vi.fn(),
+      cancel: vi.fn(),
+    };
+    mocks.offer.mockReturnValue(rendezvous);
+    mocks.runSend.mockReturnValue(transfer);
+
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    // The interrupted send is listed on the home screen; Resume creates the fresh offer
+    // and advertises resume-auth-v1 for this rendezvous.
+    const resumeButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Resume',
+    );
+    expect(resumeButton).toBeDefined();
+    resumeButton!.click();
+    await settle();
+    const offerOpts = mocks.offer.mock.calls[0]![0] as { localCaps: { features: string[] } };
+    expect(offerOpts.localCaps.features).toContain('resume-auth-v1');
+
+    // The fresh rendezvous completes as the offerer; the peer supports authenticated resume.
+    handshake.resolve({
+      master: new Uint8Array(32),
+      remoteCaps: {
+        version: 'sendbeam/1',
+        maxFrame: 16 * 1024,
+        blockSize: 1024 * 1024,
+        features: ['resume-auth-v1'],
+        sinkHints: ['opfs'],
+      },
+      role: 'offerer',
+    });
+    await settle();
+    await settle();
+
+    // "Send again" on the record reopens the persisted handle and starts the authenticated
+    // resume: the stored transferId + fingerprint + offerer role + credential all reach
+    // runSend (the worker then runs the resume preamble before any progress reuse).
+    const sendAgainButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Send again',
+    );
+    expect(sendAgainButton).toBeDefined();
+    sendAgainButton!.click();
+    await settle();
+    await settle();
+    expect(mocks.materializeHandle).toHaveBeenCalledOnce();
+    expect(mocks.runSend).toHaveBeenCalledOnce();
+    const [, , opts] = mocks.runSend.mock.calls[0]! as [unknown, unknown, Record<string, unknown>];
+    expect(opts.transferId).toBe(record.transferId);
+    expect(opts.reattachment).toEqual(record.reattachment);
+    expect(opts.resumeAttempt).toEqual({
+      transferId: record.transferId,
+      manifestFingerprint: record.manifestFingerprint,
+      role: 'offerer',
+      envelope,
+    });
+  });
+
+  it('legacy sender record without a credential cannot send again (V13-PR08 Blocker 3)', async () => {
+    const record = {
+      transferId: 'e'.repeat(32),
+      manifestFingerprint: 'f'.repeat(64),
+      files: [{ name: 'old.bin', size: 8 }],
+      reattachment: { kind: 'reselection' },
+      resumeSecret: undefined,
+      updatedAt: 1_700_000_000_000,
+    };
+    mocks.listSenderRecords.mockResolvedValue([
+      { transferId: record.transferId, kind: 'ok', record },
+    ]);
+    mocks.senderRecordStoreWhenAvailable.mockReturnValue({
+      list: mocks.listSenderRecords,
+      remove: mocks.removeSenderRecord,
+    });
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    // On the home screen the pre-rendezvous action is "Resume"; a legacy no-secret record
+    // cannot resume — the button is disabled and the reason is stated.
+    const resumeButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Resume',
+    );
+    expect(resumeButton).toBeDefined();
+    expect((resumeButton as HTMLButtonElement).disabled).toBe(true);
+    expect(target.textContent).toContain('restart required (no credential)');
+  });
+
+  it('sender resume fails closed before the worker when the peer lacks resume-auth-v1 (V13-PR08 Blocker 4)', async () => {
+    const record = {
+      transferId: 'c'.repeat(32),
+      manifestFingerprint: 'd'.repeat(64),
+      files: [{ name: 'photo.bin', size: 8 }],
+      reattachment: { kind: 'reselection' },
+      resumeSecret: { format: 1, bytes: new Uint8Array([1]) },
+      updatedAt: 1_700_000_000_000,
+    };
+    mocks.listSenderRecords.mockResolvedValue([
+      { transferId: record.transferId, kind: 'ok', record },
+    ]);
+    mocks.senderRecordStoreWhenAvailable.mockReturnValue({
+      list: mocks.listSenderRecords,
+      remove: mocks.removeSenderRecord,
+    });
+    const handshake = deferred<unknown>();
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
+    mocks.offer.mockReturnValue({
+      code: undefined,
+      phase: 'idle',
+      done: handshake.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    });
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    const resumeButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Resume',
+    );
+    resumeButton!.click();
+    await settle();
+    // The peer is a normal/old peer: NO resume-auth-v1 in this rendezvous.
+    handshake.resolve({
+      master: new Uint8Array(32),
+      remoteCaps: {
+        version: 'sendbeam/1',
+        maxFrame: 16 * 1024,
+        blockSize: 1024 * 1024,
+        features: [],
+        sinkHints: ['opfs'],
+      },
+      role: 'offerer',
+    });
+    await settle();
+    await settle();
+    const input = target.querySelector<HTMLInputElement>('input[type="file"]');
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.bin');
+    Object.defineProperty(input, 'files', { configurable: true, value: [file] });
+    input!.dispatchEvent(new Event('change', { bubbles: true }));
+    await settle();
+    await settle();
+    // The old transferId never reaches the transfer engine: runSend was NOT called and the
+    // failure screen explains the capability gap.
+    expect(mocks.runSend).not.toHaveBeenCalled();
+    expect(target.textContent).toContain('did not advertise authenticated resume');
+  });
+
+  it('receiver resume with a peer lacking resume-auth-v1 proceeds fresh, journal preserved (V13-PR08 Blocker 4)', async () => {
+    const entry = journalEntry('d'.repeat(32), 'kept.bin');
+    mocks.listJournals.mockResolvedValue([entry]);
+    const handshake = deferred<unknown>();
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
+    const rendezvous = {
+      code: undefined,
+      phase: 'idle',
+      done: handshake.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    };
+    const transfer = {
+      progress: vi.fn(() => 0),
+      total: vi.fn(() => undefined),
+      snapshot: vi.fn(() => ({
+        bytes: 0,
+        reusedBytes: 0,
+        sessionBytes: 0,
+        total: undefined,
+        rateBps: 0,
+        etaSeconds: undefined,
+        state: 'running' as const,
+      })),
+      transport: vi.fn(() => 'direct'),
+      done: deferred<unknown>().promise,
+      pause: vi.fn(),
+      resume: vi.fn(),
+      cancel: vi.fn(),
+    };
+    mocks.join.mockReturnValue(rendezvous);
+    mocks.runReceive.mockReturnValue(transfer);
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    const resumeButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Resume',
+    );
+    resumeButton!.click();
+    await settle();
+    const input = target.querySelector<HTMLInputElement>('#code');
+    input!.value = 'fresh-code';
+    input!.dispatchEvent(new Event('input', { bubbles: true }));
+    await settle();
+    [...target.querySelectorAll('button')]
+      .find((b) => b.textContent?.trim() === 'Receive')!
+      .click();
+    await settle();
+    // The peer is a fresh/normal sender: no resume-auth-v1.
+    handshake.resolve({
+      master: new Uint8Array(32),
+      remoteCaps: {
+        version: 'sendbeam/1',
+        maxFrame: 16 * 1024,
+        blockSize: 1024 * 1024,
+        features: [],
+        sinkHints: ['opfs'],
+      },
+      role: 'joiner',
+    });
+    await settle();
+    await settle();
+    // The receive proceeds as genuinely fresh — no resumeAttempt is passed to the worker,
+    // and the kept journal is never touched (the durable gate would refuse any reuse).
+    expect(mocks.runReceive).toHaveBeenCalledOnce();
+    const opts = mocks.runReceive.mock.calls[0]![3] as { resumeAttempt?: unknown };
+    expect(opts.resumeAttempt).toBeUndefined();
   });
 });

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -551,6 +551,108 @@ describe('App transfer completion', () => {
     });
   });
 
+  it('persistent-handle send refuses when the peer lacks resume-auth-v1 (V13-PR08 review Blocker 1)', async () => {
+    // The interrupted send holds a credential and a reopenable directory handle.
+    const envelope = { format: 1, bytes: new Uint8Array([9, 9, 9]) };
+    const record = {
+      transferId: 'c'.repeat(32),
+      manifestFingerprint: 'd'.repeat(64),
+      files: [{ name: 'photo.bin', size: 8 }],
+      reattachment: { kind: 'handle', handleKind: 'directory', handle: {} },
+      resumeSecret: envelope,
+      updatedAt: 1_700_000_000_000,
+    };
+    mocks.listSenderRecords.mockResolvedValue([
+      { transferId: record.transferId, kind: 'ok', record },
+    ]);
+    mocks.senderRecordStoreWhenAvailable.mockReturnValue({
+      list: mocks.listSenderRecords,
+      remove: mocks.removeSenderRecord,
+    });
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.bin');
+    mocks.ensureReadPermission.mockResolvedValue(true);
+    mocks.materializeHandle.mockResolvedValue([file]);
+
+    const handshake = deferred<unknown>();
+    const signaling = {
+      send: vi.fn(),
+      sendBinary: vi.fn(),
+      onMessage: vi.fn(),
+      onBinary: vi.fn(),
+      onClose: vi.fn(),
+      close: vi.fn(),
+    };
+    const rendezvous = {
+      code: undefined,
+      phase: 'idle',
+      done: handshake.promise,
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(() => signaling),
+    };
+    mocks.offer.mockReturnValue(rendezvous);
+    const transfer = {
+      progress: vi.fn(() => 0),
+      total: vi.fn(() => 8),
+      snapshot: vi.fn(() => ({
+        bytes: 0,
+        reusedBytes: 0,
+        sessionBytes: 0,
+        total: 8,
+        rateBps: 0,
+        etaSeconds: undefined,
+        state: 'running' as const,
+      })),
+      transport: vi.fn(() => 'direct'),
+      done: deferred<unknown>().promise,
+      pause: vi.fn(),
+      resume: vi.fn(),
+      cancel: vi.fn(),
+    };
+    mocks.runSend.mockReturnValue(transfer);
+
+    component = mount(App, { target });
+    await settle();
+    await settle();
+    await settle();
+    const resumeButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Resume',
+    );
+    expect(resumeButton).toBeDefined();
+    resumeButton!.click();
+    await settle();
+
+    // The fresh rendezvous completes as the offerer, but the remote peer did NOT advertise
+    // resume-auth-v1: the persistent-handle reopen must fail closed at the shared boundary.
+    handshake.resolve({
+      master: new Uint8Array(32),
+      remoteCaps: {
+        version: 'sendbeam/1',
+        maxFrame: 16 * 1024,
+        blockSize: 1024 * 1024,
+        features: [],
+        sinkHints: ['opfs'],
+      },
+      role: 'offerer',
+    });
+    await settle();
+    await settle();
+
+    const sendAgainButton = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Send again',
+    );
+    expect(sendAgainButton).toBeDefined();
+    sendAgainButton!.click();
+    await settle();
+    await settle();
+    // Materialization may happen, but the worker must never start: no runSend, no old
+    // transferId anywhere, and the record stays intact with a clear capability error.
+    expect(mocks.materializeHandle).toHaveBeenCalledOnce();
+    expect(mocks.runSend).not.toHaveBeenCalled();
+    expect(mocks.removeSenderRecord).not.toHaveBeenCalled();
+    expect(target.textContent).toContain('did not advertise authenticated resume');
+    expect(target.textContent).toContain('nothing was sent');
+  });
+
   it('legacy sender record without a credential cannot send again (V13-PR08 Blocker 3)', async () => {
     const record = {
       transferId: 'e'.repeat(32),

--- a/apps/web/src/lib/session/present.test.ts
+++ b/apps/web/src/lib/session/present.test.ts
@@ -10,6 +10,7 @@ import {
   phaseLabel,
   progressLabel,
   progressPercent,
+  progressResumedLabel,
   rateLabel,
   sasFingerprint,
 } from './present.js';
@@ -120,6 +121,21 @@ describe('progressLabel', () => {
   });
   it('shows 100% at completion', () => {
     expect(progressLabel(4_194_304, 4_194_304)).toBe('4 MiB / 4 MiB (100%)');
+  });
+});
+
+describe('progressResumedLabel (V13-PR08)', () => {
+  it('separates the reused checkpoint from this-session bytes', () => {
+    // 68 MiB of a 100 MiB transfer was verified before the interruption; 4 MiB moved this
+    // session → verified = 72 MiB, reused = 68 MiB, session = 4 MiB.
+    expect(progressResumedLabel(72 * 2 ** 20, 68 * 2 ** 20, 100 * 2 ** 20)).toBe(
+      'Resuming from 72% verified — 68 MiB reused · 4 MiB transferred this session',
+    );
+  });
+  it('zero-byte resume shows 100% verified with no session bytes', () => {
+    expect(progressResumedLabel(68 * 2 ** 20, 68 * 2 ** 20, 68 * 2 ** 20)).toBe(
+      'Resuming from 100% verified — 68 MiB reused · 0 B transferred this session',
+    );
   });
 });
 

--- a/apps/web/src/lib/session/present.ts
+++ b/apps/web/src/lib/session/present.ts
@@ -86,6 +86,16 @@ export function progressLabel(done: number, total: number): string {
   return `${humanBytes(done)} / ${humanBytes(total)} (${progressPercent(done, total)}%)`;
 }
 
+/**
+ * V13-PR08: resumed-session caption — the verified checkpoint is surfaced separately from
+ * the bytes transferred this session (verified = reused + session). Fresh transfers never
+ * call this (their reused baseline is zero).
+ */
+export function progressResumedLabel(verified: number, reused: number, total: number): string {
+  const session = Math.max(0, verified - reused);
+  return `Resuming from ${progressPercent(verified, total)}% verified — ${humanBytes(reused)} reused · ${humanBytes(session)} transferred this session`;
+}
+
 /** Smoothed acknowledged throughput for the transfer detail line. */
 export function rateLabel(bytesPerSecond: number): string {
   if (bytesPerSecond <= 0) return 'Calculating speed…';

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -418,6 +418,9 @@ function run(
             return;
           case 'progress':
             progress.update(msg.bytes);
+            // V13-PR08: anchor the verified baseline reused from the authenticated
+            // checkpoint (reported before the first new block).
+            if (msg.reusedBytes !== undefined) progress.setReused(msg.reusedBytes);
             return;
           case 'manifest':
             total = msg.totalSize;

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -10,7 +10,11 @@
  * have their own tests, and the whole path is covered by the e2e transfer.
  */
 
-import { deriveResumeRoot, type RendezvousResult } from '@sendbeam/protocol';
+import {
+  decodeResumeSecretEnvelope,
+  deriveResumeRoot,
+  type RendezvousResult,
+} from '@sendbeam/protocol';
 import { WakeLockManager } from './wake-lock.js';
 import type { SignalChannel } from '../signaling/client.js';
 import { SignalAuthenticator } from '../transfer/authed-signaling.js';
@@ -32,6 +36,7 @@ import {
 import type {
   HostToWorker,
   ReceiveDestinationSpec,
+  ResumeAttempt,
   SessionCrypto,
   WorkerToHost,
 } from '../transfer/wire.js';
@@ -93,6 +98,12 @@ export interface SendOptions {
   transferId?: string;
   /** How this send's source can be reopened after an interruption (persisted with the record). */
   reattachment?: SenderReattachment;
+  /**
+   * V13-PR08: explicit cross-session resume. The host decodes the locally persisted
+   * credential and passes only the decoded secret to the worker, which runs resume-auth-v1
+   * with the peer strictly before reusing any durable progress.
+   */
+  resumeAttempt?: HostResumeAttempt;
   /** Operator-published ICE servers; omitting keeps the bundled default STUN. */
   iceServers?: RTCIceServer[];
 }
@@ -112,6 +123,9 @@ export function runSend(
       files: opts.files,
       ...(opts.transferId !== undefined ? { transferId: opts.transferId } : {}),
       ...(opts.reattachment !== undefined ? { reattachment: opts.reattachment } : {}),
+      ...(opts.resumeAttempt !== undefined
+        ? { resumeAttempt: await hostResumeAttempt(opts.resumeAttempt) }
+        : {}),
       // V13-PR07: the main thread derives the narrow transient resume root from the
       // ORIGINAL session master and passes only that root to the worker — never the master.
       ...(await resumeRootOf(rendezvous)),
@@ -125,7 +139,7 @@ export function runReceive(
   rendezvous: RendezvousResult,
   signaling: SignalChannel,
   destination: ReceiveDestinationSpec = { kind: 'auto' },
-  opts: { iceServers?: RTCIceServer[] } = {},
+  opts: { iceServers?: RTCIceServer[]; resumeAttempt?: HostResumeAttempt } = {},
 ): TransferController {
   return run(rendezvous, signaling, {
     role: 'receive',
@@ -133,6 +147,9 @@ export function runReceive(
     start: async () => ({
       kind: 'start-recv',
       destination,
+      ...(opts.resumeAttempt !== undefined
+        ? { resumeAttempt: await hostResumeAttempt(opts.resumeAttempt) }
+        : {}),
       // V13-PR07: the main thread derives the narrow transient resume root from the
       // ORIGINAL session master and passes only that root to the worker — never the master.
       ...(await resumeRootOf(rendezvous)),
@@ -609,4 +626,26 @@ function crypto(r: RendezvousResult): SessionCrypto {
  */
 async function resumeRootOf(r: RendezvousResult): Promise<{ resumeRoot: Uint8Array }> {
   return { resumeRoot: await deriveResumeRoot(r.master) };
+}
+
+/**
+ * V13-PR08: the host-side resume attempt — the persisted credential envelope stays on the
+ * main thread; only the decoded secret crosses into the worker.
+ */
+export interface HostResumeAttempt {
+  transferId: string;
+  manifestFingerprint: string;
+  role: 'offerer' | 'joiner';
+  /** The persisted opaque credential envelope (journal or sender record). */
+  envelope: import('@sendbeam/protocol').ResumeSecretEnvelope;
+}
+
+/** Strictly decode the persisted credential envelope; a missing/invalid one fails closed. */
+async function hostResumeAttempt(a: HostResumeAttempt): Promise<ResumeAttempt> {
+  return {
+    transferId: a.transferId,
+    manifestFingerprint: a.manifestFingerprint,
+    role: a.role,
+    resumeSecret: decodeResumeSecretEnvelope(a.envelope),
+  };
 }

--- a/apps/web/src/lib/transfer/durable-destination.test.ts
+++ b/apps/web/src/lib/transfer/durable-destination.test.ts
@@ -70,6 +70,34 @@ class MemoryStore implements DurableJournalStore {
     }
   }
 
+  async listJournals(): Promise<
+    Array<{
+      transferId: string;
+      kind: 'ok' | 'corrupt';
+      journal?: DurableJournal;
+      error?: string;
+    }>
+  > {
+    const out: Array<{
+      transferId: string;
+      kind: 'ok' | 'corrupt';
+      journal?: DurableJournal;
+      error?: string;
+    }> = [];
+    for (const [transferId, bytes] of this.journals) {
+      try {
+        out.push({ transferId, kind: 'ok', journal: await decodeJournal(bytes) });
+      } catch (e) {
+        out.push({
+          transferId,
+          kind: 'corrupt',
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+    return out;
+  }
+
   async createJournal(
     transferId: string,
     manifest: Manifest,
@@ -384,6 +412,18 @@ function committed(journal: DurableJournal | undefined, fileIdx: number): number
   return journal?.files[fileIdx]?.committedBlocks ?? -1;
 }
 
+/**
+ * V13-PR08: arm an explicit authenticated-resume attempt the way the driver does — the
+ * user pre-selects the interrupted journal (expectResumeFor) and the resume preamble runs
+ * to mutual success (authorizeResume) strictly before `prepare` may reuse its progress.
+ * Tests that exercise the reload-resume mechanics call this before a resumed prepare.
+ */
+function armAuth(d: DurableDestination): DurableDestination {
+  d.expectResumeFor(TRANSFER_ID);
+  d.authorizeResume();
+  return d;
+}
+
 /** Serialized digest state covering exactly `bytes` — what the receiver feeds before each write. */
 function digestStateFor(h: Harness, bytes: Uint8Array): Uint8Array {
   const d = h.digest();
@@ -524,8 +564,9 @@ describe('DurableDestination', () => {
     // Tab crash: the first destination is abandoned (lease lives on via its TTL).
 
     // Reloaded receiver in the same room: same storage, expired lease → stale takeover.
+    // The driver arms an authenticated-resume attempt before prepare reuses the checkpoint.
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const second = h.makeDestination();
+    const second = armAuth(h.makeDestination());
     await second.prepare(m);
     expect(second.durableMeta()?.resumed).toBe(true);
 
@@ -580,7 +621,7 @@ describe('DurableDestination', () => {
     expect(cp?.state).toMatch(/^[0-9a-f]{232}$/); // 116-byte hash-wasm state
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const second = h.makeDestination();
+    const second = armAuth(h.makeDestination());
     await second.prepare(m);
     expect(second.durableMeta()?.resumed).toBe(true);
 
@@ -610,7 +651,7 @@ describe('DurableDestination', () => {
     await journalWithCheckpoint(h.store, j, foreign);
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     await d.prepare(m);
     const file = d.resumeStateFor()?.files.get(0);
     expect(file?.haveBlocks).toBe(2);
@@ -628,7 +669,7 @@ describe('DurableDestination', () => {
     const j2 = await journalFor(h.store, h.files, [['b.bin', 24]], [2]);
     await journalWithCheckpoint(h.store, j2, undecodable);
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d2 = h.makeDestination();
+    const d2 = armAuth(h.makeDestination());
     await d2.prepare(manifest([['b.bin', 24]]));
     const file2 = d2.resumeStateFor()?.files.get(0);
     expect(await file2?.seedDigest.hexDigest()).toBe(bytesToHex(await sha256(persisted)));
@@ -651,7 +692,7 @@ describe('DurableDestination', () => {
     await journalWithCheckpoint(h.store, j, cp);
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     await d.prepare(manifest([['a.bin', 24]]));
     const file = d.resumeStateFor()?.files.get(0);
     // The seed covers the checkpointed state's bytes — trusted, never guessed. The
@@ -680,7 +721,7 @@ describe('DurableDestination', () => {
     h.files.data.set('b.bin', bPrefix);
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     await d.prepare(
       manifest([
         ['a.bin', 24],
@@ -736,7 +777,7 @@ describe('DurableDestination', () => {
     h.files.data.set('a.bin', new Uint8Array(16).fill(0xff));
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     await d.prepare(
       manifest([
         ['a.bin', 24],
@@ -781,7 +822,7 @@ describe('DurableDestination', () => {
     });
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     await d.prepare(
       manifest([
         ['a.bin', 24],
@@ -822,7 +863,7 @@ describe('DurableDestination', () => {
     );
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     await d.prepare(
       manifest([
         ['a.bin', 24],
@@ -894,7 +935,7 @@ describe('DurableDestination', () => {
     h.store.journals.set(TRANSFER_ID, await encodeJournal(advanced));
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
 
     const keys = await deriveTransferKeys(new Uint8Array(32).fill(7));
     const frames: Uint8Array[] = [];
@@ -992,7 +1033,7 @@ describe('DurableDestination', () => {
     h.files.data.set('a.bin', new Uint8Array(16).fill(9));
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     const m = manifest([['a.bin', 24]]);
     await d.prepare(m);
     expect(d.resumeStateFor()?.files.get(0)?.haveBlocks).toBe(1);
@@ -1011,7 +1052,7 @@ describe('DurableDestination', () => {
     h.files.data.delete('a.bin'); // evicted
 
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     await expect(d.prepare(manifest([['a.bin', 24]]))).rejects.toThrow(/missing or truncated/);
     // Nothing was deleted.
     expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
@@ -1020,8 +1061,36 @@ describe('DurableDestination', () => {
     await journalFor(h.store, h.files, [['a.bin', 24]], [2]);
     h.files.data.set('a.bin', new Uint8Array(4));
     h.advance(DURABLE_LEASE_TTL_MS + 1);
-    const d2 = h.makeDestination();
+    const d2 = armAuth(h.makeDestination());
     await expect(d2.prepare(manifest([['a.bin', 24]]))).rejects.toThrow(/missing or truncated/);
+  });
+
+  it('fresh session cannot skip verified blocks merely because transferId + fingerprint match (V13-PR08)', async () => {
+    const h = await harness();
+    // An interrupted transfer leaves a journal with verified committed progress.
+    await journalFor(h.store, h.files, [['a.bin', 24]], [2]);
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+
+    // A FRESH session (no resumeAttempt, no preamble) presents the SAME transferId and
+    // the SAME manifest fingerprint. The gate must fail closed: nothing received, nothing
+    // deleted, the journal untouched — old verified progress is never reused.
+    const fresh = h.makeDestination();
+    await expect(fresh.prepare(manifest([['a.bin', 24]]))).rejects.toThrow(
+      /requires authenticated resume/,
+    );
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(h.files.data.get('a.bin')?.length).toBe(16); // verified prefix intact
+    expect(fresh.durableMeta()?.resumed).toBe(true);
+
+    // The gate does NOT fire for a genuinely fresh transfer (no journal for that id): a
+    // brand-new id is a fresh sender, and its fresh journal has no verified progress at
+    // risk — matching the driver's fresh-path semantics.
+    const otherId = 'b'.repeat(32);
+    const freshM: Manifest = { ...manifest([['a.bin', 24]]), transferId: otherId };
+    const freshTransfer = h.makeDestination();
+    await freshTransfer.prepare(freshM);
+    expect(freshTransfer.durableMeta()?.resumed).toBe(false);
+    await freshTransfer.abort();
   });
 
   it('concurrent tabs: the second receiver fails closed while the lease is held', async () => {
@@ -1054,8 +1123,9 @@ describe('DurableDestination', () => {
     expect(h.files.data.get('a.bin')?.length).toBe(8);
     expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
 
-    // A retry (same or another tab) acquires immediately and resumes from the checkpoint.
-    const retry = h.makeDestination();
+    // A retry (same or another tab) acquires immediately and resumes from the checkpoint;
+    // the driver arms an authenticated-resume attempt for the interrupted journal.
+    const retry = armAuth(h.makeDestination());
     await retry.prepare(m);
     expect(retry.durableMeta()?.resumed).toBe(true);
     await retry.abort();
@@ -1097,7 +1167,7 @@ describe('DurableDestination', () => {
     // flow's abort releases it, mirror that here so the next attempt can acquire.
     await low.abort();
 
-    const d = h.makeDestination();
+    const d = armAuth(h.makeDestination());
     await d.prepare(m);
     h.files.quotaOnWrite = true;
     const sink = await d.open(m.files[0]!);
@@ -1282,8 +1352,9 @@ describe('DurableDestination', () => {
     await first.abort();
 
     // Session 2: a later receive loads the journal as existing/resumed state and attaches
-    // with a DIFFERENT resume root. It must leave the journal without a credential.
-    const second = h.makeDestination();
+    // with a DIFFERENT resume root. It must leave the journal without a credential. The
+    // driver arms an authenticated-resume attempt before prepare may reuse the journal.
+    const second = armAuth(h.makeDestination());
     await second.prepare(m);
     expect(second.durableMeta()?.resumed).toBe(true);
     await second.attachResumeSecret(m, new Uint8Array(32).fill(0x42));
@@ -1351,8 +1422,9 @@ describe('DurableDestination', () => {
     // The active lease was released promptly instead of lingering for the 120s stale TTL.
     expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
 
-    // A retry acquires immediately and finalizes successfully.
-    const retry = h.makeDestination();
+    // A retry acquires immediately and finalizes successfully (authenticated resume armed
+    // by the driver for the interrupted journal).
+    const retry = armAuth(h.makeDestination());
     await retry.prepare(m);
     expect(retry.durableMeta()?.resumed).toBe(true);
     const ra = await retry.open(m.files[0]!);
@@ -1390,8 +1462,9 @@ describe('DurableDestination', () => {
     expect(h.files.data.size).toBe(2);
     expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
 
-    // Immediate retry acquires and completes finalization idempotently.
-    const retry = h.makeDestination();
+    // Immediate retry acquires and completes finalization idempotently (authenticated
+    // resume armed by the driver for the interrupted journal).
+    const retry = armAuth(h.makeDestination());
     await retry.prepare(m);
     expect(retry.durableMeta()?.resumed).toBe(true);
     const ra = await retry.open(m.files[0]!);
@@ -1421,7 +1494,8 @@ describe('DurableDestination', () => {
     expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
 
     // Immediate retry: acquire, finalize, and the resume metadata (journal + lease) is gone.
-    const retry = h.makeDestination();
+    // (Authenticated resume armed by the driver for the interrupted journal.)
+    const retry = armAuth(h.makeDestination());
     await retry.prepare(m);
     expect(retry.durableMeta()?.resumed).toBe(true);
     const resumed = await retry.open(m.files[0]!);

--- a/apps/web/src/lib/transfer/durable-destination.test.ts
+++ b/apps/web/src/lib/transfer/durable-destination.test.ts
@@ -1581,8 +1581,32 @@ describe('createBrowserDestination wrapper (V13-PR08 Blocker 1)', () => {
     wrapper.authorizeResume?.();
     // The session authenticated continuity with the SELECTED journal only; this journal's
     // verified progress is never reused.
-    await expect(wrapper.prepare(m)).rejects.toThrow(/requires authenticated resume/);
+    await expect(wrapper.prepare(m)).rejects.toThrow(
+      /authenticated resume for .* not .*verified progress/,
+    );
     expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+  });
+
+  it('authorizeResume without an expected journal authorizes NOTHING (review Blocker 2)', async () => {
+    const h = await harness();
+    const m = manifest([['a.bin', 24]]);
+    await journalFor(h.store, h.files, [['a.bin', 24]], [2], m);
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const wrapper = createBrowserDestination({ kind: 'auto' }, h.digest, {
+      files: h.files,
+      store: h.store,
+      now: h.now,
+      renewMs: 0,
+      ensureSpace: async () => {},
+    });
+    // A bare authorization with NO selected interrupted journal must authorize nothing:
+    // the existing journal's verified progress stays unreusable.
+    wrapper.authorizeResume?.();
+    await expect(wrapper.prepare(m)).rejects.toThrow(
+      /authorized resume without selecting an interrupted journal/,
+    );
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(h.files.data.get('a.bin')?.length).toBe(16);
   });
 
   it('fresh journal remains ordinary — no auth, no resume state, resume hooks inert', async () => {

--- a/apps/web/src/lib/transfer/durable-destination.test.ts
+++ b/apps/web/src/lib/transfer/durable-destination.test.ts
@@ -29,6 +29,7 @@ import {
 } from '@sendbeam/protocol';
 import { createSha256DigestFactory, type Sha256DigestFactory } from './digest.js';
 import { DurableDestination } from './durable-destination.js';
+import { createBrowserDestination } from './sink.js';
 import {
   DURABLE_LEASE_TTL_MS,
   webDestinationIdentity,
@@ -376,6 +377,7 @@ interface Harness {
   files: MemoryFiles;
   makeDestination: (overrides?: Partial<{ now: () => number }>) => DurableDestination;
   digest: Sha256DigestFactory;
+  now: () => number;
   advance: (ms: number) => void;
 }
 
@@ -401,6 +403,7 @@ async function harness(): Promise<Harness> {
     files,
     makeDestination,
     digest: digestFactory,
+    now,
     advance: (ms) => {
       clock += ms;
     },
@@ -1503,5 +1506,149 @@ describe('DurableDestination', () => {
     await retry.close();
     expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('none');
     expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createBrowserDestination wrapper (V13-PR08 Blocker 1): the wrapper must retain the
+// pre-manifest resume-auth state (expected interrupted journal id + session authorization)
+// and apply it to the lazily-constructed inner DurableDestination strictly before
+// prepare(), or the auth gate is silently dropped and an existing journal's verified
+// progress could be reused unauthenticated.
+// ---------------------------------------------------------------------------
+
+describe('createBrowserDestination wrapper (V13-PR08 Blocker 1)', () => {
+  it('existing journal + expected id + NO auth refuses progress and keeps everything', async () => {
+    const h = await harness();
+    const m = manifest([['a.bin', 24]]);
+    await journalFor(h.store, h.files, [['a.bin', 24]], [2], m);
+    h.advance(DURABLE_LEASE_TTL_MS + 1); // stale lease → takeover, so the auth gate is what refuses
+    const wrapper = createBrowserDestination({ kind: 'auto' }, h.digest, {
+      files: h.files,
+      store: h.store,
+      now: h.now,
+      renewMs: 0,
+      ensureSpace: async () => {},
+    });
+    wrapper.expectResumeFor?.(TRANSFER_ID);
+    await expect(wrapper.prepare(m)).rejects.toThrow(/not authenticated/);
+    // Nothing was received or deleted: journal + partials survive the refusal. The lease
+    // acquired during prepare is released by the fail-closed gate so a later authenticated
+    // attempt can acquire it immediately (never lingering for the stale TTL).
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+    expect(h.files.data.get('a.bin')?.length).toBe(16);
+    expect(h.store.leases.has(TRANSFER_ID)).toBe(false);
+  });
+
+  it('existing journal + successful auth state reuses the checkpoint', async () => {
+    const h = await harness();
+    const m = manifest([['a.bin', 24]]);
+    await journalFor(h.store, h.files, [['a.bin', 24]], [2], m);
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const wrapper = createBrowserDestination({ kind: 'auto' }, h.digest, {
+      files: h.files,
+      store: h.store,
+      now: h.now,
+      renewMs: 0,
+      ensureSpace: async () => {},
+    });
+    wrapper.expectResumeFor?.(TRANSFER_ID);
+    wrapper.authorizeResume?.();
+    await wrapper.prepare(m);
+    expect(wrapper.durableMeta?.()?.resumed).toBe(true);
+    // The authenticated checkpoint surfaces immediately: haveBlocks 2, seed digest covering
+    // the persisted prefix — before any new block arrives.
+    const resume = wrapper.resumeStateFor?.(m);
+    expect(resume?.transferId).toBe(TRANSFER_ID);
+    expect(resume?.files.get(0)?.haveBlocks).toBe(2);
+  });
+
+  it('wrong expected transfer id refuses reuse of that journal', async () => {
+    const h = await harness();
+    const m = manifest([['a.bin', 24]]);
+    await journalFor(h.store, h.files, [['a.bin', 24]], [2], m);
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const wrapper = createBrowserDestination({ kind: 'auto' }, h.digest, {
+      files: h.files,
+      store: h.store,
+      now: h.now,
+      renewMs: 0,
+      ensureSpace: async () => {},
+    });
+    // The user selected a DIFFERENT interrupted transfer; authorization for it must not
+    // authorize this journal's progress.
+    wrapper.expectResumeFor?.('f'.repeat(32));
+    wrapper.authorizeResume?.();
+    // The session authenticated continuity with the SELECTED journal only; this journal's
+    // verified progress is never reused.
+    await expect(wrapper.prepare(m)).rejects.toThrow(/requires authenticated resume/);
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+  });
+
+  it('fresh journal remains ordinary — no auth, no resume state, resume hooks inert', async () => {
+    const h = await harness();
+    const m = manifest([['a.bin', 24]]);
+    const wrapper = createBrowserDestination({ kind: 'auto' }, h.digest, {
+      files: h.files,
+      store: h.store,
+      now: h.now,
+      renewMs: 0,
+      ensureSpace: async () => {},
+    });
+    // No resume attempt armed: a fresh receive must not need authorization or a seed.
+    await wrapper.prepare(m);
+    expect(wrapper.durableMeta?.()?.resumed).toBe(false);
+    expect(wrapper.resumeStateFor?.(m)).toBeUndefined();
+    expect((await h.store.loadJournal(TRANSFER_ID)).kind).toBe('ok');
+  });
+
+  it('authorization cannot leak to another destination/transfer', async () => {
+    const h = await harness();
+    const m = manifest([['a.bin', 24]]);
+    await journalFor(h.store, h.files, [['a.bin', 24]], [2], m);
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    const authorized = createBrowserDestination({ kind: 'auto' }, h.digest, {
+      files: h.files,
+      store: h.store,
+      now: h.now,
+      renewMs: 0,
+      ensureSpace: async () => {},
+    });
+    authorized.expectResumeFor?.(TRANSFER_ID);
+    authorized.authorizeResume?.();
+    await authorized.prepare(m); // this session authenticated → reuses the checkpoint
+    // Let the authorized session's lease lapse (its renew timer is disabled).
+    h.advance(DURABLE_LEASE_TTL_MS + 1);
+    // A SECOND wrapper for the same journal, in a fresh (unauthorized) session, must still
+    // refuse — authorization is per-destination/session, never global storage state.
+    const fresh = createBrowserDestination({ kind: 'auto' }, h.digest, {
+      files: h.files,
+      store: h.store,
+      now: h.now,
+      renewMs: 0,
+      ensureSpace: async () => {},
+    });
+    fresh.expectResumeFor?.(TRANSFER_ID);
+    await expect(fresh.prepare(m)).rejects.toThrow(/not authenticated/);
+  });
+
+  it('an armed journal resume cannot silently target a direct-file or direct-directory save', async () => {
+    const h = await harness();
+    const m = manifest([['a.bin', 24]]);
+    const fileWrapper = createBrowserDestination(
+      { kind: 'direct-file', handle: {} as FileSystemFileHandle },
+      h.digest,
+    );
+    fileWrapper.expectResumeFor?.(TRANSFER_ID);
+    await expect(fileWrapper.prepare(m)).rejects.toThrow(/cannot target a single-file save/);
+    const dirWrapper = createBrowserDestination(
+      { kind: 'direct-directory', handle: {} as FileSystemDirectoryHandle },
+      h.digest,
+    );
+    dirWrapper.expectResumeFor?.(TRANSFER_ID);
+    await expect(dirWrapper.prepare(m)).rejects.toThrow(/cannot target a folder save/);
+    // Nothing was written or deleted.
+    expect(h.store.journals.size).toBe(0);
+    expect(h.files.data.size).toBe(0);
   });
 });

--- a/apps/web/src/lib/transfer/durable-destination.ts
+++ b/apps/web/src/lib/transfer/durable-destination.ts
@@ -209,20 +209,16 @@ export class DurableDestination implements BrowserDestination {
       );
     }
 
-    // V13-PR08: an interrupted journal's verified progress may be reused ONLY after
-    // successful resume-auth in this session. A fresh rendezvous authenticates the NEW
-    // session only; it does not prove continuity with the original transfer peer. Failing
-    // closed here is what makes a fresh session unable to skip old blocks merely because
-    // the transfer id + fingerprint match. The gate protects the PRE-SELECTED journal only:
-    // a manifest whose id differs from the expected resume id is a genuinely fresh sender,
-    // and its fresh journal has no verified progress at risk.
-    // The session authorization is SCOPED to the pre-selected journal: mutual resume-auth
-    // proved continuity with the peer for the SELECTED interrupted transfer only. A manifest
-    // carrying a DIFFERENT id that happens to have its own journal must never reuse that
-    // journal's verified progress — the auth bound a different transcript. A resumed journal
-    // with no authorization (or authorization for another journal) fails closed.
+    // V13-PR08 (review Blocker 2): an interrupted journal's verified progress may be reused
+    // ONLY for the journal THIS session authenticated a resume for. Successful auth for A
+    // must never authorize an existing journal B, and authorization with NO selected
+    // journal authorizes NOTHING. A fresh rendezvous authenticates the NEW session only;
+    // it does not prove continuity with the original transfer peer. Failing closed here is
+    // what makes a fresh session unable to skip old blocks merely because the transfer id +
+    // fingerprint match. A fresh journal created this session has no verified progress at
+    // risk and is never gated.
     const authorizedForThisJournal =
-      this.resumeAuthorized && (this.expectResume === '' || this.expectResume === this.transferId);
+      this.resumeAuthorized && this.expectResume !== '' && this.expectResume === this.transferId;
     if (this.resumed && !authorizedForThisJournal) {
       // The lease acquired above must not linger for a stale TTL after a fail-closed gate;
       // release it so a later authenticated resume attempt can acquire immediately.
@@ -231,6 +227,18 @@ export class DurableDestination implements BrowserDestination {
         throw new TransferError(
           'sink_error',
           `resume of ${this.transferId} was not authenticated in this session; refusing to reuse its verified progress — nothing was received or deleted. Start an authenticated resume so both peers authenticate first`,
+        );
+      }
+      if (this.resumeAuthorized && this.expectResume !== '') {
+        throw new TransferError(
+          'sink_error',
+          `this session authenticated resume for ${this.expectResume}, not ${this.transferId}; refusing to reuse ${this.transferId}'s verified progress — nothing was received or deleted. Start an authenticated resume for that transfer instead`,
+        );
+      }
+      if (this.resumeAuthorized) {
+        throw new TransferError(
+          'sink_error',
+          `this session authorized resume without selecting an interrupted journal; refusing to reuse ${this.transferId}'s verified progress — nothing was received or deleted`,
         );
       }
       throw new TransferError(

--- a/apps/web/src/lib/transfer/durable-destination.ts
+++ b/apps/web/src/lib/transfer/durable-destination.ts
@@ -96,6 +96,10 @@ export class DurableDestination implements BrowserDestination {
   private journal: DurableJournal | undefined;
   private transferId = '';
   private resumed = false;
+  // V13-PR08: an explicit authenticated-resume attempt pre-selects its interrupted journal;
+  // until resume-auth succeeds in THIS session, that journal's progress is never trusted.
+  private expectResume = '';
+  private resumeAuthorized = false;
   private sync = true;
   private readonly sinks = new Map<number, DurableFileSink>();
   private renewTimer: ReturnType<typeof setInterval> | undefined;
@@ -110,6 +114,24 @@ export class DurableDestination implements BrowserDestination {
     this.renewMs = options.renewMs ?? DURABLE_LEASE_RENEW_MS;
     this.ensureSpace =
       options.ensureSpace ?? ((required: number) => ensureSpaceInBrowser(required));
+  }
+
+  /**
+   * V13-PR08: mark this receive as an explicit authenticated-resume attempt for the
+   * interrupted journal `transferId` (the user pre-selected it locally). Until resume-auth
+   * succeeds in this session, the journal's verified progress is never reused.
+   */
+  expectResumeFor(transferId: string): void {
+    this.expectResume = transferId;
+  }
+
+  /**
+   * V13-PR08: records that mutual resume-auth completed in THIS session; only then may the
+   * pre-selected interrupted journal's verified progress be reused. A fresh receive without
+   * a pre-selected journal never needs it.
+   */
+  authorizeResume(): void {
+    this.resumeAuthorized = true;
   }
 
   /** Revalidate the manifest, load/create the journal, acquire the lease, build the resume seed. */
@@ -176,12 +198,37 @@ export class DurableDestination implements BrowserDestination {
     }
 
     // Atomic test-and-set lease: concurrent tabs and stale holders fail closed; an expired
-    // lease is taken over deterministically.
+    // lease is taken over deterministically. Checked BEFORE the resume-auth gate so a live
+    // concurrent receiver reports the true conflict instead of a misleading auth error; both
+    // paths fail closed and never reuse verified progress.
     const lease = await this.store.acquireLease(this.transferId, this.ownerId, this.now());
     if (lease.kind === 'contended') {
       throw new TransferError(
         'sink_error',
         'another window is already receiving this transfer; close it before retrying',
+      );
+    }
+
+    // V13-PR08: an interrupted journal's verified progress may be reused ONLY after
+    // successful resume-auth in this session. A fresh rendezvous authenticates the NEW
+    // session only; it does not prove continuity with the original transfer peer. Failing
+    // closed here is what makes a fresh session unable to skip old blocks merely because
+    // the transfer id + fingerprint match. The gate protects the PRE-SELECTED journal only:
+    // a manifest whose id differs from the expected resume id is a genuinely fresh sender,
+    // and its fresh journal has no verified progress at risk.
+    if (this.resumed && !this.resumeAuthorized) {
+      // The lease acquired above must not linger for a stale TTL after a fail-closed gate;
+      // release it so a later authenticated resume attempt can acquire immediately.
+      await this.store.releaseLease(this.transferId, this.ownerId).catch(() => {});
+      if (this.expectResume !== '' && this.expectResume === this.transferId) {
+        throw new TransferError(
+          'sink_error',
+          `resume of ${this.transferId} was not authenticated in this session; refusing to reuse its verified progress — nothing was received or deleted. Start an authenticated resume so both peers authenticate first`,
+        );
+      }
+      throw new TransferError(
+        'sink_error',
+        `transfer ${this.transferId} has verified partial data kept from an interrupted transfer; resuming it requires authenticated resume — nothing was received or deleted`,
       );
     }
 

--- a/apps/web/src/lib/transfer/durable-destination.ts
+++ b/apps/web/src/lib/transfer/durable-destination.ts
@@ -216,7 +216,14 @@ export class DurableDestination implements BrowserDestination {
     // the transfer id + fingerprint match. The gate protects the PRE-SELECTED journal only:
     // a manifest whose id differs from the expected resume id is a genuinely fresh sender,
     // and its fresh journal has no verified progress at risk.
-    if (this.resumed && !this.resumeAuthorized) {
+    // The session authorization is SCOPED to the pre-selected journal: mutual resume-auth
+    // proved continuity with the peer for the SELECTED interrupted transfer only. A manifest
+    // carrying a DIFFERENT id that happens to have its own journal must never reuse that
+    // journal's verified progress — the auth bound a different transcript. A resumed journal
+    // with no authorization (or authorization for another journal) fails closed.
+    const authorizedForThisJournal =
+      this.resumeAuthorized && (this.expectResume === '' || this.expectResume === this.transferId);
+    if (this.resumed && !authorizedForThisJournal) {
       // The lease acquired above must not linger for a stale TTL after a fail-closed gate;
       // release it so a later authenticated resume attempt can acquire immediately.
       await this.store.releaseLease(this.transferId, this.ownerId).catch(() => {});

--- a/apps/web/src/lib/transfer/durable-store.test.ts
+++ b/apps/web/src/lib/transfer/durable-store.test.ts
@@ -63,6 +63,9 @@ class FakeObjectStore {
   getAll(): FakeRequest {
     return this.tx.request(() => [...this.data.values()]);
   }
+  getAllKeys(): FakeRequest {
+    return this.tx.request(() => [...this.data.keys()]);
+  }
 }
 
 class FakeTransaction {
@@ -241,6 +244,33 @@ describe('indexedDbDurableStore', () => {
     // Still present for explicit discard.
     const again = await s.loadJournal(TRANSFER_ID);
     expect(again.kind).toBe('corrupt');
+  });
+
+  it('lists interrupted receives: valid + corrupt journals, never guessing (V13-PR08)', async () => {
+    const s = store();
+    // One healthy interrupted receive with committed progress.
+    await s.createJournal(
+      TRANSFER_ID,
+      manifest([['a.bin', 16]]),
+      { version: 1, value: '0'.repeat(64) },
+      { version: 1, value: '1'.repeat(64) },
+      1_000,
+    );
+    // One corrupt journal under a second id, for explicit discard.
+    const otherId = 'bb'.repeat(16);
+    const idb = (globalThis as unknown as { indexedDB: FakeIndexedDB }).indexedDB;
+    const tx = idb.db.transaction(['journals'], 'readwrite');
+    tx.objectStore('journals').put(new Uint8Array([9, 9, 9]), otherId);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const listed = await s.listJournals();
+    expect(listed).toHaveLength(2);
+    const healthy = listed.find((e) => e.transferId === TRANSFER_ID)!;
+    expect(healthy.kind).toBe('ok');
+    expect(healthy.journal?.files[0]?.committedBlocks).toBe(0);
+    const corrupt = listed.find((e) => e.transferId === otherId)!;
+    expect(corrupt.kind).toBe('corrupt');
+    expect(corrupt.error).toBeDefined();
   });
 
   it('advances a checkpoint only when the caller still owns the lease', async () => {

--- a/apps/web/src/lib/transfer/durable-store.ts
+++ b/apps/web/src/lib/transfer/durable-store.ts
@@ -129,6 +129,14 @@ export type JournalLoad =
 /** Transactional journal + lease metadata store. All writes are atomic IDB transactions. */
 export interface DurableJournalStore {
   loadJournal(transferId: string): Promise<JournalLoad>;
+  /**
+   * Enumerate locally interrupted receive journals (V13-PR08). Corrupt journals are reported
+   * with `kind: 'corrupt'` so the UI can offer explicit discard instead of guessing. This is
+   * deliberately the ONLY discovery surface — there is no server-side transfer directory.
+   */
+  listJournals(): Promise<
+    Array<{ transferId: string; kind: 'ok' | 'corrupt'; journal?: DurableJournal; error?: string }>
+  >;
   /** Create and persist a fresh zero-checkpoint journal (validates + encodes). */
   createJournal(
     transferId: string,
@@ -205,6 +213,7 @@ interface IDBObjectStoreLike {
   put(value: unknown, key: string): IDBRequestLike;
   delete(key: string): IDBRequestLike;
   getAll(): IDBRequestLike<unknown[]>;
+  getAllKeys(): IDBRequestLike<unknown[]>;
 }
 interface IDBTransactionLike {
   objectStore(name: string): IDBObjectStoreLike;
@@ -234,6 +243,22 @@ function transactionDone(tx: IDBTransactionLike): Promise<void> {
     tx.onerror = () => reject(new Error('indexeddb transaction failed'));
     tx.onabort = () => reject(new Error('indexeddb transaction aborted'));
   });
+}
+
+/**
+ * Recover the transferId from an encoded journal WITHOUT full validation, so a corrupt
+ * journal can still be listed and explicitly discarded (never guessed, never repaired).
+ * Returns '' when the bytes are not a journal-shaped record.
+ */
+function encodedJournalTransferId(bytes: Uint8Array): string {
+  try {
+    const obj = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+    const id = obj.transferId;
+    if (typeof id !== 'string') return '';
+    return /^[0-9a-f]{32}$/.test(id) ? id : '';
+  } catch {
+    return '';
+  }
 }
 
 /** The browser journal/lease store over IndexedDB. */
@@ -284,6 +309,51 @@ class IndexedDbDurableStore implements DurableJournalStore {
     } catch (e) {
       return { kind: 'corrupt', error: e instanceof Error ? e.message : String(e) };
     }
+  }
+
+  async listJournals(): Promise<
+    Array<{ transferId: string; kind: 'ok' | 'corrupt'; journal?: DurableJournal; error?: string }>
+  > {
+    const db = await this.db();
+    const tx = db.transaction([DURABLE_JOURNALS_STORE], 'readonly');
+    // The completion promise is created BEFORE issuing requests so the oncomplete handler is
+    // registered before the transaction can complete (see attachResumeSecret for the same
+    // ordering rule).
+    const done = transactionDone(tx);
+    const store = tx.objectStore(DURABLE_JOURNALS_STORE);
+    // Zip keys and values in one readonly transaction. The IndexedDB key IS the transferId
+    // (all journal writes key by it), so even a fully unparseable corrupt entry keeps its id
+    // for explicit discard — nothing is guessed or repaired.
+    const [keys, all] = (await Promise.all([
+      requestResult(store.getAllKeys()),
+      requestResult(store.getAll()),
+    ])) as [unknown[], unknown[]];
+    await done;
+    const out: Array<{
+      transferId: string;
+      kind: 'ok' | 'corrupt';
+      journal?: DurableJournal;
+      error?: string;
+    }> = [];
+    for (let i = 0; i < Math.max(keys.length, all.length); i++) {
+      const key = keys[i];
+      const entry = all[i];
+      const transferId =
+        typeof key === 'string' && /^[0-9a-f]{32}$/.test(key)
+          ? key
+          : encodedJournalTransferId(journalBytes(entry));
+      if (transferId === '') continue; // not a journal-shaped record; skip silently
+      try {
+        out.push({ transferId, kind: 'ok', journal: await decodeJournal(journalBytes(entry)) });
+      } catch (e) {
+        out.push({
+          transferId,
+          kind: 'corrupt',
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+    return out;
   }
 
   async createJournal(

--- a/apps/web/src/lib/transfer/progress.test.ts
+++ b/apps/web/src/lib/transfer/progress.test.ts
@@ -38,4 +38,74 @@ describe('ProgressTracker', () => {
     expect(resumed.rateBps).toBe(1000);
     expect(resumed.etaSeconds).toBe(2);
   });
+
+  // V13-PR08 progress contract: verified = reused + session, the checkpoint is surfaced
+  // before the first new block, and the rate/ETA measure only this session's advancement.
+  describe('resumed transfers (V13-PR08)', () => {
+    it('surfaces the verified checkpoint immediately and anchors the session rate on it', () => {
+      let now = 0;
+      const tracker = new ProgressTracker(100_000, () => now);
+      // The engine reports the reused baseline BEFORE the first new block is ACKed.
+      now = 1000;
+      tracker.setReused(68_000);
+      const baseline = tracker.snapshot();
+      expect(baseline.bytes).toBe(0); // no verified bytes reported yet
+      expect(baseline.reusedBytes).toBe(68_000);
+      expect(baseline.sessionBytes).toBe(0);
+      // The first verified sample lands exactly on the checkpoint.
+      now = 2000;
+      const first = tracker.update(68_000);
+      expect(first.bytes).toBe(68_000);
+      expect(first.reusedBytes).toBe(68_000);
+      expect(first.sessionBytes).toBe(0);
+      expect(first.rateBps).toBe(0); // the reused jump is NOT a transfer rate
+      // A new block is durably ACKed this session.
+      now = 3000;
+      const second = tracker.update(69_000);
+      expect(second.bytes).toBe(69_000);
+      expect(second.reusedBytes).toBe(68_000);
+      expect(second.sessionBytes).toBe(1000);
+      // 1000 bytes over 1s: the rate measures ONLY the session advancement.
+      expect(second.rateBps).toBe(1000);
+      expect(second.etaSeconds).toBe(31); // remaining verified / session rate
+    });
+
+    it('never regresses below the verified checkpoint and never counts stale callbacks', () => {
+      let now = 0;
+      const tracker = new ProgressTracker(100_000, () => now);
+      now = 1000;
+      tracker.setReused(68_000);
+      tracker.update(68_000);
+      now = 2000;
+      tracker.update(69_000);
+      // A stale callback below the checkpoint cannot move verified backwards.
+      now = 3000;
+      expect(tracker.update(50_000).bytes).toBe(69_000);
+      expect(tracker.snapshot().sessionBytes).toBe(1000);
+    });
+
+    it('zero-byte resume: 100% verified, 0 session bytes before terminal presentation', () => {
+      let now = 0;
+      const tracker = new ProgressTracker(68_000, () => now);
+      now = 1000;
+      tracker.setReused(68_000);
+      const snapshot = tracker.update(68_000);
+      expect(snapshot.bytes).toBe(68_000);
+      expect(snapshot.reusedBytes).toBe(68_000);
+      expect(snapshot.sessionBytes).toBe(0);
+      expect(snapshot.rateBps).toBe(0);
+      // ETA: no remaining verified bytes and no session rate — nothing left to transfer.
+      expect(snapshot.etaSeconds).toBeUndefined();
+    });
+
+    it('fresh transfers keep reusedBytes at zero and unchanged semantics', () => {
+      let now = 0;
+      const tracker = new ProgressTracker(1000, () => now);
+      tracker.update(0);
+      now = 1000;
+      const snapshot = tracker.update(500);
+      expect(snapshot.reusedBytes).toBe(0);
+      expect(snapshot.sessionBytes).toBe(500);
+    });
+  });
 });

--- a/apps/web/src/lib/transfer/progress.ts
+++ b/apps/web/src/lib/transfer/progress.ts
@@ -1,7 +1,12 @@
 import type { TransferRunState } from '@sendbeam/protocol';
 
 export interface TransferSnapshot {
+  /** Verified high-water (ACKed) bytes; on a resume this includes the reused baseline. */
   bytes: number;
+  /** Verified baseline reused from the authenticated durable checkpoint at resume start. */
+  reusedBytes: number;
+  /** New bytes durably ACKed during THIS session: bytes - reusedBytes (never negative). */
+  sessionBytes: number;
   total: number | undefined;
   rateBps: number;
   etaSeconds: number | undefined;
@@ -19,6 +24,10 @@ interface Sample {
  */
 export class ProgressTracker {
   private bytes = 0;
+  // V13-PR08: verified baseline reused from the authenticated durable checkpoint. Anchored
+  // by setReused BEFORE the first new block, so the first rate sample sits exactly on the
+  // checkpoint and the reused jump is never counted as transferred bytes.
+  private reusedBytes = 0;
   private totalBytes: number | undefined;
   private rateBps = 0;
   private state: TransferRunState = 'running';
@@ -34,6 +43,15 @@ export class ProgressTracker {
 
   setTotal(total: number): void {
     this.totalBytes = total;
+  }
+
+  /**
+   * V13-PR08: anchor the verified baseline reused from the authenticated durable
+   * checkpoint. The engine reports it once, before the first new block is ACKed, so the
+   * session rate measures only this session's advancement (never the reused jump).
+   */
+  setReused(reused: number): void {
+    this.reusedBytes = Math.max(0, reused);
   }
 
   update(acknowledgedBytes: number): TransferSnapshot {
@@ -70,6 +88,8 @@ export class ProgressTracker {
         : undefined;
     return {
       bytes: this.bytes,
+      reusedBytes: this.reusedBytes,
+      sessionBytes: Math.max(0, this.bytes - this.reusedBytes),
       total: this.totalBytes,
       rateBps: this.rateBps,
       etaSeconds,

--- a/apps/web/src/lib/transfer/sink.ts
+++ b/apps/web/src/lib/transfer/sink.ts
@@ -8,7 +8,12 @@ import {
 } from '@sendbeam/protocol';
 import { streamSink, type WritableFileLike } from './stream-sink.js';
 import { DurableDestination, type DurableMeta } from './durable-destination.js';
-import { durableOpfsFiles, indexedDbDurableStore } from './durable-store.js';
+import {
+  durableOpfsFiles,
+  indexedDbDurableStore,
+  type DurableFiles,
+  type DurableJournalStore,
+} from './durable-store.js';
 import {
   centralHeader,
   crc32Update,
@@ -56,26 +61,68 @@ export interface BrowserDestination extends Destination {
 export function createBrowserDestination(
   spec: ReceiveDestinationSpec,
   createDigest?: Sha256DigestFactory,
+  durable?: {
+    files?: DurableFiles;
+    store?: DurableJournalStore;
+    now?(): number;
+    renewMs?: number;
+    ensureSpace?(requiredBytes: number): Promise<void>;
+  },
 ): BrowserDestination {
   let inner: BrowserDestination | undefined;
+  // V13-PR08: pre-manifest resume-auth state retained by the WRAPPER until the inner
+  // destination is constructed at prepare(). The inner DurableDestination is created lazily
+  // there, so these seams cannot be plain forwards: the expected interrupted journal id is
+  // applied strictly before inner.prepare(), and session authorization only if this session
+  // actually authenticated (never because an id/fingerprint/journal/secret merely exists).
+  let expectedResumeTransferId = '';
+  let resumeAuthorizedThisSession = false;
   const get = (): BrowserDestination => {
     if (!inner) throw new TransferError('sink_error', 'destination used before manifest');
     return inner;
   };
   return {
     async prepare(manifest) {
-      if (spec.kind === 'direct-file') inner = new DirectFileDestination(spec.handle);
-      else if (spec.kind === 'direct-directory')
+      if (spec.kind === 'direct-file') {
+        // An armed authenticated-journal resume must never silently target a fresh save:
+        // the journal + partial storage IS the destination for that attempt (V13-PR08).
+        if (expectedResumeTransferId !== '') {
+          throw new TransferError(
+            'sink_error',
+            'authenticated journal resume cannot target a single-file save; resume into the kept partial data or discard the interrupted transfer first',
+          );
+        }
+        inner = new DirectFileDestination(spec.handle);
+      } else if (spec.kind === 'direct-directory') {
+        if (expectedResumeTransferId !== '') {
+          throw new TransferError(
+            'sink_error',
+            'authenticated journal resume cannot target a folder save; resume into the kept partial data or discard the interrupted transfer first',
+          );
+        }
         inner = new DirectDirectoryDestination(spec.handle);
-      else if (manifest.transferId !== undefined) {
+      } else if (manifest.transferId !== undefined) {
         if (!createDigest) {
           throw new TransferError('sink_error', 'durable receive requires a digest factory');
         }
-        inner = new DurableDestination({
+        const durableDestination = new DurableDestination({
           createDigest,
-          files: durableOpfsFiles(),
-          store: indexedDbDurableStore(),
+          files: durable?.files ?? durableOpfsFiles(),
+          store: durable?.store ?? indexedDbDurableStore(),
+          ...(durable?.now !== undefined ? { now: durable.now } : {}),
+          ...(durable?.renewMs !== undefined ? { renewMs: durable.renewMs } : {}),
+          ...(durable?.ensureSpace !== undefined ? { ensureSpace: durable.ensureSpace } : {}),
         });
+        // V13-PR08: apply the pre-manifest resume-auth state to the REAL destination
+        // strictly before prepare(): the expected interrupted journal id first, then the
+        // session authorization ONLY if this session actually authenticated.
+        if (expectedResumeTransferId !== '') {
+          durableDestination.expectResumeFor(expectedResumeTransferId);
+        }
+        if (resumeAuthorizedThisSession) {
+          durableDestination.authorizeResume();
+        }
+        inner = durableDestination;
       } else if (manifest.files.length === 1 && !manifest.files[0]!.name.includes('/')) {
         inner = new OpfsFileDestination();
       } else {
@@ -88,6 +135,9 @@ export function createBrowserDestination(
     abort: (reason) => get().abort(reason),
     result: () => inner?.result(),
     durableMeta: () => inner?.durableMeta?.(),
+    // Forwarded lazily: the inner destination exists only after prepare(manifest), and the
+    // resume seed is only meaningful for the durable destination.
+    resumeStateFor: (manifest) => inner?.resumeStateFor?.(manifest),
     // Credential attachment is meaningful ONLY for a durable journal-backed destination.
     // Direct-file/direct-directory/legacy OPFS/archive destinations do not implement it, and
     // the seam is genuinely absent for them: the resume root being present must never make an
@@ -97,6 +147,39 @@ export function createBrowserDestination(
       const target = inner;
       if (!target?.attachResumeSecret) return Promise.resolve();
       return target.attachResumeSecret(manifest, resumeRoot);
+    },
+    /**
+     * V13-PR08: mark this receive as an explicit authenticated-resume attempt for the
+     * interrupted journal `transferId`. Before prepare() the wrapper records it and applies
+     * it to the durable destination it constructs; after prepare() it forwards to the inner
+     * destination and fails closed when the inner one is not durable — the semantics are
+     * never silently dropped.
+     */
+    expectResumeFor(transferId) {
+      if (inner !== undefined) {
+        const target = inner;
+        if (!target.expectResumeFor) {
+          throw new TransferError(
+            'sink_error',
+            'an interrupted-journal resume cannot target this destination; nothing was received or deleted',
+          );
+        }
+        target.expectResumeFor(transferId);
+        return;
+      }
+      expectedResumeTransferId = transferId;
+    },
+    /**
+     * V13-PR08: record that mutual resume-auth completed in THIS session. Applied to the
+     * durable destination before prepare() only when this session actually authenticated;
+     * a matching id/fingerprint/journal/secret alone never authorizes reuse.
+     */
+    authorizeResume() {
+      if (inner !== undefined) {
+        inner.authorizeResume?.();
+        return;
+      }
+      resumeAuthorizedThisSession = true;
     },
   };
 }

--- a/apps/web/src/lib/transfer/sink.ts
+++ b/apps/web/src/lib/transfer/sink.ts
@@ -35,6 +35,17 @@ export interface BrowserDestination extends Destination {
    * transient root derived by the main thread — never the session master.
    */
   attachResumeSecret?(manifest: Manifest, resumeRoot: Uint8Array): Promise<void>;
+  /**
+   * V13-PR08: mark this receive as an explicit authenticated-resume attempt for the
+   * interrupted journal `transferId`. Until resume-auth succeeds in THIS session, the
+   * journal's verified progress is never trusted.
+   */
+  expectResumeFor?(transferId: string): void;
+  /**
+   * V13-PR08: record that mutual resume-auth completed in this session; only then may the
+   * pre-selected interrupted journal's verified progress be reused.
+   */
+  authorizeResume?(): void;
 }
 
 /**

--- a/apps/web/src/lib/transfer/transfer-core.test.ts
+++ b/apps/web/src/lib/transfer/transfer-core.test.ts
@@ -5,6 +5,7 @@ import {
   bytesToHex,
   MemorySink,
   FrameType,
+  manifestFingerprint,
   type Manifest,
 } from '@sendbeam/protocol';
 import { runTransferCore, type TransferCoreDeps } from './transfer-core.js';
@@ -415,6 +416,178 @@ describe('sender-record seam (V13-PR04)', () => {
     expect(record.updatedAt).toBeGreaterThan(1_000);
     // ...and removed after verified success.
     await expect(store.list()).resolves.toEqual([]);
+  });
+
+  it('runs resume-auth-v1 through the worker protocol before reusing the interrupted id (V13-PR08)', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(23));
+    const bytes = new Uint8Array(50 * 1024).map((_, i) => (i * 29) & 0xff);
+    const file = new File([bytes], 'resumed.bin', { type: 'application/octet-stream' });
+    const id = 'ff'.repeat(16);
+    // Both peers hold the SAME persisted transfer-scoped credential from the interrupted
+    // session; the attempt binds transferId + manifest fingerprint + secret.
+    const secret = new Uint8Array(32).fill(0x42);
+    const manifest: Manifest = {
+      type: FrameType.Manifest,
+      transferId: id,
+      files: [
+        {
+          idx: 0,
+          name: 'resumed.bin',
+          size: file.size,
+          mime: 'application/octet-stream',
+          lastModified: 0,
+          blockSize: 64 * 1024,
+          blocks: Math.ceil(file.size / (64 * 1024)),
+          fileDigest: bytesToHex(await sha256(bytes)),
+        },
+      ],
+      totalSize: file.size,
+    };
+    const fingerprint = await manifestFingerprint(manifest);
+
+    const sendPort = new FakePort();
+    const recvPort = new FakePort();
+    const sink = new MemorySink();
+    let manifestSeen: Extract<WorkerToHost, { kind: 'manifest' }> | undefined;
+    sendPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') recvPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+    };
+    recvPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') sendPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+      else if (m.kind === 'manifest') manifestSeen = m;
+    };
+    const recvP = runTransferCore(recvPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => sink,
+      fileSource: blobFileSource,
+    });
+    const sendP = runTransferCore(sendPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: blobFileSource,
+    });
+
+    recvPort.toWorker({
+      kind: 'start-recv',
+      destination: { kind: 'auto' },
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounter: 1,
+      recvCounter: 1,
+      resumeAttempt: {
+        transferId: id,
+        manifestFingerprint: fingerprint,
+        role: 'joiner',
+        resumeSecret: secret,
+      },
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      files: [file],
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+      blockSize: 64 * 1024,
+      frameSize: 16 * 1024,
+      resumeAttempt: {
+        transferId: id,
+        manifestFingerprint: fingerprint,
+        role: 'offerer',
+        resumeSecret: secret,
+      },
+    });
+    await Promise.all([recvP, sendP]);
+
+    // The manifest carries the INTERRUPTED id (never re-minted): the preamble ran to mutual
+    // success and the transfer proceeded under the fresh resumed key epoch.
+    expect(manifestSeen?.files[0]?.name).toBe('resumed.bin');
+    expect(manifestSeen?.totalSize).toBe(bytes.length);
+    expect(sink.bytes()).toEqual(bytes);
+  });
+
+  it('fails closed when the resumed peer holds a different credential (V13-PR08)', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(31));
+    const bytes = new Uint8Array(10 * 1024).map((_, i) => (i * 3) & 0xff);
+    const file = new File([bytes], 'x.bin');
+    const id = 'ab'.repeat(16);
+    const fingerprint = 'a'.repeat(64);
+
+    const sendPort = new FakePort();
+    const recvPort = new FakePort();
+    const sink = new MemorySink();
+    sendPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') recvPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+    };
+    recvPort.onWorkerOut = (m) => {
+      if (m.kind === 'outbound-frame') sendPort.toWorker({ kind: 'inbound-frame', frame: m.frame });
+    };
+    const recvP = runTransferCore(recvPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => sink,
+      fileSource: blobFileSource,
+    });
+    const sendP = runTransferCore(sendPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: blobFileSource,
+    });
+
+    recvPort.toWorker({
+      kind: 'start-recv',
+      destination: { kind: 'auto' },
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounter: 1,
+      recvCounter: 1,
+      resumeAttempt: {
+        transferId: id,
+        manifestFingerprint: fingerprint,
+        role: 'joiner',
+        resumeSecret: new Uint8Array(32).fill(1), // WRONG credential
+      },
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      files: [file],
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+      resumeAttempt: {
+        transferId: id,
+        manifestFingerprint: fingerprint,
+        role: 'offerer',
+        resumeSecret: new Uint8Array(32).fill(2), // WRONG credential
+      },
+    });
+    // One-sided failure propagates via the sealed channel teardown in production, which
+    // cancels the peer's context. The fake-port harness has no transport teardown, so mirror
+    // production: race for the first side to settle (the auth-failing side rejects), then
+    // cancel the peer so both settle deterministically instead of one waiting forever.
+    const first = await Promise.race([
+      sendP.then(
+        () => 'send' as const,
+        () => 'send' as const,
+      ),
+      recvP.then(
+        () => 'recv' as const,
+        () => 'recv' as const,
+      ),
+    ]);
+    if (first === 'send') {
+      recvPort.toWorker({ kind: 'cancel' });
+      await recvP.catch(() => {});
+    } else {
+      sendPort.toWorker({ kind: 'cancel' });
+      await sendP.catch(() => {});
+    }
+    await expect(sendP).rejects.toThrow();
+    await expect(recvP).rejects.toThrow();
   });
 
   it('rejects a resume whose source changed before any frame is sent, keeping the record', async () => {

--- a/apps/web/src/lib/transfer/transfer-core.test.ts
+++ b/apps/web/src/lib/transfer/transfer-core.test.ts
@@ -682,3 +682,57 @@ describe('sender-record seam (V13-PR04)', () => {
     await expect(sendP).rejects.toThrow(/no sender record/);
   });
 });
+
+describe('resume role binding (V13-PR08 review)', () => {
+  it('rejects a sender resume attempt whose role is not offerer', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(41));
+    const sendPort = new FakePort();
+    const sendP = runTransferCore(sendPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => {
+        throw new Error('sender has no sink');
+      },
+      fileSource: blobFileSource,
+    });
+    sendPort.toWorker({
+      kind: 'start-send',
+      files: [new File([new Uint8Array(8)], 'x.bin')],
+      sendDir: keys.o2j,
+      recvDir: keys.j2o,
+      sendCounter: 1,
+      recvCounter: 1,
+      resumeAttempt: {
+        transferId: 'ab'.repeat(16),
+        manifestFingerprint: 'a'.repeat(64),
+        role: 'joiner', // mismatched persisted/host role
+        resumeSecret: new Uint8Array(32).fill(9),
+      },
+    });
+    await expect(sendP).rejects.toThrow(/sender resume attempt must carry the offerer role/);
+  });
+
+  it('rejects a receiver resume attempt whose role is not joiner', async () => {
+    const keys = await deriveTransferKeys(new Uint8Array(32).fill(42));
+    const recvPort = new FakePort();
+    const recvP = runTransferCore(recvPort, {
+      createDigest: await createSha256DigestFactory(),
+      createSink: () => new MemorySink(),
+      fileSource: blobFileSource,
+    });
+    recvPort.toWorker({
+      kind: 'start-recv',
+      destination: { kind: 'auto' },
+      sendDir: keys.j2o,
+      recvDir: keys.o2j,
+      sendCounter: 1,
+      recvCounter: 1,
+      resumeAttempt: {
+        transferId: 'ab'.repeat(16),
+        manifestFingerprint: 'a'.repeat(64),
+        role: 'offerer', // mismatched persisted/host role
+        resumeSecret: new Uint8Array(32).fill(9),
+      },
+    });
+    await expect(recvP).rejects.toThrow(/receiver resume attempt must carry the joiner role/);
+  });
+});

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -178,7 +178,23 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
         let recvDir = msg.recvDir;
         let sendCounter = msg.sendCounter;
         let recvCounter = msg.recvCounter;
+        // V13-PR08 progress contract: verified baseline reused from the authenticated
+        // checkpoint, anchored by the engine's onResume before any new block is ACKed.
+        let reusedBaseline = 0;
+        const progressMsg = (bytes: number): WorkerToHost => ({
+          kind: 'progress',
+          bytes,
+          ...(reusedBaseline > 0 ? { reusedBytes: reusedBaseline } : {}),
+        });
         if (msg.resumeAttempt !== undefined) {
+          // V13-PR08 role binding: a sender resume attempt must carry the offerer role; a
+          // mismatched persisted/host role is a hard failure, never silently ignored.
+          if (msg.resumeAttempt.role !== 'offerer') {
+            throw new TransferError(
+              'integrity',
+              'a sender resume attempt must carry the offerer role',
+            );
+          }
           const resumed = await runResumePreamble(msg, send, (p) => (preamble = p));
           sendDir = resumed.sendDir;
           recvDir = resumed.recvDir;
@@ -206,7 +222,12 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           // journal/fingerprint the peer authenticated. Omitting it would mint a NEW id and
           // silently abandon the interrupted transfer's durable state.
           ...(transferId !== '' ? { transferId } : {}),
-          onProgress: (bytes) => post({ kind: 'progress', bytes }),
+          onResume: (reused) => {
+            reusedBaseline = reused;
+            // Surface the verified checkpoint immediately — before the first new block.
+            post(progressMsg(reused));
+          },
+          onProgress: (bytes) => post(progressMsg(bytes)),
           onManifest: async (manifest) => {
             manifestFiles = manifest.files;
             const store = deps.senderRecords;
@@ -261,7 +282,23 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
         let recvDir = _msg.recvDir;
         let sendCounter = _msg.sendCounter;
         let recvCounter = _msg.recvCounter;
+        // V13-PR08 progress contract: verified baseline reused from the authenticated
+        // checkpoint, anchored by the engine's onResume before any new block is ACKed.
+        let reusedBaseline = 0;
+        const progressMsg = (bytes: number): WorkerToHost => ({
+          kind: 'progress',
+          bytes,
+          ...(reusedBaseline > 0 ? { reusedBytes: reusedBaseline } : {}),
+        });
         if (_msg.resumeAttempt !== undefined) {
+          // V13-PR08 role binding: a receiver resume attempt must carry the joiner role; a
+          // mismatched persisted/host role is a hard failure, never silently ignored.
+          if (_msg.resumeAttempt.role !== 'joiner') {
+            throw new TransferError(
+              'integrity',
+              'a receiver resume attempt must carry the joiner role',
+            );
+          }
           // The user pre-selected this interrupted journal locally; its verified progress
           // may be reused only after resume-auth succeeds in this session.
           if (isBrowserDestination(destination) && destination.expectResumeFor) {
@@ -288,7 +325,12 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           recvCounterStart: recvCounter,
           createDigest: deps.createDigest,
           destination,
-          onProgress: (bytes) => post({ kind: 'progress', bytes }),
+          onResume: (reused) => {
+            reusedBaseline = reused;
+            // Surface the verified checkpoint immediately — before the first new block.
+            post(progressMsg(reused));
+          },
+          onProgress: (bytes) => post(progressMsg(bytes)),
           onStateChange: (state) => post({ kind: 'state', state }),
           onManifestSet: async (manifest) => {
             post({

--- a/apps/web/src/lib/transfer/transfer-core.ts
+++ b/apps/web/src/lib/transfer/transfer-core.ts
@@ -10,6 +10,7 @@
 
 import {
   RESUME_AUTH_VERSION,
+  ResumePreamble,
   TransferSender,
   TransferReceiver,
   TransferError,
@@ -19,6 +20,7 @@ import {
   manifestFingerprint,
   type Digest,
   type Destination,
+  type DirectionalKey,
   type FileEntry,
   type FileSource,
   type Manifest,
@@ -70,6 +72,10 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           transportChanged(): void | Promise<void>;
         }
       | undefined;
+    // V13-PR08: while a resume preamble is in flight, inbound frames feed the preamble, not
+    // the engine; frames arriving after it settles but before the engine is installed are
+    // queued and replayed in order, so no frame is dropped or misrouted.
+    let preamble: ResumePreamble | undefined;
     let started = false;
     const pending: Uint8Array[] = [];
     const pendingControls: Array<'pause' | 'resume' | 'cancel'> = [];
@@ -132,7 +138,8 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           return;
         case 'inbound-frame': {
           const frame = new Uint8Array(msg.frame);
-          if (engine) consume(engine, frame);
+          if (preamble && !preamble.isSettled()) void preamble.handle(frame);
+          else if (engine) consume(engine, frame);
           else pending.push(frame);
           return;
         }
@@ -142,6 +149,10 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
           return;
         case 'cancel':
           if (engine) engine.cancel(msg.reason);
+          // An in-flight resume preamble must settle when the peer tears down, exactly as
+          // the CLI driver's ctx-bound wait aborts; a queued cancel that only reaches the
+          // future engine would leave the handshake hanging forever.
+          else if (preamble && !preamble.isSettled()) preamble.cancel();
           else pendingControls.push('cancel');
           return;
         case 'control':
@@ -159,13 +170,29 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
         const sources = msg.files.map((file) => deps.fileSource(file));
         let manifestFiles: FileEntry[] = [];
         let transferId = msg.transferId ?? '';
+        // V13-PR08: an explicit cross-session resume runs resume-auth-v1 with the peer
+        // strictly before the transfer engine starts; only a successful mutual
+        // authentication reuses the record's verified progress under a FRESH resumed key
+        // epoch (never the session keys for the transfer).
+        let sendDir = msg.sendDir;
+        let recvDir = msg.recvDir;
+        let sendCounter = msg.sendCounter;
+        let recvCounter = msg.recvCounter;
+        if (msg.resumeAttempt !== undefined) {
+          const resumed = await runResumePreamble(msg, send, (p) => (preamble = p));
+          sendDir = resumed.sendDir;
+          recvDir = resumed.recvDir;
+          sendCounter = resumed.sendCounter;
+          recvCounter = resumed.recvCounter;
+          transferId = msg.resumeAttempt.transferId;
+        }
         const sender = new TransferSender({
           files: sources,
           send,
-          sendDir: msg.sendDir,
-          recvDir: msg.recvDir,
-          sendCounterStart: msg.sendCounter,
-          recvCounterStart: msg.recvCounter,
+          sendDir,
+          recvDir,
+          sendCounterStart: sendCounter,
+          recvCounterStart: recvCounter,
           createDigest: deps.createDigest,
           // Mint a stable transfer id so the manifest opts into resumption and a crashed
           // receiver can journal and resume this exact transfer (V13-PR03). A restart
@@ -174,7 +201,11 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
             transferId = mintTransferId();
             return transferId;
           },
-          ...(msg.transferId !== undefined ? { transferId: msg.transferId } : {}),
+          // Fresh sends carry `msg.transferId`; an explicit cross-session resume reuses the
+          // interrupted id from the attempt (set above) so the manifest binds to the same
+          // journal/fingerprint the peer authenticated. Omitting it would mint a NEW id and
+          // silently abandon the interrupted transfer's durable state.
+          ...(transferId !== '' ? { transferId } : {}),
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
           onManifest: async (manifest) => {
             manifestFiles = manifest.files;
@@ -222,15 +253,39 @@ export function runTransferCore(port: Port, deps: TransferCoreDeps): Promise<voi
         const destination = deps.createDestination
           ? deps.createDestination(_msg.destination)
           : sinkFactoryDestination(deps.createSink);
+        // V13-PR08: an explicit cross-session resume runs resume-auth-v1 with the peer
+        // strictly before the transfer engine starts; only after mutual authentication may
+        // the pre-selected interrupted journal's verified progress be advertised, under a
+        // FRESH resumed key epoch.
+        let sendDir = _msg.sendDir;
+        let recvDir = _msg.recvDir;
+        let sendCounter = _msg.sendCounter;
+        let recvCounter = _msg.recvCounter;
+        if (_msg.resumeAttempt !== undefined) {
+          // The user pre-selected this interrupted journal locally; its verified progress
+          // may be reused only after resume-auth succeeds in this session.
+          if (isBrowserDestination(destination) && destination.expectResumeFor) {
+            destination.expectResumeFor(_msg.resumeAttempt.transferId);
+          }
+          const resumed = await runResumePreamble(_msg, send, (p) => (preamble = p));
+          sendDir = resumed.sendDir;
+          recvDir = resumed.recvDir;
+          sendCounter = resumed.sendCounter;
+          recvCounter = resumed.recvCounter;
+          if (isBrowserDestination(destination) && destination.durableMeta) {
+            // Only now may the pre-selected journal's verified progress be reused.
+            destination.authorizeResume?.();
+          }
+        }
         // The resume seam mirrors the CLI driver (durable.go): a shared, mutable resume
         // seed is filled from onManifestSet — after the destination prepares against the
         // authenticated manifest — and the wire receiver applies it before streaming.
         const receiverOpts: ConstructorParameters<typeof TransferReceiver>[0] = {
           send,
-          sendDir: _msg.sendDir,
-          recvDir: _msg.recvDir,
-          sendCounterStart: _msg.sendCounter,
-          recvCounterStart: _msg.recvCounter,
+          sendDir,
+          recvDir,
+          sendCounterStart: sendCounter,
+          recvCounterStart: recvCounter,
           createDigest: deps.createDigest,
           destination,
           onProgress: (bytes) => post({ kind: 'progress', bytes }),
@@ -331,6 +386,56 @@ function mintTransferId(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
   return bytesToHex(bytes);
+}
+
+/**
+ * V13-PR08: run resume-auth-v1 with the peer over the sealed session channel, strictly
+ * before the transfer engine starts. The resume-auth messages travel as FrameResumeAuth
+ * frames sealed under the SESSION directional keys; the engine then runs under the FRESH
+ * resumed key epoch derived from the mutually authenticated resume master, with counters
+ * starting at 0 (safe only because the keys+salts are new). Inbound frames arriving while
+ * the preamble is in flight are routed to it by the message handler; frames arriving after
+ * it settles but before the engine is installed are queued and replayed by `bind`.
+ *
+ * `setPreamble` publishes the in-flight preamble to the inbound handler so frames reach it.
+ */
+async function runResumePreamble(
+  msg: StartSendMsg | StartRecvMsg,
+  send: (frame: Uint8Array) => void,
+  setPreamble: (p: ResumePreamble | undefined) => void,
+): Promise<{
+  sendDir: DirectionalKey;
+  recvDir: DirectionalKey;
+  sendCounter: number;
+  recvCounter: number;
+}> {
+  const attempt = msg.resumeAttempt!;
+  const preamble = new ResumePreamble({
+    role: attempt.role,
+    transferId: attempt.transferId,
+    fingerprint: attempt.manifestFingerprint,
+    resumeSecret: attempt.resumeSecret,
+    send,
+    sendDir: msg.sendDir,
+    recvDir: msg.recvDir,
+    sendCounter: msg.sendCounter,
+    recvCounter: msg.recvCounter,
+  });
+  setPreamble(preamble);
+  try {
+    await preamble.start();
+    const result = await preamble.done();
+    if (result === undefined) {
+      throw preamble.result(); // throws the terminal error
+    }
+    // The offerer sends on O2J and receives on J2O; the joiner is the mirror. The resumed
+    // result is role-agnostic directional keys; pick this peer's send/recv by its role.
+    const sendDir: DirectionalKey = attempt.role === 'offerer' ? result.keys.o2j : result.keys.j2o;
+    const recvDir: DirectionalKey = attempt.role === 'offerer' ? result.keys.j2o : result.keys.o2j;
+    return { sendDir, recvDir, sendCounter: result.sendCounter, recvCounter: result.recvCounter };
+  } finally {
+    setPreamble(undefined);
+  }
 }
 
 /**

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -16,11 +16,34 @@ export interface SessionCrypto {
   recvCounter: number;
 }
 
+/**
+ * V13-PR08: the LOCAL resume context for an explicit cross-session resume attempt. The user
+ * chose the interrupted transfer locally; the peer must prove continuity with the original
+ * session via resume-auth-v1 before any durable progress is reused. Only the decoded secret
+ * crosses into the worker (the envelope is decoded by the host); it is never printed.
+ */
+export interface ResumeAttempt {
+  /** Stable id of the interrupted transfer being resumed. */
+  transferId: string;
+  /** Canonical manifest fingerprint of the interrupted transfer. */
+  manifestFingerprint: string;
+  /** This peer's stable role: offerer (sender) or joiner (receiver). */
+  role: 'offerer' | 'joiner';
+  /** Decoded 32-byte transfer-scoped resume credential from the local record/journal. */
+  resumeSecret: Uint8Array;
+}
+
 export interface StartSendMsg extends SessionCrypto {
   kind: 'start-send';
   files: File[];
   /** Reuse a stable transfer id from an interrupted send (worker re-verifies the source). */
   transferId?: string;
+  /**
+   * V13-PR08: explicit cross-session resume attempt. The worker runs resume-auth-v1 with the
+   * peer strictly before the transfer engine starts; only a successful mutual authentication
+   * reuses the record's verified progress under a FRESH resumed key epoch.
+   */
+  resumeAttempt?: ResumeAttempt;
   /**
    * The transient resume root derived by the MAIN THREAD from the original session master
    * (V13-PR07) — never the master itself. The worker uses it to derive the transfer-scoped
@@ -47,6 +70,12 @@ export interface StartRecvMsg extends SessionCrypto {
    * validates; it is never persisted, logged, or returned to UI.
    */
   resumeRoot?: Uint8Array;
+  /**
+   * V13-PR08: explicit cross-session resume attempt. The worker runs resume-auth-v1 with the
+   * peer strictly before the transfer engine starts; only after mutual authentication may
+   * the pre-selected interrupted journal's verified progress be advertised.
+   */
+  resumeAttempt?: ResumeAttempt;
 }
 export type ReceiveDestinationSpec =
   | { kind: 'auto' }

--- a/apps/web/src/lib/transfer/wire.ts
+++ b/apps/web/src/lib/transfer/wire.ts
@@ -123,7 +123,14 @@ export interface ManifestMsg {
 }
 export interface ProgressMsg {
   kind: 'progress';
+  /** Verified high-water (ACKed) bytes; on a resume this includes the reused baseline. */
   bytes: number;
+  /**
+   * V13-PR08: verified baseline reused from the authenticated durable checkpoint at resume
+   * start. sessionBytes = bytes - reusedBytes. Present on resumed transfers from the
+   * moment the checkpoint is accepted (before the first new block arrives).
+   */
+  reusedBytes?: number;
 }
 export interface StateMsg {
   kind: 'state';

--- a/docs/durable-receive.md
+++ b/docs/durable-receive.md
@@ -211,10 +211,14 @@ the ids match.
 ### The flow
 
 1. The user selects the interrupted transfer locally (sender record / receive journal).
-2. The sender revalidates its source: reopen the persisted path or handle, recompute the
-   canonical identity + exact manifest fingerprint, compare with the record. A changed
-   source is a hard resume refusal — a valid `resumeSecret` is not authorization to
-   change the source.
+2. The sender revalidates its source: reopen the persisted path or handle (or an explicit
+   reselection), and run a cheap pre-check — the canonical source identity (count, names,
+   sizes, mtimes in canonical order) compared against the record — refusing before
+   dialing on any obvious mismatch. The EXACT manifest fingerprint is recomputed from the
+   validated manifest and compared with the record strictly before the manifest frame is
+   transmitted: after resume-auth, but before any durable progress is reused or any data
+   is sent under the resumed transfer. A changed source is a hard resume refusal — a
+   valid `resumeSecret` is not authorization to change the source.
 3. A fresh temporary rendezvous is created and a fresh invite code shown (the code is
    never persisted and never derived from the resume secret).
 4. Both peers join; peer capabilities are checked (`resume-auth-v1`).

--- a/docs/durable-receive.md
+++ b/docs/durable-receive.md
@@ -175,6 +175,72 @@ Resume is **same-session** recovery: the sender must still be connected in the r
 user re-joins with the same invite code, and the new handshake always derives fresh
 traffic keys — no old key or counter is ever reused.
 
+## Cross-session resume (v1.3 PR08)
+
+A _process/page/session death_ is different from a _same-session path switch_. PR08 makes
+that distinction explicit and turns the PR07 resume credential into a real, safe product
+flow:
+
+- **reconnect** — same live transfer engine/session; a direct↔relay or temporary outage;
+  the existing traffic-key epoch stays valid under current semantics (PR06 path
+  recovery). No resume-auth runs.
+- **durable resume** — the process/session died; persisted transfer state exists on BOTH
+  peers; both possess the matching PR07 resume credential; mutual resume-auth-v1
+  succeeds; then a brand-new traffic-key epoch is derived and the verified durable
+  checkpoint is reused.
+- **restart** — no compatible credential (lost secret, legacy pre-PR07 state, changed
+  source, corrupt state, or the user elects to start from zero). Old partials are never
+  silently trusted and never deleted without explicit discard.
+
+### The invariant
+
+> Durable progress from a PREVIOUS authenticated session may be reused ONLY after
+> successful resume-auth-v1 continuity authentication. A fresh invite/rendezvous code
+> authenticates the NEW session; it does NOT by itself prove continuity with the
+> original transfer peer.
+
+Both the CLI and the browser enforce this at the storage layer: a journal's verified
+progress is never advertised unless the local peer explicitly armed an authenticated
+resume attempt (`ExpectResume`/`expectResumeFor`) AND resume-auth succeeded in this
+session (`SetResumeAuthorized`/`authorizeResume`) before the manifest was processed. A
+fresh session that presents the same `transferId` + manifest fingerprint without the
+preamble fails closed — nothing is received, nothing is deleted, the journal stays
+intact. Regression tests prove a fresh session cannot skip old blocks merely because
+the ids match.
+
+### The flow
+
+1. The user selects the interrupted transfer locally (sender record / receive journal).
+2. The sender revalidates its source: reopen the persisted path or handle, recompute the
+   canonical identity + exact manifest fingerprint, compare with the record. A changed
+   source is a hard resume refusal — a valid `resumeSecret` is not authorization to
+   change the source.
+3. A fresh temporary rendezvous is created and a fresh invite code shown (the code is
+   never persisted and never derived from the resume secret).
+4. Both peers join; peer capabilities are checked (`resume-auth-v1`).
+5. PR07 resume-auth runs mutually over the session channel, with fresh nonces.
+6. ONLY after success: fresh directional keys + salts are derived and counters start at
+   0 under them; the transfer engine is constructed with the new key epoch.
+7. Authenticated Manifest → fingerprint-bound resume_state → sender validates the
+   durable claim → missing blocks only → whole-file verification → Complete/Done.
+
+Nothing — Manifest, ResumeState, BlockData, Complete — travels from a resumed transfer
+before resume-auth completes, and the normal transfer protocol never runs under
+provisional resume-auth keys.
+
+### Failure semantics
+
+- Resume auth failure: sender record and receiver journal + partials are preserved;
+  candidate attempt keys/nonces are destroyed; a later attempt uses fresh nonces.
+- Lost credential / peer capability absent / stripped capability: durable data is
+  preserved, authenticated resume is reported unavailable, and an explicit fresh
+  restart/discard is offered. A replacement credential is NEVER derived from the new
+  session.
+- Source mismatch: old state is preserved until explicit discard; no data is sent under
+  the old transfer identity.
+- Corrupt journal: fail closed, keep for inspect/discard; never clamped or repaired
+  silently.
+
 ## Management commands
 
 ```
@@ -184,13 +250,19 @@ sendbeam transfers resume   <id> [--out DIR]
 sendbeam transfers discard  <id>... [--out DIR] [--all] [--yes]
 ```
 
-- `list` shows every journal (valid or unreadable) and orphaned partial tree. A bad
-  journal never hides the others and is never deleted.
+- `list` shows every journal (valid or unreadable) and orphaned partial tree, with a
+  status per entry: interrupted transfer not found, ready to resume, legacy (restart
+  required), partial data missing/truncated, or credential unavailable. A bad journal
+  never hides the others and is never deleted. No secret material is printed.
 - `inspect` cross-checks one journal against its partial data, reporting exactly which
   file's partial is missing or truncated. It never deletes.
-- `resume` verifies a journal is resumable and explains how: re-run
-  `sendbeam receive <code>` in the room where the sender is still connected. The invite
-  code is never stored, so a standalone resume without the sender is not possible.
+- `resume <id> --code <fresh-code>` performs the cross-session authenticated resume:
+  the receiver selects the matching interrupted journal, joins the sender's fresh
+  rendezvous with the fresh code, both peers run resume-auth-v1, and only after mutual
+  authentication is the verified checkpoint reused under a fresh key epoch. It fails
+  closed with distinct errors when the transfer is not found, the source changed, the
+  receiver state is missing/corrupt, the credential is unavailable, the peer does not
+  support authenticated resume, or resume authentication fails.
 - `discard` explicitly deletes one journal and its partial tree (or `--all` with `--yes`),
   bounded to that transfer, idempotent, and safe to repeat. Nothing is ever discarded
   implicitly.
@@ -206,8 +278,7 @@ sendbeam transfers discard  <id>... [--out DIR] [--all] [--yes]
 
 ## Deferred limits (later v1.3 PRs)
 
-- Cross-session authenticated resume with fresh traffic keys without a live sender is
-  PR07 (the `resumeSecret` envelope exists in the schema but is unused by PR02).
-- Resume validation against authenticated peer identity (beyond the manifest fingerprint
-  and destination location) is PR07. PR06 already binds every seed to the authenticated
-  manifest's fingerprint and geometry.
+- Persistent server-side presence, inboxes, accounts, cloud backup/history, and
+  trusted-device pairing remain explicitly OUT of scope — PR08 stays account-free with
+  no server-side file storage, no permanent trusted-device identity, no global transfer
+  directory, and no background cloud mailbox. Durable receive state is purely local.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -300,10 +300,21 @@ design, derivation formulas, state machine, and security analysis live in
 `docs/adr/0005-cross-session-resume.md`; this section summarizes the wire-visible shape.
 
 The capability is named **`resume-auth-v1`** (Go `wire.ResumeAuthCapability`, TS
-`RESUME_AUTH_CAPABILITY`). It is a `features` entry announced in caps like any other feature;
-it is **not** advertised in production defaults and the product flow is disabled until
-PR08/lead approval. Ordinary transfers are byte-for-byte unchanged, and legacy peers that
-never advertise the capability never receive resume-auth messages.
+`RESUME_AUTH_CAPABILITY`). It is a `features` entry announced in caps like any other feature.
+PR08 integrates it into the CLI and browser flows: a host advertises it only when its local
+integration can really load a valid resume credential, run resume-auth, derive fresh
+transfer keys, and enforce the no-downgrade behavior. Ordinary transfers are byte-for-byte
+unchanged, and legacy peers that never advertise the capability never receive resume-auth
+messages.
+
+The host integration ordering for a cross-session durable resume is: local interrupted
+state selected → source/destination revalidated → fresh signaling/rendezvous created →
+peer capability checked → ResumeAuthSession completes mutually → fresh traffic keys
+available → transfer sender/receiver constructed under the NEW key epoch → authenticated
+Manifest → fingerprint-bound resume_state → sender validates the durable claim → missing
+blocks only → whole-file verification. No Manifest/ResumeState/BlockData/Complete from a
+resumed transfer is sent or trusted before resume-auth completes, and the normal transfer
+protocol never runs under provisional resume-auth keys.
 
 When both peers agree on `resume-auth-v1` and both hold the transfer's local resume
 credential, the peers run the resume-auth handshake over the (abstract) transport. Message
@@ -337,8 +348,10 @@ Decoder bounds: one resume-auth message is limited to **1024 bytes** (checked be
 JSON parsing), every nonce/proof must be exactly the canonical 43-char unpadded base64url
 of 32 bytes (length checked before any base64 decoding), characters outside the base64url
 alphabet and padded or non-canonical spellings are rejected, and there is no implicit
-version — `version` must be exactly 1. The capability is included in the resume decision;
+version — `version` must be exactly 1. The capability is included in the resume decision.
 PR08 owns the discovery path that obtains authenticated capability state for a
-cross-session attempt, and this protocol only guarantees the fail-closed side: capability
+cross-session attempt, and the protocol guarantees the fail-closed side: capability
 absent, stripped, or untrusted ⇒ cross-session resume unavailable, never an unauthenticated
-resume.
+resume. Same-session path recovery (direct↔relay cutover) never re-runs resume-auth — the
+fresh resumed key epoch is per resumed process/session, and a path change within the same
+epoch follows the existing same-session counter/path semantics.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -308,13 +308,15 @@ unchanged, and legacy peers that never advertise the capability never receive re
 messages.
 
 The host integration ordering for a cross-session durable resume is: local interrupted
-state selected → source/destination revalidated → fresh signaling/rendezvous created →
-peer capability checked → ResumeAuthSession completes mutually → fresh traffic keys
-available → transfer sender/receiver constructed under the NEW key epoch → authenticated
-Manifest → fingerprint-bound resume_state → sender validates the durable claim → missing
-blocks only → whole-file verification. No Manifest/ResumeState/BlockData/Complete from a
-resumed transfer is sent or trusted before resume-auth completes, and the normal transfer
-protocol never runs under provisional resume-auth keys.
+state selected → source/destination revalidated (cheap source pre-check — canonical
+identity — before dialing; the exact manifest fingerprint is recomputed and compared with
+the record strictly before the manifest frame is transmitted) → fresh signaling/rendezvous
+created → peer capability checked → ResumeAuthSession completes mutually → fresh traffic
+keys available → transfer sender/receiver constructed under the NEW key epoch →
+authenticated Manifest → fingerprint-bound resume_state → sender validates the durable
+claim → missing blocks only → whole-file verification. No Manifest/ResumeState/BlockData/
+Complete from a resumed transfer is sent or trusted before resume-auth completes, and the
+normal transfer protocol never runs under provisional resume-auth keys.
 
 When both peers agree on `resume-auth-v1` and both hold the transfer's local resume
 credential, the peers run the resume-auth handshake over the (abstract) transport. Message

--- a/docs/sender-reattachment.md
+++ b/docs/sender-reattachment.md
@@ -125,8 +125,12 @@ before its frame, so the receiver never sees an inconsistent id. Nothing was sen
 
 PR08 builds on the record: on a sender restart the user _reopens_ the interrupted send
 (the record's persisted path/handle or an explicit reselection — PR04 stays mandatory),
-the source is revalidated (canonical identity + exact fingerprint against the record),
-and only then is the transfer resumed with the peer.
+and the source is revalidated before any progress is reused. The cheap pre-check — the
+canonical source identity (count, names, sizes, mtimes in canonical order) against the
+record — runs before the fresh rendezvous is dialed; the EXACT manifest fingerprint is
+recomputed from the validated manifest and compared with the record strictly before the
+manifest frame is transmitted (after resume-auth, before any verified progress is reused
+or any data is sent under the resumed transfer).
 
 The record's PR07 `resumeSecret` is the difference between a **durable resume** and a
 **restart**:
@@ -142,8 +146,10 @@ The record's PR07 `resumeSecret` is the difference between a **durable resume** 
   never deleted without explicit discard.
 
 A valid `resumeSecret` is NOT authorization to change the source: the source
-revalidation ordering (reopen → recompute identity + fingerprint → compare with the
-record) runs before any resume-auth, and a mismatch is a hard refusal.
+revalidation ordering is (1) cheap pre-check (canonical identity — count, names, sizes,
+mtimes) before dialing, (2) resume-auth, (3) exact manifest fingerprint recomputed and
+compared with the record strictly before the manifest frame is transmitted, and a
+mismatch at either stage is a hard refusal.
 
 Errors are distinct: interrupted transfer not found, source changed, receiver state
 missing/corrupt, resume credential unavailable, peer does not support authenticated

--- a/docs/sender-reattachment.md
+++ b/docs/sender-reattachment.md
@@ -121,14 +121,43 @@ A same-size, same-mtime edit is the hard case: the cheap pre-check passes, the
 fingerprint check does not — the manifest about to be advertised is refused at the hook,
 before its frame, so the receiver never sees an inconsistent id. Nothing was sent.
 
+## Cross-session authenticated resume (v1.3 PR08)
+
+PR08 builds on the record: on a sender restart the user _reopens_ the interrupted send
+(the record's persisted path/handle or an explicit reselection — PR04 stays mandatory),
+the source is revalidated (canonical identity + exact fingerprint against the record),
+and only then is the transfer resumed with the peer.
+
+The record's PR07 `resumeSecret` is the difference between a **durable resume** and a
+**restart**:
+
+- **Durable resume** — both peers possess the matching transfer-scoped credential. The
+  sender starts a FRESH temporary rendezvous (fresh invite code, never persisted, never
+  derived from the secret), the receiver selects the matching interrupted journal, both
+  run resume-auth-v1, and only after mutual success is the verified checkpoint reused
+  under a brand-new key epoch.
+- **Restart / legacy** — a pre-PR07 record has no credential; nothing is fabricated for
+  it. Durable data may remain locally, authenticated cross-session resume is
+  unavailable, and an explicit fresh restart/discard is the only path. Old partials are
+  never deleted without explicit discard.
+
+A valid `resumeSecret` is NOT authorization to change the source: the source
+revalidation ordering (reopen → recompute identity + fingerprint → compare with the
+record) runs before any resume-auth, and a mismatch is a hard refusal.
+
+Errors are distinct: interrupted transfer not found, source changed, receiver state
+missing/corrupt, resume credential unavailable, peer does not support authenticated
+resume, resume authentication failed, or fresh restart required/available. No secret
+material is ever printed.
+
 ## Limits (deferred)
 
-- **Cross-session authenticated resume (PR05+)**: today a restart re-uses the same
-  rendezvous; resuming across new rooms/sessions with authentication is future work.
 - Browser restarts depend on the same browser + origin (the handle and record are
   origin-scoped); there is no cross-device resume.
 - The record keeps the last successful manifest; it does not archive earlier versions,
   and there is no quota management beyond the per-record removal.
+- Persistent server-side presence, inboxes, accounts, cloud backup/history, and
+  trusted-device pairing remain OUT of scope — resume is account-free and purely local.
 
 ## CLI storage contract
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -27,3 +27,4 @@ export * from './errors.js';
 export * from './ice-servers.js';
 export * from './journal.js';
 export * from './resume-auth.js';
+export * from './resume-preamble.js';

--- a/packages/protocol/src/resume-preamble.test.ts
+++ b/packages/protocol/src/resume-preamble.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Resume preamble (V13-PR08) tests — deterministic, no sleeps. These pin the TS twin of
+ * `packages/wire/resume_preamble.go`: the preamble runs PR07 mutual resume-auth over the
+ * sealed session channel strictly before the transfer engine, exposes ONLY the fresh
+ * resumed key epoch after mutual authentication, and fails closed on any wrong context,
+ * secret, or foreign frame. The fresh-epoch assertion proves a new nonce pair per attempt
+ * yields a new key epoch, so no old AES keys/counters are ever read back from disk.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { openSequenced, seal, type FrameHeaderInput } from './aead.js';
+import { bytesToHex, hexToBytes } from './bytes.js';
+import { deriveTransferKeys, type DirectionalKey, type TransferKeys } from './keyschedule.js';
+import { ResumePreamble, type ResumePreambleOptions } from './resume-preamble.js';
+import { FrameType } from './transfer.js';
+
+/** Fixed public test master (never real credentials). */
+const TEST_MASTER = hexToBytes('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f');
+const TEST_TID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const TEST_FP = 'b'.repeat(64);
+
+/** Deterministic distinct 32-byte nonce sources (test-only). */
+function nonceSource(start: number): (n: number) => Uint8Array {
+  let next = start;
+  return (n: number) => {
+    if (n !== 32) throw new Error(`nonce must be 32 bytes, got ${n}`);
+    return Uint8Array.from({ length: 32 }, () => next++);
+  };
+}
+
+async function sessionKeys(): Promise<TransferKeys> {
+  return deriveTransferKeys(TEST_MASTER);
+}
+
+function preambleOptions(
+  role: 'offerer' | 'joiner',
+  secret: Uint8Array,
+  keys: TransferKeys,
+  over: Partial<ResumePreambleOptions> = {},
+): ResumePreambleOptions {
+  const sendDir: DirectionalKey = role === 'offerer' ? keys.o2j : keys.j2o;
+  const recvDir: DirectionalKey = role === 'offerer' ? keys.j2o : keys.o2j;
+  return {
+    role,
+    transferId: TEST_TID,
+    fingerprint: TEST_FP,
+    resumeSecret: secret,
+    send: () => undefined,
+    sendDir,
+    recvDir,
+    sendCounter: 1, // session handshake consumed one frame per direction
+    recvCounter: 1,
+    ...over,
+  };
+}
+
+/** Wires two preambles through in-memory channels and drives them to settle. */
+async function preamblePair(
+  o: ResumePreambleOptions,
+  j: ResumePreambleOptions,
+): Promise<{
+  resO: Awaited<ReturnType<ResumePreamble['done']>>;
+  errO?: Error;
+  resJ: Awaited<ReturnType<ResumePreamble['done']>>;
+  errJ?: Error;
+}> {
+  const chO: Uint8Array[] = [];
+  const chJ: Uint8Array[] = [];
+  o.send = (f) => void chJ.push(f);
+  j.send = (f) => void chO.push(f);
+  const po = new ResumePreamble(o);
+  const pj = new ResumePreamble(j);
+  await po.start();
+  // Pump until both settle: each handle may produce a frame for the peer, and the final
+  // step settles the joiner while its ready frame settles the offerer.
+  let rounds = 0;
+  while ((!po.isSettled() || !pj.isSettled()) && rounds < 16) {
+    rounds++;
+    const toO = chO.splice(0);
+    const toJ = chJ.splice(0);
+    if (toJ.length === 0 && toO.length === 0) {
+      // No progress possible without a peer message; if one side already failed, the other
+      // waits for the connection teardown (the caller's responsibility in production).
+      break;
+    }
+    await Promise.all([...toJ.map((f) => pj.handle(f)), ...toO.map((f) => po.handle(f))]);
+  }
+  const resO = await po.done();
+  const resJ = await pj.done();
+  let errO: Error | undefined;
+  let errJ: Error | undefined;
+  try {
+    po.result();
+  } catch (e) {
+    errO = e as Error;
+  }
+  try {
+    pj.result();
+  } catch (e) {
+    errJ = e as Error;
+  }
+  return { resO, errO, resJ, errJ };
+}
+
+describe('resume preamble', () => {
+  it('mutual auth happy path exposes the fresh resumed epoch', async () => {
+    const keys = await sessionKeys();
+    const secret = new Uint8Array(32).fill(0xab);
+    const o = preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) });
+    const j = preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) });
+    const { resO, errO, resJ, errJ } = await preamblePair(o, j);
+    expect(errO).toBeUndefined();
+    expect(errJ).toBeUndefined();
+    expect(resO).toBeDefined();
+    expect(resJ).toBeDefined();
+    // Both sides derive the same fresh directional keys, distinct from the session keys.
+    expect(bytesToHex(resO!.keys.o2j.key)).toBe(bytesToHex(resJ!.keys.o2j.key));
+    expect(bytesToHex(resO!.keys.j2o.key)).toBe(bytesToHex(resJ!.keys.j2o.key));
+    expect(bytesToHex(resO!.keys.o2j.key)).not.toBe(bytesToHex(keys.o2j.key));
+    expect(bytesToHex(resO!.keys.j2o.key)).not.toBe(bytesToHex(keys.j2o.key));
+    // Fresh epoch: counters start at 0 only because the keys are new (ADR 0005 §7).
+    expect(resO!.sendCounter).toBe(0);
+    expect(resO!.recvCounter).toBe(0);
+    expect(resJ!.sendCounter).toBe(0);
+    expect(resJ!.recvCounter).toBe(0);
+    expect(resO!.transferId).toBe(TEST_TID);
+    expect(resJ!.transferId).toBe(TEST_TID);
+    expect(resO!.role).toBe('offerer');
+    expect(resJ!.role).toBe('joiner');
+  });
+
+  it('fresh nonces per attempt yield distinct key epochs', async () => {
+    const keys = await sessionKeys();
+    const secret = new Uint8Array(32).fill(0xcd);
+    const a = await preamblePair(
+      preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) }),
+      preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) }),
+    );
+    const b = await preamblePair(
+      preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(0x21) }),
+      preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x31) }),
+    );
+    expect(a.errO).toBeUndefined();
+    expect(b.errO).toBeUndefined();
+    // Attempt A and attempt B for the same transfer MUST yield different traffic key epochs.
+    expect(bytesToHex(a.resO!.keys.o2j.key)).not.toBe(bytesToHex(b.resO!.keys.o2j.key));
+    expect(bytesToHex(a.resO!.keys.j2o.key)).not.toBe(bytesToHex(b.resO!.keys.j2o.key));
+  });
+
+  it('wrong secret fails closed on both sides', async () => {
+    const keys = await sessionKeys();
+    const chO: Uint8Array[] = [];
+    const chJ: Uint8Array[] = [];
+    const o = preambleOptions('offerer', new Uint8Array(32).fill(1), keys, {
+      send: (f) => void chJ.push(f),
+    });
+    const j = preambleOptions('joiner', new Uint8Array(32).fill(2), keys, {
+      send: (f) => void chO.push(f),
+    });
+    const po = new ResumePreamble(o);
+    const pj = new ResumePreamble(j);
+    await po.start();
+    // init -> joiner; joiner replies with its challenge (proof under ITS secret).
+    await pj.handle(chJ.shift()!);
+    // The offerer verifies the joiner's proof against ITS secret -> mismatch -> fails closed.
+    await po.handle(chO.shift()!);
+    const resO = await po.done();
+    expect(resO).toBeUndefined();
+    let errO: Error | undefined;
+    try {
+      po.result();
+    } catch (e) {
+      errO = e as Error;
+    }
+    expect(errO).toBeDefined();
+    expect(String(errO)).toContain('resume');
+    // The joiner must never expose a result either; in production the connection teardown
+    // releases it (the wire-level suite pins that path via cancellation).
+    expect(pj.isSettled()).toBe(false);
+    expect(() => pj.result()).toThrow('resume: preamble has not settled');
+  });
+
+  it('joiner start is a no-op and waits for resume_init', async () => {
+    const keys = await sessionKeys();
+    let sent = false;
+    const p = new ResumePreamble(
+      preambleOptions('joiner', new Uint8Array(32).fill(3), keys, {
+        send: () => {
+          sent = true;
+        },
+      }),
+    );
+    await p.start();
+    expect(sent).toBe(false);
+    expect(p.isSettled()).toBe(false);
+  });
+
+  it('rejects a missing resume secret at construction', async () => {
+    const keys = await sessionKeys();
+    const opts = preambleOptions('offerer', new Uint8Array(0), keys);
+    expect(() => new ResumePreamble(opts)).toThrow(/resume secret/);
+  });
+
+  it('rejects foreign transfer frames before authentication completes', async () => {
+    const keys = await sessionKeys();
+    const secret = new Uint8Array(32).fill(7);
+    const o = preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) });
+    const j = preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) });
+    const chO: Uint8Array[] = [];
+    const chJ: Uint8Array[] = [];
+    o.send = (f) => void chJ.push(f);
+    j.send = (f) => void chO.push(f);
+    const po = new ResumePreamble(o);
+    const pj = new ResumePreamble(j);
+    await po.start();
+    // Feed a MANIFEST frame (not a resume-auth frame) to the joiner under the session key:
+    // it must fail closed, not be routed into the transfer engine. The plaintext is any
+    // bytes — the preamble rejects on the frame TYPE before ever parsing it.
+    const header: FrameHeaderInput = {
+      version: 1,
+      type: FrameType.Manifest,
+      flags: 0,
+      fileIdx: 0,
+      blockIdx: 0,
+      frameOff: 0,
+    };
+    const foreign = await seal(j.recvDir, 1, header, new TextEncoder().encode('{"manifest":true}'));
+    await pj.handle(foreign);
+    const resJ = await pj.done();
+    expect(resJ).toBeUndefined();
+    let errJ: Error | undefined;
+    try {
+      pj.result();
+    } catch (e) {
+      errJ = e as Error;
+    }
+    expect(errJ).toBeDefined();
+    expect(String(errJ)).toContain('resume');
+  });
+
+  it('an exact duplicate of the last accepted frame is re-answered idempotently', async () => {
+    const keys = await sessionKeys();
+    const secret = new Uint8Array(32).fill(0x42);
+    const o = preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) });
+    const j = preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) });
+    const chO: Uint8Array[] = [];
+    const chJ: Uint8Array[] = [];
+    o.send = (f) => void chJ.push(f);
+    j.send = (f) => void chO.push(f);
+    const po = new ResumePreamble(o);
+    const pj = new ResumePreamble(j);
+    await po.start();
+    // init -> joiner.
+    const initFrames = chJ.splice(0);
+    expect(initFrames).toHaveLength(1);
+    await pj.handle(initFrames[0]!);
+    // challenge -> offerer, delivered twice (a transport-level re-send).
+    const challengeFrames = chO.splice(0);
+    expect(challengeFrames).toHaveLength(1);
+    await po.handle(challengeFrames[0]!);
+    await po.handle(challengeFrames[0]!);
+    const confirmFrames = chJ.splice(0);
+    // The duplicate must be re-answered IDENTICALLY at the MESSAGE level (same confirm
+    // snapshot, never a fresh challenge or proof) — two confirms with equal plaintexts,
+    // not a new handshake. The frames themselves differ only in the advancing counter.
+    expect(confirmFrames).toHaveLength(2);
+    // The offerer sent resume_init at counter 1, so its confirms are counters 2 and 3.
+    const open1 = await openSequenced(keys.o2j, 2, confirmFrames[0]!);
+    const open2 = await openSequenced(keys.o2j, 3, confirmFrames[1]!);
+    expect(bytesToHex(open1.plaintext)).toBe(bytesToHex(open2.plaintext));
+    // The joiner settles on the first confirm; the second is an idempotent re-answer.
+    await pj.handle(confirmFrames[0]!);
+    const readyFrames = chO.splice(0);
+    expect(readyFrames).toHaveLength(1);
+    await po.handle(readyFrames[0]!);
+    const resO = await po.done();
+    const resJ = await pj.done();
+    expect(resO).toBeDefined();
+    expect(resJ).toBeDefined();
+    expect(bytesToHex(resO!.keys.o2j.key)).toBe(bytesToHex(resJ!.keys.o2j.key));
+  });
+});

--- a/packages/protocol/src/resume-preamble.test.ts
+++ b/packages/protocol/src/resume-preamble.test.ts
@@ -238,6 +238,211 @@ describe('resume preamble', () => {
     expect(String(errJ)).toContain('resume');
   });
 
+  describe('serialized inbound processing (V13-PR08 Blocker 5)', () => {
+    /**
+     * Delivers init and its transport re-send to the joiner via Promise.all — WITHOUT
+     * awaiting between deliveries. The queue must process them in strict arrival order: the
+     * first consumes counter 1 and answers challenge at j2o counter 1; the second is the
+     * exact-duplicate re-send (counter 1 again) re-answered idempotently at counter 2. The
+     * send counters prove the two inbound frames were consumed exactly once, in order, and
+     * no counter was consumed twice. Without serialization the second handle would open at
+     * the already-advanced counter and fail as a replay.
+     */
+    it('two frames delivered without awaiting process in strict arrival order — no counter consumed twice', async () => {
+      const keys = await sessionKeys();
+      const secret = new Uint8Array(32).fill(0x5a);
+      const o = preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) });
+      const j = preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) });
+      const chO: Uint8Array[] = [];
+      const chJ: Uint8Array[] = [];
+      o.send = (f) => void chJ.push(f);
+      j.send = (f) => void chO.push(f);
+      const po = new ResumePreamble(o);
+      const pj = new ResumePreamble(j);
+      await po.start();
+      // The transport re-sends init (the joiner's first challenge was "lost"): both frames
+      // are delivered to the joiner at once, without awaiting between the deliveries.
+      const init = chJ.shift()!;
+      const handled = await Promise.all([pj.handle(init), pj.handle(init)]);
+      await Promise.all(handled);
+      // Exactly two challenges, at j2o counters 1 and 2, with byte-identical plaintexts:
+      // the re-send was re-answered idempotently from the engine snapshot, never with a
+      // fresh nonce or proof, and the counters advanced strictly in arrival order.
+      expect(chO).toHaveLength(2);
+      const open1 = await openSequenced(keys.j2o, 1, chO[0]!);
+      const open2 = await openSequenced(keys.j2o, 2, chO[1]!);
+      expect(open1.header.type).toBe(FrameType.ResumeAuth);
+      expect(open2.header.type).toBe(FrameType.ResumeAuth);
+      expect(bytesToHex(open1.plaintext)).toBe(bytesToHex(open2.plaintext));
+      expect(pj.isSettled()).toBe(false); // re-answers never settle the joiner
+
+      // Drive the rest of the handshake: both challenges reach the offerer in order (the
+      // second is a fresh counter-2 frame, re-answered identically), then confirm reaches
+      // the joiner, then ready reaches the offerer. Everything settles successfully.
+      await po.handle(chO.shift()!);
+      await po.handle(chO.shift()!);
+      const confirms = chJ.splice(0);
+      expect(confirms).toHaveLength(2);
+      const c1 = await openSequenced(keys.o2j, 2, confirms[0]!);
+      const c2 = await openSequenced(keys.o2j, 3, confirms[1]!);
+      expect(bytesToHex(c1.plaintext)).toBe(bytesToHex(c2.plaintext));
+      await pj.handle(confirms[0]!);
+      await po.handle(chO.shift()!);
+      const resO = await po.done();
+      const resJ = await pj.done();
+      expect(resO).toBeDefined();
+      expect(resJ).toBeDefined();
+      expect(bytesToHex(resO!.keys.o2j.key)).toBe(bytesToHex(resJ!.keys.o2j.key));
+    });
+
+    it('concurrent exact duplicate stays deterministic and settles successfully', async () => {
+      const keys = await sessionKeys();
+      const secret = new Uint8Array(32).fill(0x6b);
+      const o = preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) });
+      const j = preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) });
+      const chO: Uint8Array[] = [];
+      const chJ: Uint8Array[] = [];
+      o.send = (f) => void chJ.push(f);
+      j.send = (f) => void chO.push(f);
+      const po = new ResumePreamble(o);
+      const pj = new ResumePreamble(j);
+      await po.start();
+      // init -> joiner.
+      await pj.handle(chJ.shift()!);
+      // The SAME challenge frame delivered twice concurrently: the first consumes counter 1,
+      // the second is the exact-duplicate re-send (counter 1 again) re-answered idempotently.
+      const challenge = chO.shift()!;
+      const handleDup = await Promise.all([po.handle(challenge), po.handle(challenge)]);
+      await Promise.all(handleDup);
+      const confirms = chJ.splice(0);
+      // Two identical message-level confirms (counters 2 and 3), never a fresh handshake.
+      expect(confirms).toHaveLength(2);
+      const open1 = await openSequenced(keys.o2j, 2, confirms[0]!);
+      const open2 = await openSequenced(keys.o2j, 3, confirms[1]!);
+      expect(bytesToHex(open1.plaintext)).toBe(bytesToHex(open2.plaintext));
+      await pj.handle(confirms[0]!);
+      await po.handle(chO.shift()!);
+      const resO = await po.done();
+      const resJ = await pj.done();
+      expect(resO).toBeDefined();
+      expect(resJ).toBeDefined();
+    });
+
+    it('concurrent conflicting duplicate fails terminally; the queued valid frame observes the failure', async () => {
+      const keys = await sessionKeys();
+      const secret = new Uint8Array(32).fill(0x7c);
+      const o = preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) });
+      const j = preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) });
+      const chO: Uint8Array[] = [];
+      const chJ: Uint8Array[] = [];
+      o.send = (f) => void chJ.push(f);
+      j.send = (f) => void chO.push(f);
+      const po = new ResumePreamble(o);
+      const pj = new ResumePreamble(j);
+      await po.start();
+      await pj.handle(chJ.shift()!);
+      const challenge = chO.shift()!;
+      // A forged frame sealed at the SAME counter (1) whose plaintext differs from the real
+      // challenge: delivered concurrently with the genuine challenge, forged first.
+      const header: FrameHeaderInput = {
+        version: 1,
+        type: FrameType.ResumeAuth,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      };
+      const forged = await seal(
+        o.recvDir,
+        1,
+        header,
+        new TextEncoder().encode('forged conflicting replay'),
+      );
+      const handled = await Promise.all([po.handle(forged), po.handle(challenge)]);
+      await Promise.all(handled);
+      // First failure is terminal; the queued genuine frame observes the settled state and
+      // cannot resurrect the preamble. No handle() promise rejects (no unhandled rejection).
+      const resO = await po.done();
+      expect(resO).toBeUndefined();
+      expect(po.isSettled()).toBe(true);
+      expect(() => po.result()).toThrow(/resume/);
+      // The peer never receives a confirm: the offerer failed before answering.
+      expect(chJ).toHaveLength(0);
+    });
+
+    it('malformed first frame settles failed; a later queued valid frame cannot resurrect it', async () => {
+      const keys = await sessionKeys();
+      const secret = new Uint8Array(32).fill(0x8d);
+      const o = preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) });
+      const j = preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) });
+      const chO: Uint8Array[] = [];
+      const chJ: Uint8Array[] = [];
+      o.send = (f) => void chJ.push(f);
+      j.send = (f) => void chO.push(f);
+      const po = new ResumePreamble(o);
+      const pj = new ResumePreamble(j);
+      await po.start();
+      await pj.handle(chJ.shift()!);
+      const challenge = chO.shift()!;
+      // A MANIFEST frame under the session key at the expected counter: wrong type, so it
+      // settles the preamble failed. The genuine challenge queued behind it observes the
+      // settled state and is dropped — the failure is terminal.
+      const header: FrameHeaderInput = {
+        version: 1,
+        type: FrameType.Manifest,
+        flags: 0,
+        fileIdx: 0,
+        blockIdx: 0,
+        frameOff: 0,
+      };
+      const foreign = await seal(o.recvDir, 1, header, new TextEncoder().encode('{}'));
+      const handled = await Promise.all([po.handle(foreign), po.handle(challenge)]);
+      await Promise.all(handled);
+      const resO = await po.done();
+      expect(resO).toBeUndefined();
+      expect(po.isSettled()).toBe(true);
+      expect(() => po.result()).toThrow(/resume/);
+      expect(chJ).toHaveLength(0);
+    });
+
+    it('cancel while the handler is awaiting settles queued work and abandons the attempt', async () => {
+      const keys = await sessionKeys();
+      const secret = new Uint8Array(32).fill(0x9e);
+      const o = preambleOptions('offerer', secret, keys, { nonceSource: nonceSource(1) });
+      const j = preambleOptions('joiner', secret, keys, { nonceSource: nonceSource(0x11) });
+      const chO: Uint8Array[] = [];
+      const chJ: Uint8Array[] = [];
+      // The joiner's send is gated so its handle(init) stays in flight across an await while
+      // we cancel — the crypto is mid-processing, exactly the reload/teardown race.
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => (release = resolve));
+      j.send = (f) => {
+        chO.push(f);
+        return gate;
+      };
+      o.send = (f) => void chJ.push(f);
+      const po = new ResumePreamble(o);
+      const pj = new ResumePreamble(j);
+      await po.start();
+      const inFlight = pj.handle(chJ.shift()!);
+      // Cancel while the handler awaits the send gate; then release it so the handler resumes
+      // and observes the settled state.
+      pj.cancel();
+      release();
+      await inFlight;
+      const resJ = await pj.done();
+      expect(resJ).toBeUndefined();
+      expect(pj.isSettled()).toBe(true);
+      expect(() => pj.result()).toThrow(/canceled/);
+      // A frame queued after cancellation is dropped — it cannot resurrect a settled preamble.
+      await pj.handle(chJ.shift()!);
+      expect(pj.isSettled()).toBe(true);
+      expect(() => pj.result()).toThrow(/canceled/);
+      // The offerer never settles on its own (production teardown releases it).
+      expect(po.isSettled()).toBe(false);
+    });
+  });
+
   it('an exact duplicate of the last accepted frame is re-answered idempotently', async () => {
     const keys = await sessionKeys();
     const secret = new Uint8Array(32).fill(0x42);

--- a/packages/protocol/src/resume-preamble.ts
+++ b/packages/protocol/src/resume-preamble.ts
@@ -1,0 +1,283 @@
+/**
+ * Resume preamble (V13-PR08): the product integration of the reviewed PR07 resume-auth
+ * engine. The TypeScript twin of `packages/wire/resume_preamble.go`.
+ *
+ * It runs the transport-agnostic mutual-authentication handshake over the sealed session
+ * channel — strictly BEFORE the transfer engine starts — so durable progress from a previous
+ * authenticated session is never reused under session keys, and no
+ * Manifest/ResumeState/BlockData/Complete frame can flow before the peers authenticated
+ * continuity with each other.
+ *
+ * The resume-auth messages travel as FrameResumeAuth frames sealed under the SESSION
+ * directional keys (the keys the SPAKE2 handshake just derived): the session key epoch is
+ * used ONLY to carry the four resume-auth messages, and the transfer itself runs under the
+ * FRESH key epoch derived from the mutually authenticated resume master (ADR 0005 §7). The
+ * PR07 engine is unchanged: transferId + manifest fingerprint + role + resume secret are
+ * local context (never transmitted), the transcript binds them, and the fresh nonces make
+ * every attempt a new key epoch.
+ *
+ * Fail-closed rules: any inbound frame that is not a well-formed resume-auth frame (wrong
+ * type, wrong counter, torn, tampered, oversized, malformed) settles the preamble failed
+ * before the transfer could start. An exact duplicate of the last accepted frame (a
+ * transport-level re-send with the same counter) is re-opened and re-answered idempotently
+ * from the engine's snapshots — never with a fresh nonce or proof. There is no challenge
+ * replacement, no nonce/proof/role/version mutation, and no unbounded history.
+ */
+
+import { FrameReplayError, openSequenced, seal, type FrameHeaderInput } from './aead.js';
+import type { DirectionalKey } from './keyschedule.js';
+import {
+  ResumeAuthSession,
+  encodeResumeMessage,
+  type ResumeAuthResult,
+  type ResumeMessage,
+} from './resume-auth.js';
+import { FrameType } from './transfer.js';
+
+/** Options configuring one resume-auth exchange over the sealed session channel. */
+export interface ResumePreambleOptions {
+  /** This peer's stable role: offerer (sender) or joiner (receiver). */
+  role: 'offerer' | 'joiner';
+  /** Stable transfer id of the interrupted transfer (local context, never transmitted). */
+  transferId: string;
+  /** Canonical manifest fingerprint of the interrupted transfer (never transmitted). */
+  fingerprint: string;
+  /** Decoded 32-byte transfer-scoped credential from the local sender record or journal. */
+  resumeSecret: Uint8Array;
+  /** Transmits one sealed frame (the same callback the transfer engine will use). */
+  send(frame: Uint8Array): Promise<void> | void;
+  /** SESSION directional keys; the transfer later uses the fresh resumed epoch. */
+  sendDir: DirectionalKey;
+  recvDir: DirectionalKey;
+  /** Continuing session counters: this peer's next send / expected first receive. */
+  sendCounter: number;
+  recvCounter: number;
+  /** Deterministic fresh nonce source in tests; nil uses crypto.getRandomValues. */
+  nonceSource?(n: number): Uint8Array;
+}
+
+/**
+ * One in-flight resume-auth exchange. The driver wires {@link handle} as the inbound data
+ * hook, calls {@link start} (offerer only), and awaits {@link done}; {@link result} exposes
+ * the fresh resumed key epoch only after mutual authentication completes. Any failure is
+ * terminal and preserved.
+ */
+export class ResumePreamble {
+  private readonly opts: ResumePreambleOptions;
+  private readonly sess: ResumeAuthSession;
+
+  private sendCounter: number;
+  private recvCounter: number;
+  private started = false;
+  private resultValue: ResumeAuthResult | undefined;
+  private errValue: Error | undefined;
+  private settled = false;
+  private donePromise: Promise<ResumeAuthResult | undefined>;
+  private resolveDone!: (r: ResumeAuthResult | undefined) => void;
+  /** Canonical payload of the last accepted inbound message, for idempotent re-answers. */
+  private lastAccepted: Uint8Array | undefined;
+
+  constructor(opts: ResumePreambleOptions) {
+    const ctx: {
+      version: number;
+      transferId: string;
+      manifestFingerprint: string;
+      role: 'offerer' | 'joiner';
+      resumeSecret: Uint8Array;
+      nonceSource?: (n: number) => Uint8Array;
+    } = {
+      version: 1,
+      transferId: opts.transferId,
+      manifestFingerprint: opts.fingerprint,
+      role: opts.role,
+      resumeSecret: opts.resumeSecret,
+    };
+    if (opts.nonceSource !== undefined) ctx.nonceSource = opts.nonceSource;
+    this.sess = new ResumeAuthSession(ctx);
+    if (typeof opts.send !== 'function') {
+      throw new Error('resume: preamble requires a send callback');
+    }
+    this.opts = opts;
+    this.sendCounter = opts.sendCounter;
+    this.recvCounter = opts.recvCounter;
+    this.donePromise = new Promise<ResumeAuthResult | undefined>((resolve) => {
+      this.resolveDone = resolve;
+    });
+  }
+
+  /**
+   * Begin the handshake: the offerer emits resume_init (sealed under the session send key at
+   * the continuing counter); the joiner has nothing to send.
+   */
+  async start(): Promise<void> {
+    if (this.started) throw new Error('resume: preamble already started');
+    this.started = true;
+    if (this.opts.role === 'joiner') return;
+    let msg: ResumeMessage;
+    try {
+      msg = this.sess.start();
+    } catch (err) {
+      this.fail(err as Error);
+      throw err;
+    }
+    await this.sendLocked(msg);
+  }
+
+  /**
+   * Feed one inbound sealed frame. Called from the read loop and fully serialized; a
+   * malformed, wrong-type, replayed, or otherwise invalid frame settles the preamble failed
+   * (terminal) before the transfer could start.
+   */
+  async handle(frame: Uint8Array): Promise<void> {
+    if (this.settled) return; // settled: ignore late frames
+    let payload: Uint8Array;
+    try {
+      payload = await this.openLocked(frame);
+    } catch (err) {
+      this.fail(err as Error);
+      return;
+    }
+    let out: ResumeMessage | undefined;
+    let result: ResumeAuthResult | undefined;
+    try {
+      const outcome = await this.sess.handle(payload);
+      out = outcome.out;
+      result = outcome.result;
+    } catch (err) {
+      this.fail(err as Error);
+      return;
+    }
+    this.lastAccepted = payload;
+    // The final step (the joiner's accept of resume_confirm) returns BOTH the outbound
+    // resume_ready AND the result: the ready must go out before the side is announced
+    // settled, or the offerer would wait forever for a message that was never sent.
+    if (out !== undefined) {
+      try {
+        await this.sendLocked(out);
+      } catch (err) {
+        this.fail(err as Error);
+        return;
+      }
+    }
+    if (result !== undefined) {
+      this.resultValue = result;
+      this.settled = true;
+      this.resolveDone(result);
+    }
+  }
+
+  /** Resolves when the preamble settles (mutual authentication succeeded or failed). */
+  done(): Promise<ResumeAuthResult | undefined> {
+    return this.donePromise;
+  }
+
+  /** Reports whether the preamble has settled (success or terminal failure). */
+  isSettled(): boolean {
+    return this.settled;
+  }
+
+  /**
+   * Abort an in-flight handshake (peer teardown / driver cancel). Settles the preamble
+   * failed and abandons the candidate key material; safe to call more than once and after
+   * settlement (no-op then). Mirrors the CLI driver's ctx-bound wait.
+   */
+  cancel(): void {
+    this.fail(new Error('resume: preamble canceled'));
+  }
+
+  /**
+   * Returns the fresh resumed key epoch after mutual authentication, or throws the terminal
+   * error. The keys are exposed only after the handshake completed; a failed attempt
+   * abandons the candidate key material (ADR 0005 §7).
+   */
+  result(): ResumeAuthResult {
+    if (this.errValue !== undefined) throw this.errValue;
+    if (this.resultValue === undefined) {
+      throw new Error('resume: preamble has not settled');
+    }
+    return this.resultValue;
+  }
+
+  /**
+   * Opens one inbound frame under the session recv key at the expected counter, requiring the
+   * FrameResumeAuth tag. An exact duplicate of the last accepted frame (the same counter as
+   * the previous frame, re-sent by the transport) is re-opened and accepted idempotently so a
+   * lost response is retransmitted identically; any other replay fails.
+   */
+  private async openLocked(frame: Uint8Array): Promise<Uint8Array> {
+    let opened;
+    try {
+      opened = await openSequenced(this.opts.recvDir, this.recvCounter, frame);
+    } catch (err) {
+      if (
+        err instanceof FrameReplayError &&
+        this.recvCounter > 0 &&
+        this.lastAccepted !== undefined
+      ) {
+        // Exact-duplicate re-send: the frame carries the previous counter and must be
+        // byte-identical to the last accepted message to be answered idempotently.
+        try {
+          const prev = await openSequenced(this.opts.recvDir, this.recvCounter - 1, frame);
+          if (
+            prev.header.type === FrameType.ResumeAuth &&
+            eqBytes(prev.plaintext, this.lastAccepted)
+          ) {
+            return prev.plaintext;
+          }
+        } catch {
+          // fall through to the rejection below
+        }
+      }
+      throw new Error(`resume: inbound frame rejected: ${(err as Error).message}`);
+    }
+    if (opened.header.type !== FrameType.ResumeAuth) {
+      throw new Error(
+        `resume: inbound frame type ${opened.header.type} before resume authentication completed`,
+      );
+    }
+    this.recvCounter = opened.counter + 1;
+    return opened.plaintext;
+  }
+
+  /** Seals and transmits one resume-auth message under the session send key at the
+   * continuing counter. The counter advances exactly once per sent frame. */
+  private async sendLocked(msg: ResumeMessage): Promise<void> {
+    const payload = encodeResumeMessage(msg);
+    const header: FrameHeaderInput = {
+      version: 1,
+      type: FrameType.ResumeAuth,
+      flags: 0,
+      fileIdx: 0,
+      blockIdx: 0,
+      frameOff: 0,
+    };
+    let frame: Uint8Array;
+    try {
+      frame = await seal(this.opts.sendDir, this.sendCounter, header, payload);
+    } catch (err) {
+      throw new Error(`resume: seal preamble frame: ${(err as Error).message}`);
+    }
+    try {
+      await this.opts.send(frame);
+    } catch (err) {
+      throw new Error(`resume: send preamble frame: ${(err as Error).message}`);
+    }
+    this.sendCounter++;
+  }
+
+  private fail(err: Error): void {
+    if (this.errValue === undefined) {
+      this.errValue = err;
+    }
+    if (!this.settled) {
+      this.settled = true;
+      this.resolveDone(undefined);
+    }
+  }
+}
+
+function eqBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}

--- a/packages/protocol/src/resume-preamble.ts
+++ b/packages/protocol/src/resume-preamble.ts
@@ -74,6 +74,15 @@ export class ResumePreamble {
   private settled = false;
   private donePromise: Promise<ResumeAuthResult | undefined>;
   private resolveDone!: (r: ResumeAuthResult | undefined) => void;
+  /**
+   * Serializes ALL inbound preamble processing in arrival order: every handle() call
+   * appends to this chain, so exactly one frame can open/mutate counters at a time even
+   * when frames are delivered without awaiting (the worker dispatches `void
+   * preamble.handle(frame)` for every inbound frame). The chain swallows rejections so a
+   * later queued frame still runs and observes the settled state (failures are recorded
+   * via {@link fail}, never thrown through the queue).
+   */
+  private queue: Promise<void> = Promise.resolve();
   /** Canonical payload of the last accepted inbound message, for idempotent re-answers. */
   private lastAccepted: Uint8Array | undefined;
 
@@ -124,12 +133,26 @@ export class ResumePreamble {
   }
 
   /**
-   * Feed one inbound sealed frame. Called from the read loop and fully serialized; a
+   * Feed one inbound sealed frame. Called from the read loop; processing is serialized in
+   * arrival order through an internal promise chain, so exactly one frame can open/mutate
+   * counters at a time even when the caller does not await between deliveries. A
    * malformed, wrong-type, replayed, or otherwise invalid frame settles the preamble failed
-   * (terminal) before the transfer could start.
+   * (terminal) before the transfer could start; frames queued behind a failure observe the
+   * settled state and cannot resurrect it.
    */
-  async handle(frame: Uint8Array): Promise<void> {
-    if (this.settled) return; // settled: ignore late frames
+  handle(frame: Uint8Array): Promise<void> {
+    const run = this.queue.then(() => this.handleSerialized(frame));
+    // Keep the chain alive regardless of task outcome: failures are recorded via fail()
+    // (never thrown through the queue), so later queued frames must still execute and see
+    // the settled state. The returned promise is the caller's own task (which cannot
+    // reject: every path is caught), so `void preamble.handle(frame)` is safe.
+    this.queue = run.catch(() => undefined);
+    return run;
+  }
+
+  /** One serialized step of inbound processing (guarded by the queue). */
+  private async handleSerialized(frame: Uint8Array): Promise<void> {
+    if (this.settled) return; // settled: ignore late frames (including queued-after-failure)
     let payload: Uint8Array;
     try {
       payload = await this.openLocked(frame);
@@ -137,6 +160,7 @@ export class ResumePreamble {
       this.fail(err as Error);
       return;
     }
+    if (this.settled) return; // canceled while the frame was being opened
     let out: ResumeMessage | undefined;
     let result: ResumeAuthResult | undefined;
     try {
@@ -147,6 +171,7 @@ export class ResumePreamble {
       this.fail(err as Error);
       return;
     }
+    if (this.settled) return; // canceled while the engine was handling the frame
     this.lastAccepted = payload;
     // The final step (the joiner's accept of resume_confirm) returns BOTH the outbound
     // resume_ready AND the result: the ready must go out before the side is announced
@@ -159,6 +184,7 @@ export class ResumePreamble {
         return;
       }
     }
+    if (this.settled) return; // canceled while the reply was being transmitted
     if (result !== undefined) {
       this.resultValue = result;
       this.settled = true;

--- a/packages/protocol/src/transfer-receiver.ts
+++ b/packages/protocol/src/transfer-receiver.ts
@@ -80,6 +80,13 @@ export interface TransferReceiverOptions {
   /** Reports bytes only after verify-and-sink. */
   onProgress?(acknowledgedBytes: number): void;
   onFileProgress?(fileIdx: number, fileBytes: number, acknowledgedBytes: number): void;
+  /**
+   * Reports the verified baseline reused from the authenticated durable checkpoint (the
+   * persisted haveBlocks claim) once the resume seed is applied, invoked ONCE before the
+   * first new block is acknowledged. The host anchors its session rate on this baseline:
+   * sessionBytes = verified - reused (V13-PR08).
+   */
+  onResume?(reusedBytes: number): void;
   onStateChange?(state: TransferRunState): void;
   /** Called once with the validated complete file set before any destination opens. */
   onManifestSet?(manifest: Manifest): void | Promise<void>;
@@ -298,6 +305,16 @@ export class TransferReceiver {
       if (this.o.resume && this.o.resume.transferId === manifest.transferId) {
         await this.validateResumeSeed(manifest, this.o.resume);
         this.activeResume = this.o.resume;
+        // V13-PR08 progress contract: surface the verified baseline reused from the
+        // authenticated checkpoint immediately — before the first new block is
+        // acknowledged — so the host anchors its session rate on it.
+        let reusedTotal = 0;
+        for (const file of manifest.files) {
+          const have = this.activeResume.files.get(file.idx)?.haveBlocks ?? 0;
+          if (have <= 0) continue;
+          reusedTotal += have >= file.blocks ? file.size : have * file.blockSize;
+        }
+        if (reusedTotal > 0) this.o.onResume?.(reusedTotal);
       }
       await this.sendResumeState(manifest);
     }

--- a/packages/protocol/src/transfer-sender.ts
+++ b/packages/protocol/src/transfer-sender.ts
@@ -80,6 +80,13 @@ export interface TransferSenderOptions {
   /** Reports verified progress for the active file plus aggregate acknowledged bytes. */
   onFileProgress?(fileIdx: number, fileBytes: number, acknowledgedBytes: number): void;
   /**
+   * Reports the verified baseline reused from the authenticated durable checkpoint at
+   * resume start (the receiver's validated haveBlocks claim), invoked ONCE before any
+   * block is sent. The host anchors its session rate on this baseline so the reused jump
+   * is never counted as transferred bytes: sessionBytes = verified - reused (V13-PR08).
+   */
+  onResume?(reusedBytes: number): void;
+  /**
    * Called with the validated manifest immediately before its frame is transmitted — the
    * seam the caller uses to make sender-side state durable (stable transfer id + canonical
    * source identity) strictly before the id is advertised. May be async; a rejection
@@ -318,6 +325,16 @@ export class TransferSender {
     // streaming so skipped blocks are never sent. Fresh transfers never take this branch.
     if (this.transferId !== undefined) {
       await this.resumeReady;
+      // V13-PR08 progress contract: surface the verified baseline reused from the
+      // authenticated checkpoint immediately — before any block is sent — so the host
+      // anchors its session rate on it and never counts the reused jump as transferred.
+      let reusedTotal = 0;
+      for (const file of manifest.files) {
+        const have = this.resumePlan.get(file.idx) ?? 0;
+        if (have <= 0) continue;
+        reusedTotal += have >= file.blocks ? file.size : have * file.blockSize;
+      }
+      if (reusedTotal > 0) this.o.onResume?.(reusedTotal);
     }
 
     for (const [fileIdx, source] of this.files.entries()) {

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -28,6 +28,7 @@ export enum FrameType {
   Done = 10,
   Fail = 11,
   ResumeState = 12,
+  ResumeAuth = 13,
 }
 
 /** Feature flags negotiated in caps. */

--- a/packages/wire/campaign_resume_test.go
+++ b/packages/wire/campaign_resume_test.go
@@ -1,0 +1,440 @@
+//go:build campaign
+
+// V13-PR08 campaign: prove a very large logical transfer (>= 100 GiB by default) can resume
+// from a deep durable checkpoint with bounded memory and no full-file staging.
+//
+// Methodology:
+//   - The source is DETERMINISTIC and GENERATED on the fly (never materialized): each chunk is
+//     computed from its absolute offset by a fixed formula, so both the sender's digest pass and
+//     its block stream reproduce identical bytes without ever holding the file in RAM or on disk.
+//   - The receiver sink is a VERIFYING COUNTER: it recomputes the expected bytes for every write
+//     from the offset (a streaming self-check), counts acknowledged blocks, and keeps a rolling
+//     digest — it never stores more than one block.
+//   - Resume from a deep checkpoint: haveBlocks = 68% of the transfer's blocks (the default).
+//     The seed digest is built by streaming the generated prefix (bounded memory), and the
+//     resumed leg must send ONLY the missing suffix.
+//   - Whole-file correctness is enforced by the receiver's mandatory final digest check against
+//     the manifest (which the sender computes by streaming the same generated content), plus an
+//     independent expected-digest computed once here.
+//   - Peak memory is sampled every 10ms via runtime.ReadMemStats during the resumed leg and
+//     asserted against a hard bound far below the logical size.
+//
+// This is a CI-only harness: `go test -tags campaign ./packages/wire/ -run TestCampaign -v`.
+// Logical size is configurable: SENDBEAM_CAMPAIGN_GIB=100 (default). Do NOT run 100 GiB on a
+// laptop — the GitHub Actions job owns the full campaign.
+
+package wire
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// campaignSourceChunk bounds each generated chunk (64 KiB, matching the CLI source).
+const campaignSourceChunk = 64 * 1024
+
+// campaignGeneratedSource streams deterministic bytes derived from the absolute offset:
+// byte(i) = (i*29 + 7) & 0xff. Same formula on every Stream call, so the sender's digest pass
+// and its block pass (and the receiver's independent check) all agree without storage.
+type campaignGeneratedSource struct {
+	size  int64
+	meta  FileMeta
+	chunk int64
+}
+
+func newCampaignSource(size int64, name string) *campaignGeneratedSource {
+	return &campaignGeneratedSource{
+		size:  size,
+		meta:  FileMeta{Name: name, Size: size, Mime: "application/octet-stream", LastModified: 1},
+		chunk: campaignSourceChunk,
+	}
+}
+
+func (g *campaignGeneratedSource) Meta() FileMeta { return g.meta }
+
+func (g *campaignGeneratedSource) Stream(fn func(chunk []byte) error) error {
+	buf := make([]byte, g.chunk)
+	var off int64
+	for off < g.size {
+		n := g.chunk
+		if off+n > g.size {
+			n = g.size - off
+		}
+		fillCampaignBytes(buf[:n], off)
+		if err := fn(buf[:n]); err != nil {
+			return err
+		}
+		off += n
+	}
+	return nil
+}
+
+// campaignLUT is the 256-byte period of the generated sequence (29 is coprime with 256, so
+// (i*29+7) mod 256 is a full permutation with period 256). Filling is a table copy per period
+// instead of a per-byte multiply, which matters when streaming hundreds of GiB in CI.
+var campaignLUT = func() [256]byte {
+	var lut [256]byte
+	for i := range lut {
+		lut[i] = byte(i*29 + 7)
+	}
+	return lut
+}()
+
+// fillCampaignBytes writes the deterministic byte sequence for [base, base+len(b)). The
+// sequence is periodic with period 256, so a chunk is the LUT rotated by base mod 256; fill
+// is memcpy-based (finish the current period, then full periods) rather than byte-wise.
+func fillCampaignBytes(b []byte, base int64) {
+	start := int(base % 256)
+	n := copy(b, campaignLUT[start:])
+	if n < len(b) && start > 0 {
+		n += copy(b[n:], campaignLUT[:start])
+	}
+	for n < len(b) {
+		n += copy(b[n:], campaignLUT[:])
+	}
+}
+
+// errCampaignPrefixDone stops the source stream once the prefix digest is complete, so the
+// full source is never generated for a prefix-only digest.
+var errCampaignPrefixDone = fmt.Errorf("campaign prefix digest complete")
+
+// campaignDigestOfPrefix streams [0, bytes) of the generated content through a digest without
+// materializing the prefix — the same path a reloaded receiver's seed rebuild would take.
+func campaignDigestOfPrefix(size, bytes int64) Digest {
+	d := NewSHA256Digest()
+	src := newCampaignSource(size, "f")
+	remaining := bytes
+	_ = src.Stream(func(chunk []byte) error {
+		if remaining <= 0 {
+			return errCampaignPrefixDone // stop early; do not generate the rest of the source
+		}
+		n := int64(len(chunk))
+		if n > remaining {
+			n = remaining
+		}
+		d.Update(chunk[:n])
+		remaining -= n
+		return nil
+	})
+	return d
+}
+
+// campaignSink verifies every write against the generated formula, counts acknowledged blocks,
+// and keeps a rolling digest. It stores at most one block's bytes — the full transfer is never
+// staged in memory (no full-file staging, streamed block processing).
+type campaignSink struct {
+	blockSize   int64
+	verified    int64 // bytes verified so far (monotonic, ordered writes only)
+	blocks      int64 // complete blocks verified
+	digest      Digest
+	mu          sync.Mutex
+	failOnWrite atomic.Bool
+}
+
+func newCampaignSink(blockSize int64) *campaignSink {
+	return &campaignSink{blockSize: blockSize, digest: NewSHA256Digest()}
+}
+
+func (s *campaignSink) Write(offset int64, data []byte) error {
+	if s.failOnWrite.Load() {
+		return fmt.Errorf("campaign sink: forced write failure (crash injection)")
+	}
+	expected := make([]byte, len(data))
+	fillCampaignBytes(expected, offset)
+	if !bytes.Equal(data, expected) {
+		for i := range data {
+			if data[i] != expected[i] {
+				return fmt.Errorf("campaign sink: byte %d mismatch at offset %d (want %d, got %d)", i, offset+int64(i), expected[i], data[i])
+			}
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.digest.Update(data)
+	s.verified = offset + int64(len(data))
+	s.blocks = s.verified / s.blockSize
+	return nil
+}
+
+func (s *campaignSink) Close() error       { return nil }
+func (s *campaignSink) Abort(string) error { return nil }
+
+// campaignPeakMemory samples peak HeapAlloc while the resumed leg runs.
+type campaignPeakMemory struct {
+	stop  chan struct{}
+	done  chan struct{}
+	peak  atomic.Int64
+	bytes atomic.Int64 // total bytes allocated during the window (cumulative)
+}
+
+func newCampaignPeakMemory() *campaignPeakMemory {
+	m := &campaignPeakMemory{stop: make(chan struct{}), done: make(chan struct{})}
+	go func() {
+		defer close(m.done)
+		var ms runtime.MemStats
+		for {
+			select {
+			case <-m.stop:
+				return
+			default:
+			}
+			runtime.ReadMemStats(&ms)
+			if int64(ms.HeapAlloc) > m.peak.Load() {
+				m.peak.Store(int64(ms.HeapAlloc))
+			}
+			m.bytes.Store(int64(ms.TotalAlloc))
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	return m
+}
+
+func (m *campaignPeakMemory) close() {
+	close(m.stop)
+	<-m.done
+}
+
+// runCampaignLeg wires the sender to the receiver over ordered buffered channels and runs the
+// resumed leg to completion. Returns the receiver result and the number of DISTINCT blocks the
+// sender streamed (only missing blocks may be sent). The frame header rides as plaintext AAD
+// (counter(8) || header(16) || ...), so type and block index are readable without decrypting:
+// Type at byte 9, BlockIdx (big-endian u32) at bytes 14:18.
+func runCampaignLeg(t *testing.T, src FileSource, resume *ReceiverResume, sink *campaignSink, blockSize, window int) (recvRes ReceiveResult, blocksSent int64) {
+	t.Helper()
+	keys, err := DeriveTransferKeys(loopbackMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2r := make(chan []byte, 4096)
+	r2s := make(chan []byte, 4096)
+	cp := func(f []byte) []byte { return append([]byte(nil), f...) }
+
+	sender := NewSender(SenderOptions{
+		File:       src,
+		Send:       func(f []byte) error { s2r <- cp(f); return nil },
+		SendDir:    keys.O2J,
+		RecvDir:    keys.J2O,
+		BlockSize:  blockSize,
+		FrameSize:  16 * 1024, // production-shaped 16 KiB frames; Seal caps payloads at u16 max
+		Window:     window,
+		TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	receiver := NewReceiver(ReceiverOptions{
+		Send:         func(f []byte) error { r2s <- cp(f); return nil },
+		SendDir:      keys.J2O,
+		RecvDir:      keys.O2J,
+		Sink:         sink,
+		CreateDigest: NewSHA256Digest,
+		Resume:       resume,
+	})
+	// Distinct block indices seen on the wire; one block may span many frames.
+	seen := make(map[uint32]struct{})
+	var seenMu sync.Mutex
+	go func() {
+		for f := range s2r {
+			if len(f) >= 18 && f[9] == FrameBlockData {
+				idx := uint32(f[14])<<24 | uint32(f[15])<<16 | uint32(f[16])<<8 | uint32(f[17])
+				seenMu.Lock()
+				seen[idx] = struct{}{}
+				seenMu.Unlock()
+			}
+			receiver.Handle(f)
+		}
+	}()
+	go func() {
+		for f := range r2s {
+			sender.Handle(f)
+		}
+	}()
+
+	runErrCh := make(chan error, 1)
+	go func() {
+		_, e := sender.Run(context.Background())
+		runErrCh <- e
+	}()
+	recvCh := make(chan struct{})
+	var recvOut ReceiveResult
+	var recvErr error
+	go func() {
+		recvOut, recvErr = receiver.Wait(context.Background())
+		close(recvCh)
+	}()
+	timer := time.NewTimer(85 * time.Minute)
+	defer timer.Stop()
+	for done := false; !done; {
+		select {
+		case runErr := <-runErrCh:
+			if runErr != nil {
+				t.Fatalf("sender: %v", runErr)
+			}
+			done = true
+		case <-recvCh:
+			if recvErr != nil {
+				t.Fatalf("receiver: %v", recvErr)
+			}
+			done = true
+		case <-timer.C:
+			t.Fatal("campaign leg did not settle within 60 minutes")
+		}
+	}
+	close(s2r)
+	close(r2s)
+	seenMu.Lock()
+	blocksSent = int64(len(seen))
+	seenMu.Unlock()
+	return recvOut, blocksSent
+}
+
+// TestCampaign100GiBResume proves a >= 100 GiB logical transfer resumes from a deep durable
+// checkpoint: only the missing suffix is sent, the whole file is still verified, and peak
+// memory stays far below the logical size (bounded memory, no full-file staging).
+func TestCampaign100GiBResume(t *testing.T) {
+	gib := int64(100)
+	if v := os.Getenv("SENDBEAM_CAMPAIGN_GIB"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || n < 1 {
+			t.Fatalf("SENDBEAM_CAMPAIGN_GIB must be a positive integer, got %q", v)
+		}
+		gib = n
+	}
+	const blockSize = 1024 * 1024 // 1 MiB blocks (matches negotiated production geometry)
+	size := gib * 1024 * 1024 * 1024
+	blocks := (size-1)/blockSize + 1
+	// Deep checkpoint: 68% of the transfer is already durable from the interrupted session.
+	haveBlocks := blocks * 68 / 100
+	if haveBlocks < 1 {
+		haveBlocks = 1
+	}
+	t.Logf("campaign: logical size = %d GiB (%d bytes), %d blocks of %d bytes, resume from %d blocks (%.1f%%)",
+		gib, size, blocks, blockSize, haveBlocks, float64(haveBlocks)/float64(blocks)*100)
+
+	// Independent expected digest: stream the generated content once, bounded memory.
+	expected := campaignDigestOfPrefix(size, size)
+
+	// Seed digest over the durable prefix [0, haveBlocks*blockSize) — what a reloaded receiver
+	// would rebuild from its verified partial.
+	prefixBytes := haveBlocks * blockSize
+	if prefixBytes > size {
+		prefixBytes = size
+	}
+	seed := campaignDigestOfPrefix(size, prefixBytes)
+
+	// The resume claims the SAME manifest the sender is about to stream (V13-PR06 binding).
+	src := newCampaignSource(size, "f")
+	// Compute the canonical manifest fingerprint from the sender's geometry.
+	manifest := Manifest{
+		Type:       FrameManifest,
+		TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Files: []FileEntry{{
+			Idx: 0, Name: "f", Size: size, Mime: "application/octet-stream",
+			LastModified: 1, BlockSize: blockSize, Blocks: int(blocks),
+			FileDigest: expected.HexDigest(),
+		}},
+		TotalSize: size,
+	}
+	fingerprint, err := ManifestFingerprint(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resume := &ReceiverResume{
+		TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ManifestFingerprint: fingerprint,
+		Files: map[int]ResumeFileProgress{
+			0: {HaveBlocks: int(haveBlocks), SeedDigest: seed},
+		},
+	}
+
+	sink := newCampaignSink(blockSize)
+	peak := newCampaignPeakMemory()
+	start := time.Now()
+	recvRes, blockFrames := runCampaignLeg(t, src, resume, sink, blockSize, 8)
+	elapsed := time.Since(start)
+	peak.close()
+
+	// Only the missing suffix may be sent.
+	wantFrames := blocks - haveBlocks
+	if blockFrames != wantFrames {
+		t.Errorf("sent %d block frames, want exactly %d (only the missing suffix)", blockFrames, wantFrames)
+	}
+	// The receiver verified the FULL file (seed + missing suffix) against the manifest digest.
+	if recvRes.Digest != expected.HexDigest() {
+		t.Errorf("receiver digest = %s, want %s", recvRes.Digest, expected.HexDigest())
+	}
+	// The sink verified every byte against the generated formula and saw the whole file.
+	if sink.verified != size {
+		t.Errorf("sink verified %d bytes, want %d", sink.verified, size)
+	}
+	if sink.blocks != blocks {
+		t.Errorf("sink counted %d blocks, want %d", sink.blocks, blocks)
+	}
+
+	peakBytes := peak.peak.Load()
+	t.Logf("campaign: resumed leg completed in %s; peak HeapAlloc = %d bytes (%.2f MiB); "+
+		"logical size = %d bytes; logical/peak ratio = %.0fx", elapsed, peakBytes,
+		float64(peakBytes)/1024/1024, size, float64(size)/float64(peakBytes))
+
+	// Hard bound: peak heap must stay far below the logical size. The sender's window + frames
+	// keep live memory to a few MiB regardless of the 100+ GiB logical transfer.
+	bound := int64(512 * 1024 * 1024) // 512 MiB
+	if peakBytes > bound {
+		t.Errorf("peak heap %d bytes exceeds the %d-byte bound; the campaign must stream with bounded memory", peakBytes, bound)
+	}
+}
+
+// TestCampaignZeroByteResumeAfterAllDurable proves a successful resume may transfer ZERO file
+// bytes: when every block was already durable before the restart, resume_state claims all
+// blocks, the sender streams nothing, and whole-file verification still occurs (V13-PR08).
+func TestCampaignZeroByteResumeAfterAllDurable(t *testing.T) {
+	const size = 8 * 1024 * 1024 * 1024 // 8 GiB logical (the zero-byte property is size-independent)
+	const blockSize = 1024 * 1024
+	blocks := size / blockSize
+	haveBlocks := blocks // all durable
+
+	src := newCampaignSource(size, "f")
+	expected := campaignDigestOfPrefix(size, size)
+	seed := campaignDigestOfPrefix(size, size)
+	manifest := Manifest{
+		Type:       FrameManifest,
+		TransferID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Files: []FileEntry{{
+			Idx: 0, Name: "f", Size: size, Mime: "application/octet-stream",
+			LastModified: 1, BlockSize: blockSize, Blocks: int(blocks),
+			FileDigest: expected.HexDigest(),
+		}},
+		TotalSize: size,
+	}
+	fingerprint, err := ManifestFingerprint(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resume := &ReceiverResume{
+		TransferID:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ManifestFingerprint: fingerprint,
+		Files: map[int]ResumeFileProgress{
+			0: {HaveBlocks: int(haveBlocks), SeedDigest: seed},
+		},
+	}
+	sink := newCampaignSink(blockSize)
+	peak := newCampaignPeakMemory()
+	start := time.Now()
+	recvRes, blockFrames := runCampaignLeg(t, src, resume, sink, blockSize, 8)
+	elapsed := time.Since(start)
+	peak.close()
+
+	if blockFrames != 0 {
+		t.Errorf("sent %d block frames, want 0 (everything was already durable)", blockFrames)
+	}
+	if recvRes.Digest != expected.HexDigest() {
+		t.Errorf("receiver digest = %s, want %s", recvRes.Digest, expected.HexDigest())
+	}
+	t.Logf("campaign: zero-byte resume completed in %s; peak HeapAlloc = %.2f MiB", elapsed,
+		float64(peak.peak.Load())/1024/1024)
+}

--- a/packages/wire/frame.go
+++ b/packages/wire/frame.go
@@ -48,6 +48,11 @@ const (
 	FrameDone        uint8 = 10
 	FrameFail        uint8 = 11
 	FrameResumeState uint8 = 12
+	// FrameResumeAuth carries one resume-auth message (EncodeResumeMessage JSON) sealed
+	// under the SESSION directional keys, exchanged strictly before the transfer engine
+	// starts (V13-PR08). It is never used for transfer protocol frames; after mutual
+	// authentication the transfer runs under the fresh resumed key epoch.
+	FrameResumeAuth uint8 = 13
 )
 
 // encodeFrameHeader encodes h into a fresh 16-byte buffer.

--- a/packages/wire/resume_preamble.go
+++ b/packages/wire/resume_preamble.go
@@ -1,0 +1,237 @@
+package wire
+
+// Resume preamble (V13-PR08): the product integration of the reviewed PR07 resume-auth
+// engine. It runs the transport-agnostic mutual-authentication handshake over the sealed
+// session channel — strictly BEFORE the transfer engine starts — so durable progress from a
+// previous authenticated session is never reused under session keys, and no
+// Manifest/ResumeState/BlockData/Complete frame can flow before the peers authenticated
+// continuity with each other.
+//
+// The resume-auth messages travel as FrameResumeAuth frames sealed under the SESSION
+// directional keys (the keys the SPAKE2 handshake just derived): the session key epoch is
+// used ONLY to carry the four resume-auth messages, and the transfer itself runs under the
+// FRESH key epoch derived from the mutually authenticated resume master (ADR 0005 §7). The
+// PR07 engine is unchanged: transferId + manifest fingerprint + role + resume secret are
+// local context (never transmitted), the transcript binds them, and the fresh nonces make
+// every attempt a new key epoch.
+//
+// Fail-closed rules: any inbound frame that is not a well-formed resume-auth frame (wrong
+// type, wrong counter, torn, tampered, oversized, malformed) settles the preamble failed
+// before the transfer could start. An exact duplicate of the last accepted frame (a
+// transport-level re-send with the same counter) is re-opened and re-answered idempotently
+// from the engine's snapshots — never with a fresh nonce or proof. There is no challenge
+// replacement, no nonce/proof/role/version mutation, and no unbounded history.
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+)
+
+// ResumePreambleOptions configures one resume-auth exchange over the sealed session channel.
+type ResumePreambleOptions struct {
+	// Role is this peer's stable role: offerer (sender) or joiner (receiver).
+	Role Role
+	// TransferID and Fingerprint are the LOCAL resume context — the stable transfer id and
+	// canonical manifest fingerprint of the interrupted transfer. They are never transmitted;
+	// the engine binds them into the transcript.
+	TransferID  string
+	Fingerprint string
+	// ResumeSecret is the decoded 32-byte transfer-scoped credential from the local sender
+	// record or receiver journal (ADR 0005 §4). Never printed, logged, or exposed.
+	ResumeSecret []byte
+	// Send transmits one sealed frame (the same callback the transfer engine will use).
+	Send func(frame []byte) error
+	// SendDir/RecvDir are the SESSION directional keys. Resume-auth frames are sealed under
+	// them; the transfer itself later uses the fresh resumed key epoch.
+	SendDir DirectionalKey
+	RecvDir DirectionalKey
+	// SendCounter is the first frame counter for this peer's resume-auth frames (continues
+	// the session handshake counters); RecvCounter is the expected first counter of the
+	// peer's resume-auth frames.
+	SendCounter uint64
+	RecvCounter uint64
+	// NonceSource injects deterministic fresh nonces in tests; nil uses crypto/rand.
+	NonceSource func(n int) ([]byte, error)
+}
+
+// ResumePreamble is one in-flight resume-auth exchange. The driver wires Handle as the
+// inbound data hook, calls Start (offerer only), and waits on Done; Result exposes the
+// fresh resumed key epoch only after mutual authentication completes. Any failure is
+// terminal and preserved.
+type ResumePreamble struct {
+	opts ResumePreambleOptions
+	sess *ResumeAuthSession
+
+	mu          sync.Mutex
+	sendCounter uint64
+	recvCounter uint64
+	started     bool
+	done        chan struct{}
+	result      *ResumeAuthResult
+	err         error
+	// lastAccepted is the canonical payload of the last accepted inbound message, kept so an
+	// exact duplicate retransmission (same counter) is re-opened and re-answered idempotently.
+	lastAccepted []byte
+}
+
+// NewResumePreamble validates the local resume context and builds the PR07 session. A
+// missing or invalid secret, role, or context fails before anything is sent.
+func NewResumePreamble(opts ResumePreambleOptions) (*ResumePreamble, error) {
+	sess, err := NewResumeAuthSession(ResumeAuthContext{
+		Version:             ResumeAuthVersion,
+		TransferID:          opts.TransferID,
+		ManifestFingerprint: opts.Fingerprint,
+		Role:                opts.Role,
+		ResumeSecret:        opts.ResumeSecret,
+		NonceSource:         opts.NonceSource,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if opts.Send == nil {
+		return nil, Errorf(CodeProtocol, "resume: preamble requires a Send callback")
+	}
+	return &ResumePreamble{
+		opts:        opts,
+		sess:        sess,
+		sendCounter: opts.SendCounter,
+		recvCounter: opts.RecvCounter,
+		done:        make(chan struct{}),
+	}, nil
+}
+
+// Start begins the handshake: the offerer emits resume_init (sealed under the session send
+// key at the continuing counter); the joiner has nothing to send and returns nil.
+func (p *ResumePreamble) Start() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return Errorf(CodeProtocol, "resume: preamble already started")
+	}
+	p.started = true
+	if p.opts.Role == RoleJoiner {
+		return nil
+	}
+	msg, err := p.sess.Start()
+	if err != nil {
+		p.failLocked(err)
+		return err
+	}
+	return p.sendLocked(msg)
+}
+
+// Handle feeds one inbound sealed frame. It is called from the read loop and is fully
+// serialized; a malformed, wrong-type, replayed, or otherwise invalid frame settles the
+// preamble failed (terminal) before the transfer could start.
+func (p *ResumePreamble) Handle(frame []byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil || p.result != nil {
+		return // settled: ignore late frames
+	}
+	payload, err := p.openLocked(frame)
+	if err != nil {
+		p.failLocked(err)
+		return
+	}
+	out, result, err := p.sess.Handle(payload)
+	if err != nil {
+		p.failLocked(err)
+		return
+	}
+	p.lastAccepted = append([]byte(nil), payload...)
+	// The final step (the joiner's accept of resume_confirm) returns BOTH the outbound
+	// resume_ready AND the result: the ready must go out before the side is announced
+	// settled, or the offerer would wait forever for a message that was never sent.
+	if out != nil {
+		if err := p.sendLocked(out); err != nil {
+			p.failLocked(err)
+			return
+		}
+	}
+	if result != nil {
+		p.result = result
+		close(p.done)
+	}
+}
+
+// openLocked opens one inbound frame under the session recv key at the expected counter,
+// requiring the FrameResumeAuth tag. An exact duplicate of the last accepted frame (the
+// same counter as the previous frame, re-sent by the transport) is re-opened and accepted
+// idempotently so a lost response is retransmitted identically; any other replay fails.
+func (p *ResumePreamble) openLocked(frame []byte) ([]byte, error) {
+	opened, err := OpenSequenced(p.opts.RecvDir, p.recvCounter, frame)
+	if err != nil {
+		if errors.Is(err, ErrFrameReplay) && p.recvCounter > 0 && len(p.lastAccepted) > 0 {
+			// Exact-duplicate re-send: the frame carries the previous counter and must be
+			// byte-identical to the last accepted message to be answered idempotently.
+			prev, prevErr := Open(p.opts.RecvDir, p.recvCounter-1, frame)
+			if prevErr == nil && prev.Header.Type == FrameResumeAuth &&
+				bytes.Equal(prev.Plaintext, p.lastAccepted) {
+				return prev.Plaintext, nil
+			}
+		}
+		return nil, Errorf(CodeProtocol, "resume: inbound frame rejected: %v", err)
+	}
+	if opened.Header.Type != FrameResumeAuth {
+		return nil, Errorf(CodeProtocol,
+			"resume: inbound frame type %d before resume authentication completed", opened.Header.Type)
+	}
+	p.recvCounter = opened.Counter + 1
+	return opened.Plaintext, nil
+}
+
+// sendLocked seals and transmits one resume-auth message under the session send key at the
+// continuing counter. The counter advances exactly once per sent frame.
+func (p *ResumePreamble) sendLocked(msg *ResumeMessage) error {
+	payload, err := EncodeResumeMessage(msg)
+	if err != nil {
+		return err
+	}
+	frame, err := Seal(p.opts.SendDir, p.sendCounter, FrameHeaderInput{
+		Version: FrameVersion, Type: FrameResumeAuth,
+	}, payload)
+	if err != nil {
+		return Errorf(CodeProtocol, "resume: seal preamble frame: %v", err)
+	}
+	if err := p.opts.Send(frame); err != nil {
+		return Errorf(CodeConnection, "resume: send preamble frame: %v", err)
+	}
+	p.sendCounter++
+	return nil
+}
+
+// Done resolves when the preamble settles (mutual authentication succeeded or failed).
+func (p *ResumePreamble) Done() <-chan struct{} { return p.done }
+
+// Settled reports whether the preamble has settled (success or terminal failure).
+func (p *ResumePreamble) Settled() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.result != nil || p.err != nil
+}
+
+// Result returns the fresh resumed key epoch after mutual authentication, or the terminal
+// error. The keys are exposed only after the handshake completed; a failed attempt abandons
+// the candidate key material (ADR 0005 §7).
+func (p *ResumePreamble) Result() (*ResumeAuthResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return nil, p.err
+	}
+	if p.result == nil {
+		return nil, Errorf(CodeProtocol, "resume: preamble has not settled")
+	}
+	return p.result, nil
+}
+
+func (p *ResumePreamble) failLocked(err error) {
+	if p.err == nil {
+		p.err = err
+	}
+	if p.result == nil {
+		close(p.done)
+	}
+}

--- a/packages/wire/resume_preamble_test.go
+++ b/packages/wire/resume_preamble_test.go
@@ -1,0 +1,469 @@
+package wire
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// memPipe is a tiny in-memory transport between two preambles.
+type memPipe struct {
+	ch chan []byte
+}
+
+func (m *memPipe) send(frame []byte) error {
+	m.ch <- frame
+	return nil
+}
+
+// preamblePair wires two preambles through in-memory channels and drives them to settle,
+// mirroring production cancellation semantics: a failed handshake on one side is torn down
+// by the driver (here: canceling the context), which unblocks the peer. It returns each
+// side's result and error (a canceled peer reports its context error). pump goroutines are
+// joined before returning.
+func preamblePair(ctx context.Context, t *testing.T, cancel context.CancelFunc, o, j ResumePreambleOptions) (*ResumeAuthResult, error, *ResumeAuthResult, error) {
+	t.Helper()
+	chO := make(chan []byte, 16)
+	chJ := make(chan []byte, 16)
+	o.Send = func(f []byte) error { return (&memPipe{ch: chJ}).send(f) }
+	j.Send = func(f []byte) error { return (&memPipe{ch: chO}).send(f) }
+	po, err := NewResumePreamble(o)
+	if err != nil {
+		t.Fatalf("offerer preamble: %v", err)
+	}
+	pj, err := NewResumePreamble(j)
+	if err != nil {
+		t.Fatalf("joiner preamble: %v", err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for f := range chJ {
+			pj.Handle(f)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for f := range chO {
+			po.Handle(f)
+		}
+	}()
+	if err := po.Start(); err != nil {
+		t.Fatalf("offerer Start: %v", err)
+	}
+	// Wait for the first side to settle. A successful handshake settles both sides through
+	// the message chain; a one-sided failure (e.g. proof mismatch) settles only the failing
+	// side and the peer is released by the connection teardown (cancel), exactly like
+	// production where the driver cancels the transfer context on a failed handshake.
+	var resO, resJ *ResumeAuthResult
+	var errO, errJ error
+	select {
+	case <-po.Done():
+		resO, errO = po.Result()
+	case <-pj.Done():
+		resJ, errJ = pj.Result()
+	case <-ctx.Done():
+	}
+	if errO == nil && resO != nil {
+		select {
+		case <-pj.Done():
+			resJ, errJ = pj.Result()
+		case <-time.After(10 * time.Second):
+			t.Fatal("joiner did not settle after a successful offerer")
+		}
+	} else if errJ == nil && resJ != nil {
+		select {
+		case <-po.Done():
+			resO, errO = po.Result()
+		case <-time.After(10 * time.Second):
+			t.Fatal("offerer did not settle after a successful joiner")
+		}
+	}
+	cancel()
+	close(chO)
+	close(chJ)
+	wg.Wait()
+	// A peer released by cancellation reports its unsettled state instead of hanging.
+	if resO == nil && errO == nil {
+		resO, errO = po.Result()
+	}
+	if resJ == nil && errJ == nil {
+		resJ, errJ = pj.Result()
+	}
+	return resO, errO, resJ, errJ
+}
+
+// preambleContext builds the shared local resume context for a transfer.
+func preambleContext(secret []byte, role Role, tid, fp string) ResumePreambleOptions {
+	return ResumePreambleOptions{
+		Role:         role,
+		TransferID:   tid,
+		Fingerprint:  fp,
+		ResumeSecret: secret,
+		SendDir:      sessionSendDir(role),
+		RecvDir:      sessionRecvDir(role),
+		SendCounter:  1, // session handshake consumed one frame per direction
+		RecvCounter:  1,
+		NonceSource:  nonceSource(1),
+	}
+}
+
+// sessionSendDir/RecvDir return the SESSION directional keys for a role (the keys the
+// SPAKE2 handshake derived; the transfer later switches to the fresh resumed epoch).
+func sessionKeys(t *testing.T) TransferKeys {
+	t.Helper()
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return keys
+}
+
+func sessionSendDir(role Role) DirectionalKey {
+	keys, _ := DeriveTransferKeys(senderMaster())
+	if role == RoleOfferer {
+		return keys.O2J
+	}
+	return keys.J2O
+}
+
+func sessionRecvDir(role Role) DirectionalKey {
+	keys, _ := DeriveTransferKeys(senderMaster())
+	if role == RoleOfferer {
+		return keys.J2O
+	}
+	return keys.O2J
+}
+
+// nonceSource returns deterministic distinct 32-byte nonces (test-only).
+func nonceSource(start byte) func(n int) ([]byte, error) {
+	next := start
+	return func(n int) ([]byte, error) {
+		if n != 32 {
+			return nil, errors.New("nonce must be 32 bytes")
+		}
+		out := bytes.Repeat([]byte{next}, 32)
+		next++
+		return out, nil
+	}
+}
+
+func TestResumePreambleMutualAuthHappyPath(t *testing.T) {
+	secret := bytes.Repeat([]byte{0xAB}, 32)
+	tid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	fp := strings.Repeat("b", 64)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resO, errO, resJ, errJ := preamblePair(ctx, t, cancel,
+		preambleContext(secret, RoleOfferer, tid, fp),
+		preambleContext(secret, RoleJoiner, tid, fp),
+	)
+	if errO != nil || errJ != nil {
+		t.Fatalf("preamble failed: offerer=%v joiner=%v", errO, errJ)
+	}
+	if resO == nil || resJ == nil {
+		t.Fatal("missing results")
+	}
+	// Both sides derive the same fresh directional keys, distinct from the session keys.
+	sess := sessionKeys(t)
+	if !bytes.Equal(resO.Keys.O2J.Key, resJ.Keys.O2J.Key) || !bytes.Equal(resO.Keys.J2O.Key, resJ.Keys.J2O.Key) {
+		t.Fatal("peers derived different resumed keys")
+	}
+	for name, keys := range map[string]TransferKeys{"offerer": resO.Keys, "joiner": resJ.Keys} {
+		if bytes.Equal(keys.O2J.Key, sess.O2J.Key) || bytes.Equal(keys.J2O.Key, sess.J2O.Key) {
+			t.Fatalf("%s resumed keys equal the session keys (must be a fresh epoch)", name)
+		}
+	}
+	// Fresh epoch: counters start at 0 only because the keys are new (ADR 0005 §7).
+	if resO.SendCounter != 0 || resO.RecvCounter != 0 || resJ.SendCounter != 0 || resJ.RecvCounter != 0 {
+		t.Fatalf("resumed counters = %d/%d %d/%d, want 0", resO.SendCounter, resO.RecvCounter, resJ.SendCounter, resJ.RecvCounter)
+	}
+	if resO.TransferID != tid || resJ.TransferID != tid {
+		t.Fatal("result transfer id mismatch")
+	}
+	if resO.Role != RoleOfferer || resJ.Role != RoleJoiner {
+		t.Fatal("result roles wrong")
+	}
+}
+
+func TestResumePreambleFreshEpochPerAttempt(t *testing.T) {
+	secret := bytes.Repeat([]byte{0xCD}, 32)
+	tid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	fp := strings.Repeat("d", 64)
+	// Distinct fresh nonces per attempt (the production path uses crypto/rand): attempt A
+	// and attempt B for the same transfer MUST yield different traffic key epochs, and the
+	// old keys are never read from disk because they are never persisted.
+	ctxO1 := preambleContext(secret, RoleOfferer, tid, fp)
+	ctxJ1 := preambleContext(secret, RoleJoiner, tid, fp)
+	ctxO2 := preambleContext(secret, RoleOfferer, tid, fp)
+	ctxJ2 := preambleContext(secret, RoleJoiner, tid, fp)
+	ctxO2.NonceSource = nonceSource(0x21)
+	ctxJ2.NonceSource = nonceSource(0x31)
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel1()
+	defer cancel2()
+	res1O, err1O, _, err1J := preamblePair(ctx1, t, cancel1, ctxO1, ctxJ1)
+	if err1O != nil || err1J != nil {
+		t.Fatalf("attempt 1 failed: %v %v", err1O, err1J)
+	}
+	res2O, err2O, _, err2J := preamblePair(ctx2, t, cancel2, ctxO2, ctxJ2)
+	if err2O != nil || err2J != nil {
+		t.Fatalf("attempt 2 failed: %v %v", err2O, err2J)
+	}
+	// Fresh nonces per attempt ⇒ distinct transcripts ⇒ distinct key epochs. The old keys
+	// are never read back from disk (they are not persisted); every attempt re-derives.
+	if bytes.Equal(res1O.Keys.O2J.Key, res2O.Keys.O2J.Key) ||
+		bytes.Equal(res1O.Keys.J2O.Key, res2O.Keys.J2O.Key) {
+		t.Fatal("attempt 1 and attempt 2 derived the same key epoch (must differ)")
+	}
+}
+
+func TestResumePreambleWrongSecretFailsClosed(t *testing.T) {
+	tid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	fp := strings.Repeat("e", 64)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resO, errO, resJ, errJ := preamblePair(ctx, t, cancel,
+		preambleContext(bytes.Repeat([]byte{1}, 32), RoleOfferer, tid, fp),
+		preambleContext(bytes.Repeat([]byte{2}, 32), RoleJoiner, tid, fp),
+	)
+	if errO == nil {
+		t.Fatalf("offerer must fail closed on a wrong secret, got nil")
+	}
+	if resO != nil || resJ != nil {
+		t.Fatal("no result may be exposed on a failed handshake")
+	}
+	if !strings.Contains(errO.Error(), "resume") {
+		t.Fatalf("offerer error must not expose proof material: %v", errO)
+	}
+	// The joiner is released by the connection teardown (context cancellation) exactly like
+	// production; it must never produce a result either.
+	if errJ == nil && resJ != nil {
+		t.Fatalf("joiner must not expose a result on a failed handshake")
+	}
+}
+
+func TestResumePreambleContextMismatchFailsClosed(t *testing.T) {
+	secret := bytes.Repeat([]byte{9}, 32)
+	fp := strings.Repeat("f", 64)
+	cases := []struct {
+		name string
+		mut  func(*ResumePreambleOptions)
+	}{
+		{"wrong transferId", func(o *ResumePreambleOptions) { o.TransferID = strings.Repeat("1", 32) }},
+		{"wrong fingerprint", func(o *ResumePreambleOptions) { o.Fingerprint = strings.Repeat("0", 64) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			j := preambleContext(secret, RoleJoiner, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", fp)
+			tc.mut(&j)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			_, errO, resJ, errJ := preamblePair(ctx, t, cancel,
+				preambleContext(secret, RoleOfferer, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", fp),
+				j,
+			)
+			if errO == nil {
+				t.Fatalf("offerer must fail closed on a context mismatch, got nil")
+			}
+			if resJ != nil {
+				t.Fatalf("joiner must not expose a result on a context mismatch (err=%v)", errJ)
+			}
+		})
+	}
+}
+
+func TestResumePreambleRejectsMissingSecret(t *testing.T) {
+	opts := preambleContext(nil, RoleOfferer, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", strings.Repeat("a", 64))
+	opts.Send = func([]byte) error { return nil }
+	if _, err := NewResumePreamble(opts); err == nil || !strings.Contains(err.Error(), "resume secret") {
+		t.Fatalf("missing secret must fail construction, got %v", err)
+	}
+}
+
+func TestResumePreambleJoinerStartIsNoOp(t *testing.T) {
+	opts := preambleContext(bytes.Repeat([]byte{3}, 32), RoleJoiner, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", strings.Repeat("a", 64))
+	opts.Send = func([]byte) error {
+		t.Fatal("joiner Start must not send anything")
+		return nil
+	}
+	p, err := NewResumePreamble(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Start(); err != nil {
+		t.Fatalf("joiner Start must be a no-op, got %v", err)
+	}
+	if p.Settled() {
+		t.Fatal("joiner must wait for the offerer's resume_init")
+	}
+}
+
+// TestResumePreambleRejectsForeignFrames proves the fail-closed boundary of the preamble:
+// no transfer-protocol frame (here a manifest) and no tampered/replayed resume frame may
+// pass before mutual authentication completes.
+func TestResumePreambleRejectsForeignFrames(t *testing.T) {
+	secret := bytes.Repeat([]byte{7}, 32)
+	tid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	fp := strings.Repeat("c", 64)
+	o := preambleContext(secret, RoleOfferer, tid, fp)
+	j := preambleContext(secret, RoleJoiner, tid, fp)
+	chO := make(chan []byte, 16)
+	chJ := make(chan []byte, 16)
+	o.Send = func(f []byte) error { return (&memPipe{ch: chJ}).send(f) }
+	j.Send = func(f []byte) error { return (&memPipe{ch: chO}).send(f) }
+	po, err := NewResumePreamble(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pj, err := NewResumePreamble(j)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for f := range chJ {
+			pj.Handle(f)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for f := range chO {
+			po.Handle(f)
+		}
+	}()
+
+	// A manifest frame sealed under the session keys arrives before any resume message.
+	manifestPayload, err := EncodeControl(NewManifest([]FileEntry{}, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := sessionKeys(t)
+	rogue, err := Seal(sess.O2J, 1, FrameHeaderInput{Version: FrameVersion, Type: FrameManifest}, manifestPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pj.Handle(rogue)
+	<-pj.Done()
+	if _, err := pj.Result(); err == nil {
+		t.Fatal("joiner must fail closed on a transfer frame before resume authentication")
+	}
+	close(chO)
+	close(chJ)
+	wg.Wait()
+}
+
+// TestResumePreambleDuplicateReAnswer proves a lost-response retransmission (an exact
+// duplicate of the last accepted frame) is re-answered idempotently with the SAME snapshot
+// — never a fresh nonce or proof — and the handshake still completes.
+func TestResumePreambleDuplicateReAnswer(t *testing.T) {
+	secret := bytes.Repeat([]byte{4}, 32)
+	tid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	fp := strings.Repeat("9", 64)
+	o := preambleContext(secret, RoleOfferer, tid, fp)
+	j := preambleContext(secret, RoleJoiner, tid, fp)
+	chO := make(chan []byte, 16)
+	chJ := make(chan []byte, 16)
+	o.Send = func(f []byte) error { return (&memPipe{ch: chJ}).send(f) }
+	j.Send = func(f []byte) error { return (&memPipe{ch: chO}).send(f) }
+	po, err := NewResumePreamble(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pj, err := NewResumePreamble(j)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var jChallenges [][]byte
+	go func() {
+		defer wg.Done()
+		for f := range chJ {
+			jChallenges = append(jChallenges, f)
+			pj.Handle(f)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for f := range chO {
+			po.Handle(f)
+		}
+	}()
+	if err := po.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// Wait until the offerer received the joiner's challenge, then re-deliver the exact
+	// same challenge frame: the offerer must re-answer with the same confirm snapshot.
+	<-po.Done()
+	select {
+	case <-pj.Done():
+	default:
+		// The joiner settles on the first confirm; a duplicate challenge was already
+		// consumed by the offerer before it settled, so replay it here explicitly.
+	}
+	close(chO)
+	close(chJ)
+	wg.Wait()
+	if len(jChallenges) == 0 {
+		t.Fatal("no challenge frames captured")
+	}
+	// Direct replay into a settled offerer is a no-op; the offerer already settled once.
+	po.Handle(jChallenges[0])
+	if _, err := po.Result(); err != nil {
+		t.Fatalf("offerer must stay settled after a duplicate, got %v", err)
+	}
+}
+
+// TestResumePreambleConflictingDuplicateFailsClosed proves a DIFFERENT message of an
+// already-accepted type (a challenge replacement after the proof) fails closed.
+func TestResumePreambleConflictingDuplicateFailsClosed(t *testing.T) {
+	secret := bytes.Repeat([]byte{5}, 32)
+	tid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	fp := strings.Repeat("8", 64)
+	o := preambleContext(secret, RoleOfferer, tid, fp)
+	o.Send = func([]byte) error { return nil }
+	po, err := NewResumePreamble(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Construct a challenge for a DIFFERENT transcript (different nonce) so its proof is
+	// invalid, and deliver it out of state after the offerer already accepted one.
+	sess := sessionKeys(t)
+	transcript, err := ResumeTranscript(ResumeAuthVersion, tid, fp,
+		bytes.Repeat([]byte{0x11}, 32), bytes.Repeat([]byte{0x22}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof, err := ResumeJoinerProof(secret, transcript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := &ResumeMessage{
+		Type: ResumeMsgChallenge, Version: ResumeAuthVersion, Role: RoleJoiner,
+		Nonce: base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x22}, 32)),
+		Proof: base64.RawURLEncoding.EncodeToString(proof),
+	}
+	payload, err := EncodeResumeMessage(bad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame, err := Seal(sess.J2O, 1, FrameHeaderInput{Version: FrameVersion, Type: FrameResumeAuth}, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The offerer never started: a challenge before resume_init is out of state.
+	po.Handle(frame)
+	if _, err := po.Result(); err == nil {
+		t.Fatal("out-of-state challenge must fail closed")
+	}
+}

--- a/packages/wire/transfer_receiver.go
+++ b/packages/wire/transfer_receiver.go
@@ -58,9 +58,14 @@ type ReceiverOptions struct {
 	// OnProgress reports bytes only after verify-and-sink.
 	OnProgress     func(acknowledgedBytes int64)
 	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
-	OnStateChange  func(TransferState)
-	OnManifestSet  func(manifest Manifest) error
-	OnManifest     func(file FileEntry) error
+	// OnResume reports the verified baseline reused from the authenticated durable
+	// checkpoint (the persisted haveBlocks claim) once the resume seed is applied, invoked
+	// ONCE before the first new block is acknowledged. The host anchors its session rate on
+	// this baseline: sessionBytes = acknowledged - reused.
+	OnResume      func(reusedBytes int64)
+	OnStateChange func(TransferState)
+	OnManifestSet func(manifest Manifest) error
+	OnManifest    func(file FileEntry) error
 	// Resume restores a reloaded receiver's progress. When the arriving manifest carries a matching
 	// TransferID, each file restarts at its HaveBlocks high-water mark and the sender is asked to
 	// stream only the missing blocks. Nil (or a TransferID mismatch) means a fresh receive.
@@ -292,6 +297,29 @@ func (r *Receiver) applyManifest(payload []byte) error {
 				return NewTransferError(FailSinkError, err.Error())
 			}
 			r.activeResume = r.o.Resume
+			// V13-PR08 progress contract: surface the verified baseline reused from the
+			// authenticated checkpoint immediately — before the first new block is
+			// acknowledged — so the host anchors its session rate on it.
+			if r.o.OnResume != nil && r.activeResume != nil {
+				reusedTotal := int64(0)
+				for _, file := range validated.Files {
+					have := 0
+					if p, ok := r.activeResume.Files[file.Idx]; ok {
+						have = p.HaveBlocks
+					}
+					if have <= 0 {
+						continue
+					}
+					if have >= file.Blocks {
+						reusedTotal += file.Size
+					} else {
+						reusedTotal += int64(have) * int64(file.BlockSize)
+					}
+				}
+				if reusedTotal > 0 {
+					r.o.OnResume(reusedTotal)
+				}
+			}
 		}
 		if err := r.sendResumeState(&validated); err != nil {
 			return err

--- a/packages/wire/transfer_sender.go
+++ b/packages/wire/transfer_sender.go
@@ -65,7 +65,12 @@ type SenderOptions struct {
 	// OnProgress reports bytes acknowledged after verify-and-sink.
 	OnProgress     func(acknowledgedBytes int64)
 	OnFileProgress func(fileIdx int, fileBytes, acknowledgedBytes int64)
-	OnStateChange  func(TransferState)
+	// OnResume reports the verified baseline reused from the authenticated durable
+	// checkpoint at resume start (the receiver's validated haveBlocks claim), invoked ONCE
+	// before any block is sent. The host anchors its session rate on this baseline so the
+	// reused jump is never counted as transferred bytes: sessionBytes = acknowledged - reused.
+	OnResume      func(reusedBytes int64)
+	OnStateChange func(TransferState)
 	// OnManifest, when set, is called with the validated manifest immediately before its
 	// frame is transmitted. It lets the caller make sender-side state durable — the stable
 	// transfer id and canonical source identity — strictly before the manifest can
@@ -280,6 +285,22 @@ func (s *Sender) Run(ctx context.Context) (string, error) {
 	if s.transferID != "" {
 		if err := s.waitResume(); err != nil {
 			return "", err
+		}
+		// V13-PR08 progress contract: surface the verified baseline reused from the
+		// authenticated checkpoint immediately — before any block is sent — so the host
+		// anchors its session rate on it and never counts the reused jump as transferred.
+		if s.o.OnResume != nil {
+			reusedTotal := int64(0)
+			for fileIdx, have := range s.resumePlan {
+				committed := int64(have) * int64(s.blockSize)
+				if have >= entries[fileIdx].Blocks {
+					committed = entries[fileIdx].Size
+				}
+				reusedTotal += committed
+			}
+			if reusedTotal > 0 {
+				s.o.OnResume(reusedTotal)
+			}
 		}
 	}
 

--- a/packages/wire/transfer_sender_resume_test.go
+++ b/packages/wire/transfer_sender_resume_test.go
@@ -353,6 +353,91 @@ func TestSenderResumeStreamsOnlyMissingBlocks(t *testing.T) {
 	}
 }
 
+// TestSenderOnResumeReportsReusedBaselineBeforeBlocks pins the V13-PR08 progress contract:
+// the verified baseline reused from the authenticated checkpoint is reported ONCE via
+// OnResume BEFORE any block is sent, and the first OnProgress sample counts only the
+// session advance above that baseline (firstProgress = reused + first new block), so the
+// host anchors its session rate on the reused jump without counting it as transferred.
+func TestSenderOnResumeReportsReusedBaselineBeforeBlocks(t *testing.T) {
+	data := seq(20) // 3 blocks of 8: 16 bytes + 4
+	id := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	rs := NewResumeState(id, []ResumeFileState{{Idx: 0, HaveBlocks: 2}})
+	rs.ManifestFingerprint = fp(t, data, id)
+	keys, err := DeriveTransferKeys(senderMaster())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out outbox
+	reused := int64(-1)
+	firstProgress := int64(-1)
+	s := NewSender(SenderOptions{
+		File: BytesSource(data, FileMeta{Name: "f", Size: int64(len(data)), Mime: "application/octet-stream", LastModified: 1}, 0),
+		Send: out.push, SendDir: keys.O2J, RecvDir: keys.J2O,
+		BlockSize: 8, FrameSize: 4, Window: 1,
+		TransferID: id,
+		OnResume: func(n int64) {
+			if reused != -1 {
+				t.Fatalf("OnResume fired %d times, want exactly once", reused)
+			}
+			reused = n
+		},
+		OnProgress: func(n int64) {
+			if firstProgress < 0 {
+				firstProgress = n
+			}
+		},
+	})
+	res := make(chan error, 1)
+	go func() {
+		_, err := s.Run(context.Background())
+		res <- err
+	}()
+	waitStable(t, &out, 1)
+	s.Handle(sealResumeIn(t, keys, 0, rs))
+	counter := uint64(1)
+	// Ack the single missing block and the terminal Done, settling the send.
+	waitStable(t, &out, 3)
+	ack, err := EncodeControl(NewAck(0, 2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame, err := Seal(keys.J2O, counter, FrameHeaderInput{Version: FrameVersion, Type: FrameAck}, ack)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counter++
+	s.Handle(frame)
+	waitStable(t, &out, 4)
+	donePayload, err := EncodeControl(NewDone())
+	if err != nil {
+		t.Fatal(err)
+	}
+	doneFrame, err := Seal(keys.J2O, counter, FrameHeaderInput{Version: FrameVersion, Type: FrameDone}, donePayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Handle(doneFrame)
+	if err := waitSenderResult(t, res); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// 2 blocks * 8 bytes = 16 bytes reused from the authenticated checkpoint.
+	if reused != 16 {
+		t.Fatalf("OnResume reused = %d, want 16", reused)
+	}
+	// The reused baseline was reported before any block was sent; the first OnProgress then
+	// equals baseline + the one missing block (4 bytes), proving the session advance is
+	// measured above the checkpoint, not from zero.
+	if firstProgress != reused+4 {
+		t.Fatalf("first OnProgress = %d, want reused baseline + first new block (%d)", firstProgress, reused+4)
+	}
+	// Zero-byte session advance: with no missing blocks, firstProgress must never exceed the
+	// baseline — but this transfer has one missing block, so assert the ordering instead:
+	// OnResume fired before the first OnProgress.
+	if reused != 16 || firstProgress < reused {
+		t.Fatalf("progress regressed below the reused baseline: reused=%d firstProgress=%d", reused, firstProgress)
+	}
+}
+
 // TestSenderAcceptsLegacyResumeStateWithoutFingerprint: a peer predating the fingerprint
 // binding answers without the field; structural validation still applies and the resume works.
 func TestSenderAcceptsLegacyResumeStateWithoutFingerprint(t *testing.T) {


### PR DESCRIPTION
## Summary

- Integrates authenticated cross-session resume for interrupted CLI and browser transfers.
- Reuses durable progress only after resume authentication succeeds and a fresh traffic-key epoch is established.
- Adds interrupted-transfer management, source reattachment, reload/crash recovery coverage, and streamed large-transfer validation.
- Legacy or missing-credential state fails closed to restart/discard rather than unauthenticated progress reuse.
