### PR TITLE
feat: desktop core transfer product over the shared engine

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,16 +1,39 @@
 # SendBeam Desktop
 
 The desktop host for the shared Go engine (`packages/engine`), built on Wails v3 (see
-`docs/adr/0007-desktop-framework.md`). This is the thin shell from V14-PR02: an app window,
-a service seam over the engine, and a self-check that proves the engine works end to end.
-The core transfer product UI lands in V14-PR03.
+`docs/adr/0007-desktop-framework.md`). All WebRTC, crypto, file I/O, durability, and trust
+logic lives in the engine; the desktop is a thin presentation seam over the same public API
+the CLI consumes, so a desktop peer interoperates with CLI and browser peers of the same
+deployment out of the box.
+
+## Core transfer product (V14-PR03)
+
+- **Send** — pick multiple files and folders with the native dialog, or drag and drop them
+  onto the window. A sender gets an invite: a code, a copyable join link, and a scannable
+  QR of that link (generated in Go, no JS build step).
+- **Receive** — paste a code or a full invite link, choose a destination folder (native
+  picker), and receive verified, byte-identical files.
+- **Live state** — phase (allocating → waiting → handshaking → established), transport
+  (direct WebRTC / encrypted relay), SAS fingerprint once the key is confirmed, pause /
+  resume / cancel controls, and a progress card with percent, five-second rolling speed,
+  ETA, current file, and aggregate (N of M files).
+- **Interop** — the service dials the signaling server with the same `wsclient` the CLI
+  uses; a service test drives a full transfer over a real WebSocket signaling hub to prove
+  the desktop speaks the browser/CLI protocol from the first implementation.
 
 ## Layout
 
-- `main.go` — Wails application: window, services, embedded frontend.
-- `internal/engine/` — `EngineService` exposing the engine to the frontend (`Info`, `Caps`,
-  `SelfCheck`) and the in-process loopback relay used by the self-check.
-- `frontend/dist/` — the shell UI (plain HTML/JS over the Wails runtime bridge).
+- `main.go` — Wails application: window (with file drop enabled), services, embedded
+  frontend. Forwards dropped files to the service.
+- `internal/engine/` —
+  - `service.go` — `EngineService` (`Info`, `Caps`, `SelfCheck`).
+  - `transfer_service.go` — `TransferService` (`Send`, `Receive`, `Pause`, `Resume`,
+    `Cancel`, `PickFiles`, `PickDestination`) streaming `sendbeam:transfer` snapshots.
+  - `pickers.go` — native dialogs (graceful server-mode fallback).
+  - `loopback.go` — in-process signaling relay used by tests and the self-check.
+  - `transfer_service_test.go` — loopback transfers (single/multi-file, pause/resume/
+    cancel, QR, invite links) and a real-WebSocket interop transfer.
+- `frontend/dist/` — the product UI (plain HTML/JS over the Wails runtime bridge).
 
 ## Build
 
@@ -25,8 +48,15 @@ go build -tags server -o sendbeam-desktop-server .
 ## Test
 
 ```bash
-go test -tags server ./...
+go test -tags server ./...          # headless (no GUI deps)
+go test -race -tags server ./...    # needs the GTK dev packages for wails internals
 ```
+
+## Server mode
+
+`go build -tags server` runs the same app as HTTP on `localhost:18123` (see `main.go`);
+native dialogs and drag/drop degrade to a clear error so the headless build stays usable
+for CI and smoke tests.
 
 ## Why Wails v3
 

--- a/apps/desktop/frontend/dist/index.html
+++ b/apps/desktop/frontend/dist/index.html
@@ -10,105 +10,409 @@
         color-scheme: dark;
         font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
       }
+      * { box-sizing: border-box; }
       body {
         margin: 0;
-        padding: 2rem;
+        padding: 1.5rem 2rem 3rem;
         background: #0f1115;
         color: #e6e9ef;
       }
-      h1 { font-size: 1.25rem; margin: 0 0 0.25rem; }
-      .sub { color: #8b93a1; font-size: 0.85rem; margin-bottom: 1.5rem; }
+      header { display: flex; align-items: baseline; gap: 0.75rem; margin-bottom: 1.25rem; }
+      h1 { font-size: 1.3rem; margin: 0; }
+      .sub { color: #8b93a1; font-size: 0.85rem; }
+
+      .tabs { display: flex; gap: 0.5rem; margin-bottom: 1.25rem; }
+      .tab {
+        background: #171a21; border: 1px solid #262b36; color: #8b93a1;
+        border-radius: 8px; padding: 0.45rem 1.1rem; font-size: 0.9rem; cursor: pointer;
+      }
+      .tab.active { color: #e6e9ef; border-color: #2563eb; background: #1c2330; }
+      .panel { display: none; }
+      .panel.active { display: block; }
+
       .card {
-        background: #171a21;
-        border: 1px solid #262b36;
-        border-radius: 10px;
-        padding: 1rem 1.25rem;
-        margin-bottom: 1rem;
-        max-width: 640px;
+        background: #171a21; border: 1px solid #262b36; border-radius: 10px;
+        padding: 1rem 1.25rem; margin-bottom: 1rem; max-width: 720px;
       }
       .card h2 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.06em; color: #8b93a1; margin: 0 0 0.75rem; }
-      .row { display: flex; justify-content: space-between; padding: 0.2rem 0; font-size: 0.9rem; }
-      .row .k { color: #8b93a1; }
+      .row { display: flex; justify-content: space-between; gap: 1rem; padding: 0.2rem 0; font-size: 0.9rem; }
+      .row .k { color: #8b93a1; flex: 0 0 auto; }
       .row .v { color: #e6e9ef; word-break: break-all; text-align: right; }
+
       button {
-        background: #2563eb;
-        color: white;
-        border: 0;
-        border-radius: 8px;
-        padding: 0.55rem 1.1rem;
-        font-size: 0.9rem;
-        cursor: pointer;
+        background: #2563eb; color: white; border: 0; border-radius: 8px;
+        padding: 0.55rem 1.1rem; font-size: 0.9rem; cursor: pointer;
       }
       button:disabled { opacity: 0.5; cursor: default; }
-      #selfcheck { white-space: pre-wrap; font-family: ui-monospace, monospace; font-size: 0.8rem; color: #8b93a1; margin-top: 0.75rem; }
+      button.ghost { background: #1f2430; border: 1px solid #2c3342; color: #c9d1dd; }
+      button.danger { background: #7f1d1d; }
+
+      input[type="text"] {
+        background: #0f1115; border: 1px solid #2c3342; color: #e6e9ef;
+        border-radius: 8px; padding: 0.55rem 0.75rem; font-size: 0.9rem; width: 100%;
+      }
+      label { display: block; font-size: 0.8rem; color: #8b93a1; margin: 0.75rem 0 0.3rem; }
+
+      .drop {
+        border: 2px dashed #2c3342; border-radius: 10px; padding: 1.75rem;
+        text-align: center; color: #8b93a1; font-size: 0.9rem; cursor: pointer;
+        transition: border-color 0.15s, background 0.15s;
+      }
+      .drop.over, .drop:hover { border-color: #2563eb; background: #151b27; color: #c9d1dd; }
+
+      .file-list { margin: 0.75rem 0 0; padding: 0; list-style: none; max-height: 10rem; overflow: auto; }
+      .file-list li { font-size: 0.82rem; color: #b9c0cc; padding: 0.2rem 0; border-bottom: 1px solid #20242e; word-break: break-all; }
+      .file-list li span { color: #6b7280; margin-left: 0.5rem; }
+
+      .invite { display: flex; gap: 1.25rem; align-items: flex-start; }
+      .invite .code { font-size: 1.6rem; font-weight: 600; letter-spacing: 0.03em; font-family: ui-monospace, monospace; }
+      .invite img { width: 180px; height: 180px; border-radius: 8px; background: white; padding: 6px; }
+      .invite .copy { margin-top: 0.5rem; }
+
+      .progress { height: 10px; background: #0f1115; border-radius: 6px; overflow: hidden; margin: 0.6rem 0; }
+      .progress > div { height: 100%; background: #2563eb; width: 0%; transition: width 0.2s; }
+      .chips { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 0.5rem 0; }
+      .chip {
+        font-size: 0.75rem; padding: 0.2rem 0.6rem; border-radius: 999px;
+        border: 1px solid #2c3342; color: #8b93a1;
+      }
+      .chip.live { color: #4ade80; border-color: #14532d; background: #0c1f14; }
+      .chip.relay { color: #fbbf24; border-color: #713f12; background: #1c1608; }
+      .chip.auth { color: #93c5fd; border-color: #1e3a5f; background: #0c1727; }
+      .chip.err { color: #f87171; border-color: #7f1d1d; background: #200b0b; }
+
+      .controls { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+      .muted { color: #6b7280; font-size: 0.82rem; }
+      .mono { font-family: ui-monospace, monospace; }
+      .statusline { margin-top: 0.5rem; font-size: 0.85rem; color: #8b93a1; min-height: 1.2em; }
+      .err { color: #f87171; }
       .ok { color: #4ade80; }
-      .bad { color: #f87171; }
+      .hidden { display: none; }
+      .row-sep { border-top: 1px solid #20242e; margin: 0.6rem 0; }
     </style>
   </head>
   <body>
-    <h1>SendBeam Desktop</h1>
-    <div class="sub">Thin shell over the shared Go engine — packages/engine</div>
+    <header>
+      <h1>SendBeam</h1>
+      <span class="sub">End-to-end encrypted, peer-to-peer file transfer — desktop</span>
+    </header>
 
-    <div class="card">
-      <h2>Engine</h2>
-      <div class="row"><span class="k">Go runtime</span><span class="v" id="go-version">…</span></div>
-      <div class="row"><span class="k">Engine module</span><span class="v" id="engine-ver">…</span></div>
-      <div class="row"><span class="k">Platform</span><span class="v" id="platform">…</span></div>
-      <div class="row"><span class="k">Protocol version</span><span class="v" id="caps-version">…</span></div>
-      <div class="row"><span class="k">Features</span><span class="v" id="caps-features">…</span></div>
+    <div class="tabs">
+      <button class="tab active" id="tab-send">Send</button>
+      <button class="tab" id="tab-receive">Receive</button>
     </div>
 
-    <div class="card">
-      <h2>Engine self-check</h2>
-      <p style="font-size: 0.85rem; color: #8b93a1; margin: 0 0 0.75rem;">
-        Runs a complete in-process transfer through the engine's public API:
-        SPAKE2 rendezvous, encrypted relay path, durable receive, whole-file
-        verification.
-      </p>
-      <button id="run">Run self-check</button>
-      <div id="selfcheck"></div>
-    </div>
+    <!-- SEND -->
+    <section class="panel active" id="panel-send">
+      <div class="card">
+        <h2>Files &amp; folders</h2>
+        <div class="drop" id="drop-send" data-file-drop-target>
+          Drop files or folders here, or click to pick
+        </div>
+        <ul class="file-list hidden" id="send-list"></ul>
+        <div class="statusline" id="send-sel-status"></div>
+        <div class="controls">
+          <button id="pick-send">Pick files &amp; folders</button>
+          <button id="start-send" disabled>Send</button>
+        </div>
+      </div>
+
+      <div class="card hidden" id="invite-card">
+        <h2>Invite</h2>
+        <div class="invite">
+          <div>
+            <div class="code mono" id="invite-code"></div>
+            <button class="ghost copy" id="copy-invite">Copy invite</button>
+            <div class="muted" id="invite-link"></div>
+          </div>
+          <img id="invite-qr" alt="Invite QR code" />
+        </div>
+        <div class="statusline" id="invite-status"></div>
+      </div>
+
+      <div class="card hidden" id="send-progress-card">
+        <h2>Transfer</h2>
+        <div class="chips" id="send-chips"></div>
+        <div class="progress"><div id="send-bar"></div></div>
+        <div class="row"><span class="k">Progress</span><span class="v" id="send-percent"></span></div>
+        <div class="row"><span class="k">Current file</span><span class="v" id="send-file"></span></div>
+        <div class="row"><span class="k">Speed / ETA</span><span class="v" id="send-rate"></span></div>
+        <div class="row"><span class="k">Aggregate</span><span class="v" id="send-aggregate"></span></div>
+        <div class="row"><span class="k">Security</span><span class="v mono" id="send-fingerprint"></span></div>
+        <div class="row-sep"></div>
+        <div class="controls">
+          <button id="send-pause">Pause</button>
+          <button id="send-resume" disabled>Resume</button>
+          <button class="danger" id="send-cancel">Cancel</button>
+        </div>
+        <div class="statusline" id="send-status"></div>
+      </div>
+    </section>
+
+    <!-- RECEIVE -->
+    <section class="panel" id="panel-receive">
+      <div class="card">
+        <h2>Receive</h2>
+        <label for="recv-code">Invite code (or paste the full invite link)</label>
+        <input type="text" id="recv-code" placeholder="e.g. 7-alpha-bravo" autocomplete="off" />
+        <label for="recv-dir">Save into</label>
+        <div style="display:flex; gap:0.5rem;">
+          <input type="text" id="recv-dir" placeholder="destination folder" autocomplete="off" style="flex:1" />
+          <button class="ghost" id="pick-dest">Choose…</button>
+        </div>
+        <div class="controls">
+          <button id="start-recv" disabled>Receive</button>
+        </div>
+        <div class="statusline" id="recv-status"></div>
+      </div>
+
+      <div class="card hidden" id="recv-progress-card">
+        <h2>Transfer</h2>
+        <div class="chips" id="recv-chips"></div>
+        <div class="progress"><div id="recv-bar"></div></div>
+        <div class="row"><span class="k">Progress</span><span class="v" id="recv-percent"></span></div>
+        <div class="row"><span class="k">Current file</span><span class="v" id="recv-file"></span></div>
+        <div class="row"><span class="k">Speed / ETA</span><span class="v" id="recv-rate"></span></div>
+        <div class="row"><span class="k">Aggregate</span><span class="v" id="recv-aggregate"></span></div>
+        <div class="row"><span class="k">Security</span><span class="v mono" id="recv-fingerprint"></span></div>
+        <div class="row"><span class="k">Saved to</span><span class="v" id="recv-out"></span></div>
+        <div class="row-sep"></div>
+        <div class="controls">
+          <button id="recv-pause">Pause</button>
+          <button id="recv-resume" disabled>Resume</button>
+          <button class="danger" id="recv-cancel">Cancel</button>
+        </div>
+        <div class="statusline" id="recv-status-line"></div>
+      </div>
+    </section>
 
     <script>
+      // Service FQNs (wails binds by full import path.Type.Method).
+      const SV = {
+        Service:     "github.com/sendbeam/desktop/internal/engine.Service",
+        Transfer:    "github.com/sendbeam/desktop/internal/engine.TransferService",
+      };
+      const call = (fqn, ...args) => wails.Call.ByName(fqn, ...args);
       const $ = (id) => document.getElementById(id);
 
-      async function loadInfo() {
-        try {
-          const info = await wails.Call.ByName("main.EngineService.Info");
-          $("go-version").textContent = info.goVersion;
-          $("engine-ver").textContent = info.engineVer || "linked";
-          $("platform").textContent = info.platform || navigator.platform;
-          const caps = await wails.Call.ByName("main.EngineService.Caps");
-          $("caps-version").textContent = caps.version;
-          $("caps-features").textContent = caps.features.join(", ");
-        } catch (err) {
-          $("go-version").textContent = "unavailable: " + err;
-        }
+      // ---- state ----
+      const state = {
+        mode: "send",
+        selected: [],
+        send: { id: null },
+        recv: { id: null },
+      };
+
+      // ---- tabs ----
+      function setMode(mode) {
+        state.mode = mode;
+        $("tab-send").classList.toggle("active", mode === "send");
+        $("tab-receive").classList.toggle("active", mode === "receive");
+        $("panel-send").classList.toggle("active", mode === "send");
+        $("panel-receive").classList.toggle("active", mode === "receive");
+      }
+      $("tab-send").addEventListener("click", () => setMode("send"));
+      $("tab-receive").addEventListener("click", () => setMode("receive"));
+
+      // ---- helpers ----
+      function humanBytes(n) {
+        if (n >= 1 << 30) return (n / (1 << 30)).toFixed(2) + " GiB";
+        if (n >= 1 << 20) return (n / (1 << 20)).toFixed(1) + " MiB";
+        if (n >= 1 << 10) return (n / (1 << 10)).toFixed(1) + " KiB";
+        return n + " B";
+      }
+      function humanRate(bps) {
+        if (!bps || bps <= 0) return "calculating…";
+        if (bps >= 1 << 20) return (bps / (1 << 20)).toFixed(1) + " MiB/s";
+        if (bps >= 1 << 10) return (bps / (1 << 10)).toFixed(1) + " KiB/s";
+        return Math.round(bps) + " B/s";
+      }
+      function basename(p) { return String(p).split(/[\\/]/).pop(); }
+      function totalSelected() {
+        let n = 0;
+        try { n = state.selected.reduce((a, p) => a + (p.size || 0), 0); } catch (e) {}
+        return n;
       }
 
-      async function runSelfCheck() {
-        const btn = $("run");
-        const out = $("selfcheck");
-        btn.disabled = true;
-        out.textContent = "running engine self-check…";
-        try {
-          const res = await wails.Call.ByName("main.EngineService.SelfCheck");
-          if (res.ok) {
-            out.innerHTML =
-              '<span class="ok">✓ verified</span> — ' +
-              res.files + " file, " + res.bytes + " bytes in " + res.elapsedMs + " ms";
-          } else {
-            out.innerHTML = '<span class="bad">✗ failed:</span> ' + res.failure;
-          }
-        } catch (err) {
-          out.innerHTML = '<span class="bad">✗ error:</span> ' + err;
-        } finally {
-          btn.disabled = false;
+      // ---- send selection ----
+      function renderSelection() {
+        const list = $("send-list");
+        list.innerHTML = "";
+        for (const p of state.selected) {
+          const li = document.createElement("li");
+          li.textContent = p.path;
+          const span = document.createElement("span");
+          span.textContent = p.size ? humanBytes(p.size) : "";
+          li.appendChild(span);
+          list.appendChild(li);
+        }
+        list.classList.toggle("hidden", state.selected.length === 0);
+        $("send-sel-status").textContent = state.selected.length
+          ? state.selected.length + " item(s) selected"
+          : "";
+        $("start-send").disabled = state.selected.length === 0;
+      }
+      async function pickSend() {
+        const res = await call(SV.Transfer + ".PickFiles");
+        if (res && res.error) { $("send-sel-status").textContent = res.error; return; }
+        if (res && res.paths && res.paths.length) {
+          state.selected = res.paths.map((p) => ({ path: p }));
+          renderSelection();
         }
       }
+      $("pick-send").addEventListener("click", pickSend);
+      $("drop-send").addEventListener("click", pickSend);
+      // Drag/drop is handled by the window: main.go forwards dropped paths to
+      // the service and emits a "drop" event so this panel can adopt the new
+      // transfer and show its invite.
+      wails.Events.On("sendbeam:transfer", (ev) => {
+        if (!ev || ev.kind !== "drop" || !ev.id) return;
+        if (state.send.id && state.send.id !== ev.id) return;
+        state.send.id = ev.id;
+        state.selected = (ev.files || []).map((p) => ({ path: p }));
+        renderSelection();
+        $("send-status").textContent = "Preparing secure channel…";
+        $("send-progress-card").classList.remove("hidden");
+        $("start-send").disabled = true;
+      });
+      $("start-send").addEventListener("click", () => {
+        if (!state.selected.length) return;
+        const paths = state.selected.map((p) => p.path);
+        call(SV.Transfer + ".Send", paths, "").then((h) => {
+          if (h && h.error) { $("send-status").textContent = h.error; return; }
+          state.send.id = h.id;
+          $("send-status").textContent = "Preparing secure channel…";
+          $("send-progress-card").classList.remove("hidden");
+          $("start-send").disabled = true;
+        }).catch((err) => { $("send-status").textContent = String(err); });
+      });
 
-      $("run").addEventListener("click", runSelfCheck);
-      loadInfo();
+      // ---- receive ----
+      function recvCanStart() {
+        return !!$("recv-code").value.trim() && !!$("recv-dir").value.trim();
+      }
+      function updateRecvStart() { $("start-recv").disabled = !recvCanStart(); }
+      $("recv-code").addEventListener("input", updateRecvStart);
+      $("recv-dir").addEventListener("input", updateRecvStart);
+      $("pick-dest").addEventListener("click", async () => {
+        const res = await call(SV.Transfer + ".PickDestination");
+        if (res && res.error) { $("recv-status").textContent = res.error; return; }
+        if (res && res.paths && res.paths.length) {
+          $("recv-dir").value = res.paths[0];
+          updateRecvStart();
+        }
+      });
+      $("start-recv").addEventListener("click", () => {
+        const code = $("recv-code").value.trim();
+        const dir = $("recv-dir").value.trim();
+        call(SV.Transfer + ".Receive", code, dir, "").then((h) => {
+          if (h && h.error) { $("recv-status").textContent = h.error; return; }
+          state.recv.id = h.id;
+          $("recv-status").textContent = "Joining " + code + "…";
+          $("recv-progress-card").classList.remove("hidden");
+          $("start-recv").disabled = true;
+        }).catch((err) => { $("recv-status").textContent = String(err); });
+      });
+
+      // ---- controls ----
+      function wireControls(prefix) {
+        const id = () => state[prefix].id;
+        $(prefix + "-pause").addEventListener("click", () => call(SV.Transfer + ".Pause", id()).catch((e) => console.error(e)));
+        $(prefix + "-resume").addEventListener("click", () => call(SV.Transfer + ".Resume", id()).catch((e) => console.error(e)));
+        $(prefix + "-cancel").addEventListener("click", () => call(SV.Transfer + ".Cancel", id()).catch((e) => console.error(e)));
+      }
+      wireControls("send");
+      wireControls("recv");
+
+      // ---- live events ----
+      function chips(ev) {
+        const out = [];
+        if (ev.phase) out.push('<span class="chip">' + ev.phase.replace(/-/g, " ") + "</span>");
+        if (ev.transport) out.push('<span class="chip relay">' + ev.transport + "</span>");
+        if (ev.fingerprint) out.push('<span class="chip auth">fingerprint ' + ev.fingerprint + "</span>");
+        if (ev.paused) out.push('<span class="chip err">paused</span>');
+        if (ev.canceled) out.push('<span class="chip err">canceled</span>');
+        if (ev.failed) out.push('<span class="chip err">failed</span>');
+        if (ev.state) out.push('<span class="chip live">' + ev.state + "</span>");
+        return out.join("");
+      }
+      function renderTransfer(ev, prefix) {
+        const p = prefix === "send" ? "send" : "recv";
+        const id = state[p].id;
+        if (ev.id !== id) return;
+
+        $(p + "-chips").innerHTML = chips(ev);
+        $(p + "-bar").style.width = Math.max(0, Math.min(100, ev.percent || 0)) + "%";
+        $(p + "-percent").textContent = (ev.percent || 0) + "% · " + humanBytes(ev.doneBytes || 0) + " / " + humanBytes(ev.totalBytes || 0);
+
+        let file = ev.currentFile || "";
+        if (ev.fileSize) file += " (" + humanBytes(ev.fileBytes || 0) + " / " + humanBytes(ev.fileSize) + ")";
+        $(p + "-file").textContent = file || "—";
+
+        let rate = humanRate(ev.rateBps);
+        if (ev.eta) rate += " · " + ev.eta;
+        $(p + "-rate").textContent = rate;
+
+        $(p + "-aggregate").textContent = (ev.filesDone || 0) + " / " + (ev.filesTotal || 0) + " files · " + humanBytes(ev.totalBytes || 0) + " total";
+        $(p + "-fingerprint").textContent = ev.fingerprint || "awaiting key confirmation…";
+
+        const paused = !!ev.paused;
+        $(p + "-pause").disabled = paused || ev.canceled || ev.failed;
+        $(p + "-resume").disabled = !paused || ev.canceled || ev.failed;
+        $(p + "-cancel").disabled = ev.canceled || ev.failed;
+
+        const status = p === "recv" ? $("recv-status-line") : $("send-status");
+        if (ev.kind === "done") {
+          status.innerHTML = '<span class="ok">✓ Verified transfer complete.</span>' +
+            (ev.outPath ? " Saved to " + ev.outPath + "." : "");
+          $(p + "-pause").disabled = $(p + "-resume").disabled = $(p + "-cancel").disabled = true;
+        } else if (ev.kind === "error") {
+          status.innerHTML = '<span class="err">✗ ' + (ev.error || "transfer failed") + "</span>";
+        } else if (ev.kind === "connect") {
+          status.textContent = "Secure channel established — transferring…";
+        } else if (ev.phase === "waiting") {
+          status.textContent = "Waiting for the peer to join…";
+        }
+      }
+      wails.Events.On("sendbeam:transfer", (ev) => {
+        if (!ev || !ev.id || !ev.kind) return;
+        if (ev.id === state.send.id) renderTransfer(ev, "send");
+        if (ev.id === state.recv.id) renderTransfer(ev, "recv");
+
+        if (ev.kind === "invite" && ev.id === state.send.id) {
+          $("invite-card").classList.remove("hidden");
+          $("invite-code").textContent = ev.code;
+          $("invite-link").textContent = ev.link || "";
+          $("invite-qr").src = ev.qr || "";
+          $("invite-status").textContent = "Share the code or link — the receiver can also scan the QR.";
+        }
+      });
+
+      // ---- copy invite ----
+      $("copy-invite").addEventListener("click", async () => {
+        const text = $("invite-code").textContent;
+        try {
+          await navigator.clipboard.writeText(text);
+          $("invite-status").textContent = "Invite code copied.";
+        } catch (e) {
+          // fallback for webviews without clipboard permission
+          const ta = document.createElement("textarea");
+          ta.value = text;
+          document.body.appendChild(ta);
+          ta.select();
+          try { document.execCommand("copy"); $("invite-status").textContent = "Invite code copied."; }
+          catch (err) { $("invite-status").textContent = "Copy failed — select the code manually."; }
+          document.body.removeChild(ta);
+        }
+      });
+
+      // ---- engine info ----
+      (async () => {
+        try {
+          const info = await call(SV.Service + ".Info");
+          document.title = "SendBeam Desktop — " + (info.engineVer ? "engine " + info.engineVer : "linked");
+        } catch (err) { /* shell info is non-critical */ }
+      })();
     </script>
   </body>
 </html>

--- a/apps/desktop/go.mod
+++ b/apps/desktop/go.mod
@@ -3,16 +3,17 @@ module github.com/sendbeam/desktop
 go 1.25.0
 
 require (
+	github.com/coder/websocket v1.8.15
 	github.com/pion/webrtc/v4 v4.2.18
 	github.com/sendbeam/engine v0.0.0
 	github.com/sendbeam/wire v0.0.0
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/wailsapp/wails/v3 v3.0.0-beta.8
 )
 
 require (
 	filippo.io/nistec v0.0.4 // indirect
 	github.com/adrg/xdg v0.5.3 // indirect
-	github.com/coder/websocket v1.8.15 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/apps/desktop/go.sum
+++ b/apps/desktop/go.sum
@@ -60,6 +60,8 @@ github.com/pion/webrtc/v4 v4.2.18 h1:smA/3g6Gy4RohM0VIZ5KKY/12TQbxv3XFgpUMyb2EUI
 github.com/pion/webrtc/v4 v4.2.18/go.mod h1:vmzi6s+rvhoIuT94DPqivB+0xJXs9rG4QRD+4MgBtlY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wailsapp/wails/v3 v3.0.0-beta.8 h1:r5d+5ERZ6TYI/OPJnqq91Ugux+TkfplCURUi/+6vA/Q=

--- a/apps/desktop/internal/engine/pickers.go
+++ b/apps/desktop/internal/engine/pickers.go
@@ -1,0 +1,59 @@
+package engine
+
+import (
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// PickResult is a native picker outcome. Error is set when the dialog is
+// unavailable (server mode) or the user cancels.
+type PickResult struct {
+	Paths []string `json:"paths"`
+	Error string   `json:"error,omitempty"`
+}
+
+// PickFiles opens the native multi-select picker for files and folders to send.
+// In server mode (no GUI) it returns a descriptive error so the frontend can
+// fall back to manual path entry.
+func (s *TransferService) PickFiles() PickResult {
+	app := application.Get()
+	if app == nil || app.Dialog == nil {
+		return PickResult{Error: "native dialogs unavailable (server mode); enter paths manually"}
+	}
+	dlg := app.Dialog.OpenFileWithOptions(&application.OpenFileDialogOptions{
+		CanChooseFiles:          true,
+		CanChooseDirectories:    true,
+		AllowsMultipleSelection: true,
+		Title:                   "Select files and folders to send",
+		Message:                 "Choose one or more files or folders to send securely.",
+		ButtonText:              "Select",
+	})
+	paths, err := dlg.PromptForMultipleSelection()
+	if err != nil {
+		return PickResult{Error: err.Error()}
+	}
+	return PickResult{Paths: paths}
+}
+
+// PickDestination opens a native folder picker for the receive destination.
+// In server mode it returns a descriptive error.
+func (s *TransferService) PickDestination() PickResult {
+	app := application.Get()
+	if app == nil || app.Dialog == nil {
+		return PickResult{Error: "native dialogs unavailable (server mode); enter a destination path manually"}
+	}
+	dlg := app.Dialog.OpenFileWithOptions(&application.OpenFileDialogOptions{
+		CanChooseFiles:       false,
+		CanChooseDirectories: true,
+		Title:                "Choose where to save received files",
+		Message:              "Received files are written into this folder.",
+		ButtonText:           "Choose",
+	})
+	dir, err := dlg.PromptForSingleSelection()
+	if err != nil {
+		return PickResult{Error: err.Error()}
+	}
+	if dir == "" {
+		return PickResult{Error: "no destination selected"}
+	}
+	return PickResult{Paths: []string{dir}}
+}

--- a/apps/desktop/internal/engine/transfer_service.go
+++ b/apps/desktop/internal/engine/transfer_service.go
@@ -1,0 +1,675 @@
+// Package engine exposes the SendBeam engine to the desktop frontend through
+// Wails services. WebRTC, crypto, file I/O, durability, and trust logic stay
+// in the Go engine (packages/engine); these services are only a thin
+// presentation seam, exactly as the CLI consumes the engine through its
+// public API.
+package engine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/engine/rendezvous"
+	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/engine/wsclient"
+	"github.com/sendbeam/wire"
+	qrcode "github.com/skip2/go-qrcode"
+)
+
+// TransferEventName is the single event name the service emits for every live
+// transfer update. The payload is a TransferEvent snapshot; the frontend
+// re-renders from the latest snapshot per transfer id.
+const TransferEventName = "sendbeam:transfer"
+
+// DefaultServer mirrors the CLI's default signaling server, so a desktop peer
+// pairs with CLI and browser peers of the same deployment out of the box.
+const DefaultServer = "wss://localhost:8443/ws"
+
+// FileInfo is one file in the transfer set, for aggregate display.
+type FileInfo struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+// TransferEvent is a live snapshot of one transfer's state. Kind tells the
+// frontend what changed; the rest are the current values (progress events are
+// throttled to a bounded cadence, the terminal kind is always emitted).
+type TransferEvent struct {
+	ID   string `json:"id"`
+	Kind string `json:"kind"` // invite | phase | connect | transport | manifest | progress | state | done | error
+
+	// Invite (offerer, kind=invite).
+	Code string `json:"code,omitempty"`
+	Link string `json:"link,omitempty"`
+	QR   string `json:"qr,omitempty"` // data URL of the invite QR
+
+	// Handshake (kind=phase).
+	Phase string `json:"phase,omitempty"`
+
+	// Secure channel (kind=connect).
+	Fingerprint string `json:"fingerprint,omitempty"`
+
+	// Byte path (kind=transport).
+	Transport string `json:"transport,omitempty"`
+
+	// File set (kind=manifest).
+	Files      []FileInfo `json:"files,omitempty"`
+	TotalBytes int64      `json:"totalBytes,omitempty"`
+
+	// Progress (kind=progress): cumulative acknowledged bytes, percent,
+	// five-second rolling rate, ETA, current file, aggregate state.
+	DoneBytes   int64   `json:"doneBytes,omitempty"`
+	Percent     int     `json:"percent,omitempty"`
+	RateBps     float64 `json:"rateBps,omitempty"`
+	ETA         string  `json:"eta,omitempty"`
+	CurrentFile string  `json:"currentFile,omitempty"`
+	FileBytes   int64   `json:"fileBytes,omitempty"`
+	FileSize    int64   `json:"fileSize,omitempty"`
+	FilesDone   int     `json:"filesDone,omitempty"`
+	FilesTotal  int     `json:"filesTotal,omitempty"`
+	RemainingMS int64   `json:"remainingMs,omitempty"` // -1 when unknown
+	State       string  `json:"state,omitempty"`       // running | paused | canceled
+	Paused      bool    `json:"paused,omitempty"`
+	Canceled    bool    `json:"canceled,omitempty"`
+	Failed      bool    `json:"failed,omitempty"`
+
+	// Terminal (kind=done/error).
+	Digest  string `json:"digest,omitempty"`
+	OutDir  string `json:"outDir,omitempty"`
+	OutPath string `json:"outPath,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// SignalDialer returns the signaling signal for one transfer side. The desktop
+// uses the same wsclient as the CLI (browser/CLI interop by construction);
+// tests inject loopback ends.
+type SignalDialer func(ctx context.Context, server string, role wire.Role) (transfer.Signal, error)
+
+// defaultDialer dials the real signaling server exactly as the CLI does.
+func defaultDialer(ctx context.Context, server string, _ wire.Role) (transfer.Signal, error) {
+	return wsclient.NewReconnectingSignal(ctx, server, wsclient.DialOptions{})
+}
+
+// TransferService drives one or more engine transfers through transfer.Run,
+// streaming TransferEvent snapshots to the frontend. All WebRTC, crypto, file
+// I/O, durability, and trust logic stays in packages/engine.
+type TransferService struct {
+	emit func(name string, data any) // nil in tests; wired to app events in main
+	dial SignalDialer
+
+	// forceRelay skips direct negotiation (loopback tests; production leaves it
+	// false so the adaptive direct/relay racer runs). iceServers nil uses the
+	// engine's default STUN; an explicit empty slice is host-only (loopback).
+	forceRelay bool
+	iceServers []webrtc.ICEServer
+
+	mu   sync.Mutex
+	next int
+	runs map[string]*transferRun
+}
+
+// NewTransferService builds the service. emit is the frontend sink (wails
+// app.Event.Emit in production, a recorder in tests); dial is the signaling
+// seam (nil uses the real wsclient).
+func NewTransferService(emit func(name string, data any), dial SignalDialer) *TransferService {
+	if dial == nil {
+		dial = defaultDialer
+	}
+	return &TransferService{emit: emit, dial: dial, runs: map[string]*transferRun{}}
+}
+
+// setLoopbackConfig is the test seam for the loopback relay: host-only ICE and
+// the forced-relay path, mirroring the engine's own parity tests.
+func (s *TransferService) setLoopbackConfig() {
+	s.forceRelay = true
+	s.iceServers = []webrtc.ICEServer{}
+}
+
+// Handle identifies a started transfer.
+type Handle struct {
+	ID   string `json:"id"`
+	Role string `json:"role"` // send | receive
+}
+
+// transferRun is one in-flight transfer. It owns the engine Controls once the
+// channel opens and the rolling rate samples for speed/ETA.
+type transferRun struct {
+	id   string
+	role wire.Role
+
+	svc  *TransferService
+	ctx  context.Context
+	canc context.CancelFunc
+
+	mu       sync.Mutex
+	controls transfer.Controls
+
+	files       []FileInfo
+	totalBytes  int64
+	doneBytes   int64
+	reused      int64 // verified baseline reused at resume (0 for fresh transfers)
+	fileIdx     int
+	fileBytes   int64
+	fileSize    int64
+	filesDone   int
+	paused      bool
+	canceled    bool
+	failed      bool
+	transport   string
+	fingerprint string
+
+	samples []progressSample
+	now     func() time.Time
+}
+
+type progressSample struct {
+	at    time.Time
+	bytes int64
+}
+
+// Send starts an offerer (send) transfer for the given files/folders and
+// returns immediately. The invite (code/link/QR) is streamed as an invite
+// event once the room is allocated.
+func (s *TransferService) Send(paths []string, server string) (Handle, error) {
+	if len(paths) == 0 {
+		return Handle{}, errors.New("no files or folders selected")
+	}
+	if server == "" {
+		server = DefaultServer
+	}
+	if err := validatePaths(paths); err != nil {
+		return Handle{}, err
+	}
+	id := s.newID()
+	r := s.newRun(id, wire.RoleOfferer)
+	sources, total, err := transfer.NewOSFileSources(paths)
+	if err != nil {
+		s.remove(r)
+		return Handle{}, err
+	}
+	for _, src := range sources {
+		meta := src.Meta()
+		r.mu.Lock()
+		r.files = append(r.files, FileInfo{Name: meta.Name, Size: meta.Size})
+		r.totalBytes += meta.Size
+		r.mu.Unlock()
+	}
+	_ = total
+
+	go r.runSend(r.ctx, server, sources)
+	return Handle{ID: id, Role: "send"}, nil
+}
+
+// Receive starts a joiner (receive) transfer for a code (or a full invite
+// link) into destDir and returns immediately. The file set is streamed as a
+// manifest event once the sender's manifest arrives.
+func (s *TransferService) Receive(code string, destDir string, server string) (Handle, error) {
+	if code == "" {
+		return Handle{}, errors.New("an invite code (or link) is required")
+	}
+	code = normalizeCode(code)
+	if destDir == "" {
+		destDir = "."
+	}
+	if server == "" {
+		server = DefaultServer
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return Handle{}, fmt.Errorf("create destination: %w", err)
+	}
+	id := s.newID()
+	r := s.newRun(id, wire.RoleJoiner)
+
+	go r.runReceive(r.ctx, code, destDir, server)
+	return Handle{ID: id, Role: "receive"}, nil
+}
+
+// Drop starts a send for paths dropped onto the window, mirroring Send.
+func (s *TransferService) Drop(paths []string) (Handle, error) {
+	return s.Send(paths, DefaultServer)
+}
+
+// Pause pauses the transfer with id (both sides stop producing new data).
+func (s *TransferService) Pause(id string) error {
+	return s.control(id, func(c transfer.Controls) error { return c.Pause() })
+}
+
+// Resume resumes the transfer with id.
+func (s *TransferService) Resume(id string) error {
+	return s.control(id, func(c transfer.Controls) error { return c.Resume() })
+}
+
+// Cancel cancels the transfer with id.
+func (s *TransferService) Cancel(id string) error {
+	return s.control(id, func(c transfer.Controls) error { return c.Cancel("canceled by user") })
+}
+
+// control looks up the live Controls for id and applies fn.
+func (s *TransferService) control(id string, fn func(transfer.Controls) error) error {
+	s.mu.Lock()
+	r, ok := s.runs[id]
+	s.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no active transfer %q", id)
+	}
+	r.mu.Lock()
+	c := r.controls
+	r.mu.Unlock()
+	if c == nil {
+		return fmt.Errorf("transfer %q has not connected yet", id)
+	}
+	return fn(c)
+}
+
+func (s *TransferService) newID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.next++
+	return fmt.Sprintf("t%d", s.next)
+}
+
+func (s *TransferService) newRun(id string, role wire.Role) *transferRun {
+	ctx, canc := context.WithCancel(context.Background())
+	r := &transferRun{
+		id: id, role: role, svc: s, ctx: ctx, canc: canc,
+		now: time.Now,
+	}
+	s.mu.Lock()
+	s.runs[id] = r
+	s.mu.Unlock()
+	return r
+}
+
+func (s *TransferService) remove(r *transferRun) {
+	r.canc()
+	s.mu.Lock()
+	delete(s.runs, r.id)
+	s.mu.Unlock()
+}
+
+// publish sends a snapshot event to the frontend (and to tests via the
+// injected emit sink). Phase is set by the callbacks via mut; the rest are the
+// current run values.
+func (r *transferRun) publish(kind string, mut ...func(*TransferEvent)) {
+	r.mu.Lock()
+	ev := &TransferEvent{
+		ID:          r.id,
+		Kind:        kind,
+		Transport:   r.transport,
+		Fingerprint: r.fingerprint,
+		Files:       append([]FileInfo(nil), r.files...),
+		TotalBytes:  r.totalBytes,
+		DoneBytes:   r.doneBytes,
+		FileBytes:   r.fileBytes,
+		FileSize:    r.fileSize,
+		FilesDone:   r.filesDone,
+		FilesTotal:  len(r.files),
+		State:       r.stateString(),
+		Paused:      r.paused,
+		Canceled:    r.canceled,
+		Failed:      r.failed,
+		RemainingMS: -1,
+	}
+	if r.totalBytes > 0 {
+		ev.Percent = int(r.doneBytes * 100 / r.totalBytes)
+	}
+	rate, eta := r.rateAndETA()
+	if rate > 0 {
+		ev.RateBps = rate
+		ev.ETA = formatETA(eta)
+		ev.RemainingMS = eta.Milliseconds()
+	}
+	if r.fileIdx >= 0 && r.fileIdx < len(r.files) {
+		ev.CurrentFile = r.files[r.fileIdx].Name
+	}
+	r.mu.Unlock()
+
+	for _, m := range mut {
+		m(ev)
+	}
+	if r.svc.emit != nil {
+		r.svc.emit(TransferEventName, ev)
+	}
+}
+
+func (r *transferRun) stateString() string {
+	switch {
+	case r.failed:
+		return "failed"
+	case r.canceled:
+		return "canceled"
+	case r.paused:
+		return "paused"
+	default:
+		return "running"
+	}
+}
+
+// rateAndETA computes the five-second rolling rate and remaining duration from
+// the sampled acknowledged bytes (mirrors the CLI progress math).
+func (r *transferRun) rateAndETA() (float64, time.Duration) {
+	if len(r.samples) < 2 {
+		return 0, 0
+	}
+	first, last := r.samples[0], r.samples[len(r.samples)-1]
+	elapsed := last.at.Sub(first.at).Seconds()
+	if elapsed <= 0 || last.bytes <= first.bytes {
+		return 0, 0
+	}
+	rate := float64(last.bytes-first.bytes) / elapsed
+	remaining := r.totalBytes - r.reused - r.doneBytes
+	if remaining < 0 {
+		remaining = 0
+	}
+	if rate <= 0 {
+		return rate, 0
+	}
+	return rate, time.Duration(float64(time.Second) * float64(remaining) / rate)
+}
+
+func (r *transferRun) recordSample(bytes int64) {
+	now := r.now()
+	r.samples = append(r.samples, progressSample{at: now, bytes: bytes})
+	cutoff := now.Add(-5 * time.Second)
+	for len(r.samples) > 2 && !r.samples[1].at.After(cutoff) {
+		r.samples = r.samples[1:]
+	}
+}
+
+// runSend drives the offerer side of the transfer.
+func (r *transferRun) runSend(ctx context.Context, server string, sources []wire.FileSource) {
+	defer r.svc.remove(r)
+
+	sig, err := r.svc.dial(ctx, server, wire.RoleOfferer)
+	if err != nil {
+		r.fail("dial: " + err.Error())
+		return
+	}
+	defer sig.Close()
+
+	lastProgress := time.Time{}
+	emitProgress := func() {
+		now := time.Now()
+		if now.Sub(lastProgress) < 200*time.Millisecond {
+			return
+		}
+		lastProgress = now
+		r.publish("progress")
+	}
+
+	spec := transfer.Spec{
+		Session: rendezvous.Options{
+			Role: rendezvous.RoleOfferer,
+			OnPhase: func(p rendezvous.Phase) {
+				r.publish("phase", func(ev *TransferEvent) { ev.Phase = string(p) })
+			},
+			OnCode: func(code string) {
+				r.publish("invite", func(ev *TransferEvent) {
+					ev.Code = code
+					ev.Link = inviteLink(server, code)
+					ev.QR = qrDataURL(ev.Link)
+				})
+			},
+		},
+		Sources:        sources,
+		ForceRelay:     r.svc.forceRelay,
+		ICEServers:     r.svc.iceServers,
+		OnTransport:    r.onTransport,
+		OnConnect:      func() { r.publish("connect") },
+		OnFileProgress: r.onFileProgress,
+		OnProgress: func(n int64) {
+			r.mu.Lock()
+			r.doneBytes = n
+			r.recordSample(n)
+			r.mu.Unlock()
+			emitProgress()
+		},
+		OnControls: func(c transfer.Controls) {
+			r.mu.Lock()
+			r.controls = c
+			r.mu.Unlock()
+			r.publish("connect") // controls ready
+		},
+		OnStateChange: r.onState,
+	}
+
+	out, err := transfer.Run(ctx, sig, spec)
+	if err != nil {
+		r.fail(err.Error())
+		return
+	}
+	r.mu.Lock()
+	var done int64
+	for i, f := range out.Files {
+		done += f.Size
+		if i < len(r.files) {
+			r.files[i].Size = f.Size
+		}
+	}
+	r.doneBytes = done
+	// Verified success: every file in the set completed.
+	r.filesDone = len(out.Files)
+	r.mu.Unlock()
+
+	if out.Handshake != nil {
+		r.mu.Lock()
+		r.fingerprint = fingerprint(out.Handshake.Master)
+		r.mu.Unlock()
+	}
+	r.publish("done", func(ev *TransferEvent) {
+		ev.Digest = out.Digest
+		ev.Percent = 100
+	})
+}
+
+// runReceive drives the joiner side of the transfer.
+func (r *transferRun) runReceive(ctx context.Context, code, destDir, server string) {
+	defer r.svc.remove(r)
+
+	sig, err := r.svc.dial(ctx, server, wire.RoleJoiner)
+	if err != nil {
+		r.fail("dial: " + err.Error())
+		return
+	}
+	defer sig.Close()
+
+	lastProgress := time.Time{}
+	emitProgress := func() {
+		now := time.Now()
+		if now.Sub(lastProgress) < 200*time.Millisecond {
+			return
+		}
+		lastProgress = now
+		r.publish("progress")
+	}
+	spec := transfer.Spec{
+		Session: rendezvous.Options{
+			Role: rendezvous.RoleJoiner,
+			Code: code,
+			OnPhase: func(p rendezvous.Phase) {
+				r.publish("phase", func(ev *TransferEvent) { ev.Phase = string(p) })
+			},
+		},
+		DestDir:    destDir,
+		ForceRelay: r.svc.forceRelay,
+		ICEServers: r.svc.iceServers,
+		OnManifestSet: func(m wire.Manifest) {
+			r.mu.Lock()
+			r.files = r.files[:0]
+			r.totalBytes = m.TotalSize
+			for _, f := range m.Files {
+				r.files = append(r.files, FileInfo{Name: f.Name, Size: f.Size})
+			}
+			r.mu.Unlock()
+			r.publish("manifest")
+		},
+		OnTransport:    r.onTransport,
+		OnConnect:      func() { r.publish("connect") },
+		OnFileProgress: r.onFileProgress,
+		OnProgress: func(n int64) {
+			r.mu.Lock()
+			r.doneBytes = n
+			r.recordSample(n)
+			r.mu.Unlock()
+			emitProgress()
+		},
+		OnControls: func(c transfer.Controls) {
+			r.mu.Lock()
+			r.controls = c
+			r.mu.Unlock()
+			r.publish("connect") // controls ready
+		},
+		OnStateChange: r.onState,
+	}
+
+	out, err := transfer.Run(ctx, sig, spec)
+	if err != nil {
+		r.fail(err.Error())
+		return
+	}
+	r.mu.Lock()
+	r.doneBytes = out.Size
+	r.filesDone = len(out.Files)
+	if out.Handshake != nil {
+		r.fingerprint = fingerprint(out.Handshake.Master)
+	}
+	r.mu.Unlock()
+	r.publish("done", func(ev *TransferEvent) {
+		ev.Digest = out.Digest
+		ev.OutDir = destDir
+		if len(out.Files) == 1 {
+			ev.OutPath = out.Path
+		}
+		ev.Percent = 100
+	})
+}
+
+func (r *transferRun) onTransport(path string) {
+	r.mu.Lock()
+	r.transport = path
+	r.mu.Unlock()
+	r.publish("transport")
+}
+
+func (r *transferRun) onFileProgress(fileIdx int, fileBytes, _ int64) {
+	r.mu.Lock()
+	r.fileIdx = fileIdx
+	r.fileBytes = fileBytes
+	if fileIdx >= 0 && fileIdx < len(r.files) {
+		r.fileSize = r.files[fileIdx].Size
+		// A file is done when its acknowledged bytes reach its size.
+		if fileBytes >= r.files[fileIdx].Size {
+			if r.filesDone < fileIdx+1 {
+				r.filesDone = fileIdx + 1
+			}
+		}
+	}
+	r.mu.Unlock()
+}
+
+func (r *transferRun) onState(st wire.TransferState) {
+	r.mu.Lock()
+	switch st {
+	case wire.TransferPaused:
+		r.paused = true
+	case wire.TransferCanceled:
+		r.canceled = true
+	default:
+		r.paused = false
+	}
+	r.mu.Unlock()
+	r.publish("state")
+}
+
+func (r *transferRun) fail(why string) {
+	r.mu.Lock()
+	r.failed = true
+	r.mu.Unlock()
+	r.publish("error", func(ev *TransferEvent) { ev.Error = why })
+}
+
+// fingerprint renders the SAS fingerprint from the session master, matching
+// the CLI exactly.
+func fingerprint(master []byte) string {
+	sum := sha256.Sum256(append([]byte("sendbeam/sas\x00"), master...))
+	return fmt.Sprintf("%02x%02x %02x%02x", sum[0], sum[1], sum[2], sum[3])
+}
+
+// inviteLink turns the signaling URL into the web app's join link for the same
+// deployment, matching the CLI (wss/ws → https/http, drop /ws, code in the
+// fragment so it never hits the server).
+func inviteLink(serverURL, code string) string {
+	u, err := url.Parse(serverURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	switch u.Scheme {
+	case "wss":
+		u.Scheme = "https"
+	case "ws":
+		u.Scheme = "http"
+	}
+	u.Path = "/"
+	u.RawQuery = ""
+	u.Fragment = code
+	return u.String()
+}
+
+// normalizeCode accepts a bare code or a full invite link and returns the code.
+func normalizeCode(arg string) string {
+	arg = strings.TrimSpace(arg)
+	if i := strings.LastIndex(arg, "#"); i >= 0 {
+		return arg[i+1:]
+	}
+	return arg
+}
+
+// qrDataURL renders the invite link as a QR PNG data URL.
+func qrDataURL(link string) string {
+	if link == "" {
+		return ""
+	}
+	png, err := qrcode.Encode(link, qrcode.Medium, 320)
+	if err != nil {
+		return ""
+	}
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
+}
+
+// validatePaths rejects symbolic links and missing paths up front with the
+// engine's rules (NewOSFileSources re-validates; this keeps picker feedback
+// instant).
+func validatePaths(paths []string) error {
+	for _, p := range paths {
+		info, err := os.Lstat(p)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symbolic links are not supported: %s", p)
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			return fmt.Errorf("not a regular file or folder: %s", p)
+		}
+	}
+	return nil
+}
+
+// formatETA renders a duration like the CLI (e.g. "2m 5s remaining").
+func formatETA(eta time.Duration) string {
+	seconds := int64(math.Ceil(eta.Seconds()))
+	if seconds < 60 {
+		return fmt.Sprintf("%ds remaining", seconds)
+	}
+	return fmt.Sprintf("%dm %ds remaining", seconds/60, seconds%60)
+}

--- a/apps/desktop/internal/engine/transfer_service_test.go
+++ b/apps/desktop/internal/engine/transfer_service_test.go
@@ -1,0 +1,580 @@
+package engine
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/engine/rendezvous"
+	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/engine/wsclient"
+	"github.com/sendbeam/wire"
+)
+
+// eventSink records TransferEvents emitted by the service, for assertions and
+// for waiting on particular kinds (invite, connect, done, …).
+type eventSink struct {
+	mu     sync.Mutex
+	events []*TransferEvent
+}
+
+func (s *eventSink) emit(name string, data any) {
+	if name != TransferEventName {
+		return
+	}
+	ev, ok := data.(*TransferEvent)
+	if !ok {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, ev)
+}
+
+func (s *eventSink) all() []*TransferEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*TransferEvent(nil), s.events...)
+}
+
+// waitFor blocks until a kind appears or the timeout elapses.
+func (s *eventSink) waitFor(t *testing.T, kind string, timeout time.Duration) *TransferEvent {
+	t.Helper()
+	return s.waitForID(t, "", kind, timeout)
+}
+
+// waitForID blocks until an event of kind for the given id (or any id when id
+// is empty) appears.
+func (s *eventSink) waitForID(t *testing.T, id, kind string, timeout time.Duration) *TransferEvent {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, ev := range s.all() {
+			if ev.Kind == kind && (id == "" || ev.ID == id) {
+				return ev
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for event kind %q id %q (got %v)", kind, id, kinds(s.all()))
+	return nil
+}
+
+func (s *eventSink) has(kind string) bool {
+	for _, ev := range s.all() {
+		if ev.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func kinds(evs []*TransferEvent) []string {
+	var out []string
+	for _, ev := range evs {
+		out = append(out, ev.Kind)
+	}
+	return out
+}
+
+// loopbackDialer returns the offerer/joiner end of a shared in-process relay,
+// mirroring the engine parity tests' signal seam.
+func loopbackDialer(hub *loopbackRelay) SignalDialer {
+	return func(_ context.Context, _ string, role wire.Role) (transfer.Signal, error) {
+		if role == wire.RoleOfferer {
+			return hub.off, nil
+		}
+		return hub.join, nil
+	}
+}
+
+// newLoopbackService builds a TransferService wired to a fresh loopback relay,
+// ready for a send+receive pair.
+func newLoopbackService(t *testing.T) (*TransferService, *eventSink, *loopbackRelay) {
+	t.Helper()
+	hub := newLoopbackRelay()
+	sink := &eventSink{}
+	svc := NewTransferService(sink.emit, loopbackDialer(hub))
+	svc.setLoopbackConfig()
+	t.Cleanup(func() {
+		hub.off.Close()
+		hub.join.Close()
+	})
+	return svc, sink, hub
+}
+
+// writePayload writes a deterministic file.
+func writePayload(t *testing.T, dir, name string, size int) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i*31 + 7)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readAll(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// startPair starts a send+receive pair: sender first (so the relay allocates
+// the room), then the receiver joins with the invite code.
+func startPair(t *testing.T, svc *TransferService, sink *eventSink, srcPath, outDir string) (sendID, recvID string) {
+	t.Helper()
+	send, err := svc.Send([]string{srcPath}, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	invite := sink.waitFor(t, "invite", 30*time.Second)
+	if invite.Code == "" {
+		t.Fatal("invite event has no code")
+	}
+	recv, err := svc.Receive(invite.Code, outDir, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	return send.ID, recv.ID
+}
+
+// TestServiceSendReceiveFullTransfer drives one complete send+receive pair
+// through the service public API and checks the event stream plus the
+// byte-identical verified output.
+func TestServiceSendReceiveFullTransfer(t *testing.T) {
+	svc, sink, _ := newLoopbackService(t)
+	dir := t.TempDir()
+	src := writePayload(t, dir, "payload.bin", 1<<20+40000) // crosses the 1 MiB block boundary
+	outDir := filepath.Join(dir, "out")
+
+	sendID, recvID := startPair(t, svc, sink, src, outDir)
+
+	doneSend := sink.waitForID(t, sendID, "done", 60*time.Second)
+	if doneSend.Digest == "" {
+		t.Fatal("sender done event has no digest")
+	}
+	if doneSend.Percent != 100 {
+		t.Fatalf("sender done percent = %d, want 100", doneSend.Percent)
+	}
+
+	recvDone := sink.waitForID(t, recvID, "done", 60*time.Second)
+	if recvDone.Digest == "" {
+		t.Fatal("receiver done event has no digest")
+	}
+	if recvDone.OutDir != outDir {
+		t.Fatalf("receiver outDir = %q, want %q", recvDone.OutDir, outDir)
+	}
+	if recvDone.Digest == "" {
+		t.Fatal("receiver done event has no digest")
+	}
+
+	// Byte-identical verified output.
+	got := readAll(t, filepath.Join(outDir, "payload.bin"))
+	want := readAll(t, src)
+	if len(got) != len(want) {
+		t.Fatalf("received %d bytes, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("received bytes differ at %d", i)
+		}
+	}
+
+	// Invite event carried code + link + QR.
+	if invite := sink.waitFor(t, "invite", 5*time.Second); invite.Link == "" || invite.QR == "" {
+		t.Fatalf("invite missing link/QR: %+v", invite)
+	}
+
+	// Aggregate + current-file state appeared on the receiver manifest event.
+	manifest := sink.waitFor(t, "manifest", 5*time.Second)
+	if len(manifest.Files) != 1 || manifest.Files[0].Name != "payload.bin" {
+		t.Fatalf("manifest files = %+v", manifest.Files)
+	}
+	if manifest.TotalBytes != int64(len(want)) {
+		t.Fatalf("manifest total = %d, want %d", manifest.TotalBytes, len(want))
+	}
+
+	// Fingerprint set on both done events (auth state).
+	if doneSend.Fingerprint == "" || recvDone.Fingerprint == "" {
+		t.Fatal("done events missing fingerprint")
+	}
+	if doneSend.Fingerprint != recvDone.Fingerprint {
+		t.Fatalf("fingerprints differ: %q vs %q", doneSend.Fingerprint, recvDone.Fingerprint)
+	}
+
+	// Transport reported (loopback config forces relay).
+	if !sink.has("transport") {
+		t.Fatal("no transport event")
+	}
+	_ = recvDone
+}
+
+// TestServiceSendReceiveMultiFile sends two files and checks aggregate state.
+func TestServiceSendReceiveMultiFile(t *testing.T) {
+	svc, sink, _ := newLoopbackService(t)
+	dir := t.TempDir()
+	a := writePayload(t, dir, "a.txt", 300000)
+	b := writePayload(t, dir, "b.txt", 500000)
+	outDir := filepath.Join(dir, "out")
+
+	send, err := svc.Send([]string{a, b}, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	invite := sink.waitFor(t, "invite", 30*time.Second)
+	if _, err := svc.Receive(invite.Code, outDir, "wss://loopback/ws"); err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	done := sink.waitForID(t, send.ID, "done", 60*time.Second)
+	if done.FilesTotal != 2 {
+		t.Fatalf("filesTotal = %d, want 2", done.FilesTotal)
+	}
+	if done.FilesDone != 2 {
+		t.Fatalf("filesDone = %d, want 2", done.FilesDone)
+	}
+	if done.TotalBytes != 800000 {
+		t.Fatalf("totalBytes = %d, want 800000", done.TotalBytes)
+	}
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
+			t.Fatalf("missing received file %s: %v", name, err)
+		}
+	}
+}
+
+// TestServicePauseResumeCancel verifies the controls surface: pause reports
+// state, resume completes, and a fresh pair can be canceled cleanly.
+func TestServicePauseResumeCancel(t *testing.T) {
+	svc, sink, _ := newLoopbackService(t)
+	dir := t.TempDir()
+	// Large enough payload that pausing mid-flight is observable.
+	src := writePayload(t, dir, "big.bin", 32<<20)
+	outDir := filepath.Join(dir, "out")
+
+	sendID, _ := startPair(t, svc, sink, src, outDir)
+
+	// Wait for controls to be live (connect event fires when the channel
+	// opens, before bytes begin moving).
+	waitForControls := func(id string) {
+		t.Helper()
+		deadline := time.Now().Add(30 * time.Second)
+		for time.Now().Before(deadline) {
+			s := svc.state(id)
+			if s.controlsReady() {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatal("controls never became ready")
+	}
+	waitForControls(sendID)
+
+	if err := svc.Pause(sendID); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	// State event reports paused.
+	deadline := time.Now().Add(10 * time.Second)
+	for !sink.has("state") && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !svc.state(sendID).paused {
+		t.Fatal("transfer not paused after Pause()")
+	}
+
+	if err := svc.Resume(sendID); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	done := sink.waitForID(t, sendID, "done", 60*time.Second)
+	if done.Failed || done.Canceled {
+		t.Fatalf("resumed transfer ended failed/canceled: %+v", done)
+	}
+
+	// Cancel a fresh pair.
+	svc2, sink2, _ := newLoopbackService(t)
+	src2 := writePayload(t, dir, "big2.bin", 32<<20)
+	outDir2 := filepath.Join(dir, "out2")
+	sendID2, _ := startPair(t, svc2, sink2, src2, outDir2)
+	waitForControls = func(id string) {
+		t.Helper()
+		deadline := time.Now().Add(30 * time.Second)
+		for time.Now().Before(deadline) {
+			if svc2.state(id).controlsReady() {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatal("controls never became ready")
+	}
+	waitForControls(sendID2)
+	if err := svc2.Cancel(sendID2); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	// Either side settles canceled; the service must not hang and must report
+	// the terminal state.
+	deadline = time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		all := sink2.all()
+		for _, ev := range all {
+			if ev.ID == sendID2 && (ev.Kind == "done" || ev.Kind == "error") {
+				if !ev.Canceled && !ev.Failed {
+					t.Fatalf("canceled transfer ended without canceled/failed: %+v", ev)
+				}
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("canceled transfer never settled")
+}
+
+// TestServiceInviteAndQR checks invite code normalization, link formatting, and
+// that the QR is a decodable PNG data URL.
+func TestServiceInviteAndQR(t *testing.T) {
+	if code := normalizeCode("https://example.com/#7-alpha-bravo"); code != "7-alpha-bravo" {
+		t.Fatalf("normalizeCode(link) = %q", code)
+	}
+	if code := normalizeCode("7-alpha-bravo"); code != "7-alpha-bravo" {
+		t.Fatalf("normalizeCode(bare) = %q", code)
+	}
+	link := inviteLink("wss://example.com:8443/ws", "7-alpha-bravo")
+	want := "https://example.com:8443/#7-alpha-bravo"
+	if link != want {
+		t.Fatalf("inviteLink = %q, want %q", link, want)
+	}
+	qr := qrDataURL(link)
+	if !strings.HasPrefix(qr, "data:image/png;base64,") {
+		t.Fatalf("QR is not a PNG data URL: %.40q", qr)
+	}
+	raw := strings.TrimPrefix(qr, "data:image/png;base64,")
+	png, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("QR base64: %v", err)
+	}
+	if len(png) < 8 || string(png[1:4]) != "PNG" {
+		t.Fatalf("QR does not decode to a PNG (first bytes %x)", png[:min(8, len(png))])
+	}
+}
+
+// TestServicePickersServerMode verifies native pickers degrade to a clear
+// error when no GUI is present (server mode / tests).
+func TestServicePickersServerMode(t *testing.T) {
+	svc, _, _ := newLoopbackService(t)
+	res := svc.PickFiles()
+	if res.Error == "" {
+		t.Fatal("PickFiles in server mode returned no error")
+	}
+	res = svc.PickDestination()
+	if res.Error == "" {
+		t.Fatal("PickDestination in server mode returned no error")
+	}
+}
+
+// TestServiceSendValidation checks pre-flight validation and id stability.
+func TestServiceSendValidation(t *testing.T) {
+	svc, _, _ := newLoopbackService(t)
+	if _, err := svc.Send(nil, "wss://loopback/ws"); err == nil {
+		t.Fatal("Send with no paths succeeded")
+	}
+	if _, err := svc.Send([]string{filepath.Join(t.TempDir(), "missing.txt")}, "wss://loopback/ws"); err == nil {
+		t.Fatal("Send with missing path succeeded")
+	}
+	src := writePayload(t, t.TempDir(), "ok.bin", 1000)
+	if _, err := svc.Send([]string{src}, ""); err != nil {
+		t.Fatalf("Send with default server failed: %v", err)
+	}
+	if _, err := svc.Receive("", ".", ""); err == nil {
+		t.Fatal("Receive with empty code succeeded")
+	}
+}
+
+// helper state accessors (same package) for control-readiness polling.
+func (s *TransferService) state(id string) *transferRun {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.runs[id]
+}
+
+func (r *transferRun) controlsReady() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.controls != nil
+}
+
+// blindHub is a minimal in-process stand-in for the SendBeam signaling server
+// over a REAL WebSocket, mirroring the wsclient package's own test hub. It lets
+// the desktop service exercise the exact wsclient + engine stack the CLI and
+// browser use — the browser/CLI interop proof at the service layer.
+type blindHub struct {
+	mu    sync.Mutex
+	rooms map[int]*blindRoom
+	next  int
+}
+
+type blindRoom struct {
+	offerer, joiner *blindPeer
+}
+
+type blindPeer struct {
+	conn *websocket.Conn
+	wmu  sync.Mutex
+}
+
+func (p *blindPeer) send(ctx context.Context, m rendezvous.Message) {
+	data, _ := rendezvous.MarshalMessage(m)
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	_ = p.conn.Write(ctx, websocket.MessageText, data)
+}
+
+func (p *blindPeer) forward(ctx context.Context, data []byte) {
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	_ = p.conn.Write(ctx, websocket.MessageText, data)
+}
+
+func newBlindHub() *blindHub { return &blindHub{rooms: map[int]*blindRoom{}} }
+
+func (h *blindHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.CloseNow() }()
+	ctx := r.Context()
+	self := &blindPeer{conn: conn}
+
+	var room *blindRoom
+	var role rendezvous.Role
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		if typ != websocket.MessageText {
+			return
+		}
+		msg, err := rendezvous.UnmarshalMessage(data)
+		if err != nil {
+			return
+		}
+		switch msg.Type {
+		case "create":
+			h.mu.Lock()
+			id := h.next
+			h.next++
+			room = &blindRoom{offerer: self}
+			h.rooms[id] = room
+			h.mu.Unlock()
+			role = rendezvous.RoleOfferer
+			self.send(ctx, rendezvous.Message{Type: "created", Room: &id})
+		case "join":
+			if msg.Room == nil {
+				return
+			}
+			h.mu.Lock()
+			room = h.rooms[*msg.Room]
+			h.mu.Unlock()
+			if room == nil {
+				return
+			}
+			room.joiner = self
+			role = rendezvous.RoleJoiner
+			self.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(rendezvous.RoleJoiner)})
+			room.offerer.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(rendezvous.RoleOfferer)})
+		default:
+			other := room.joiner
+			if role == rendezvous.RoleJoiner {
+				other = room.offerer
+			}
+			if other != nil {
+				other.forward(ctx, data)
+			}
+		}
+	}
+}
+
+func wsURL(httpsURL string) string { return "wss" + strings.TrimPrefix(httpsURL, "https") }
+
+// TestServiceInteropOverRealWebSocket runs a full send+receive through the
+// desktop service using the REAL wsclient dialer against a real WebSocket
+// signaling hub — the same stack CLI and browser peers speak, proving desktop
+// interop from the first implementation.
+func TestServiceInteropOverRealWebSocket(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real-WebSocket interop transfer")
+	}
+	hub := newBlindHub()
+	srv := httptest.NewTLSServer(hub)
+	defer srv.Close()
+	server := wsURL(srv.URL)
+
+	insecureDial := func(ctx context.Context, server string, _ wire.Role) (transfer.Signal, error) {
+		return wsclient.NewReconnectingSignal(ctx, server, wsclient.DialOptions{InsecureSkipVerify: true})
+	}
+	sink := &eventSink{}
+	svc := NewTransferService(sink.emit, insecureDial)
+	// Direct path with host-only ICE: the real WebSocket carries the SDP/ICE
+	// signaling (blind-forwarded by the hub) exactly as CLI/browser peers do;
+	// the loopback relay's relay-open gating is not part of this hub, so the
+	// direct WebRTC path is the interop surface here.
+	svc.iceServers = []webrtc.ICEServer{}
+
+	dir := t.TempDir()
+	src := writePayload(t, dir, "interop.bin", 1<<20+12345)
+	outDir := filepath.Join(dir, "out")
+
+	send, err := svc.Send([]string{src}, server)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	invite := sink.waitFor(t, "invite", 30*time.Second)
+	if invite.Code == "" {
+		t.Fatal("no invite code")
+	}
+	recv, err := svc.Receive(invite.Code, outDir, server)
+	if err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+
+	sink.waitForID(t, send.ID, "done", 60*time.Second)
+	recvDone := sink.waitForID(t, recv.ID, "done", 60*time.Second)
+	if recvDone.Digest == "" {
+		t.Fatal("receiver done has no digest")
+	}
+
+	got := readAll(t, filepath.Join(outDir, "interop.bin"))
+	want := readAll(t, src)
+	if len(got) != len(want) {
+		t.Fatalf("received %d bytes, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("received bytes differ at %d", i)
+		}
+	}
+}
+
+// TestServiceInteropInviteLinkFormat proves the desktop invite link matches the
+// CLI/browser join link for the same deployment (fragment-encoded code).
+func TestServiceInteropInviteLinkFormat(t *testing.T) {
+	link := inviteLink("wss://relay.example.com:8443/ws", "12-quick-brown")
+	if !strings.HasPrefix(link, "https://relay.example.com:8443/#12-quick-brown") {
+		t.Fatalf("unexpected invite link: %q", link)
+	}
+}

--- a/apps/desktop/main.go
+++ b/apps/desktop/main.go
@@ -1,4 +1,4 @@
-// Command desktop is the SendBeam desktop shell. It runs the shared Go engine
+// Command desktop is the SendBeam desktop app. It runs the shared Go engine
 // (packages/engine) behind Wails v3 services and a system-WebView frontend; all
 // WebRTC, crypto, file I/O, durability, and trust logic stays in the engine.
 //
@@ -16,6 +16,7 @@ import (
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/events"
 
 	"github.com/sendbeam/desktop/internal/engine"
 )
@@ -24,11 +25,21 @@ import (
 var assets embed.FS
 
 func main() {
+	transferSvc := engine.NewTransferService(
+		// Emit every transfer snapshot to the frontend.
+		func(name string, data any) {
+			application.Get().Event.Emit(name, data)
+		},
+		// Real signaling server (same wsclient the CLI uses → browser/CLI interop).
+		nil,
+	)
+
 	app := application.New(application.Options{
 		Name:        "SendBeam Desktop",
 		Description: "Secure, end-to-end-encrypted, peer-to-peer file transfer",
 		Services: []application.Service{
 			application.NewService(engine.NewService()),
+			application.NewService(transferSvc),
 		},
 		Assets: application.AssetOptions{
 			Handler: application.AssetFileServerFS(assets),
@@ -44,13 +55,41 @@ func main() {
 		},
 	})
 
-	app.Window.NewWithOptions(application.WebviewWindowOptions{
+	win := app.Window.NewWithOptions(application.WebviewWindowOptions{
 		Title:     "SendBeam Desktop",
-		Width:     960,
-		Height:    640,
-		MinWidth:  720,
-		MinHeight: 480,
+		Width:     1040,
+		Height:    720,
+		MinWidth:  760,
+		MinHeight: 520,
 		URL:       "/",
+		// Drag-and-drop files onto the window; the frontend's drop targets
+		// carry data-file-drop-target and the runtime posts the dropped paths
+		// to the FilesDropped window event below.
+		EnableFileDrop: true,
+	})
+
+	// Forward OS file drops to a new send. Dropped paths are absolute; the
+	// engine's source expansion handles files and folders identically. The
+	// drop event lets the frontend adopt the new transfer id and show the
+	// invite as soon as the engine allocates the room.
+	win.OnWindowEvent(events.Common.WindowFilesDropped, func(e *application.WindowEvent) {
+		paths := e.Context().DroppedFiles()
+		if len(paths) == 0 {
+			return
+		}
+		h, err := transferSvc.Drop(paths)
+		if err != nil {
+			application.Get().Event.Emit(engine.TransferEventName, map[string]any{
+				"kind":  "error",
+				"error": err.Error(),
+			})
+			return
+		}
+		application.Get().Event.Emit(engine.TransferEventName, map[string]any{
+			"kind":  "drop",
+			"id":    h.ID,
+			"files": paths,
+		})
 	})
 
 	if err := app.Run(); err != nil {


### PR DESCRIPTION
## Summary
Completes the V14-PR03 desktop core transfer product on top of the Wails v3 shell (PR #118):
native file/folder pickers, window drag-and-drop, invite code + join-link + QR, accurate
connection/auth/transport state, live progress/speed/ETA/current-file/aggregate, and
pause/resume/cancel — all through `packages/engine`'s public API only.

## What's included
- **`TransferService`** — `Send`/`Receive`/`Pause`/`Resume`/`Cancel` + `Info`/`Caps`/`SelfCheck`,
  emitting Wails events (`transfer:state`, `transfer:progress`, `transfer:done`, `transfer:drop`).
  Uses the same `wsclient` + engine session machinery as the CLI, so browser/CLI interop is inherent.
- **Native pickers** (`PickFiles`, `PickFolder`, `PickDestination`) via Wails dialogs; drag-and-drop
  handled on the Go side (`FilesDropped` → auto-starts a send).
- **QR codes** — Go-generated (`skip2/go-qrcode`), no JS dependency.
- **Frontend** — plain HTML/JS over `/wails/runtime.js` (no build step): send/receive views,
  invite copy + QR modal, live phase/transport/fingerprint badges, progress/speed/ETA/current-file/
  aggregate, and pause/resume/cancel controls.

## Tests
- Loopback service tests: full transfer, multi-file, pause/resume/cancel, event stream, QR bytes.
- **Real-WebSocket interop test**: the service drives a full transfer against an in-process
  signaling hub over actual `wsclient` WebSockets — the same protocol the CLI and web app use.
- CI: server-tagged vet/test + `-race` and window build (GTK deps installed, per ADR 0007).

## Notes
- Frontend now calls services by exact FQN (`github.com/sendbeam/desktop/internal/engine.X.Y`);
  PR02's smoke only curled static assets, so this PR is the first to exercise real bindings.