### PR TITLE
chore(ci): repository hardening and safe publishing policy

### DIFF
--- a/.github/workflows/campaign.yml
+++ b/.github/workflows/campaign.yml
@@ -1,0 +1,36 @@
+name: campaign
+
+on:
+  schedule:
+    # Run weekly on Sunday at 04:00 UTC
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: campaign-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  campaign:
+    # Heavyweight validation: the >= 100 GiB streamed resume campaign proves a very
+    # large logical transfer resumes from a deep durable checkpoint with bounded memory and no
+    # full-file staging. Owned by periodic CI and manual dispatch, never ordinary PR CI.
+    name: campaign (100 GiB streamed resume)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: packages/wire/go.sum
+
+      - name: Run 100 GiB campaign
+        working-directory: packages/wire
+        # go test's default 10-minute timeout killed the stream mid-run; the campaign needs
+        # the job's full budget (hashing 100+ GiB takes tens of minutes), so raise it.
+        run: go test -tags campaign -timeout 90m -run 'TestCampaign' -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,75 @@ on:
 permissions:
   contents: read
 
+# Concurrency configuration:
+# - PR runs: grouped by PR number with cancel-in-progress: true so new pushes cancel stale PR checks.
+# - Push runs (main): grouped by unique commit SHA with cancel-in-progress: false so every canonical main SHA receives its own durable validation without being cancelled by later pushes.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  metadata:
+    name: metadata & attribution hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify PR metadata and title formatting
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Validating PR #$PR_NUMBER title: '$PR_TITLE'"
+          # 1. Validate conventional commit format: type(scope)?: description
+          if ! echo "$PR_TITLE" | grep -Eq '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9_-]+\))?: .+'; then
+            echo "::error::PR title must follow Conventional Commits format (e.g. 'feat: description' or 'chore(ci): description')."
+            exit 1
+          fi
+
+          # 2. Check for manual/hardcoded PR number suffixes in PR title itself (GitHub appends ' (#<pr>)' automatically on squash merge)
+          if echo "$PR_TITLE" | grep -Eq '\(#[0-9]+\)$'; then
+            echo "::error::PR title should NOT include a manual '(#...)' suffix. GitHub adds ' (#$PR_NUMBER)' automatically upon squash merge."
+            exit 1
+          fi
+
+          # 3. Check for planning/internal task IDs in title
+          if echo "$PR_TITLE" | grep -Eiq 'V[0-9]+-PR[0-9]+'; then
+            echo "::error::PR title must not contain internal planning tags (e.g. V14-PR04)."
+            exit 1
+          fi
+
+      - name: Guard against AI/tool contributor attribution
+        run: |
+          # Check commit messages in the current branch/PR against known automated coding-agent attribution trailers
+          FORBIDDEN_PATTERNS='(Generated with Codebuff|Co-Authored-By:.*Codebuff|Freebuff|AI-generated-by|tool-generated-by|generated-by:)'
+
+          # Inspect commit range
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            COMMITS=$(git rev-list "$BASE_SHA..$HEAD_SHA" || true)
+          else
+            # On direct push, check the pushed commits
+            COMMITS="${{ github.sha }}"
+          fi
+
+          for c in $COMMITS; do
+            MSG=$(git log -1 --format='%B' "$c")
+            AUTHOR=$(git log -1 --format='%an <%ae>' "$c")
+            COMMITTER=$(git log -1 --format='%cn <%ce>' "$c")
+
+            FULL_META="$AUTHOR"$'\n'"$COMMITTER"$'\n'"$MSG"
+            if echo "$FULL_META" | grep -Eiq "$FORBIDDEN_PATTERNS"; then
+              echo "::error::Commit $c contains forbidden automated agent attribution in metadata."
+              exit 1
+            fi
+          done
+          echo "Attribution hygiene check passed."
+
   web:
     name: web (lint, typecheck, test, build)
     runs-on: ubuntu-latest
@@ -165,27 +229,6 @@ jobs:
         with:
           version: v2.12.2
           working-directory: apps/desktop
-
-  campaign:
-    # V13-PR08 heavyweight validation: the >= 100 GiB streamed resume campaign proves a very
-    # large logical transfer resumes from a deep durable checkpoint with bounded memory and no
-    # full-file staging. Owned by CI, never the laptop (hashing 100+ GiB takes minutes).
-    name: campaign (100 GiB streamed resume)
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-          cache-dependency-path: packages/wire/go.sum
-
-      - name: Run 100 GiB campaign
-        working-directory: packages/wire
-        # go test's default 10-minute timeout killed the stream mid-run; the campaign needs
-        # the job's full budget (hashing 100+ GiB takes tens of minutes), so raise it.
-        run: go test -tags campaign -timeout 90m -run 'TestCampaign' -v ./...
 
   branding:
     name: branding (no stale SendArc references)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,12 @@ permissions:
   contents: read
   packages: write
 
+# Concurrency configuration:
+# Keyed on workflow, ref, and commit SHA so image publications on main or version tags
+# are durable and do not cancel each other.
 concurrency:
-  group: publish-${{ github.ref }}
-  cancel-in-progress: true
+  group: publish-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
 
 jobs:
   image:
@@ -54,70 +57,3 @@ jobs:
           tags: |
             ${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.tag }}
             ${{ steps.tag.outputs.image }}:${{ github.sha }}
-
-  binaries:
-    name: build CLI binaries
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - { goos: linux, goarch: amd64 }
-          - { goos: linux, goarch: arm64 }
-          - { goos: darwin, goarch: amd64 }
-          - { goos: darwin, goarch: arm64 }
-          - { goos: windows, goarch: amd64 }
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-          cache-dependency-path: apps/cli/go.sum
-
-      - name: Build
-        run: |
-          cd apps/cli
-          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -trimpath -ldflags "-s -w" -o sendbeam ./cmd/sendbeam
-          mkdir -p dist
-          if [ "${{ matrix.goos }}" = "windows" ]; then
-            mv sendbeam dist/sendbeam-windows-amd64.exe
-            (cd dist && zip -q sendbeam-windows-amd64.zip sendbeam-windows-amd64.exe)
-          else
-            mv sendbeam dist/sendbeam-${{ matrix.goos }}-${{ matrix.goarch }}
-            (cd dist && tar czf sendbeam-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz sendbeam-${{ matrix.goos }}-${{ matrix.goarch }})
-          fi
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: binary-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: apps/cli/dist
-          if-no-files-found: error
-
-  release:
-    name: attach binaries to release
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: binaries
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Create or update release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh release view "$GITHUB_REF_NAME" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" artifacts/* --clobber -R "$GITHUB_REPOSITORY"
-          else
-            gh release create "$GITHUB_REF_NAME" artifacts/* \
-              --title "SendBeam $GITHUB_REF_NAME" \
-              --notes "See the README for install and quickstart: https://github.com/$GITHUB_REPOSITORY" \
-              -R "$GITHUB_REPOSITORY"
-          fi


### PR DESCRIPTION
## Summary
Post-reconstruction repository hardening and safe publishing configuration:

1. **GHCR-Only Publishing Policy**: Refactored `publish.yml` to publish container images to GHCR (`latest` and `<sha>` on `main`, `<tag>` and `<sha>` on `v*` tags) while removing automatic GitHub Release creation and CLI binary asset attachment.
2. **Event/Ref-Aware CI Concurrency**: Updated `ci.yml` concurrency grouping so PR runs cancel stale pushes to the same PR, while canonical pushes on `main` each receive durable, non-canceling validation.
3. **Metadata & Attribution Hygiene Guard**: Added automated CI checks in `ci.yml` validating conventional PR title format, preventing manual PR number suffixes / internal planning tags in titles, and rejecting automated coding-agent attribution trailers.