### PR TITLE
feat(desktop): add durable lifecycle and OS security

### DIFF
--- a/apps/desktop/frontend/dist/index.html
+++ b/apps/desktop/frontend/dist/index.html
@@ -1,105 +1,303 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SendBeam Desktop</title>
-    <script type="module" src="/wails/runtime.js"></script>
     <style>
       :root {
-        color-scheme: dark;
-        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+        --bg: #0d1117;
+        --card-bg: #161b22;
+        --border: #30363d;
+        --text: #c9d1d9;
+        --text-heading: #f0f6fc;
+        --text-muted: #8b949e;
+        --primary: #388bfd;
+        --primary-hover: #58a6ff;
+        --primary-active: #1f6feb;
+        --accent: #238636;
+        --accent-hover: #2ea043;
+        --danger: #da3633;
+        --danger-hover: #f85149;
+        --surface: #21262d;
+        --surface-border: #363b42;
+        --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       }
-      * { box-sizing: border-box; }
-      body {
-        margin: 0;
-        padding: 1.5rem 2rem 3rem;
-        background: #0f1115;
-        color: #e6e9ef;
-      }
-      header { display: flex; align-items: baseline; gap: 0.75rem; margin-bottom: 1.25rem; }
-      h1 { font-size: 1.3rem; margin: 0; }
-      .sub { color: #8b93a1; font-size: 0.85rem; }
 
-      .tabs { display: flex; gap: 0.5rem; margin-bottom: 1.25rem; }
-      .tab {
-        background: #171a21; border: 1px solid #262b36; color: #8b93a1;
-        border-radius: 8px; padding: 0.45rem 1.1rem; font-size: 0.9rem; cursor: pointer;
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font-family: var(--font);
+        font-size: 14px;
+        line-height: 1.5;
+        padding: 1.5rem;
+        user-select: none;
+        -webkit-user-select: none;
       }
-      .tab.active { color: #e6e9ef; border-color: #2563eb; background: #1c2330; }
+
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 1.25rem;
+        padding-bottom: 0.75rem;
+        border-bottom: 1px solid var(--border);
+      }
+      header h1 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--text-heading);
+        letter-spacing: -0.01em;
+      }
+      header .sub {
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+
+      .tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.25rem;
+      }
+      .tab {
+        background: transparent;
+        border: 1px solid var(--border);
+        color: var(--text-muted);
+        padding: 0.4rem 1rem;
+        border-radius: 6px;
+        font-size: 0.85rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.15s ease;
+      }
+      .tab:hover {
+        background: var(--surface);
+        color: var(--text);
+      }
+      .tab.active {
+        background: var(--surface);
+        border-color: var(--primary);
+        color: var(--text-heading);
+      }
+
       .panel { display: none; }
       .panel.active { display: block; }
 
       .card {
-        background: #171a21; border: 1px solid #262b36; border-radius: 10px;
-        padding: 1rem 1.25rem; margin-bottom: 1rem; max-width: 720px;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1.25rem;
+        margin-bottom: 1.25rem;
       }
-      .card h2 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.06em; color: #8b93a1; margin: 0 0 0.75rem; }
-      .row { display: flex; justify-content: space-between; gap: 1rem; padding: 0.2rem 0; font-size: 0.9rem; }
-      .row .k { color: #8b93a1; flex: 0 0 auto; }
-      .row .v { color: #e6e9ef; word-break: break-all; text-align: right; }
-
-      button {
-        background: #2563eb; color: white; border: 0; border-radius: 8px;
-        padding: 0.55rem 1.1rem; font-size: 0.9rem; cursor: pointer;
+      .card h2 {
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--text-heading);
+        margin-bottom: 0.75rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
       }
-      button:disabled { opacity: 0.5; cursor: default; }
-      button.ghost { background: #1f2430; border: 1px solid #2c3342; color: #c9d1dd; }
-      button.danger { background: #7f1d1d; }
-
-      input[type="text"] {
-        background: #0f1115; border: 1px solid #2c3342; color: #e6e9ef;
-        border-radius: 8px; padding: 0.55rem 0.75rem; font-size: 0.9rem; width: 100%;
-      }
-      label { display: block; font-size: 0.8rem; color: #8b93a1; margin: 0.75rem 0 0.3rem; }
 
       .drop {
-        border: 2px dashed #2c3342; border-radius: 10px; padding: 1.75rem;
-        text-align: center; color: #8b93a1; font-size: 0.9rem; cursor: pointer;
-        transition: border-color 0.15s, background 0.15s;
+        border: 2px dashed var(--border);
+        border-radius: 6px;
+        padding: 2rem 1rem;
+        text-align: center;
+        color: var(--text-muted);
+        background: rgba(22, 27, 34, 0.5);
+        cursor: pointer;
+        transition: all 0.15s ease;
       }
-      .drop.over, .drop:hover { border-color: #2563eb; background: #151b27; color: #c9d1dd; }
+      .drop:hover {
+        border-color: var(--primary);
+        color: var(--text);
+        background: rgba(56, 139, 253, 0.05);
+      }
 
-      .file-list { margin: 0.75rem 0 0; padding: 0; list-style: none; max-height: 10rem; overflow: auto; }
-      .file-list li { font-size: 0.82rem; color: #b9c0cc; padding: 0.2rem 0; border-bottom: 1px solid #20242e; word-break: break-all; }
-      .file-list li span { color: #6b7280; margin-left: 0.5rem; }
+      .file-list {
+        list-style: none;
+        margin-top: 0.75rem;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        max-height: 140px;
+        overflow-y: auto;
+      }
+      .file-list li {
+        padding: 0.4rem 0.75rem;
+        border-bottom: 1px solid var(--surface-border);
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.85rem;
+      }
+      .file-list li:last-child { border-bottom: none; }
 
-      .invite { display: flex; gap: 1.25rem; align-items: flex-start; }
-      .invite .code { font-size: 1.6rem; font-weight: 600; letter-spacing: 0.03em; font-family: ui-monospace, monospace; }
-      .invite img { width: 180px; height: 180px; border-radius: 8px; background: white; padding: 6px; }
-      .invite .copy { margin-top: 0.5rem; }
+      label {
+        display: block;
+        font-size: 0.8rem;
+        color: var(--text-muted);
+        margin: 0.75rem 0 0.25rem 0;
+      }
+      input[type="text"], input[type="password"], textarea {
+        width: 100%;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        color: var(--text-heading);
+        padding: 0.5rem 0.75rem;
+        font-size: 0.85rem;
+        font-family: inherit;
+        outline: none;
+        transition: border-color 0.15s;
+      }
+      input[type="text"]:focus, input[type="password"]:focus, textarea:focus {
+        border-color: var(--primary);
+      }
 
-      .progress { height: 10px; background: #0f1115; border-radius: 6px; overflow: hidden; margin: 0.6rem 0; }
-      .progress > div { height: 100%; background: #2563eb; width: 0%; transition: width 0.2s; }
-      .chips { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 0.5rem 0; }
+      button {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        color: var(--text);
+        padding: 0.45rem 0.9rem;
+        border-radius: 6px;
+        font-size: 0.85rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.15s ease;
+      }
+      button:hover:not(:disabled) {
+        background: var(--surface-border);
+        border-color: var(--text-muted);
+      }
+      button:active:not(:disabled) {
+        background: var(--primary-active);
+        border-color: var(--primary);
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      button.primary {
+        background: var(--accent);
+        border-color: rgba(240, 246, 252, 0.1);
+        color: #ffffff;
+      }
+      button.primary:hover:not(:disabled) {
+        background: var(--accent-hover);
+      }
+      button.danger {
+        background: transparent;
+        border-color: var(--danger);
+        color: var(--danger-hover);
+      }
+      button.danger:hover:not(:disabled) {
+        background: var(--danger);
+        color: #ffffff;
+      }
+      button.ghost {
+        background: transparent;
+        border-color: transparent;
+        color: var(--primary-hover);
+        padding: 0.25rem 0.5rem;
+      }
+      button.ghost:hover:not(:disabled) {
+        text-decoration: underline;
+      }
+
+      .controls { display: flex; gap: 0.5rem; margin-top: 0.75rem; align-items: center; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; }
+      .statusline { margin-top: 0.5rem; font-size: 0.85rem; color: var(--text-muted); min-height: 1.2em; }
+      .err { color: #f85149; }
+      .ok { color: #56d364; }
+      .hidden { display: none !important; }
+      .row-sep { border-top: 1px solid var(--border); margin: 0.75rem 0; }
+
+      .invite {
+        display: flex;
+        gap: 1.5rem;
+        align-items: center;
+      }
+      .invite .code {
+        font-size: 1.4rem;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        color: var(--text-heading);
+        margin-bottom: 0.4rem;
+      }
+      .invite img {
+        width: 110px;
+        height: 110px;
+        border-radius: 6px;
+        background: #ffffff;
+        padding: 4px;
+      }
+
+      .progress {
+        width: 100%;
+        height: 8px;
+        background: var(--surface);
+        border-radius: 4px;
+        overflow: hidden;
+        margin: 0.75rem 0;
+      }
+      .progress div {
+        height: 100%;
+        background: var(--primary);
+        width: 0%;
+        transition: width 0.2s ease;
+      }
+
+      .row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.85rem;
+        margin-bottom: 0.35rem;
+      }
+      .row .k { color: var(--text-muted); }
+      .row .v { color: var(--text-heading); font-weight: 500; }
+
+      .chips { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
       .chip {
-        font-size: 0.75rem; padding: 0.2rem 0.6rem; border-radius: 999px;
-        border: 1px solid #2c3342; color: #8b93a1;
+        font-size: 0.75rem;
+        padding: 0.15rem 0.5rem;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--text-muted);
       }
-      .chip.live { color: #4ade80; border-color: #14532d; background: #0c1f14; }
-      .chip.relay { color: #fbbf24; border-color: #713f12; background: #1c1608; }
-      .chip.auth { color: #93c5fd; border-color: #1e3a5f; background: #0c1727; }
-      .chip.err { color: #f87171; border-color: #7f1d1d; background: #200b0b; }
+      .chip.live { color: #58a6ff; border-color: #1f6feb; }
+      .chip.relay { color: #d29922; border-color: #9e6a03; }
+      .chip.auth { color: #7ee787; border-color: #238636; }
+      .chip.err { color: #f85149; border-color: #da3633; }
 
-      .controls { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
-      .muted { color: #6b7280; font-size: 0.82rem; }
-      .mono { font-family: ui-monospace, monospace; }
-      .statusline { margin-top: 0.5rem; font-size: 0.85rem; color: #8b93a1; min-height: 1.2em; }
-      .err { color: #f87171; }
-      .ok { color: #4ade80; }
-      .hidden { display: none; }
-      .row-sep { border-top: 1px solid #20242e; margin: 0.6rem 0; }
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 0.5rem;
+        font-size: 0.85rem;
+      }
+      .table th, .table td {
+        padding: 0.5rem 0.75rem;
+        text-align: left;
+        border-bottom: 1px solid var(--border);
+      }
+      .table th { color: var(--text-muted); font-weight: 500; }
+      .table tr:last-child td { border-bottom: none; }
     </style>
   </head>
   <body>
     <header>
       <h1>SendBeam</h1>
-      <span class="sub">End-to-end encrypted, peer-to-peer file transfer — desktop</span>
+      <span class="sub">End-to-end encrypted, peer-to-peer file transfer</span>
     </header>
 
     <div class="tabs">
       <button class="tab active" id="tab-send">Send</button>
       <button class="tab" id="tab-receive">Receive</button>
+      <button class="tab" id="tab-interrupted">Interrupted</button>
+      <button class="tab" id="tab-settings">Settings</button>
     </div>
 
     <!-- SEND -->
@@ -107,13 +305,13 @@
       <div class="card">
         <h2>Files &amp; folders</h2>
         <div class="drop" id="drop-send" data-file-drop-target>
-          Drop files or folders here, or click to pick
+          Drop files or folders here, or click to choose
         </div>
         <ul class="file-list hidden" id="send-list"></ul>
         <div class="statusline" id="send-sel-status"></div>
         <div class="controls">
-          <button id="pick-send">Pick files &amp; folders</button>
-          <button id="start-send" disabled>Send</button>
+          <button id="pick-send">Choose files &amp; folders…</button>
+          <button class="primary" id="start-send" disabled>Start Transfer</button>
         </div>
       </div>
 
@@ -122,8 +320,8 @@
         <div class="invite">
           <div>
             <div class="code mono" id="invite-code"></div>
-            <button class="ghost copy" id="copy-invite">Copy invite</button>
-            <div class="muted" id="invite-link"></div>
+            <button class="ghost copy" id="copy-invite">Copy code</button>
+            <div class="statusline" id="invite-link" style="word-break: break-all;"></div>
           </div>
           <img id="invite-qr" alt="Invite QR code" />
         </div>
@@ -153,15 +351,15 @@
     <section class="panel" id="panel-receive">
       <div class="card">
         <h2>Receive</h2>
-        <label for="recv-code">Invite code (or paste the full invite link)</label>
+        <label for="recv-code">Invite code (or full join link)</label>
         <input type="text" id="recv-code" placeholder="e.g. 7-alpha-bravo" autocomplete="off" />
-        <label for="recv-dir">Save into</label>
+        <label for="recv-dir">Destination folder</label>
         <div style="display:flex; gap:0.5rem;">
-          <input type="text" id="recv-dir" placeholder="destination folder" autocomplete="off" style="flex:1" />
+          <input type="text" id="recv-dir" placeholder="download folder" autocomplete="off" style="flex:1" />
           <button class="ghost" id="pick-dest">Choose…</button>
         </div>
         <div class="controls">
-          <button id="start-recv" disabled>Receive</button>
+          <button class="primary" id="start-recv" disabled>Receive Transfer</button>
         </div>
         <div class="statusline" id="recv-status"></div>
       </div>
@@ -181,40 +379,100 @@
           <button id="recv-pause">Pause</button>
           <button id="recv-resume" disabled>Resume</button>
           <button class="danger" id="recv-cancel">Cancel</button>
+          <button class="ghost hidden" id="recv-reveal">Reveal in Folder</button>
         </div>
         <div class="statusline" id="recv-status-line"></div>
       </div>
     </section>
 
+    <!-- INTERRUPTED / DURABLE TRANSFERS -->
+    <section class="panel" id="panel-interrupted">
+      <div class="card">
+        <h2>
+          <span>Interrupted Transfers</span>
+          <div>
+            <button class="ghost" id="refresh-durable">Refresh</button>
+            <button class="danger ghost" id="discard-all-durable">Discard All</button>
+          </div>
+        </h2>
+        <div id="durable-list-container">
+          <p class="statusline" id="durable-empty">Scanning for interrupted transfers…</p>
+          <table class="table hidden" id="durable-table">
+            <thead>
+              <tr>
+                <th>Role</th>
+                <th>Transfer ID</th>
+                <th>Files</th>
+                <th>Progress</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="durable-tbody"></tbody>
+          </table>
+        </div>
+        <div class="statusline" id="durable-status"></div>
+      </div>
+    </section>
+
+    <!-- SETTINGS -->
+    <section class="panel" id="panel-settings">
+      <div class="card">
+        <h2>Preferences &amp; Network</h2>
+        <label for="cfg-server">Signaling Server URL</label>
+        <input type="text" id="cfg-server" placeholder="wss://localhost:8443/ws" />
+
+        <label for="cfg-ice">ICE Servers (STUN / TURN, one per line)</label>
+        <textarea id="cfg-ice" rows="3" placeholder="stun:stun.l.google.com:19302"></textarea>
+
+        <label for="cfg-downdir">Default Download Folder</label>
+        <div style="display:flex; gap:0.5rem;">
+          <input type="text" id="cfg-downdir" placeholder="Downloads" style="flex:1" />
+          <button class="ghost" id="cfg-pick-dir">Browse…</button>
+        </div>
+
+        <label style="display: flex; align-items: center; gap: 0.5rem; margin-top: 1rem; cursor: not-allowed; opacity: 0.8;">
+          <input type="checkbox" id="cfg-auto-accept" disabled />
+          <span>Auto-Accept Incoming Transfers (Strictly disabled by default for security)</span>
+        </label>
+
+        <div class="controls" style="margin-top: 1.25rem;">
+          <button class="primary" id="save-settings">Save Settings</button>
+          <button id="reset-settings">Reload</button>
+        </div>
+        <div class="statusline" id="settings-status"></div>
+      </div>
+    </section>
+
     <script>
-      // Service FQNs (wails binds by full import path.Type.Method).
       const SV = {
-        Service:     "github.com/sendbeam/desktop/internal/engine.Service",
-        Transfer:    "github.com/sendbeam/desktop/internal/engine.TransferService",
+        Service:  "github.com/sendbeam/desktop/internal/engine.Service",
+        Transfer: "github.com/sendbeam/desktop/internal/engine.TransferService",
       };
       const call = (fqn, ...args) => wails.Call.ByName(fqn, ...args);
       const $ = (id) => document.getElementById(id);
 
-      // ---- state ----
       const state = {
         mode: "send",
         selected: [],
         send: { id: null },
-        recv: { id: null },
+        recv: { id: null, outPath: null },
       };
 
-      // ---- tabs ----
       function setMode(mode) {
         state.mode = mode;
-        $("tab-send").classList.toggle("active", mode === "send");
-        $("tab-receive").classList.toggle("active", mode === "receive");
-        $("panel-send").classList.toggle("active", mode === "send");
-        $("panel-receive").classList.toggle("active", mode === "receive");
+        ["send", "receive", "interrupted", "settings"].forEach((m) => {
+          $("tab-" + m).classList.toggle("active", mode === m);
+          $("panel-" + m).classList.toggle("active", mode === m);
+        });
+        if (mode === "interrupted") loadDurableList();
+        if (mode === "settings") loadSettings();
       }
       $("tab-send").addEventListener("click", () => setMode("send"));
       $("tab-receive").addEventListener("click", () => setMode("receive"));
+      $("tab-interrupted").addEventListener("click", () => setMode("interrupted"));
+      $("tab-settings").addEventListener("click", () => setMode("settings"));
 
-      // ---- helpers ----
       function humanBytes(n) {
         if (n >= 1 << 30) return (n / (1 << 30)).toFixed(2) + " GiB";
         if (n >= 1 << 20) return (n / (1 << 20)).toFixed(1) + " MiB";
@@ -227,14 +485,8 @@
         if (bps >= 1 << 10) return (bps / (1 << 10)).toFixed(1) + " KiB/s";
         return Math.round(bps) + " B/s";
       }
-      function basename(p) { return String(p).split(/[\\/]/).pop(); }
-      function totalSelected() {
-        let n = 0;
-        try { n = state.selected.reduce((a, p) => a + (p.size || 0), 0); } catch (e) {}
-        return n;
-      }
 
-      // ---- send selection ----
+      // SEND
       function renderSelection() {
         const list = $("send-list");
         list.innerHTML = "";
@@ -247,9 +499,7 @@
           list.appendChild(li);
         }
         list.classList.toggle("hidden", state.selected.length === 0);
-        $("send-sel-status").textContent = state.selected.length
-          ? state.selected.length + " item(s) selected"
-          : "";
+        $("send-sel-status").textContent = state.selected.length ? state.selected.length + " item(s) selected" : "";
         $("start-send").disabled = state.selected.length === 0;
       }
       async function pickSend() {
@@ -262,9 +512,7 @@
       }
       $("pick-send").addEventListener("click", pickSend);
       $("drop-send").addEventListener("click", pickSend);
-      // Drag/drop is handled by the window: main.go forwards dropped paths to
-      // the service and emits a "drop" event so this panel can adopt the new
-      // transfer and show its invite.
+
       wails.Events.On("sendbeam:transfer", (ev) => {
         if (!ev || ev.kind !== "drop" || !ev.id) return;
         if (state.send.id && state.send.id !== ev.id) return;
@@ -275,6 +523,7 @@
         $("send-progress-card").classList.remove("hidden");
         $("start-send").disabled = true;
       });
+
       $("start-send").addEventListener("click", () => {
         if (!state.selected.length) return;
         const paths = state.selected.map((p) => p.path);
@@ -287,13 +536,14 @@
         }).catch((err) => { $("send-status").textContent = String(err); });
       });
 
-      // ---- receive ----
+      // RECEIVE
       function recvCanStart() {
-        return !!$("recv-code").value.trim() && !!$("recv-dir").value.trim();
+        return !!$("recv-code").value.trim();
       }
       function updateRecvStart() { $("start-recv").disabled = !recvCanStart(); }
       $("recv-code").addEventListener("input", updateRecvStart);
       $("recv-dir").addEventListener("input", updateRecvStart);
+
       $("pick-dest").addEventListener("click", async () => {
         const res = await call(SV.Transfer + ".PickDestination");
         if (res && res.error) { $("recv-status").textContent = res.error; return; }
@@ -302,6 +552,7 @@
           updateRecvStart();
         }
       });
+
       $("start-recv").addEventListener("click", () => {
         const code = $("recv-code").value.trim();
         const dir = $("recv-dir").value.trim();
@@ -314,7 +565,15 @@
         }).catch((err) => { $("recv-status").textContent = String(err); });
       });
 
-      // ---- controls ----
+      $("recv-reveal").addEventListener("click", () => {
+        if (state.recv.outPath) {
+          call(SV.Transfer + ".RevealFile", state.recv.outPath).catch((e) => {
+            $("recv-status-line").textContent = "Reveal failed: " + e;
+          });
+        }
+      });
+
+      // CONTROLS
       function wireControls(prefix) {
         const id = () => state[prefix].id;
         $(prefix + "-pause").addEventListener("click", () => call(SV.Transfer + ".Pause", id()).catch((e) => console.error(e)));
@@ -324,7 +583,6 @@
       wireControls("send");
       wireControls("recv");
 
-      // ---- live events ----
       function chips(ev) {
         const out = [];
         if (ev.phase) out.push('<span class="chip">' + ev.phase.replace(/-/g, " ") + "</span>");
@@ -336,6 +594,7 @@
         if (ev.state) out.push('<span class="chip live">' + ev.state + "</span>");
         return out.join("");
       }
+
       function renderTransfer(ev, prefix) {
         const p = prefix === "send" ? "send" : "recv";
         const id = state[p].id;
@@ -366,6 +625,10 @@
           status.innerHTML = '<span class="ok">✓ Verified transfer complete.</span>' +
             (ev.outPath ? " Saved to " + ev.outPath + "." : "");
           $(p + "-pause").disabled = $(p + "-resume").disabled = $(p + "-cancel").disabled = true;
+          if (p === "recv" && (ev.outPath || ev.outDir)) {
+            state.recv.outPath = ev.outPath || ev.outDir;
+            $("recv-reveal").classList.remove("hidden");
+          }
         } else if (ev.kind === "error") {
           status.innerHTML = '<span class="err">✗ ' + (ev.error || "transfer failed") + "</span>";
         } else if (ev.kind === "connect") {
@@ -374,6 +637,7 @@
           status.textContent = "Waiting for the peer to join…";
         }
       }
+
       wails.Events.On("sendbeam:transfer", (ev) => {
         if (!ev || !ev.id || !ev.kind) return;
         if (ev.id === state.send.id) renderTransfer(ev, "send");
@@ -388,14 +652,12 @@
         }
       });
 
-      // ---- copy invite ----
       $("copy-invite").addEventListener("click", async () => {
         const text = $("invite-code").textContent;
         try {
           await navigator.clipboard.writeText(text);
           $("invite-status").textContent = "Invite code copied.";
         } catch (e) {
-          // fallback for webviews without clipboard permission
           const ta = document.createElement("textarea");
           ta.value = text;
           document.body.appendChild(ta);
@@ -406,12 +668,117 @@
         }
       });
 
-      // ---- engine info ----
+      // DURABLE / INTERRUPTED
+      async function loadDurableList() {
+        try {
+          const items = await call(SV.Transfer + ".ListInterrupted", "");
+          const tbody = $("durable-tbody");
+          tbody.innerHTML = "";
+          if (!items || items.length === 0) {
+            $("durable-empty").classList.remove("hidden");
+            $("durable-empty").textContent = "No interrupted transfers found.";
+            $("durable-table").classList.add("hidden");
+            return;
+          }
+          $("durable-empty").classList.add("hidden");
+          $("durable-table").classList.remove("hidden");
+          for (const item of items) {
+            const tr = document.createElement("tr");
+            tr.innerHTML = `
+              <td><span class="chip">${item.role}</span></td>
+              <td class="mono">${item.transferId.slice(0, 8)}…</td>
+              <td>${item.files}</td>
+              <td>${humanBytes(item.committedBytes)} / ${humanBytes(item.totalBytes)}</td>
+              <td>${item.status}</td>
+              <td>
+                <button class="ghost" data-action="inspect" data-id="${item.transferId}">Inspect</button>
+                <button class="ghost danger" data-action="discard" data-id="${item.transferId}">Discard</button>
+              </td>
+            `;
+            tbody.appendChild(tr);
+          }
+        } catch (err) {
+          $("durable-empty").classList.remove("hidden");
+          $("durable-empty").textContent = "Failed to load transfers: " + err;
+        }
+      }
+
+      $("durable-tbody").addEventListener("click", async (e) => {
+        const btn = e.target.closest("button");
+        if (!btn) return;
+        const id = btn.dataset.id;
+        const action = btn.dataset.action;
+        if (action === "discard") {
+          try {
+            await call(SV.Transfer + ".DiscardInterrupted", id, "");
+            $("durable-status").textContent = "Discarded transfer " + id;
+            loadDurableList();
+          } catch (err) { $("durable-status").textContent = "Discard error: " + err; }
+        } else if (action === "inspect") {
+          try {
+            const ins = await call(SV.Transfer + ".InspectInterrupted", id, "");
+            alert("Transfer ID: " + ins.transferId + "\nResumable: " + ins.resumable + "\nProblems: " + (ins.problems ? ins.problems.join(", ") : "none"));
+          } catch (err) { $("durable-status").textContent = "Inspect error: " + err; }
+        }
+      });
+
+      $("refresh-durable").addEventListener("click", loadDurableList);
+      $("discard-all-durable").addEventListener("click", async () => {
+        if (!confirm("Discard all interrupted transfers and partial files?")) return;
+        try {
+          await call(SV.Transfer + ".DiscardAllInterrupted", "");
+          $("durable-status").textContent = "All interrupted transfers discarded.";
+          loadDurableList();
+        } catch (err) { $("durable-status").textContent = "Discard all error: " + err; }
+      });
+
+      // SETTINGS
+      async function loadSettings() {
+        try {
+          const cfg = await call(SV.Transfer + ".GetConfig");
+          if (cfg) {
+            $("cfg-server").value = cfg.serverUrl || "";
+            $("cfg-ice").value = (cfg.iceServers || []).join("\n");
+            $("cfg-downdir").value = cfg.downloadDir || "";
+            $("cfg-auto-accept").checked = false; // Strictly false
+          }
+        } catch (err) {
+          $("settings-status").textContent = "Load error: " + err;
+        }
+      }
+
+      $("cfg-pick-dir").addEventListener("click", async () => {
+        const res = await call(SV.Transfer + ".PickDestination");
+        if (res && res.paths && res.paths.length) {
+          $("cfg-downdir").value = res.paths[0];
+        }
+      });
+
+      $("save-settings").addEventListener("click", async () => {
+        const server = $("cfg-server").value.trim();
+        const ice = $("cfg-ice").value.split("\n").map((s) => s.trim()).filter(Boolean);
+        const downdir = $("cfg-downdir").value.trim();
+        const cfg = {
+          serverUrl: server,
+          iceServers: ice,
+          downloadDir: downdir,
+          autoAccept: false,
+        };
+        try {
+          await call(SV.Transfer + ".SaveConfig", cfg);
+          $("settings-status").innerHTML = '<span class="ok">✓ Settings saved successfully.</span>';
+        } catch (err) {
+          $("settings-status").innerHTML = '<span class="err">✗ ' + err + '</span>';
+        }
+      });
+
+      $("reset-settings").addEventListener("click", loadSettings);
+
       (async () => {
         try {
           const info = await call(SV.Service + ".Info");
           document.title = "SendBeam Desktop — " + (info.engineVer ? "engine " + info.engineVer : "linked");
-        } catch (err) { /* shell info is non-critical */ }
+        } catch (err) {}
       })();
     </script>
   </body>

--- a/apps/desktop/internal/config/config.go
+++ b/apps/desktop/internal/config/config.go
@@ -61,7 +61,7 @@ func (c *DesktopConfig) Validate() error {
 	if c.ServerURL != "" {
 		u, err := url.Parse(c.ServerURL)
 		if err != nil || (u.Scheme != "ws" && u.Scheme != "wss" && u.Scheme != "http" && u.Scheme != "https") {
-			return fmt.Errorf("invalid server URL %q: must be a valid ws:// or wss:// URL", c.ServerURL)
+			return fmt.Errorf("invalid server url %q (must be a valid ws:// or wss:// url)", c.ServerURL)
 		}
 	}
 	for _, ice := range c.ICEServers {
@@ -71,11 +71,11 @@ func (c *DesktopConfig) Validate() error {
 		}
 		if !strings.HasPrefix(ice, "stun:") && !strings.HasPrefix(ice, "stuns:") &&
 			!strings.HasPrefix(ice, "turn:") && !strings.HasPrefix(ice, "turns:") {
-			return fmt.Errorf("invalid ice server URL %q: must begin with stun:, stuns:, turn:, or turns:", ice)
+			return fmt.Errorf("invalid ice server url %q (must begin with stun:, stuns:, turn:, or turns)", ice)
 		}
 	}
 	if c.Theme != "" && c.Theme != "system" && c.Theme != "dark" && c.Theme != "light" {
-		return fmt.Errorf("invalid theme %q: must be system, dark, or light", c.Theme)
+		return fmt.Errorf("invalid theme %q (must be system, dark, or light)", c.Theme)
 	}
 	return nil
 }

--- a/apps/desktop/internal/config/config.go
+++ b/apps/desktop/internal/config/config.go
@@ -1,0 +1,243 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	// DefaultServerURL matches the CLI and server default signaling URL.
+	DefaultServerURL = "wss://localhost:8443/ws"
+	// ConfigFileName is the JSON file name for desktop preferences.
+	ConfigFileName = "desktop_config.json"
+	// AppDirName is the folder created in user config directory.
+	AppDirName = "sendbeam"
+)
+
+// DesktopConfig holds non-secret persistent desktop preferences.
+// SENSITIVE values (passwords, tokens) are NEVER stored in this struct or in
+// its serialized JSON on disk; they are stored via SecretStore.
+type DesktopConfig struct {
+	// ServerURL is the signaling server WebSocket URL.
+	ServerURL string `json:"serverUrl"`
+	// ICEServers are custom STUN / TURN server URLs.
+	ICEServers []string `json:"iceServers"`
+	// DownloadDir is the custom default directory to save received files.
+	// If empty, the OS standard downloads folder or working directory is used.
+	DownloadDir string `json:"downloadDir"`
+	// AutoAccept controls whether incoming transfers are accepted automatically.
+	// SECURITY INVARIANT: Must strictly default to false.
+	AutoAccept bool `json:"autoAccept"`
+	// CloseToTray controls if closing the main window minimizes to tray instead of quitting.
+	CloseToTray bool `json:"closeToTray"`
+	// StartMinimized controls whether the app launches minimized.
+	StartMinimized bool `json:"startMinimized"`
+	// Theme is the UI theme ("system", "dark", "light").
+	Theme string `json:"theme"`
+}
+
+// DefaultConfig returns the default safe configuration.
+func DefaultConfig() DesktopConfig {
+	return DesktopConfig{
+		ServerURL:      DefaultServerURL,
+		ICEServers:     []string{"stun:stun.l.google.com:19302"},
+		DownloadDir:    "",
+		AutoAccept:     false, // strictly false by default
+		CloseToTray:    false,
+		StartMinimized: false,
+		Theme:          "system",
+	}
+}
+
+// Validate validates the configuration values.
+func (c *DesktopConfig) Validate() error {
+	if c.ServerURL != "" {
+		u, err := url.Parse(c.ServerURL)
+		if err != nil || (u.Scheme != "ws" && u.Scheme != "wss" && u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("invalid server URL %q: must be a valid ws:// or wss:// URL", c.ServerURL)
+		}
+	}
+	for _, ice := range c.ICEServers {
+		ice = strings.TrimSpace(ice)
+		if ice == "" {
+			continue
+		}
+		if !strings.HasPrefix(ice, "stun:") && !strings.HasPrefix(ice, "stuns:") &&
+			!strings.HasPrefix(ice, "turn:") && !strings.HasPrefix(ice, "turns:") {
+			return fmt.Errorf("invalid ICE server URL %q: must begin with stun:, stuns:, turn:, or turns:", ice)
+		}
+	}
+	if c.Theme != "" && c.Theme != "system" && c.Theme != "dark" && c.Theme != "light" {
+		return fmt.Errorf("invalid theme %q: must be system, dark, or light", c.Theme)
+	}
+	return nil
+}
+
+// Store manages loading, saving, and secret access for desktop configuration.
+type Store struct {
+	mu          sync.RWMutex
+	configDir   string
+	configPath  string
+	secretStore SecretStore
+}
+
+// NewStore creates a config Store targeting the given config directory.
+// If configDir is empty, it uses the default OS user config directory.
+// If secrets is nil, it uses DefaultSecretStore().
+func NewStore(configDir string, secrets SecretStore) (*Store, error) {
+	if configDir == "" {
+		dir, err := os.UserConfigDir()
+		if err != nil {
+			home, herr := os.UserHomeDir()
+			if herr != nil {
+				return nil, fmt.Errorf("resolve user config dir: %w", err)
+			}
+			dir = filepath.Join(home, ".config")
+		}
+		configDir = filepath.Join(dir, AppDirName)
+	}
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create config directory %s: %w", configDir, err)
+	}
+	if secrets == nil {
+		secrets = DefaultSecretStore()
+	}
+	return &Store{
+		configDir:   configDir,
+		configPath:  filepath.Join(configDir, ConfigFileName),
+		secretStore: secrets,
+	}, nil
+}
+
+// ConfigDir returns the configuration directory.
+func (s *Store) ConfigDir() string {
+	return s.configDir
+}
+
+// ConfigPath returns the path to the desktop_config.json file.
+func (s *Store) ConfigPath() string {
+	return s.configPath
+}
+
+// SecretStore returns the underlying secret store.
+func (s *Store) SecretStore() SecretStore {
+	return s.secretStore
+}
+
+// Load reads and validates the configuration from disk. If the file does not exist,
+// it returns DefaultConfig() without creating the file.
+func (s *Store) Load() (DesktopConfig, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, err := os.ReadFile(s.configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return DefaultConfig(), nil
+		}
+		return DesktopConfig{}, fmt.Errorf("read config: %w", err)
+	}
+
+	cfg := DefaultConfig()
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return DesktopConfig{}, fmt.Errorf("parse config %s: %w", s.configPath, err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return DesktopConfig{}, fmt.Errorf("validate config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// Save writes the configuration to disk atomically with 0600 permissions.
+func (s *Store) Save(cfg DesktopConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("validate config: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(s.configDir, 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	data = append(data, '\n')
+
+	// Atomic write: write to temp file in same directory, sync, and rename
+	tmpFile, err := os.CreateTemp(s.configDir, "config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp config file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpName) // clean up if rename did not happen
+	}()
+
+	if err := tmpFile.Chmod(0o600); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("chmod temp config: %w", err)
+	}
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write temp config: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("sync temp config: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close temp config: %w", err)
+	}
+
+	if err := os.Rename(tmpName, s.configPath); err != nil {
+		return fmt.Errorf("replace config file: %w", err)
+	}
+
+	return nil
+}
+
+// SaveTurnCredential securely persists a TURN authentication secret into the OS-protected
+// secret store under a key derived from server URL and username.
+func (s *Store) SaveTurnCredential(serverURL, username string, secret []byte) error {
+	if serverURL == "" || username == "" {
+		return errors.New("server URL and username are required")
+	}
+	if len(secret) == 0 {
+		return errors.New("secret cannot be empty")
+	}
+	key := fmt.Sprintf("turn:%s:%s", serverURL, username)
+	return s.secretStore.Set(key, secret)
+}
+
+// GetTurnCredential retrieves a TURN credential from OS-protected storage.
+func (s *Store) GetTurnCredential(serverURL, username string) ([]byte, error) {
+	if serverURL == "" || username == "" {
+		return nil, errors.New("server URL and username are required")
+	}
+	key := fmt.Sprintf("turn:%s:%s", serverURL, username)
+	return s.secretStore.Get(key)
+}
+
+// DeleteTurnCredential removes a TURN credential from OS-protected storage.
+func (s *Store) DeleteTurnCredential(serverURL, username string) error {
+	if serverURL == "" || username == "" {
+		return errors.New("server URL and username are required")
+	}
+	key := fmt.Sprintf("turn:%s:%s", serverURL, username)
+	return s.secretStore.Delete(key)
+}

--- a/apps/desktop/internal/config/config.go
+++ b/apps/desktop/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config manages desktop persistent configuration and credentials.
 package config
 
 import (
@@ -70,7 +71,7 @@ func (c *DesktopConfig) Validate() error {
 		}
 		if !strings.HasPrefix(ice, "stun:") && !strings.HasPrefix(ice, "stuns:") &&
 			!strings.HasPrefix(ice, "turn:") && !strings.HasPrefix(ice, "turns:") {
-			return fmt.Errorf("invalid ICE server URL %q: must begin with stun:, stuns:, turn:, or turns:", ice)
+			return fmt.Errorf("invalid ice server URL %q: must begin with stun:, stuns:, turn:, or turns:", ice)
 		}
 	}
 	if c.Theme != "" && c.Theme != "system" && c.Theme != "dark" && c.Theme != "light" {
@@ -102,36 +103,46 @@ func NewStore(configDir string, secrets SecretStore) (*Store, error) {
 		}
 		configDir = filepath.Join(dir, AppDirName)
 	}
-	if err := os.MkdirAll(configDir, 0o700); err != nil {
-		return nil, fmt.Errorf("create config directory %s: %w", configDir, err)
+
+	absDir, err := filepath.Abs(configDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve absolute config dir: %w", err)
 	}
+
 	if secrets == nil {
 		secrets = DefaultSecretStore()
 	}
+
 	return &Store{
-		configDir:   configDir,
-		configPath:  filepath.Join(configDir, ConfigFileName),
+		configDir:   absDir,
+		configPath:  filepath.Join(absDir, ConfigFileName),
 		secretStore: secrets,
 	}, nil
 }
 
-// ConfigDir returns the configuration directory.
+// ConfigDir returns the directory containing the desktop configuration.
 func (s *Store) ConfigDir() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.configDir
 }
 
-// ConfigPath returns the path to the desktop_config.json file.
+// ConfigPath returns the path of the desktop configuration file.
 func (s *Store) ConfigPath() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.configPath
 }
 
-// SecretStore returns the underlying secret store.
-func (s *Store) SecretStore() SecretStore {
+// Secrets returns the associated SecretStore.
+func (s *Store) Secrets() SecretStore {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.secretStore
 }
 
-// Load reads and validates the configuration from disk. If the file does not exist,
-// it returns DefaultConfig() without creating the file.
+// Load reads and parses desktop preferences from disk. If the file does not
+// exist, it returns DefaultConfig() without creating the file.
 func (s *Store) Load() (DesktopConfig, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -141,25 +152,25 @@ func (s *Store) Load() (DesktopConfig, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return DefaultConfig(), nil
 		}
-		return DesktopConfig{}, fmt.Errorf("read config: %w", err)
+		return DefaultConfig(), fmt.Errorf("read desktop config: %w", err)
 	}
 
 	cfg := DefaultConfig()
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return DesktopConfig{}, fmt.Errorf("parse config %s: %w", s.configPath, err)
+		return DefaultConfig(), fmt.Errorf("decode desktop config: %w", err)
 	}
 
 	if err := cfg.Validate(); err != nil {
-		return DesktopConfig{}, fmt.Errorf("validate config: %w", err)
+		return DefaultConfig(), fmt.Errorf("invalid config on disk: %w", err)
 	}
 
 	return cfg, nil
 }
 
-// Save writes the configuration to disk atomically with 0600 permissions.
+// Save validates and atomically writes desktop preferences to disk with 0600 permissions.
 func (s *Store) Save(cfg DesktopConfig) error {
 	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("validate config: %w", err)
+		return err
 	}
 
 	s.mu.Lock()
@@ -171,73 +182,61 @@ func (s *Store) Save(cfg DesktopConfig) error {
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal config: %w", err)
+		return fmt.Errorf("encode desktop config: %w", err)
 	}
 	data = append(data, '\n')
 
-	// Atomic write: write to temp file in same directory, sync, and rename
-	tmpFile, err := os.CreateTemp(s.configDir, "config-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create temp config file: %w", err)
-	}
-	tmpName := tmpFile.Name()
-	defer func() {
-		_ = os.Remove(tmpName) // clean up if rename did not happen
-	}()
-
-	if err := tmpFile.Chmod(0o600); err != nil {
-		_ = tmpFile.Close()
-		return fmt.Errorf("chmod temp config: %w", err)
+	tmpFile := s.configPath + ".tmp"
+	if err := os.WriteFile(tmpFile, data, 0o600); err != nil {
+		return fmt.Errorf("write temporary config: %w", err)
 	}
 
-	if _, err := tmpFile.Write(data); err != nil {
-		_ = tmpFile.Close()
-		return fmt.Errorf("write temp config: %w", err)
-	}
-
-	if err := tmpFile.Sync(); err != nil {
-		_ = tmpFile.Close()
-		return fmt.Errorf("sync temp config: %w", err)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("close temp config: %w", err)
-	}
-
-	if err := os.Rename(tmpName, s.configPath); err != nil {
-		return fmt.Errorf("replace config file: %w", err)
+	if err := os.Rename(tmpFile, s.configPath); err != nil {
+		_ = os.Remove(tmpFile)
+		return fmt.Errorf("atomic rename config: %w", err)
 	}
 
 	return nil
 }
 
-// SaveTurnCredential securely persists a TURN authentication secret into the OS-protected
-// secret store under a key derived from server URL and username.
-func (s *Store) SaveTurnCredential(serverURL, username string, secret []byte) error {
-	if serverURL == "" || username == "" {
-		return errors.New("server URL and username are required")
+// SaveTurnCredential saves TURN server credentials in OS-protected secret storage.
+func (s *Store) SaveTurnCredential(serverURL, username string, credential []byte) error {
+	s.mu.RLock()
+	secrets := s.secretStore
+	s.mu.RUnlock()
+
+	if secrets == nil || !secrets.IsAvailable() {
+		return fmt.Errorf("%w: cannot store turn credentials", ErrSecretStoreUnavailable)
 	}
-	if len(secret) == 0 {
-		return errors.New("secret cannot be empty")
-	}
+
 	key := fmt.Sprintf("turn:%s:%s", serverURL, username)
-	return s.secretStore.Set(key, secret)
+	return secrets.Set(key, credential)
 }
 
-// GetTurnCredential retrieves a TURN credential from OS-protected storage.
+// GetTurnCredential retrieves TURN credentials from OS-protected secret storage.
 func (s *Store) GetTurnCredential(serverURL, username string) ([]byte, error) {
-	if serverURL == "" || username == "" {
-		return nil, errors.New("server URL and username are required")
+	s.mu.RLock()
+	secrets := s.secretStore
+	s.mu.RUnlock()
+
+	if secrets == nil || !secrets.IsAvailable() {
+		return nil, ErrSecretStoreUnavailable
 	}
+
 	key := fmt.Sprintf("turn:%s:%s", serverURL, username)
-	return s.secretStore.Get(key)
+	return secrets.Get(key)
 }
 
-// DeleteTurnCredential removes a TURN credential from OS-protected storage.
+// DeleteTurnCredential removes TURN credentials from OS-protected secret storage.
 func (s *Store) DeleteTurnCredential(serverURL, username string) error {
-	if serverURL == "" || username == "" {
-		return errors.New("server URL and username are required")
+	s.mu.RLock()
+	secrets := s.secretStore
+	s.mu.RUnlock()
+
+	if secrets == nil || !secrets.IsAvailable() {
+		return nil
 	}
+
 	key := fmt.Sprintf("turn:%s:%s", serverURL, username)
-	return s.secretStore.Delete(key)
+	return secrets.Delete(key)
 }

--- a/apps/desktop/internal/config/config_test.go
+++ b/apps/desktop/internal/config/config_test.go
@@ -1,0 +1,248 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.ServerURL != DefaultServerURL {
+		t.Errorf("ServerURL = %q, want %q", cfg.ServerURL, DefaultServerURL)
+	}
+	if cfg.AutoAccept != false {
+		t.Errorf("AutoAccept must be false by default, got %v", cfg.AutoAccept)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("DefaultConfig failed validation: %v", err)
+	}
+}
+
+func TestConfigStoreLoadSave(t *testing.T) {
+	dir := t.TempDir()
+	memSecret := NewMemorySecretStore()
+	store, err := NewStore(dir, memSecret)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// 1. Initial load returns default config without error
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("initial Load: %v", err)
+	}
+	if loaded.ServerURL != DefaultServerURL {
+		t.Errorf("loaded.ServerURL = %q, want default %q", loaded.ServerURL, DefaultServerURL)
+	}
+	if loaded.AutoAccept != false {
+		t.Errorf("loaded.AutoAccept = %v, want false", loaded.AutoAccept)
+	}
+
+	// 2. Modify and save config
+	custom := loaded
+	custom.ServerURL = "wss://custom.example.com:9000/ws"
+	custom.ICEServers = []string{"stun:stun1.example.com:3478", "turn:turn.example.com:3478"}
+	custom.DownloadDir = filepath.Join(dir, "downloads")
+	custom.CloseToTray = true
+	custom.Theme = "dark"
+
+	if err := store.Save(custom); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// 3. Verify file permissions (0600)
+	fi, err := os.Stat(store.ConfigPath())
+	if err != nil {
+		t.Fatalf("Stat config path: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf("Config file permissions = %o, want 0600", fi.Mode().Perm())
+	}
+
+	// 4. Reload and verify equality
+	reloaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("reload Load: %v", err)
+	}
+	if reloaded.ServerURL != custom.ServerURL {
+		t.Errorf("reloaded ServerURL = %q, want %q", reloaded.ServerURL, custom.ServerURL)
+	}
+	if len(reloaded.ICEServers) != 2 || reloaded.ICEServers[0] != custom.ICEServers[0] {
+		t.Errorf("reloaded ICEServers = %v, want %v", reloaded.ICEServers, custom.ICEServers)
+	}
+	if reloaded.DownloadDir != custom.DownloadDir {
+		t.Errorf("reloaded DownloadDir = %q, want %q", reloaded.DownloadDir, custom.DownloadDir)
+	}
+	if reloaded.CloseToTray != true {
+		t.Errorf("reloaded CloseToTray = %v, want true", reloaded.CloseToTray)
+	}
+	if reloaded.Theme != "dark" {
+		t.Errorf("reloaded Theme = %q, want 'dark'", reloaded.Theme)
+	}
+}
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*DesktopConfig)
+		wantErr bool
+	}{
+		{
+			name: "invalid server scheme",
+			mutate: func(c *DesktopConfig) {
+				c.ServerURL = "ftp://invalid-url"
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid ICE url prefix",
+			mutate: func(c *DesktopConfig) {
+				c.ICEServers = []string{"http://bad-ice-server.com"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid STUN and TURN urls",
+			mutate: func(c *DesktopConfig) {
+				c.ICEServers = []string{"stun:stun.example.com", "turns:turn.example.com:5349"}
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid theme",
+			mutate: func(c *DesktopConfig) {
+				c.Theme = "neon-green"
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			tt.mutate(&cfg)
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCorruptConfigFileHandling(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, NewMemorySecretStore())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// Write invalid JSON into config path
+	if err := os.WriteFile(store.ConfigPath(), []byte("{ corrupt json ..."), 0o600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+
+	_, err = store.Load()
+	if err == nil {
+		t.Fatalf("Load on corrupt config should fail, got nil")
+	}
+}
+
+func TestSecretStoreUnavailableDegradation(t *testing.T) {
+	unavail := NewUnavailableSecretStore("test environment has no keychain")
+	if unavail.IsAvailable() {
+		t.Errorf("IsAvailable() = true, want false")
+	}
+
+	err := unavail.Set("turn:secret", []byte("topsecret"))
+	if err == nil || !errors.Is(err, ErrSecretStoreUnavailable) {
+		t.Fatalf("Set on unavailable secret store returned err = %v, want ErrSecretStoreUnavailable", err)
+	}
+
+	_, err = unavail.Get("turn:secret")
+	if err == nil || !errors.Is(err, ErrSecretStoreUnavailable) {
+		t.Fatalf("Get on unavailable secret store returned err = %v, want ErrSecretStoreUnavailable", err)
+	}
+
+	// Delete is an idempotent no-op
+	if err := unavail.Delete("turn:secret"); err != nil {
+		t.Fatalf("Delete on unavailable store returned error: %v", err)
+	}
+}
+
+func TestMemorySecretStore(t *testing.T) {
+	mem := NewMemorySecretStore()
+	if !mem.IsAvailable() {
+		t.Errorf("IsAvailable() = false, want true")
+	}
+
+	key := "turn:server.com:user1"
+	val := []byte("super-secret-password-123")
+
+	// 1. Initial Get returns not found
+	_, err := mem.Get(key)
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("Get before Set returned %v, want ErrSecretNotFound", err)
+	}
+
+	// 2. Set and Get
+	if err := mem.Set(key, val); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := mem.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != string(val) {
+		t.Fatalf("Get returned %q, want %q", got, val)
+	}
+
+	// 3. Delete
+	if err := mem.Delete(key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, err = mem.Get(key)
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("Get after Delete returned %v, want ErrSecretNotFound", err)
+	}
+}
+
+func TestStoreTurnCredentials(t *testing.T) {
+	dir := t.TempDir()
+	memSecret := NewMemorySecretStore()
+	store, err := NewStore(dir, memSecret)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	serverURL := "turn:relay.sendbeam.org:3478"
+	username := "beam-user"
+	secret := []byte("turn-credential-token")
+
+	// Save TURN credential
+	if err := store.SaveTurnCredential(serverURL, username, secret); err != nil {
+		t.Fatalf("SaveTurnCredential: %v", err)
+	}
+
+	// Retrieve TURN credential
+	got, err := store.GetTurnCredential(serverURL, username)
+	if err != nil {
+		t.Fatalf("GetTurnCredential: %v", err)
+	}
+	if string(got) != string(secret) {
+		t.Fatalf("GetTurnCredential = %q, want %q", got, secret)
+	}
+
+	// Delete TURN credential
+	if err := store.DeleteTurnCredential(serverURL, username); err != nil {
+		t.Fatalf("DeleteTurnCredential: %v", err)
+	}
+
+	_, err = store.GetTurnCredential(serverURL, username)
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("GetTurnCredential after delete returned %v, want ErrSecretNotFound", err)
+	}
+}

--- a/apps/desktop/internal/config/secret_store.go
+++ b/apps/desktop/internal/config/secret_store.go
@@ -46,17 +46,17 @@ func NewUnavailableSecretStore(reason string) *UnavailableSecretStore {
 }
 
 // Get always returns an error indicating secret storage is unavailable.
-func (u *UnavailableSecretStore) Get(key string) ([]byte, error) {
+func (u *UnavailableSecretStore) Get(_ string) ([]byte, error) {
 	return nil, fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
 }
 
 // Set always returns an error indicating secret storage is unavailable.
-func (u *UnavailableSecretStore) Set(key string, secret []byte) error {
+func (u *UnavailableSecretStore) Set(_ string, _ []byte) error {
 	return fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
 }
 
 // Delete is an idempotent no-op on unavailable stores.
-func (u *UnavailableSecretStore) Delete(key string) error {
+func (u *UnavailableSecretStore) Delete(_ string) error {
 	return nil
 }
 

--- a/apps/desktop/internal/config/secret_store.go
+++ b/apps/desktop/internal/config/secret_store.go
@@ -1,0 +1,180 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var (
+	// ErrSecretStoreUnavailable is returned when attempting to persist secrets on a
+	// system where OS-protected credential storage is unavailable. Silent downgrade
+	// to plaintext persistence is strictly refused.
+	ErrSecretStoreUnavailable = errors.New("os protected secret storage is unavailable; saving raw secrets in plaintext is refused")
+	// ErrSecretNotFound is returned when the requested secret key does not exist.
+	ErrSecretNotFound = errors.New("secret not found")
+)
+
+// SecretStore is the interface for OS-protected persistent secret storage.
+// Implementations MUST NOT store raw secrets in plaintext JSON, localStorage,
+// or diagnostic logs.
+type SecretStore interface {
+	Get(key string) ([]byte, error)
+	Set(key string, secret []byte) error
+	Delete(key string) error
+	IsAvailable() bool
+	BackendName() string
+}
+
+// UnavailableSecretStore is used when no reliable OS-protected secret store is
+// available. It fails closed and explicitly informs the caller rather than
+// silently storing secrets insecurely.
+type UnavailableSecretStore struct {
+	reason string
+}
+
+// NewUnavailableSecretStore creates an UnavailableSecretStore.
+func NewUnavailableSecretStore(reason string) *UnavailableSecretStore {
+	if reason == "" {
+		reason = "no protected credential facility detected"
+	}
+	return &UnavailableSecretStore{reason: reason}
+}
+
+func (u *UnavailableSecretStore) Get(key string) ([]byte, error) {
+	return nil, fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
+}
+
+func (u *UnavailableSecretStore) Set(key string, secret []byte) error {
+	return fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
+}
+
+func (u *UnavailableSecretStore) Delete(key string) error {
+	return nil // deleting from an unavailable store is an idempotent no-op
+}
+
+func (u *UnavailableSecretStore) IsAvailable() bool {
+	return false
+}
+
+func (u *UnavailableSecretStore) BackendName() string {
+	return "unavailable (" + u.reason + ")"
+}
+
+// MemorySecretStore is an in-memory thread-safe secret store for tests or ephemeral runs.
+type MemorySecretStore struct {
+	mu      sync.RWMutex
+	secrets map[string][]byte
+}
+
+// NewMemorySecretStore creates a new MemorySecretStore.
+func NewMemorySecretStore() *MemorySecretStore {
+	return &MemorySecretStore{secrets: make(map[string][]byte)}
+}
+
+func (m *MemorySecretStore) Get(key string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	val, ok := m.secrets[key]
+	if !ok {
+		return nil, ErrSecretNotFound
+	}
+	cpy := make([]byte, len(val))
+	copy(cpy, val)
+	return cpy, nil
+}
+
+func (m *MemorySecretStore) Set(key string, secret []byte) error {
+	if key == "" {
+		return errors.New("secret key cannot be empty")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cpy := make([]byte, len(secret))
+	copy(cpy, secret)
+	m.secrets[key] = cpy
+	return nil
+}
+
+func (m *MemorySecretStore) Delete(key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.secrets, key)
+	return nil
+}
+
+func (m *MemorySecretStore) IsAvailable() bool {
+	return true
+}
+
+func (m *MemorySecretStore) BackendName() string {
+	return "memory"
+}
+
+// DarwinKeychainSecretStore uses the macOS Security CLI (/usr/bin/security)
+// to manage secrets in the macOS Keychain.
+type DarwinKeychainSecretStore struct {
+	serviceName string
+}
+
+// NewDarwinKeychainSecretStore creates a Darwin keychain secret store.
+func NewDarwinKeychainSecretStore(serviceName string) *DarwinKeychainSecretStore {
+	if serviceName == "" {
+		serviceName = "SendBeam"
+	}
+	return &DarwinKeychainSecretStore{serviceName: serviceName}
+}
+
+func (d *DarwinKeychainSecretStore) Get(key string) ([]byte, error) {
+	cmd := exec.Command("/usr/bin/security", "find-generic-password", "-s", d.serviceName, "-a", key, "-w")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, ErrSecretNotFound
+	}
+	return []byte(strings.TrimRight(string(out), "\r\n")), nil
+}
+
+func (d *DarwinKeychainSecretStore) Set(key string, secret []byte) error {
+	cmd := exec.Command("/usr/bin/security", "add-generic-password", "-U", "-s", d.serviceName, "-a", key, "-w", string(secret))
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("keychain set error: %w", err)
+	}
+	return nil
+}
+
+func (d *DarwinKeychainSecretStore) Delete(key string) error {
+	cmd := exec.Command("/usr/bin/security", "delete-generic-password", "-s", d.serviceName, "-a", key)
+	_ = cmd.Run() // idempotent ignore if not found
+	return nil
+}
+
+func (d *DarwinKeychainSecretStore) IsAvailable() bool {
+	_, err := exec.LookPath("/usr/bin/security")
+	return err == nil
+}
+
+func (d *DarwinKeychainSecretStore) BackendName() string {
+	return "darwin-keychain"
+}
+
+// DefaultSecretStore returns the best available OS-protected secret store for the
+// current platform, or an UnavailableSecretStore with clear degradation rationale.
+func DefaultSecretStore() SecretStore {
+	switch runtime.GOOS {
+	case "darwin":
+		store := NewDarwinKeychainSecretStore("SendBeam")
+		if store.IsAvailable() {
+			return store
+		}
+		return NewUnavailableSecretStore("macOS security CLI not found")
+	case "windows":
+		return NewUnavailableSecretStore("Windows DPAPI integration disabled in current build")
+	case "linux":
+		return NewUnavailableSecretStore("Linux Secret Service daemon not available")
+	default:
+		return NewUnavailableSecretStore("unsupported operating system for protected credentials: " + runtime.GOOS)
+	}
+}

--- a/apps/desktop/internal/config/secret_store.go
+++ b/apps/desktop/internal/config/secret_store.go
@@ -1,3 +1,4 @@
+// Package config manages desktop persistent configuration and credentials.
 package config
 
 import (
@@ -44,22 +45,27 @@ func NewUnavailableSecretStore(reason string) *UnavailableSecretStore {
 	return &UnavailableSecretStore{reason: reason}
 }
 
+// Get always returns an error indicating secret storage is unavailable.
 func (u *UnavailableSecretStore) Get(key string) ([]byte, error) {
 	return nil, fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
 }
 
+// Set always returns an error indicating secret storage is unavailable.
 func (u *UnavailableSecretStore) Set(key string, secret []byte) error {
 	return fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
 }
 
+// Delete is an idempotent no-op on unavailable stores.
 func (u *UnavailableSecretStore) Delete(key string) error {
-	return nil // deleting from an unavailable store is an idempotent no-op
+	return nil
 }
 
+// IsAvailable reports false for unavailable stores.
 func (u *UnavailableSecretStore) IsAvailable() bool {
 	return false
 }
 
+// BackendName returns a descriptive unavailable status.
 func (u *UnavailableSecretStore) BackendName() string {
 	return "unavailable (" + u.reason + ")"
 }
@@ -75,6 +81,7 @@ func NewMemorySecretStore() *MemorySecretStore {
 	return &MemorySecretStore{secrets: make(map[string][]byte)}
 }
 
+// Get retrieves a stored secret by key.
 func (m *MemorySecretStore) Get(key string) ([]byte, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -87,6 +94,7 @@ func (m *MemorySecretStore) Get(key string) ([]byte, error) {
 	return cpy, nil
 }
 
+// Set stores a secret by key.
 func (m *MemorySecretStore) Set(key string, secret []byte) error {
 	if key == "" {
 		return errors.New("secret key cannot be empty")
@@ -99,6 +107,7 @@ func (m *MemorySecretStore) Set(key string, secret []byte) error {
 	return nil
 }
 
+// Delete removes a stored secret by key.
 func (m *MemorySecretStore) Delete(key string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -106,10 +115,12 @@ func (m *MemorySecretStore) Delete(key string) error {
 	return nil
 }
 
+// IsAvailable reports true for in-memory stores.
 func (m *MemorySecretStore) IsAvailable() bool {
 	return true
 }
 
+// BackendName returns "memory".
 func (m *MemorySecretStore) BackendName() string {
 	return "memory"
 }
@@ -128,53 +139,54 @@ func NewDarwinKeychainSecretStore(serviceName string) *DarwinKeychainSecretStore
 	return &DarwinKeychainSecretStore{serviceName: serviceName}
 }
 
+// Get retrieves a generic password from the macOS Keychain.
 func (d *DarwinKeychainSecretStore) Get(key string) ([]byte, error) {
 	cmd := exec.Command("/usr/bin/security", "find-generic-password", "-s", d.serviceName, "-a", key, "-w")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, ErrSecretNotFound
 	}
-	return []byte(strings.TrimRight(string(out), "\r\n")), nil
+	trimmed := strings.TrimRight(string(out), "\r\n")
+	return []byte(trimmed), nil
 }
 
+// Set saves or updates a generic password in the macOS Keychain.
 func (d *DarwinKeychainSecretStore) Set(key string, secret []byte) error {
+	if key == "" {
+		return errors.New("secret key cannot be empty")
+	}
 	cmd := exec.Command("/usr/bin/security", "add-generic-password", "-U", "-s", d.serviceName, "-a", key, "-w", string(secret))
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("keychain set error: %w", err)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("keychain set error: %s (%w)", strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }
 
+// Delete removes a generic password from the macOS Keychain.
 func (d *DarwinKeychainSecretStore) Delete(key string) error {
 	cmd := exec.Command("/usr/bin/security", "delete-generic-password", "-s", d.serviceName, "-a", key)
-	_ = cmd.Run() // idempotent ignore if not found
+	_ = cmd.Run()
 	return nil
 }
 
+// IsAvailable reports true when running on Darwin.
 func (d *DarwinKeychainSecretStore) IsAvailable() bool {
-	_, err := exec.LookPath("/usr/bin/security")
-	return err == nil
+	return runtime.GOOS == "darwin"
 }
 
+// BackendName returns "macos-keychain".
 func (d *DarwinKeychainSecretStore) BackendName() string {
-	return "darwin-keychain"
+	return "macos-keychain"
 }
 
-// DefaultSecretStore returns the best available OS-protected secret store for the
-// current platform, or an UnavailableSecretStore with clear degradation rationale.
+// DefaultSecretStore resolves the appropriate OS-protected secret store
+// for the current platform. If none is available, it returns an UnavailableSecretStore
+// to fail closed rather than falling back to plaintext storage.
 func DefaultSecretStore() SecretStore {
 	switch runtime.GOOS {
 	case "darwin":
-		store := NewDarwinKeychainSecretStore("SendBeam")
-		if store.IsAvailable() {
-			return store
-		}
-		return NewUnavailableSecretStore("macOS security CLI not found")
-	case "windows":
-		return NewUnavailableSecretStore("Windows DPAPI integration disabled in current build")
-	case "linux":
-		return NewUnavailableSecretStore("Linux Secret Service daemon not available")
+		return NewDarwinKeychainSecretStore("SendBeam")
 	default:
-		return NewUnavailableSecretStore("unsupported operating system for protected credentials: " + runtime.GOOS)
+		return NewUnavailableSecretStore("native OS credential helper not configured for " + runtime.GOOS)
 	}
 }

--- a/apps/desktop/internal/engine/durability_test.go
+++ b/apps/desktop/internal/engine/durability_test.go
@@ -1,0 +1,394 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/desktop/internal/config"
+	"github.com/sendbeam/desktop/internal/lifecycle"
+	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/wire"
+)
+
+func TestDesktopDurableListingAndInspect(t *testing.T) {
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "downloads")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sink := &eventSink{}
+	svc := NewTransferService(sink.emit, nil)
+	senderStoreDir := filepath.Join(dir, "sender_state")
+	sStore, err := transfer.OpenSenderStore(senderStoreDir)
+	if err != nil {
+		t.Fatalf("OpenSenderStore: %v", err)
+	}
+	svc.SetSenderStore(sStore)
+
+	dStore, err := transfer.OpenStore(outDir)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+
+	// 1. Create a simulated valid durable receive journal
+	tid := "0123456789abcdef0123456789abcdef"
+	secretEnv := &wire.ResumeSecretEnvelope{
+		Version: 1,
+		Value:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+
+	manifest := wire.Manifest{
+		TransferID: tid,
+		TotalSize:  128 * 1024,
+		Files: []wire.FileEntry{
+			{Idx: 0, Name: "test.dat", Size: 128 * 1024, Blocks: 2, BlockSize: 64 * 1024, FileDigest: strings.Repeat("a", 64)},
+		},
+	}
+	srcIdent := wire.JournalIdentity{Version: 1, Value: "src"}
+	destIdent := wire.JournalIdentity{Version: 1, Value: "dest"}
+	now := time.Now()
+	j, err := wire.NewJournal(tid, manifest, srcIdent, destIdent, now)
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
+	j.ResumeSecret = &wire.JournalResumeSecret{
+		Version: secretEnv.Version,
+		Value:   secretEnv.Value,
+	}
+	if err := j.CommitBlocks(0, 1, now); err != nil {
+		t.Fatalf("CommitBlocks: %v", err)
+	}
+	if err := wire.WriteJournalAtomic(dStore.JournalPath(tid), j); err != nil {
+		t.Fatalf("WriteJournalAtomic: %v", err)
+	}
+
+	// Create matching partial file for the 1 committed block (64 KiB)
+	partPath := dStore.PartialPath(tid, "test.dat")
+	if err := os.MkdirAll(filepath.Dir(partPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(partPath, make([]byte, 64*1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Create a simulated sender record
+	srcFile := writePayload(t, dir, "source.bin", 1024)
+	nowMilli := time.Now().UnixMilli()
+	sendManifest := wire.Manifest{
+		TransferID: "fedcba9876543210fedcba9876543210",
+		TotalSize:  1024,
+		Files: []wire.FileEntry{
+			{Idx: 0, Name: "source.bin", Size: 1024, Blocks: 1, BlockSize: 64 * 1024, LastModified: nowMilli, FileDigest: strings.Repeat("b", 64)},
+		},
+	}
+	validated, _ := wire.ValidateManifest(sendManifest)
+	fp, _ := wire.ManifestFingerprint(validated)
+	rec := transfer.SenderRecord{
+		SchemaVersion:       2,
+		TransferID:          validated.TransferID,
+		ManifestFingerprint: fp,
+		ProtocolVersion:     wire.ProtocolVersion,
+		CreatedAt:           nowMilli,
+		UpdatedAt:           nowMilli,
+		Paths:               []string{srcFile},
+		Files: []transfer.SenderFileState{
+			{Idx: 0, Name: "source.bin", Size: 1024, LastModified: nowMilli, BlockSize: 64 * 1024, Blocks: 1, FileDigest: strings.Repeat("b", 64)},
+		},
+		ResumeSecret: secretEnv,
+	}
+	if err := sStore.Save(rec); err != nil {
+		t.Fatalf("sStore.Save: %v", err)
+	}
+
+	// 3. Test ListInterrupted
+	items, err := svc.ListInterrupted(outDir)
+	if err != nil {
+		t.Fatalf("ListInterrupted: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("ListInterrupted returned %d items, want 2", len(items))
+	}
+
+	var recvItem, sendItem *DurableTransferItem
+	for i := range items {
+		if items[i].Role == "receive" {
+			recvItem = &items[i]
+		} else if items[i].Role == "send" {
+			sendItem = &items[i]
+		}
+	}
+	if recvItem == nil || recvItem.TransferID != tid || !recvItem.Resumable {
+		t.Errorf("recvItem = %+v, want valid resumable receive item", recvItem)
+	}
+	if sendItem == nil || sendItem.Role != "send" {
+		t.Errorf("sendItem = %+v, want valid send item", sendItem)
+	}
+
+	// 4. Test InspectInterrupted
+	ins, err := svc.InspectInterrupted(tid, outDir)
+	if err != nil {
+		t.Fatalf("InspectInterrupted: %v", err)
+	}
+	if ins.TransferID != tid || !ins.Resumable || len(ins.Problems) != 0 {
+		t.Errorf("InspectInterrupted = %+v, want resumable with 0 problems", ins)
+	}
+	if len(ins.Files) != 1 || ins.Files[0].Name != "test.dat" {
+		t.Errorf("InspectInterrupted files = %v, want 1 file test.dat", ins.Files)
+	}
+
+	// 5. Test DiscardInterrupted (idempotent)
+	if err := svc.DiscardInterrupted(tid, outDir); err != nil {
+		t.Fatalf("DiscardInterrupted: %v", err)
+	}
+
+	// After discard, receive item is gone
+	itemsAfter, err := svc.ListInterrupted(outDir)
+	if err != nil {
+		t.Fatalf("ListInterrupted after discard: %v", err)
+	}
+	if len(itemsAfter) != 1 || itemsAfter[0].Role != "send" {
+		t.Errorf("ListInterrupted after discard returned %v, want 1 send item", itemsAfter)
+	}
+
+	// 6. Test DiscardAllInterrupted
+	if err := svc.DiscardAllInterrupted(outDir); err != nil {
+		t.Fatalf("DiscardAllInterrupted: %v", err)
+	}
+	itemsEmpty, err := svc.ListInterrupted(outDir)
+	if err != nil {
+		t.Fatalf("ListInterrupted after DiscardAll: %v", err)
+	}
+	if len(itemsEmpty) != 0 {
+		t.Errorf("ListInterrupted after DiscardAll returned %v, want empty", itemsEmpty)
+	}
+}
+
+func TestDesktopDurableResumeHappyPath(t *testing.T) {
+	svc, sink, hub := newLoopbackService(t)
+	dir := t.TempDir()
+	srcPath := writePayload(t, dir, "resumable.bin", 256*1024)
+	outDir := filepath.Join(dir, "received")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	senderDir := filepath.Join(dir, "sender_state")
+	sStore, err := transfer.OpenSenderStore(senderDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.SetSenderStore(sStore)
+
+	notifier := lifecycle.NewTestNotifier()
+	svc.SetNotifier(notifier)
+
+	// Step 1: Start transfer #1
+	send1, err := svc.Send([]string{srcPath}, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Send #1: %v", err)
+	}
+	inv1 := sink.waitFor(t, "invite", 10*time.Second)
+
+	recv1, err := svc.Receive(inv1.Code, outDir, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Receive #1: %v", err)
+	}
+	_ = recv1
+	sink.waitForID(t, send1.ID, "connect", 10*time.Second)
+
+	// Let the transfer complete
+	sink.waitForID(t, send1.ID, "done", 10*time.Second)
+	sink.waitForID(t, recv1.ID, "done", 10*time.Second)
+
+	// Verify verified output
+	got := readAll(t, filepath.Join(outDir, "resumable.bin"))
+	want := readAll(t, srcPath)
+	if len(got) != len(want) {
+		t.Fatalf("received %d bytes, want %d", len(got), len(want))
+	}
+
+	// Verify notification was sent only on verified completion
+	events := notifier.Events()
+	var successEvents []lifecycle.NotificationEvent
+	for _, e := range events {
+		if e.Kind == "success" {
+			successEvents = append(successEvents, e)
+		}
+	}
+	if len(successEvents) == 0 {
+		t.Fatalf("no success notifications recorded")
+	}
+
+	_ = hub
+}
+
+func TestDesktopDurableResumeRefusesCorruptJournal(t *testing.T) {
+	svc, sink, _ := newLoopbackService(t)
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "out")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dStore, err := transfer.OpenStore(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tid := "deadbeefdeadbeefdeadbeefdeadbeef"
+	// Write a corrupt journal (empty / invalid JSON)
+	if err := os.WriteFile(dStore.JournalPath(tid), []byte("{\"corrupt\": true"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// ResumeInterrupted on corrupt journal must fail closed
+	_, err = svc.ResumeInterrupted(tid, "7-alpha-bravo", outDir, "wss://loopback/ws")
+	if err == nil {
+		t.Fatalf("ResumeInterrupted on corrupt journal expected error, got nil")
+	}
+
+	// Ensure no partial or output was promoted to final
+	files, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		if f.Name() != ".sendbeam" {
+			t.Fatalf("unexpected file %q created in outDir on corrupt resume", f.Name())
+		}
+	}
+	_ = sink
+}
+
+func TestDesktopPathSafetyAndDestinationEscapeDefense(t *testing.T) {
+	sink := &eventSink{}
+	svc := NewTransferService(sink.emit, nil)
+
+	dir := t.TempDir()
+	validFile := writePayload(t, dir, "valid.txt", 100)
+
+	// 1. Valid file passes validation
+	if err := validatePaths([]string{validFile}); err != nil {
+		t.Fatalf("validatePaths valid file failed: %v", err)
+	}
+
+	// 2. Non-existent file fails validation
+	if err := validatePaths([]string{filepath.Join(dir, "missing.txt")}); err == nil {
+		t.Fatalf("validatePaths missing file expected error, got nil")
+	}
+
+	// 3. RevealFile path validation
+	launcherCalled := false
+	rm := lifecycle.NewRevealManager(func(target string) error {
+		launcherCalled = true
+		return nil
+	})
+	svc.SetRevealManager(rm)
+
+	// Valid reveal
+	if err := svc.RevealFile(validFile); err != nil {
+		t.Fatalf("RevealFile valid failed: %v", err)
+	}
+	if !launcherCalled {
+		t.Errorf("launcher was not called for valid file")
+	}
+
+	// Traversal / non-existent reveal fails closed
+	if err := svc.RevealFile(filepath.Join(dir, "../outside.txt")); err == nil {
+		t.Fatalf("RevealFile non-existent expected error, got nil")
+	}
+}
+
+func TestDesktopConfigPersistenceAndAutoAcceptSafety(t *testing.T) {
+	dir := t.TempDir()
+	cfgStore, err := config.NewStore(dir, config.NewMemorySecretStore())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	sink := &eventSink{}
+	svc := NewTransferService(sink.emit, nil)
+	svc.SetConfigStore(cfgStore)
+
+	// Default config must have AutoAccept = false
+	cfg, err := svc.GetConfig()
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	if cfg.AutoAccept != false {
+		t.Fatalf("AutoAccept must strictly be false by default, got %v", cfg.AutoAccept)
+	}
+	if cfg.ServerURL != config.DefaultServerURL {
+		t.Errorf("ServerURL = %q, want %q", cfg.ServerURL, config.DefaultServerURL)
+	}
+
+	// Update and save custom config
+	cfg.ServerURL = "wss://custom.server.org:8443/ws"
+	cfg.DownloadDir = filepath.Join(dir, "saved_downloads")
+	cfg.ICEServers = []string{"stun:stun.custom.org:3478"}
+
+	if err := svc.SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	reloaded, err := svc.GetConfig()
+	if err != nil {
+		t.Fatalf("GetConfig reloaded: %v", err)
+	}
+	if reloaded.ServerURL != cfg.ServerURL || reloaded.DownloadDir != cfg.DownloadDir {
+		t.Errorf("reloaded config mismatch: %+v vs %+v", reloaded, cfg)
+	}
+
+	// AutoAccept remains false
+	if reloaded.AutoAccept != false {
+		t.Errorf("AutoAccept must remain false, got %v", reloaded.AutoAccept)
+	}
+}
+
+func TestDesktopGracefulShutdown(t *testing.T) {
+	svc, sink, hub := newLoopbackService(t)
+	dir := t.TempDir()
+	srcPath := writePayload(t, dir, "large.bin", 2*1024*1024)
+	outDir := filepath.Join(dir, "out")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	send, err := svc.Send([]string{srcPath}, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	invite := sink.waitFor(t, "invite", 10*time.Second)
+
+	_, err = svc.Receive(invite.Code, outDir, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+
+	sink.waitForID(t, send.ID, "connect", 10*time.Second)
+
+	// While transfer is in flight, active count > 0
+	if count := svc.ActiveCount(); count == 0 {
+		t.Errorf("ActiveCount = 0 during active transfer")
+	}
+
+	// Call Shutdown with a bounded timeout
+	start := time.Now()
+	if err := svc.Shutdown(2 * time.Second); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 3*time.Second {
+		t.Errorf("Shutdown took %v, expected under 3s", elapsed)
+	}
+
+	if count := svc.ActiveCount(); count != 0 {
+		t.Errorf("ActiveCount after shutdown = %d, want 0", count)
+	}
+	_ = hub
+}

--- a/apps/desktop/internal/engine/durability_test.go
+++ b/apps/desktop/internal/engine/durability_test.go
@@ -115,9 +115,10 @@ func TestDesktopDurableListingAndInspect(t *testing.T) {
 
 	var recvItem, sendItem *DurableTransferItem
 	for i := range items {
-		if items[i].Role == "receive" {
+		switch items[i].Role {
+		case "receive":
 			recvItem = &items[i]
-		} else if items[i].Role == "send" {
+		case "send":
 			sendItem = &items[i]
 		}
 	}
@@ -283,7 +284,7 @@ func TestDesktopPathSafetyAndDestinationEscapeDefense(t *testing.T) {
 
 	// 3. RevealFile path validation
 	launcherCalled := false
-	rm := lifecycle.NewRevealManager(func(target string) error {
+	rm := lifecycle.NewRevealManager(func(_ string) error {
 		launcherCalled = true
 		return nil
 	})

--- a/apps/desktop/internal/engine/transfer_service.go
+++ b/apps/desktop/internal/engine/transfer_service.go
@@ -14,11 +14,14 @@ import (
 	"math"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/desktop/internal/config"
+	"github.com/sendbeam/desktop/internal/lifecycle"
 	"github.com/sendbeam/engine/rendezvous"
 	"github.com/sendbeam/engine/transfer"
 	"github.com/sendbeam/engine/wsclient"
@@ -82,12 +85,44 @@ type TransferEvent struct {
 	Paused      bool    `json:"paused,omitempty"`
 	Canceled    bool    `json:"canceled,omitempty"`
 	Failed      bool    `json:"failed,omitempty"`
+	Resumed     bool    `json:"resumed,omitempty"`
 
 	// Terminal (kind=done/error).
 	Digest  string `json:"digest,omitempty"`
 	OutDir  string `json:"outDir,omitempty"`
 	OutPath string `json:"outPath,omitempty"`
 	Error   string `json:"error,omitempty"`
+}
+
+// DurableTransferItem describes an interrupted transfer (sender or receiver)
+// surfaced to the desktop management UI.
+type DurableTransferItem struct {
+	TransferID     string   `json:"transferId"`
+	Role           string   `json:"role"` // send | receive
+	TotalBytes     int64    `json:"totalBytes"`
+	CommittedBytes int64    `json:"committedBytes"`
+	Files          int      `json:"files"`
+	CreatedAt      int64    `json:"createdAt"`
+	UpdatedAt      int64    `json:"updatedAt"`
+	Status         string   `json:"status"`
+	Resumable      bool     `json:"resumable"`
+	Paths          []string `json:"paths,omitempty"`
+}
+
+// DurableInspectResult is the diagnostic outcome of inspecting a durable journal.
+type DurableInspectResult struct {
+	TransferID          string     `json:"transferId"`
+	TotalBytes          int64      `json:"totalBytes"`
+	CommittedBytes      int64      `json:"committedBytes"`
+	CreatedAt           int64      `json:"createdAt"`
+	UpdatedAt           int64      `json:"updatedAt"`
+	ProtocolVersion     string     `json:"protocolVersion"`
+	ManifestFingerprint string     `json:"manifestFingerprint"`
+	JournalPath         string     `json:"journalPath"`
+	PartialDir          string     `json:"partialDir"`
+	Resumable           bool       `json:"resumable"`
+	Problems            []string   `json:"problems,omitempty"`
+	Files               []FileInfo `json:"files,omitempty"`
 }
 
 // SignalDialer returns the signaling signal for one transfer side. The desktop
@@ -116,6 +151,12 @@ type TransferService struct {
 	mu   sync.Mutex
 	next int
 	runs map[string]*transferRun
+
+	configStore    *config.Store
+	notifier       lifecycle.Notifier
+	revealMgr      *lifecycle.RevealManager
+	senderStore    *transfer.SenderStore
+	durableStoreFn func(outDir string) (*transfer.DurableStore, error)
 }
 
 // NewTransferService builds the service. emit is the frontend sink (wails
@@ -125,7 +166,68 @@ func NewTransferService(emit func(name string, data any), dial SignalDialer) *Tr
 	if dial == nil {
 		dial = defaultDialer
 	}
-	return &TransferService{emit: emit, dial: dial, runs: map[string]*transferRun{}}
+	cfgStore, _ := config.NewStore("", nil)
+	sStoreDir, _ := transfer.SenderStoreDir()
+	var sStore *transfer.SenderStore
+	if sStoreDir != "" {
+		sStore, _ = transfer.OpenSenderStore(sStoreDir)
+	}
+
+	return &TransferService{
+		emit:           emit,
+		dial:           dial,
+		runs:           map[string]*transferRun{},
+		configStore:    cfgStore,
+		notifier:       &lifecycle.SilentNotifier{},
+		revealMgr:      lifecycle.NewRevealManager(nil),
+		senderStore:    sStore,
+		durableStoreFn: transfer.OpenStore,
+	}
+}
+
+// SetNotifier sets the notification sink.
+func (s *TransferService) SetNotifier(n lifecycle.Notifier) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notifier = n
+}
+
+// SetRevealManager sets the reveal manager.
+func (s *TransferService) SetRevealManager(r *lifecycle.RevealManager) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.revealMgr = r
+}
+
+// SetConfigStore sets the config store.
+func (s *TransferService) SetConfigStore(cs *config.Store) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.configStore = cs
+}
+
+// SetSenderStore sets the sender store for tests.
+func (s *TransferService) SetSenderStore(ss *transfer.SenderStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.senderStore = ss
+}
+
+// SetDurableStoreFn overrides the durable store factory for tests.
+func (s *TransferService) SetDurableStoreFn(fn func(outDir string) (*transfer.DurableStore, error)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.durableStoreFn = fn
+}
+
+func (s *TransferService) openDurableStore(outDir string) (*transfer.DurableStore, error) {
+	s.mu.Lock()
+	fn := s.durableStoreFn
+	s.mu.Unlock()
+	if fn == nil {
+		fn = transfer.OpenStore
+	}
+	return fn(outDir)
 }
 
 // setLoopbackConfig is the test seam for the loopback relay: host-only ICE and
@@ -165,6 +267,7 @@ type transferRun struct {
 	paused      bool
 	canceled    bool
 	failed      bool
+	resumed     bool
 	transport   string
 	fingerprint string
 
@@ -185,7 +288,14 @@ func (s *TransferService) Send(paths []string, server string) (Handle, error) {
 		return Handle{}, errors.New("no files or folders selected")
 	}
 	if server == "" {
-		server = DefaultServer
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.ServerURL != "" {
+				server = cfg.ServerURL
+			}
+		}
+		if server == "" {
+			server = DefaultServer
+		}
 	}
 	if err := validatePaths(paths); err != nil {
 		return Handle{}, err
@@ -206,7 +316,7 @@ func (s *TransferService) Send(paths []string, server string) (Handle, error) {
 	}
 	_ = total
 
-	go r.runSend(r.ctx, server, sources)
+	go r.runSend(r.ctx, server, sources, paths)
 	return Handle{ID: id, Role: "send"}, nil
 }
 
@@ -219,10 +329,24 @@ func (s *TransferService) Receive(code string, destDir string, server string) (H
 	}
 	code = normalizeCode(code)
 	if destDir == "" {
-		destDir = "."
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.DownloadDir != "" {
+				destDir = cfg.DownloadDir
+			}
+		}
+		if destDir == "" {
+			destDir = "."
+		}
 	}
 	if server == "" {
-		server = DefaultServer
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.ServerURL != "" {
+				server = cfg.ServerURL
+			}
+		}
+		if server == "" {
+			server = DefaultServer
+		}
 	}
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return Handle{}, fmt.Errorf("create destination: %w", err)
@@ -236,7 +360,7 @@ func (s *TransferService) Receive(code string, destDir string, server string) (H
 
 // Drop starts a send for paths dropped onto the window, mirroring Send.
 func (s *TransferService) Drop(paths []string) (Handle, error) {
-	return s.Send(paths, DefaultServer)
+	return s.Send(paths, "")
 }
 
 // Pause pauses the transfer with id (both sides stop producing new data).
@@ -252,6 +376,300 @@ func (s *TransferService) Resume(id string) error {
 // Cancel cancels the transfer with id.
 func (s *TransferService) Cancel(id string) error {
 	return s.control(id, func(c transfer.Controls) error { return c.Cancel("canceled by user") })
+}
+
+// ListInterrupted surfaces interrupted durable receive journals and sender records.
+func (s *TransferService) ListInterrupted(outDir string) ([]DurableTransferItem, error) {
+	if outDir == "" {
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.DownloadDir != "" {
+				outDir = cfg.DownloadDir
+			}
+		}
+		if outDir == "" {
+			outDir = "."
+		}
+	}
+
+	var items []DurableTransferItem
+
+	// 1. Durable receive entries
+	if store, err := s.openDurableStore(outDir); err == nil {
+		if entries, err := store.List(); err == nil {
+			for _, e := range entries {
+				item := DurableTransferItem{
+					TransferID:     e.TransferID,
+					Role:           "receive",
+					TotalBytes:     e.TotalSize,
+					CommittedBytes: e.CommittedBytes,
+					Files:          e.Files,
+					CreatedAt:      e.UpdatedAt,
+					UpdatedAt:      e.UpdatedAt,
+					Status:         durableStatus(e),
+					Resumable:      e.JournalOK && e.PartialOK && e.HasResumeSecret,
+				}
+				items = append(items, item)
+			}
+		}
+	}
+
+	// 2. Interrupted sender records
+	s.mu.Lock()
+	sstore := s.senderStore
+	s.mu.Unlock()
+	if sstore != nil {
+		if senderEntries, err := sstore.List(); err == nil {
+			for _, e := range senderEntries {
+				item := DurableTransferItem{
+					TransferID:     e.TransferID,
+					Role:           "send",
+					TotalBytes:     e.TotalSize,
+					CommittedBytes: 0,
+					Files:          e.Files,
+					CreatedAt:      e.CreatedAt,
+					UpdatedAt:      e.UpdatedAt,
+					Status:         senderStatus(e),
+					Resumable:      e.RecordOK && e.HasResumeSecret,
+					Paths:          e.Paths,
+				}
+				items = append(items, item)
+			}
+		}
+	}
+
+	return items, nil
+}
+
+// InspectInterrupted checks the consistency of one interrupted receive journal.
+func (s *TransferService) InspectInterrupted(transferID string, outDir string) (DurableInspectResult, error) {
+	if transferID == "" {
+		return DurableInspectResult{}, errors.New("transfer id is required")
+	}
+	if outDir == "" {
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.DownloadDir != "" {
+				outDir = cfg.DownloadDir
+			}
+		}
+		if outDir == "" {
+			outDir = "."
+		}
+	}
+	store, err := s.openDurableStore(outDir)
+	if err != nil {
+		return DurableInspectResult{}, err
+	}
+	ins, err := store.Inspect(transferID)
+	if err != nil {
+		return DurableInspectResult{}, err
+	}
+
+	res := DurableInspectResult{
+		TransferID:          ins.Journal.TransferID,
+		TotalBytes:          ins.Total,
+		CommittedBytes:      ins.Committed,
+		CreatedAt:           ins.Journal.CreatedAt,
+		UpdatedAt:           ins.Journal.UpdatedAt,
+		ProtocolVersion:     ins.Journal.ProtocolVersion,
+		ManifestFingerprint: ins.Journal.ManifestFingerprint,
+		JournalPath:         ins.JournalPath,
+		PartialDir:          ins.PartialDir,
+		Resumable:           ins.Resumable,
+		Problems:            ins.Problems,
+	}
+	for _, f := range ins.Journal.Files {
+		res.Files = append(res.Files, FileInfo{Name: f.Name, Size: f.Size})
+	}
+	return res, nil
+}
+
+// ResumeInterrupted resumes an interrupted receive transfer using its stored credentials.
+func (s *TransferService) ResumeInterrupted(transferID string, code string, destDir string, server string) (Handle, error) {
+	if transferID == "" {
+		return Handle{}, errors.New("transfer id is required")
+	}
+	if code == "" {
+		return Handle{}, errors.New("an invite code from the sender is required to resume")
+	}
+	code = normalizeCode(code)
+	if destDir == "" {
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.DownloadDir != "" {
+				destDir = cfg.DownloadDir
+			}
+		}
+		if destDir == "" {
+			destDir = "."
+		}
+	}
+	if server == "" {
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.ServerURL != "" {
+				server = cfg.ServerURL
+			}
+		}
+		if server == "" {
+			server = DefaultServer
+		}
+	}
+
+	store, err := s.openDurableStore(destDir)
+	if err != nil {
+		return Handle{}, err
+	}
+	ins, err := store.Inspect(transferID)
+	if err != nil {
+		return Handle{}, err
+	}
+	if !ins.Resumable {
+		return Handle{}, fmt.Errorf("transfer %s is not resumable: %s", transferID, strings.Join(ins.Problems, "; "))
+	}
+	if ins.Journal.ResumeSecret == nil {
+		return Handle{}, fmt.Errorf("transfer %s has no resume credential (legacy state); restart required", transferID)
+	}
+	secret, err := wire.DecodeResumeSecretEnvelope(&wire.ResumeSecretEnvelope{
+		Version: ins.Journal.ResumeSecret.Version,
+		Value:   ins.Journal.ResumeSecret.Value,
+	})
+	if err != nil {
+		return Handle{}, fmt.Errorf("decode resume credential for %s: %w", transferID, err)
+	}
+
+	id := s.newID()
+	r := s.newRun(id, wire.RoleJoiner)
+	go r.runResumeReceive(r.ctx, transferID, code, destDir, server, secret, ins)
+	return Handle{ID: id, Role: "receive"}, nil
+}
+
+// DiscardInterrupted removes persistent state for one transfer id (idempotent).
+func (s *TransferService) DiscardInterrupted(transferID string, outDir string) error {
+	if transferID == "" {
+		return errors.New("transfer id is required")
+	}
+	if outDir == "" {
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.DownloadDir != "" {
+				outDir = cfg.DownloadDir
+			}
+		}
+		if outDir == "" {
+			outDir = "."
+		}
+	}
+
+	// Discard receive journal + partials
+	if store, err := s.openDurableStore(outDir); err == nil {
+		_ = store.Discard(transferID)
+	}
+	// Discard sender record
+	s.mu.Lock()
+	sstore := s.senderStore
+	s.mu.Unlock()
+	if sstore != nil {
+		_ = sstore.Discard(transferID)
+	}
+	return nil
+}
+
+// DiscardAllInterrupted removes all durable transfer journals and sender records (idempotent).
+func (s *TransferService) DiscardAllInterrupted(outDir string) error {
+	if outDir == "" {
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.DownloadDir != "" {
+				outDir = cfg.DownloadDir
+			}
+		}
+		if outDir == "" {
+			outDir = "."
+		}
+	}
+	if store, err := s.openDurableStore(outDir); err == nil {
+		_ = store.DiscardAll()
+	}
+	s.mu.Lock()
+	sstore := s.senderStore
+	s.mu.Unlock()
+	if sstore != nil {
+		_ = sstore.DiscardAll()
+	}
+	return nil
+}
+
+// RevealFile reveals the verified output file in the OS file manager.
+func (s *TransferService) RevealFile(filePath string) error {
+	s.mu.Lock()
+	rm := s.revealMgr
+	s.mu.Unlock()
+	if rm == nil {
+		rm = lifecycle.NewRevealManager(nil)
+	}
+	return rm.Reveal(filePath)
+}
+
+// GetConfig returns the desktop persistent configuration.
+func (s *TransferService) GetConfig() (config.DesktopConfig, error) {
+	s.mu.Lock()
+	cs := s.configStore
+	s.mu.Unlock()
+	if cs == nil {
+		return config.DefaultConfig(), nil
+	}
+	return cs.Load()
+}
+
+// SaveConfig saves the desktop persistent configuration.
+func (s *TransferService) SaveConfig(cfg config.DesktopConfig) error {
+	s.mu.Lock()
+	cs := s.configStore
+	s.mu.Unlock()
+	if cs == nil {
+		return errors.New("config store not available")
+	}
+	return cs.Save(cfg)
+}
+
+// ActiveCount returns the number of in-flight transfers.
+func (s *TransferService) ActiveCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.runs)
+}
+
+// Shutdown gracefully cancels active transfers and waits for bounded teardown.
+func (s *TransferService) Shutdown(timeout time.Duration) error {
+	s.mu.Lock()
+	runs := make([]*transferRun, 0, len(s.runs))
+	for _, r := range s.runs {
+		runs = append(runs, r)
+	}
+	s.mu.Unlock()
+
+	if len(runs) == 0 {
+		return nil
+	}
+
+	for _, r := range runs {
+		r.canc()
+		r.mu.Lock()
+		ctrl := r.controls
+		r.mu.Unlock()
+		if ctrl != nil {
+			_ = ctrl.Cancel("application shutting down")
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		s.mu.Lock()
+		remaining := len(s.runs)
+		s.mu.Unlock()
+		if remaining == 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	return nil
 }
 
 // control looks up the live Controls for id and applies fn.
@@ -318,6 +736,7 @@ func (r *transferRun) publish(kind string, mut ...func(*TransferEvent)) {
 		Paused:      r.paused,
 		Canceled:    r.canceled,
 		Failed:      r.failed,
+		Resumed:     r.resumed,
 		RemainingMS: -1,
 	}
 	if r.totalBytes > 0 {
@@ -387,12 +806,15 @@ func (r *transferRun) recordSample(bytes int64) {
 }
 
 // runSend drives the offerer side of the transfer.
-func (r *transferRun) runSend(ctx context.Context, server string, sources []wire.FileSource) {
+func (r *transferRun) runSend(ctx context.Context, server string, sources []wire.FileSource, paths []string) {
 	defer r.svc.remove(r)
 
 	sig, err := r.svc.dial(ctx, server, wire.RoleOfferer)
 	if err != nil {
 		r.fail("dial: " + err.Error())
+		if r.svc.notifier != nil {
+			r.svc.notifier.NotifyFailure("Transfer Failed", "dial: "+err.Error())
+		}
 		return
 	}
 	defer sig.Close()
@@ -407,9 +829,46 @@ func (r *transferRun) runSend(ctx context.Context, server string, sources []wire
 		r.publish("progress")
 	}
 
+	var transferID string
+	var onSendManifest func(wire.Manifest) error
+	var resumeCtx *transfer.ResumeContext
+	reused := false
+	r.svc.mu.Lock()
+	sstore := r.svc.senderStore
+	r.svc.mu.Unlock()
+	if sstore != nil {
+		var prepErr error
+		transferID, onSendManifest, reused, prepErr = transfer.PrepareSender(sstore, paths, sources)
+		if prepErr != nil {
+			r.fail("prepare sender: " + prepErr.Error())
+			if r.svc.notifier != nil {
+				r.svc.notifier.NotifyFailure("Transfer Failed", "prepare sender: "+prepErr.Error())
+			}
+			return
+		}
+		if reused {
+			if srec, ok, lookupErr := sstore.Lookup(transfer.PathKey(paths)); lookupErr == nil && ok && srec.ResumeSecret != nil {
+				if secret, err := wire.DecodeResumeSecretEnvelope(srec.ResumeSecret); err == nil {
+					resumeCtx = &transfer.ResumeContext{
+						TransferID:          srec.TransferID,
+						ManifestFingerprint: srec.ManifestFingerprint,
+						Role:                wire.RoleOfferer,
+						ResumeSecret:        secret,
+					}
+				}
+			}
+		}
+	}
+
+	caps := rendezvous.DefaultCaps()
+	if resumeCtx != nil {
+		caps.Features = append(caps.Features, wire.ResumeAuthCapability)
+	}
+
 	spec := transfer.Spec{
 		Session: rendezvous.Options{
-			Role: rendezvous.RoleOfferer,
+			Role:      rendezvous.RoleOfferer,
+			LocalCaps: &caps,
 			OnPhase: func(p rendezvous.Phase) {
 				r.publish("phase", func(ev *TransferEvent) { ev.Phase = string(p) })
 			},
@@ -422,11 +881,33 @@ func (r *transferRun) runSend(ctx context.Context, server string, sources []wire
 			},
 		},
 		Sources:        sources,
+		TransferID:     transferID,
+		OnSendManifest: onSendManifest,
+		OnResumeCredential: func(manifest wire.Manifest, resumeRoot []byte) error {
+			if sstore != nil {
+				return sstore.AttachResumeSecret(manifest, resumeRoot, !reused)
+			}
+			return nil
+		},
+		Resume: resumeCtx,
+		OnResume: func(res transfer.ResumeResult) {
+			if res.Authenticated {
+				r.mu.Lock()
+				r.resumed = true
+				r.mu.Unlock()
+				r.publish("progress", func(ev *TransferEvent) { ev.Resumed = true })
+			}
+		},
 		ForceRelay:     r.svc.forceRelay,
 		ICEServers:     r.svc.iceServers,
 		OnTransport:    r.onTransport,
 		OnConnect:      func() { r.publish("connect") },
 		OnFileProgress: r.onFileProgress,
+		OnResumeProgress: func(reusedBytes int64) {
+			r.mu.Lock()
+			r.reused = reusedBytes
+			r.mu.Unlock()
+		},
 		OnProgress: func(n int64) {
 			r.mu.Lock()
 			r.doneBytes = n
@@ -446,6 +927,9 @@ func (r *transferRun) runSend(ctx context.Context, server string, sources []wire
 	out, err := transfer.Run(ctx, sig, spec)
 	if err != nil {
 		r.fail(err.Error())
+		if r.svc.notifier != nil {
+			r.svc.notifier.NotifyFailure("Transfer Failed", err.Error())
+		}
 		return
 	}
 	r.mu.Lock()
@@ -459,17 +943,24 @@ func (r *transferRun) runSend(ctx context.Context, server string, sources []wire
 	r.doneBytes = done
 	// Verified success: every file in the set completed.
 	r.filesDone = len(out.Files)
+	if out.Handshake != nil {
+		r.fingerprint = fingerprint(out.Handshake.Master)
+	}
 	r.mu.Unlock()
 
-	if out.Handshake != nil {
-		r.mu.Lock()
-		r.fingerprint = fingerprint(out.Handshake.Master)
-		r.mu.Unlock()
+	if sstore != nil && transferID != "" {
+		_ = sstore.Discard(transferID)
 	}
+
 	r.publish("done", func(ev *TransferEvent) {
 		ev.Digest = out.Digest
 		ev.Percent = 100
 	})
+
+	if r.svc.notifier != nil {
+		summary := fmt.Sprintf("Sent %d file(s) (%s)", len(out.Files), humanBytes(r.totalBytes))
+		r.svc.notifier.NotifySuccess("Transfer Complete", summary, "")
+	}
 }
 
 // runReceive drives the joiner side of the transfer.
@@ -479,6 +970,9 @@ func (r *transferRun) runReceive(ctx context.Context, code, destDir, server stri
 	sig, err := r.svc.dial(ctx, server, wire.RoleJoiner)
 	if err != nil {
 		r.fail("dial: " + err.Error())
+		if r.svc.notifier != nil {
+			r.svc.notifier.NotifyFailure("Transfer Failed", "dial: "+err.Error())
+		}
 		return
 	}
 	defer sig.Close()
@@ -535,6 +1029,9 @@ func (r *transferRun) runReceive(ctx context.Context, code, destDir, server stri
 	out, err := transfer.Run(ctx, sig, spec)
 	if err != nil {
 		r.fail(err.Error())
+		if r.svc.notifier != nil {
+			r.svc.notifier.NotifyFailure("Transfer Failed", err.Error())
+		}
 		return
 	}
 	r.mu.Lock()
@@ -544,6 +1041,12 @@ func (r *transferRun) runReceive(ctx context.Context, code, destDir, server stri
 		r.fingerprint = fingerprint(out.Handshake.Master)
 	}
 	r.mu.Unlock()
+
+	outPath := out.Path
+	if len(out.Files) > 1 {
+		outPath = destDir
+	}
+
 	r.publish("done", func(ev *TransferEvent) {
 		ev.Digest = out.Digest
 		ev.OutDir = destDir
@@ -552,6 +1055,144 @@ func (r *transferRun) runReceive(ctx context.Context, code, destDir, server stri
 		}
 		ev.Percent = 100
 	})
+
+	if r.svc.notifier != nil {
+		label := out.Name
+		if len(out.Files) > 1 {
+			label = fmt.Sprintf("%d files", len(out.Files))
+		}
+		summary := fmt.Sprintf("Received %s (%s) into %s", label, humanBytes(out.Size), destDir)
+		r.svc.notifier.NotifySuccess("Transfer Complete", summary, outPath)
+	}
+}
+
+// runResumeReceive drives an interrupted receive transfer resumption.
+func (r *transferRun) runResumeReceive(ctx context.Context, transferID, code, destDir, server string, secret []byte, ins *transfer.Inspect) {
+	defer r.svc.remove(r)
+
+	sig, err := r.svc.dial(ctx, server, wire.RoleJoiner)
+	if err != nil {
+		r.fail("dial: " + err.Error())
+		if r.svc.notifier != nil {
+			r.svc.notifier.NotifyFailure("Transfer Failed", "dial: "+err.Error())
+		}
+		return
+	}
+	defer sig.Close()
+
+	lastProgress := time.Time{}
+	emitProgress := func() {
+		now := time.Now()
+		if now.Sub(lastProgress) < 200*time.Millisecond {
+			return
+		}
+		lastProgress = now
+		r.publish("progress")
+	}
+
+	caps := rendezvous.DefaultCaps()
+	caps.Features = append(caps.Features, wire.ResumeAuthCapability)
+
+	resumeCtx := &transfer.ResumeContext{
+		TransferID:          transferID,
+		ManifestFingerprint: ins.Journal.ManifestFingerprint,
+		Role:                wire.RoleJoiner,
+		ResumeSecret:        secret,
+	}
+
+	spec := transfer.Spec{
+		Session: rendezvous.Options{
+			Role:      rendezvous.RoleJoiner,
+			Code:      code,
+			LocalCaps: &caps,
+			OnPhase: func(p rendezvous.Phase) {
+				r.publish("phase", func(ev *TransferEvent) { ev.Phase = string(p) })
+			},
+		},
+		DestDir:    destDir,
+		ForceRelay: r.svc.forceRelay,
+		ICEServers: r.svc.iceServers,
+		Resume:     resumeCtx,
+		OnResume: func(res transfer.ResumeResult) {
+			if res.Authenticated {
+				r.mu.Lock()
+				r.resumed = true
+				r.mu.Unlock()
+				r.publish("progress", func(ev *TransferEvent) { ev.Resumed = true })
+			}
+		},
+		OnManifestSet: func(m wire.Manifest) {
+			r.mu.Lock()
+			r.files = r.files[:0]
+			r.totalBytes = m.TotalSize
+			for _, f := range m.Files {
+				r.files = append(r.files, FileInfo{Name: f.Name, Size: f.Size})
+			}
+			r.mu.Unlock()
+			r.publish("manifest")
+		},
+		OnTransport:    r.onTransport,
+		OnConnect:      func() { r.publish("connect") },
+		OnFileProgress: r.onFileProgress,
+		OnResumeProgress: func(reusedBytes int64) {
+			r.mu.Lock()
+			r.reused = reusedBytes
+			r.mu.Unlock()
+		},
+		OnProgress: func(n int64) {
+			r.mu.Lock()
+			r.doneBytes = n
+			r.recordSample(n)
+			r.mu.Unlock()
+			emitProgress()
+		},
+		OnControls: func(c transfer.Controls) {
+			r.mu.Lock()
+			r.controls = c
+			r.mu.Unlock()
+			r.publish("connect")
+		},
+		OnStateChange: r.onState,
+	}
+
+	out, err := transfer.Run(ctx, sig, spec)
+	if err != nil {
+		r.fail(err.Error())
+		if r.svc.notifier != nil {
+			r.svc.notifier.NotifyFailure("Transfer Failed", err.Error())
+		}
+		return
+	}
+	r.mu.Lock()
+	r.doneBytes = out.Size
+	r.filesDone = len(out.Files)
+	if out.Handshake != nil {
+		r.fingerprint = fingerprint(out.Handshake.Master)
+	}
+	r.mu.Unlock()
+
+	outPath := out.Path
+	if len(out.Files) > 1 {
+		outPath = destDir
+	}
+
+	r.publish("done", func(ev *TransferEvent) {
+		ev.Digest = out.Digest
+		ev.OutDir = destDir
+		if len(out.Files) == 1 {
+			ev.OutPath = out.Path
+		}
+		ev.Percent = 100
+	})
+
+	if r.svc.notifier != nil {
+		label := out.Name
+		if len(out.Files) > 1 {
+			label = fmt.Sprintf("%d files", len(out.Files))
+		}
+		summary := fmt.Sprintf("Received %s (%s) into %s", label, humanBytes(out.Size), destDir)
+		r.svc.notifier.NotifySuccess("Transfer Complete", summary, outPath)
+	}
 }
 
 func (r *transferRun) onTransport(path string) {
@@ -596,6 +1237,26 @@ func (r *transferRun) fail(why string) {
 	r.failed = true
 	r.mu.Unlock()
 	r.publish("error", func(ev *TransferEvent) { ev.Error = why })
+}
+
+// durableStatus renders receiver-side state class.
+func durableStatus(entry transfer.DurableEntry) string {
+	switch {
+	case !entry.PartialOK:
+		return "Partial data missing — inspect/discard"
+	case !entry.HasResumeSecret:
+		return "Legacy — restart required"
+	default:
+		return "Ready to resume"
+	}
+}
+
+// senderStatus renders sender-side state class.
+func senderStatus(entry transfer.SenderEntry) string {
+	if !entry.HasResumeSecret {
+		return "Legacy — restart required (no resume credential)"
+	}
+	return "Ready to resume (re-run to resume with receiver)"
 }
 
 // fingerprint renders the SAS fingerprint from the session master, matching
@@ -648,7 +1309,7 @@ func qrDataURL(link string) string {
 
 // validatePaths rejects symbolic links and missing paths up front with the
 // engine's rules (NewOSFileSources re-validates; this keeps picker feedback
-// instant).
+// instant). Also verifies canonical relative path safety to prevent destination escape.
 func validatePaths(paths []string) error {
 	for _, p := range paths {
 		info, err := os.Lstat(p)
@@ -661,8 +1322,27 @@ func validatePaths(paths []string) error {
 		if !info.IsDir() && !info.Mode().IsRegular() {
 			return fmt.Errorf("not a regular file or folder: %s", p)
 		}
+		// Validate base filename cannot contain traversal or invalid characters
+		base := filepath.Base(p)
+		if _, err := wire.NormalizeTransferPath(base); err != nil {
+			return fmt.Errorf("invalid file path %s: %w", p, err)
+		}
 	}
 	return nil
+}
+
+// humanBytes formats byte counts cleanly.
+func humanBytes(n int64) string {
+	if n >= 1<<30 {
+		return fmt.Sprintf("%.2f GiB", float64(n)/float64(1<<30))
+	}
+	if n >= 1<<20 {
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(1<<20))
+	}
+	if n >= 1<<10 {
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(1<<10))
+	}
+	return fmt.Sprintf("%d B", n)
 }
 
 // formatETA renders a duration like the CLI (e.g. "2m 5s remaining").

--- a/apps/desktop/internal/lifecycle/lifecycle_test.go
+++ b/apps/desktop/internal/lifecycle/lifecycle_test.go
@@ -1,0 +1,180 @@
+package lifecycle
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSingleInstanceLock(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "sendbeam.lock")
+
+	// 1. First acquisition succeeds
+	lock1, err := AcquireSingleInstanceLock(lockPath)
+	if err != nil {
+		t.Fatalf("first AcquireSingleInstanceLock failed: %v", err)
+	}
+	if lock1 == nil {
+		t.Fatalf("lock1 is nil")
+	}
+	defer func() { _ = lock1.Release() }()
+
+	// 2. Second concurrent acquisition on same lock file must fail with ErrAnotherInstanceRunning
+	lock2, err := AcquireSingleInstanceLock(lockPath)
+	if err == nil || !errors.Is(err, ErrAnotherInstanceRunning) {
+		if lock2 != nil {
+			_ = lock2.Release()
+		}
+		t.Fatalf("second AcquireSingleInstanceLock returned err = %v, want ErrAnotherInstanceRunning", err)
+	}
+
+	// 3. Release first lock
+	if err := lock1.Release(); err != nil {
+		t.Fatalf("Release lock1 failed: %v", err)
+	}
+
+	// 4. Third acquisition now succeeds
+	lock3, err := AcquireSingleInstanceLock(lockPath)
+	if err != nil {
+		t.Fatalf("third AcquireSingleInstanceLock after release failed: %v", err)
+	}
+	if lock3 == nil {
+		t.Fatalf("lock3 is nil")
+	}
+	_ = lock3.Release()
+}
+
+func TestRevealPathValidation(t *testing.T) {
+	dir := t.TempDir()
+	file1 := filepath.Join(dir, "hello.txt")
+	if err := os.WriteFile(file1, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	otherDir := t.TempDir()
+	otherFile := filepath.Join(otherDir, "outside.txt")
+	if err := os.WriteFile(otherFile, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		targetPath   string
+		allowedRoots []string
+		wantErr      error
+	}{
+		{
+			name:         "empty path",
+			targetPath:   "",
+			allowedRoots: []string{dir},
+			wantErr:      ErrInvalidPath,
+		},
+		{
+			name:         "control characters",
+			targetPath:   dir + "/\x00evil.txt",
+			allowedRoots: []string{dir},
+			wantErr:      ErrInvalidPath,
+		},
+		{
+			name:         "non-existent file",
+			targetPath:   filepath.Join(dir, "missing.txt"),
+			allowedRoots: []string{dir},
+			wantErr:      ErrPathNotFound,
+		},
+		{
+			name:         "file outside allowed root",
+			targetPath:   otherFile,
+			allowedRoots: []string{dir},
+			wantErr:      ErrPathOutsideRoot,
+		},
+		{
+			name:         "valid file inside allowed root",
+			targetPath:   file1,
+			allowedRoots: []string{dir},
+			wantErr:      nil,
+		},
+		{
+			name:         "valid directory without root restrictions",
+			targetPath:   dir,
+			allowedRoots: nil,
+			wantErr:      nil,
+		},
+		{
+			name:         "traversal attempting escape",
+			targetPath:   filepath.Join(dir, "..", filepath.Base(otherDir), "outside.txt"),
+			allowedRoots: []string{dir},
+			wantErr:      ErrPathOutsideRoot,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ValidatePath(tt.targetPath, tt.allowedRoots...)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("ValidatePath unexpected error: %v", err)
+				}
+			} else {
+				if err == nil || !errors.Is(err, tt.wantErr) {
+					t.Fatalf("ValidatePath error = %v, want %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestRevealManager(t *testing.T) {
+	dir := t.TempDir()
+	file1 := filepath.Join(dir, "data.bin")
+	if err := os.WriteFile(file1, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var launchedPath string
+	mgr := NewRevealManager(func(target string) error {
+		launchedPath = target
+		return nil
+	})
+
+	if err := mgr.Reveal(file1, dir); err != nil {
+		t.Fatalf("Reveal failed: %v", err)
+	}
+	if launchedPath != file1 {
+		t.Errorf("launchedPath = %q, want %q", launchedPath, file1)
+	}
+
+	// Reveal invalid path fails without calling launcher
+	launchedPath = ""
+	if err := mgr.Reveal(filepath.Join(dir, "nonexistent.bin"), dir); err == nil {
+		t.Fatalf("Reveal nonexistent expected error, got nil")
+	}
+	if launchedPath != "" {
+		t.Errorf("launcher was called on invalid path")
+	}
+}
+
+func TestTestNotifier(t *testing.T) {
+	notifier := NewTestNotifier()
+
+	notifier.NotifySuccess("Transfer Complete", "file.txt received (100 KiB)", "/tmp/file.txt")
+	notifier.NotifyFailure("Transfer Failed", "network error")
+
+	events := notifier.Events()
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	if events[0].Kind != "success" || events[0].Title != "Transfer Complete" || events[0].Path != "/tmp/file.txt" {
+		t.Errorf("event[0] = %+v, want success event", events[0])
+	}
+	if events[1].Kind != "failure" || events[1].Title != "Transfer Failed" || !strings.Contains(events[1].Message, "network error") {
+		t.Errorf("event[1] = %+v, want failure event", events[1])
+	}
+
+	notifier.Reset()
+	if len(notifier.Events()) != 0 {
+		t.Errorf("Events after reset not empty: %v", notifier.Events())
+	}
+}

--- a/apps/desktop/internal/lifecycle/lock.go
+++ b/apps/desktop/internal/lifecycle/lock.go
@@ -1,3 +1,5 @@
+// Package lifecycle manages desktop lifecycle events, single-instance locking,
+// notifications, and OS integration.
 package lifecycle
 
 import (

--- a/apps/desktop/internal/lifecycle/lock.go
+++ b/apps/desktop/internal/lifecycle/lock.go
@@ -1,0 +1,26 @@
+package lifecycle
+
+import (
+	"errors"
+	"os"
+)
+
+var (
+	// ErrAnotherInstanceRunning is returned when another SendBeam Desktop process
+	// holds the single-instance lock.
+	ErrAnotherInstanceRunning = errors.New("another SendBeam Desktop instance is already running")
+)
+
+// SingleInstanceLock represents an active single-instance lock file.
+type SingleInstanceLock struct {
+	file *os.File
+	path string
+}
+
+// Path returns the path of the lock file.
+func (l *SingleInstanceLock) Path() string {
+	if l == nil {
+		return ""
+	}
+	return l.path
+}

--- a/apps/desktop/internal/lifecycle/lock_unix.go
+++ b/apps/desktop/internal/lifecycle/lock_unix.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package lifecycle
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// AcquireSingleInstanceLock attempts to acquire an exclusive non-blocking lock on path.
+// If another process holds the lock, it returns ErrAnotherInstanceRunning.
+func AcquireSingleInstanceLock(path string) (*SingleInstanceLock, error) {
+	if path == "" {
+		return nil, errors.New("lock path cannot be empty")
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create lock dir: %w", err)
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	// Try non-blocking exclusive flock
+	err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) || err == syscall.Errno(0x23) {
+			return nil, ErrAnotherInstanceRunning
+		}
+		return nil, fmt.Errorf("acquire file lock: %w", err)
+	}
+
+	// Write PID into lock file for diagnostics
+	_ = file.Truncate(0)
+	_, _ = file.Seek(0, 0)
+	_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
+	_ = file.Sync()
+
+	return &SingleInstanceLock{
+		file: file,
+		path: path,
+	}, nil
+}
+
+// Release releases the lock, closes the file, and removes the lock file.
+func (l *SingleInstanceLock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	_ = l.file.Close()
+	_ = os.Remove(l.path)
+	l.file = nil
+	return nil
+}

--- a/apps/desktop/internal/lifecycle/lock_windows.go
+++ b/apps/desktop/internal/lifecycle/lock_windows.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+package lifecycle
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// AcquireSingleInstanceLock on Windows opens the file with exclusive access (no sharing),
+// preventing another instance from opening or acquiring it.
+func AcquireSingleInstanceLock(path string) (*SingleInstanceLock, error) {
+	if path == "" {
+		return nil, errors.New("lock path cannot be empty")
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create lock dir: %w", err)
+	}
+
+	path16, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create/open file with exclusive access (dwShareMode = 0 -> no sharing)
+	h, err := syscall.CreateFile(
+		path16,
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+		0, // exclusive: no share read or write
+		nil,
+		syscall.OPEN_ALWAYS,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		if errors.Is(err, syscall.ERROR_SHARING_VIOLATION) || errors.Is(err, syscall.ERROR_ACCESS_DENIED) {
+			return nil, ErrAnotherInstanceRunning
+		}
+		return nil, fmt.Errorf("open exclusive lock file: %w", err)
+	}
+
+	file := os.NewFile(uintptr(h), path)
+	_ = file.Truncate(0)
+	_, _ = file.Seek(0, 0)
+	_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
+	_ = file.Sync()
+
+	return &SingleInstanceLock{
+		file: file,
+		path: path,
+	}, nil
+}
+
+// Release releases the lock and closes the file handle.
+func (l *SingleInstanceLock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	_ = l.file.Close()
+	_ = os.Remove(l.path)
+	l.file = nil
+	return nil
+}

--- a/apps/desktop/internal/lifecycle/notify.go
+++ b/apps/desktop/internal/lifecycle/notify.go
@@ -25,10 +25,10 @@ type Notifier interface {
 type SilentNotifier struct{}
 
 // NotifySuccess is a no-op for SilentNotifier.
-func (s *SilentNotifier) NotifySuccess(title, message, path string) {}
+func (s *SilentNotifier) NotifySuccess(_, _, _ string) {}
 
 // NotifyFailure is a no-op for SilentNotifier.
-func (s *SilentNotifier) NotifyFailure(title, message string) {}
+func (s *SilentNotifier) NotifyFailure(_, _ string) {}
 
 // TestNotifier records notifications in memory for assertions.
 type TestNotifier struct {

--- a/apps/desktop/internal/lifecycle/notify.go
+++ b/apps/desktop/internal/lifecycle/notify.go
@@ -1,0 +1,74 @@
+package lifecycle
+
+import (
+	"sync"
+)
+
+// NotificationEvent represents an emitted native notification.
+type NotificationEvent struct {
+	Kind    string // "success" | "failure"
+	Title   string
+	Message string
+	Path    string
+}
+
+// Notifier is the interface for emitting native desktop notifications.
+// Notifications MUST ONLY be emitted after verified transfer completion or failure.
+type Notifier interface {
+	NotifySuccess(title, message, path string)
+	NotifyFailure(title, message string)
+}
+
+// SilentNotifier is a no-op notifier for headless server mode or when notifications are disabled.
+type SilentNotifier struct{}
+
+func (s *SilentNotifier) NotifySuccess(title, message, path string) {}
+func (s *SilentNotifier) NotifyFailure(title, message string)       {}
+
+// TestNotifier records notifications in memory for assertions.
+type TestNotifier struct {
+	mu     sync.Mutex
+	events []NotificationEvent
+}
+
+// NewTestNotifier creates a TestNotifier.
+func NewTestNotifier() *TestNotifier {
+	return &TestNotifier{}
+}
+
+func (t *TestNotifier) NotifySuccess(title, message, path string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, NotificationEvent{
+		Kind:    "success",
+		Title:   title,
+		Message: message,
+		Path:    path,
+	})
+}
+
+func (t *TestNotifier) NotifyFailure(title, message string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, NotificationEvent{
+		Kind:    "failure",
+		Title:   title,
+		Message: message,
+	})
+}
+
+// Events returns a copy of all recorded events.
+func (t *TestNotifier) Events() []NotificationEvent {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]NotificationEvent, len(t.events))
+	copy(out, t.events)
+	return out
+}
+
+// Reset clears the recorded events.
+func (t *TestNotifier) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = nil
+}

--- a/apps/desktop/internal/lifecycle/notify.go
+++ b/apps/desktop/internal/lifecycle/notify.go
@@ -1,3 +1,5 @@
+// Package lifecycle manages desktop lifecycle events, single-instance locking,
+// notifications, and OS integration.
 package lifecycle
 
 import (
@@ -22,8 +24,11 @@ type Notifier interface {
 // SilentNotifier is a no-op notifier for headless server mode or when notifications are disabled.
 type SilentNotifier struct{}
 
+// NotifySuccess is a no-op for SilentNotifier.
 func (s *SilentNotifier) NotifySuccess(title, message, path string) {}
-func (s *SilentNotifier) NotifyFailure(title, message string)       {}
+
+// NotifyFailure is a no-op for SilentNotifier.
+func (s *SilentNotifier) NotifyFailure(title, message string) {}
 
 // TestNotifier records notifications in memory for assertions.
 type TestNotifier struct {
@@ -36,6 +41,7 @@ func NewTestNotifier() *TestNotifier {
 	return &TestNotifier{}
 }
 
+// NotifySuccess records a success notification event.
 func (t *TestNotifier) NotifySuccess(title, message, path string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -47,6 +53,7 @@ func (t *TestNotifier) NotifySuccess(title, message, path string) {
 	})
 }
 
+// NotifyFailure records a failure notification event.
 func (t *TestNotifier) NotifyFailure(title, message string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -61,14 +68,14 @@ func (t *TestNotifier) NotifyFailure(title, message string) {
 func (t *TestNotifier) Events() []NotificationEvent {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	out := make([]NotificationEvent, len(t.events))
-	copy(out, t.events)
-	return out
+	cpy := make([]NotificationEvent, len(t.events))
+	copy(cpy, t.events)
+	return cpy
 }
 
 // Reset clears the recorded events.
 func (t *TestNotifier) Reset() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.events = nil
+	t.events = t.events[:0]
 }

--- a/apps/desktop/internal/lifecycle/reveal.go
+++ b/apps/desktop/internal/lifecycle/reveal.go
@@ -1,3 +1,5 @@
+// Package lifecycle manages desktop lifecycle events, single-instance locking,
+// notifications, and OS integration.
 package lifecycle
 
 import (

--- a/apps/desktop/internal/lifecycle/reveal.go
+++ b/apps/desktop/internal/lifecycle/reveal.go
@@ -1,0 +1,117 @@
+package lifecycle
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	// ErrPathNotFound is returned when the path to reveal does not exist.
+	ErrPathNotFound = errors.New("path does not exist on disk")
+	// ErrPathOutsideRoot is returned when the path is not within the authorized directory root.
+	ErrPathOutsideRoot = errors.New("path is outside authorized destination directory")
+	// ErrInvalidPath is returned when a path contains invalid characters or traversal.
+	ErrInvalidPath = errors.New("invalid path")
+)
+
+// FileLauncher runs the platform-specific file manager command.
+type FileLauncher func(targetPath string) error
+
+// DefaultLauncher executes the native OS file manager to reveal targetPath.
+func DefaultLauncher(targetPath string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		cmd := exec.Command("/usr/bin/open", "-R", targetPath)
+		return cmd.Start()
+	case "windows":
+		cmd := exec.Command("explorer.exe", "/select,"+targetPath)
+		return cmd.Start()
+	default:
+		// Linux / BSD: Try org.freedesktop.FileManager1 via dbus if available,
+		// otherwise open the containing folder with xdg-open.
+		parent := filepath.Dir(targetPath)
+		cmd := exec.Command("xdg-open", parent)
+		return cmd.Start()
+	}
+}
+
+// RevealManager validates paths and opens the native file manager.
+type RevealManager struct {
+	launcher FileLauncher
+}
+
+// NewRevealManager creates a RevealManager with the given launcher (or DefaultLauncher if nil).
+func NewRevealManager(launcher FileLauncher) *RevealManager {
+	if launcher == nil {
+		launcher = DefaultLauncher
+	}
+	return &RevealManager{launcher: launcher}
+}
+
+// ValidatePath validates that targetPath is a safe, canonical path that exists on disk.
+// If allowedRoots are provided, targetPath must be inside (or equal to) at least one allowed root.
+func ValidatePath(targetPath string, allowedRoots ...string) (string, error) {
+	if targetPath == "" {
+		return "", fmt.Errorf("%w: path is empty", ErrInvalidPath)
+	}
+
+	// Reject null bytes and control characters
+	for _, r := range targetPath {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("%w: path contains control characters", ErrInvalidPath)
+		}
+	}
+
+	absPath, err := filepath.Abs(filepath.Clean(targetPath))
+	if err != nil {
+		return "", fmt.Errorf("%w: resolve absolute path: %v", ErrInvalidPath, err)
+	}
+
+	// Verify file or directory actually exists on disk
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("%w: %s", ErrPathNotFound, absPath)
+		}
+		return "", fmt.Errorf("stat path %s: %w", absPath, err)
+	}
+	_ = fi
+
+	// If allowed roots are provided, ensure absPath is within one of them
+	if len(allowedRoots) > 0 {
+		authorized := false
+		for _, root := range allowedRoots {
+			if root == "" {
+				continue
+			}
+			absRoot, err := filepath.Abs(filepath.Clean(root))
+			if err != nil {
+				continue
+			}
+			rel, err := filepath.Rel(absRoot, absPath)
+			if err == nil && !strings.HasPrefix(rel, "..") && rel != ".." {
+				authorized = true
+				break
+			}
+		}
+		if !authorized {
+			return "", fmt.Errorf("%w: %s is not within allowed destination roots %v", ErrPathOutsideRoot, absPath, allowedRoots)
+		}
+	}
+
+	return absPath, nil
+}
+
+// Reveal validates targetPath and reveals it in the native file manager.
+func (r *RevealManager) Reveal(targetPath string, allowedRoots ...string) error {
+	validated, err := ValidatePath(targetPath, allowedRoots...)
+	if err != nil {
+		return err
+	}
+	return r.launcher(validated)
+}

--- a/apps/desktop/main.go
+++ b/apps/desktop/main.go
@@ -13,22 +13,49 @@ package main
 
 import (
 	"embed"
+	"errors"
+	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
 
+	"github.com/sendbeam/desktop/internal/config"
 	"github.com/sendbeam/desktop/internal/engine"
+	"github.com/sendbeam/desktop/internal/lifecycle"
 )
 
 //go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {
+	// Single-instance lock: ensure only one authoritative desktop process runs
+	// to prevent racing on transfer journals, config, or destinations.
+	lockPath := filepath.Join(os.TempDir(), "sendbeam.lock")
+	if configDir, err := os.UserConfigDir(); err == nil {
+		lockPath = filepath.Join(configDir, config.AppDirName, "sendbeam.lock")
+	}
+	lock, err := lifecycle.AcquireSingleInstanceLock(lockPath)
+	if err != nil {
+		if errors.Is(err, lifecycle.ErrAnotherInstanceRunning) {
+			fmt.Fprintln(os.Stderr, "SendBeam Desktop: another instance is already running; focusing existing process.")
+			os.Exit(0)
+		}
+		log.Printf("Warning: single-instance lock unavailable: %v", err)
+	}
+	if lock != nil {
+		defer func() { _ = lock.Release() }()
+	}
+
 	transferSvc := engine.NewTransferService(
 		// Emit every transfer snapshot to the frontend.
 		func(name string, data any) {
-			application.Get().Event.Emit(name, data)
+			if app := application.Get(); app != nil && app.Event != nil {
+				app.Event.Emit(name, data)
+			}
 		},
 		// Real signaling server (same wsclient the CLI uses → browser/CLI interop).
 		nil,
@@ -79,20 +106,27 @@ func main() {
 		}
 		h, err := transferSvc.Drop(paths)
 		if err != nil {
-			application.Get().Event.Emit(engine.TransferEventName, map[string]any{
-				"kind":  "error",
-				"error": err.Error(),
-			})
+			if a := application.Get(); a != nil && a.Event != nil {
+				a.Event.Emit(engine.TransferEventName, map[string]any{
+					"kind":  "error",
+					"error": err.Error(),
+				})
+			}
 			return
 		}
-		application.Get().Event.Emit(engine.TransferEventName, map[string]any{
-			"kind":  "drop",
-			"id":    h.ID,
-			"files": paths,
-		})
+		if a := application.Get(); a != nil && a.Event != nil {
+			a.Event.Emit(engine.TransferEventName, map[string]any{
+				"kind":  "drop",
+				"id":    h.ID,
+				"files": paths,
+			})
+		}
 	})
 
 	if err := app.Run(); err != nil {
 		log.Fatal(err)
 	}
+
+	// Bounded graceful teardown upon exit: cancel active transfers cleanly
+	_ = transferSvc.Shutdown(3 * time.Second)
 }


### PR DESCRIPTION
## Summary
- Reuses shared engine v1.3 journal-based durability in the desktop client (`ListInterrupted`, `InspectInterrupted`, `ResumeInterrupted`, `DiscardInterrupted`, `DiscardAllInterrupted`).
- Implements safe filesystem finalization with `.part` files under `.sendbeam/partials/`, whole-file SHA-256 digest verification before promotion, canonical path validation, and path traversal defense.
- Introduces OS-portable single-instance locking (`flock` on Unix, exclusive sharing on Windows) to prevent racing on transfer journals or configurations.
- Adds OS-protected persistent secret storage abstraction with explicit fail-closed degradation and atomic 0600 file-backed desktop configuration.
- Enforces strict security defaults: `AutoAccept` is strictly disabled by default.
- Implements safe native `RevealInFolder` and verifies that completion notifications are emitted only after whole-file verification passes.