### PR TITLE
fix(desktop): finish platform lifecycle security

### DIFF
--- a/apps/desktop/internal/config/config.go
+++ b/apps/desktop/internal/config/config.go
@@ -73,6 +73,17 @@ func (c *DesktopConfig) Validate() error {
 			!strings.HasPrefix(ice, "turn:") && !strings.HasPrefix(ice, "turns:") {
 			return fmt.Errorf("invalid ice server url %q (must begin with stun:, stuns:, turn:, or turns)", ice)
 		}
+		// Embedded passwords in configuration are strictly forbidden to prevent plaintext secret leaks.
+		if strings.HasPrefix(ice, "turn:") || strings.HasPrefix(ice, "turns:") {
+			rest := strings.TrimPrefix(strings.TrimPrefix(ice, "turns:"), "turn:")
+			rest = strings.TrimPrefix(rest, "//")
+			if atIdx := strings.LastIndex(rest, "@"); atIdx != -1 {
+				userInfo := rest[:atIdx]
+				if strings.Contains(userInfo, ":") {
+					return fmt.Errorf("invalid ice server %q: embedded passwords are forbidden in configuration; store credentials through the protected credential store", ice)
+				}
+			}
+		}
 	}
 	if c.Theme != "" && c.Theme != "system" && c.Theme != "dark" && c.Theme != "light" {
 		return fmt.Errorf("invalid theme %q (must be system, dark, or light)", c.Theme)

--- a/apps/desktop/internal/config/config_test.go
+++ b/apps/desktop/internal/config/config_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -43,7 +45,7 @@ func TestConfigStoreLoadSave(t *testing.T) {
 	// 2. Modify and save config
 	custom := loaded
 	custom.ServerURL = "wss://custom.example.com:9000/ws"
-	custom.ICEServers = []string{"stun:stun1.example.com:3478", "turn:turn.example.com:3478"}
+	custom.ICEServers = []string{"stun:stun1.example.com:3478", "turn:turnuser@turn.example.com:3478"}
 	custom.DownloadDir = filepath.Join(dir, "downloads")
 	custom.CloseToTray = true
 	custom.Theme = "dark"
@@ -132,11 +134,25 @@ func TestConfigValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "valid STUN and TURN urls",
+			name: "valid STUN and username-only TURN urls",
 			mutate: func(c *DesktopConfig) {
-				c.ICEServers = []string{"stun:stun.example.com", "turns:turn.example.com:5349"}
+				c.ICEServers = []string{"stun:stun.example.com", "turn:beamuser@turn.example.com:3478", "turns:relay.example.com:5349"}
 			},
 			wantErr: false,
+		},
+		{
+			name: "embedded TURN password in config is forbidden",
+			mutate: func(c *DesktopConfig) {
+				c.ICEServers = []string{"turn:beamuser:plaintextpassword@turn.example.com:3478"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "embedded TURNS password with slashes is forbidden",
+			mutate: func(c *DesktopConfig) {
+				c.ICEServers = []string{"turns://beamuser:secret123@relay.example.com:5349"}
+			},
+			wantErr: true,
 		},
 		{
 			name: "invalid theme",
@@ -304,5 +320,65 @@ func TestUnavailableSecretStoreRefusesPlaintextPersistence(t *testing.T) {
 		if e.Name() != ConfigFileName {
 			t.Fatalf("unexpected file %q created on disk when secret store is unavailable", e.Name())
 		}
+	}
+}
+
+func TestDPAPICiphertextBlobRoundTrip(t *testing.T) {
+	testPayloads := [][]byte{
+		[]byte("simple-ascii-secret"),
+		[]byte(""),
+		[]byte("\x00\x01\x02\x03\xff\xfe\xfd\x00binary-data"),
+		[]byte("unicode-🔑-secret-🔒-token"),
+		bytes.Repeat([]byte("A"), 4096),
+	}
+
+	for _, payload := range testPayloads {
+		encoded := EncodeDPAPICiphertextBlob(payload)
+		decoded, err := DecodeDPAPICiphertextBlob(encoded)
+		if err != nil {
+			t.Fatalf("DecodeDPAPICiphertextBlob error: %v", err)
+		}
+		if !bytes.Equal(decoded, payload) {
+			t.Fatalf("DPAPI round-trip mismatch: got %v, want %v", decoded, payload)
+		}
+	}
+
+	// Corrupt Base64 decoding fails safely
+	if _, err := DecodeDPAPICiphertextBlob("!!!not-valid-base64!!!"); err == nil {
+		t.Fatalf("DecodeDPAPICiphertextBlob on corrupt data expected error, got nil")
+	}
+}
+
+func TestConfigFileContainsNoSecrets(t *testing.T) {
+	dir := t.TempDir()
+	memSecret := NewMemorySecretStore()
+	store, err := NewStore(dir, memSecret)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	serverURL := "turn:relay.sendbeam.org:3478"
+	username := "beamuser"
+	secretPass := "ultra-confidential-password-xyz"
+
+	// 1. Save TURN password to SecretStore
+	if err := store.SaveTurnCredential(serverURL, username, []byte(secretPass)); err != nil {
+		t.Fatalf("SaveTurnCredential: %v", err)
+	}
+
+	// 2. Save desktop config with non-secret ICE server URL
+	cfg := DefaultConfig()
+	cfg.ICEServers = []string{"stun:stun1.example.com:3478", "turn:beamuser@relay.sendbeam.org:3478"}
+	if err := store.Save(cfg); err != nil {
+		t.Fatalf("Save config: %v", err)
+	}
+
+	// 3. Inspect raw desktop_config.json on disk
+	rawJSON, err := os.ReadFile(store.ConfigPath())
+	if err != nil {
+		t.Fatalf("ReadFile config: %v", err)
+	}
+	if strings.Contains(string(rawJSON), secretPass) {
+		t.Fatalf("desktop_config.json leaked secret password! content: %s", string(rawJSON))
 	}
 }

--- a/apps/desktop/internal/config/secret_store.go
+++ b/apps/desktop/internal/config/secret_store.go
@@ -4,6 +4,7 @@ package config
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -146,6 +147,9 @@ func NewDarwinKeychainSecretStore(serviceName string) *DarwinKeychainSecretStore
 
 // Get retrieves a generic password from the macOS Keychain.
 func (d *DarwinKeychainSecretStore) Get(key string) ([]byte, error) {
+	if !d.IsAvailable() {
+		return nil, ErrSecretStoreUnavailable
+	}
 	cmd := exec.Command("/usr/bin/security", "find-generic-password", "-s", d.serviceName, "-a", key, "-w")
 	out, err := cmd.Output()
 	if err != nil {
@@ -157,6 +161,9 @@ func (d *DarwinKeychainSecretStore) Get(key string) ([]byte, error) {
 
 // Set saves or updates a generic password in the macOS Keychain.
 func (d *DarwinKeychainSecretStore) Set(key string, secret []byte) error {
+	if !d.IsAvailable() {
+		return ErrSecretStoreUnavailable
+	}
 	if key == "" {
 		return errors.New("secret key cannot be empty")
 	}
@@ -169,14 +176,21 @@ func (d *DarwinKeychainSecretStore) Set(key string, secret []byte) error {
 
 // Delete removes a generic password from the macOS Keychain.
 func (d *DarwinKeychainSecretStore) Delete(key string) error {
+	if !d.IsAvailable() {
+		return nil
+	}
 	cmd := exec.Command("/usr/bin/security", "delete-generic-password", "-s", d.serviceName, "-a", key)
 	_ = cmd.Run()
 	return nil
 }
 
-// IsAvailable reports true when running on Darwin.
+// IsAvailable reports true on Darwin when security CLI is in PATH.
 func (d *DarwinKeychainSecretStore) IsAvailable() bool {
-	return runtime.GOOS == "darwin"
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	_, err := exec.LookPath("security")
+	return err == nil
 }
 
 // BackendName returns "macos-keychain".
@@ -275,6 +289,16 @@ func (w *WindowsDPAPIStore) keyPath(key string) string {
 	return filepath.Join(w.storageDir, hex.EncodeToString(h[:])+".dpapi")
 }
 
+// EncodeDPAPICiphertextBlob formats DPAPI protected ciphertext into a Base64 string for disk storage.
+func EncodeDPAPICiphertextBlob(rawCiphertext []byte) string {
+	return base64.StdEncoding.EncodeToString(rawCiphertext)
+}
+
+// DecodeDPAPICiphertextBlob parses a Base64 string from disk into raw DPAPI ciphertext bytes.
+func DecodeDPAPICiphertextBlob(b64Ciphertext string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(strings.TrimSpace(b64Ciphertext))
+}
+
 // Get reads and decrypts a DPAPI-protected secret.
 func (w *WindowsDPAPIStore) Get(key string) ([]byte, error) {
 	if !w.IsAvailable() {
@@ -289,15 +313,22 @@ func (w *WindowsDPAPIStore) Get(key string) ([]byte, error) {
 		return nil, fmt.Errorf("read dpapi file: %w", err)
 	}
 
-	// Decrypt via PowerShell ProtectedData
-	script := fmt.Sprintf(`[Convert]::ToBase64String([System.Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String('%s'), $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser))`, strings.TrimSpace(string(encData)))
+	// Validate ciphertext format
+	if _, err := DecodeDPAPICiphertextBlob(string(encData)); err != nil {
+		return nil, fmt.Errorf("corrupt dpapi ciphertext file: %w", err)
+	}
+
+	// Unprotect via PowerShell ProtectedData reading Base64 ciphertext from stdin
+	// and outputting Base64 decrypted plaintext to stdout (no secrets in command line args).
+	script := `$in = [Console]::In.ReadToEnd().Trim(); if ([string]::IsNullOrEmpty($in)) { exit 1 }; $enc = [Convert]::FromBase64String($in); $raw = [System.Security.Cryptography.ProtectedData]::Unprotect($enc, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser); [Console]::Out.Write([Convert]::ToBase64String($raw))`
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd.Stdin = strings.NewReader(strings.TrimSpace(string(encData)))
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("dpapi unprotect error: %w", err)
 	}
 	dec64 := strings.TrimSpace(string(out))
-	return hex.DecodeString(dec64)
+	return base64.StdEncoding.DecodeString(dec64)
 }
 
 // Set encrypts and writes a DPAPI-protected secret.
@@ -312,17 +343,24 @@ func (w *WindowsDPAPIStore) Set(key string, secret []byte) error {
 		return fmt.Errorf("create secrets dir: %w", err)
 	}
 
-	hexSecret := hex.EncodeToString(secret)
-	script := fmt.Sprintf(`[Convert]::ToBase64String([System.Security.Cryptography.ProtectedData]::Protect([System.Text.Encoding]::UTF8.GetBytes('%s'), $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser))`, hexSecret)
+	// Protect via PowerShell ProtectedData reading Base64 plaintext from stdin
+	// and outputting Base64 ciphertext to stdout (no secrets in command line args).
+	script := `$in = [Console]::In.ReadToEnd().Trim(); if ([string]::IsNullOrEmpty($in)) { exit 1 }; $raw = [Convert]::FromBase64String($in); $enc = [System.Security.Cryptography.ProtectedData]::Protect($raw, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser); [Console]::Out.Write([Convert]::ToBase64String($enc))`
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd.Stdin = strings.NewReader(base64.StdEncoding.EncodeToString(secret))
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("dpapi protect error: %w", err)
 	}
 
+	b64Ciphertext := strings.TrimSpace(string(out))
+	if _, err := DecodeDPAPICiphertextBlob(b64Ciphertext); err != nil {
+		return fmt.Errorf("invalid dpapi output ciphertext: %w", err)
+	}
+
 	p := w.keyPath(key)
 	tmp := p + ".tmp"
-	if err := os.WriteFile(tmp, []byte(strings.TrimSpace(string(out))), 0o600); err != nil {
+	if err := os.WriteFile(tmp, []byte(b64Ciphertext), 0o600); err != nil {
 		return fmt.Errorf("write dpapi file: %w", err)
 	}
 	if err := os.Rename(tmp, p); err != nil {
@@ -341,9 +379,13 @@ func (w *WindowsDPAPIStore) Delete(key string) error {
 	return nil
 }
 
-// IsAvailable reports true when running on Windows.
+// IsAvailable reports true when running on Windows and PowerShell is in PATH.
 func (w *WindowsDPAPIStore) IsAvailable() bool {
-	return runtime.GOOS == "windows"
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	_, err := exec.LookPath("powershell")
+	return err == nil
 }
 
 // BackendName returns "windows-dpapi".

--- a/apps/desktop/internal/engine/durability_test.go
+++ b/apps/desktop/internal/engine/durability_test.go
@@ -254,6 +254,52 @@ func TestDesktopDurableResumeHappyPath(t *testing.T) {
 	_ = hub
 }
 
+func TestDesktopRevealCompletedBoundToArbitraryDestination(t *testing.T) {
+	svc, sink, hub := newLoopbackService(t)
+	dir := t.TempDir()
+	// Destination chosen outside standard Downloads/Desktop/CWD/tmp
+	customDestDir := filepath.Join(dir, "custom_arbitrary_picker_destination_xyz")
+	if err := os.MkdirAll(customDestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	srcFile := writePayload(t, dir, "arbitrary_doc.pdf", 64*1024)
+
+	send, err := svc.Send([]string{srcFile}, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	invite := sink.waitFor(t, "invite", 10*time.Second)
+
+	recv, err := svc.Receive(invite.Code, customDestDir, "wss://loopback/ws")
+	if err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+
+	sink.waitForID(t, send.ID, "done", 10*time.Second)
+	sink.waitForID(t, recv.ID, "done", 10*time.Second)
+
+	var revealedPath string
+	rm := lifecycle.NewRevealManager(func(target string) error {
+		revealedPath = target
+		return nil
+	})
+	svc.SetRevealManager(rm)
+
+	// RevealCompleted succeeds because destination root was faithfully recorded
+	if err := svc.RevealCompleted(recv.ID); err != nil {
+		t.Fatalf("RevealCompleted on arbitrary custom destination failed: %v", err)
+	}
+
+	expected := filepath.Join(customDestDir, "arbitrary_doc.pdf")
+	realExpected, _ := filepath.EvalSymlinks(expected)
+	if revealedPath != realExpected && revealedPath != expected {
+		t.Errorf("revealedPath = %q, want %q", revealedPath, expected)
+	}
+
+	_ = hub
+}
+
 func TestDesktopDurableResumeRefusesCorruptJournal(t *testing.T) {
 	svc, sink, _ := newLoopbackService(t)
 	dir := t.TempDir()
@@ -411,6 +457,30 @@ func TestDesktopPersistedICEServersApplication(t *testing.T) {
 	}
 }
 
+func TestDesktopRejectEmbeddedTURNPassword(t *testing.T) {
+	dir := t.TempDir()
+	memSecret := config.NewMemorySecretStore()
+	cfgStore, err := config.NewStore(dir, memSecret)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// Bypass Validate() to simulate malicious or legacy file with embedded password
+	cfg := config.DefaultConfig()
+	cfg.ICEServers = []string{"turn:beamuser:embeddedpwd@relay.custom.org:3478"}
+
+	svc := NewTransferService(nil, nil)
+	svc.SetConfigStore(cfgStore)
+
+	// Save raw config bypass
+	_ = os.WriteFile(cfgStore.ConfigPath(), []byte(`{"iceServers":["turn:beamuser:embeddedpwd@relay.custom.org:3478"]}`), 0o600)
+
+	_, err = svc.resolveICEServers()
+	if err == nil || !strings.Contains(err.Error(), "embedded password") {
+		t.Fatalf("resolveICEServers expected embedded password rejection error, got %v", err)
+	}
+}
+
 func TestDesktopTurnCredentialUnavailableDegradation(t *testing.T) {
 	dir := t.TempDir()
 	unavail := config.NewUnavailableSecretStore("explicit test unavailable")
@@ -431,26 +501,6 @@ func TestDesktopTurnCredentialUnavailableDegradation(t *testing.T) {
 	_, err = svc.resolveICEServers()
 	if err == nil || !strings.Contains(err.Error(), "protected secret store is unavailable") {
 		t.Fatalf("resolveICEServers expected secret store unavailable error, got %v", err)
-	}
-}
-
-func TestDesktopLifecycleHooks(t *testing.T) {
-	sink := &eventSink{}
-	svc := NewTransferService(sink.emit, nil)
-
-	// Call lifecycle hooks
-	svc.OnSuspend()
-	svc.OnResume()
-	svc.OnNetworkChange()
-
-	events := sink.all()
-	if len(events) != 3 {
-		t.Fatalf("expected 3 lifecycle events, got %d", len(events))
-	}
-	for i, ev := range events {
-		if ev.Kind != "lifecycle" {
-			t.Errorf("events[%d].Kind = %q, want 'lifecycle'", i, ev.Kind)
-		}
 	}
 }
 

--- a/apps/desktop/internal/engine/transfer_service.go
+++ b/apps/desktop/internal/engine/transfer_service.go
@@ -3,6 +3,11 @@
 // in the Go engine (packages/engine); these services are only a thin
 // presentation seam, exactly as the CLI consumes the engine through its
 // public API.
+//
+// Lifecycle & Network Recovery Architecture:
+// Desktop network disruption, host sleep/wake recovery, and transport reconnection
+// are driven automatically by the engine's adaptive supervisor and reconnecting
+// signaling transport (packages/engine/wsclient and packages/engine/transfer).
 package engine
 
 import (
@@ -125,6 +130,12 @@ type DurableInspectResult struct {
 	Files               []FileInfo `json:"files,omitempty"`
 }
 
+// completedDestination stores the verified final output path alongside its exact trusted destination root.
+type completedDestination struct {
+	Path string
+	Root string
+}
+
 // SignalDialer returns the signaling signal for one transfer side. The desktop
 // uses the same wsclient as the CLI (browser/CLI interop by construction);
 // tests inject loopback ends.
@@ -157,7 +168,7 @@ type TransferService struct {
 	revealMgr             *lifecycle.RevealManager
 	senderStore           *transfer.SenderStore
 	durableStoreFn        func(outDir string) (*transfer.DurableStore, error)
-	completedDestinations map[string]string
+	completedDestinations map[string]completedDestination
 }
 
 // NewTransferService builds the service. emit is the frontend sink (wails
@@ -183,7 +194,7 @@ func NewTransferService(emit func(name string, data any), dial SignalDialer) *Tr
 		revealMgr:             lifecycle.NewRevealManager(nil),
 		senderStore:           sStore,
 		durableStoreFn:        transfer.OpenStore,
-		completedDestinations: map[string]string{},
+		completedDestinations: map[string]completedDestination{},
 	}
 }
 
@@ -232,30 +243,10 @@ func (s *TransferService) openDurableStore(outDir string) (*transfer.DurableStor
 	return fn(outDir)
 }
 
-func (s *TransferService) recordCompleted(id, outPath string) {
+func (s *TransferService) recordCompleted(id string, dest completedDestination) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.completedDestinations[id] = outPath
-}
-
-func (s *TransferService) authorizedRoots() []string {
-	var roots []string
-	if s.configStore != nil {
-		if cfg, err := s.configStore.Load(); err == nil && cfg.DownloadDir != "" {
-			roots = append(roots, cfg.DownloadDir)
-		}
-	}
-	if userHome, err := os.UserHomeDir(); err == nil {
-		roots = append(roots, filepath.Join(userHome, "Downloads"))
-		roots = append(roots, filepath.Join(userHome, "Desktop"))
-	}
-	if wd, err := os.Getwd(); err == nil {
-		roots = append(roots, wd)
-	}
-	if tmp := os.TempDir(); tmp != "" {
-		roots = append(roots, tmp)
-	}
-	return roots
+	s.completedDestinations[id] = dest
 }
 
 func parseTURNServer(rawURL string) (urlNoUser, username, password string) {
@@ -317,28 +308,26 @@ func (s *TransferService) resolveICEServers() ([]webrtc.ICEServer, error) {
 		}
 		if strings.HasPrefix(raw, "turn:") || strings.HasPrefix(raw, "turns:") {
 			urlNoUser, username, pwd := parseTURNServer(raw)
+			if pwd != "" {
+				return nil, fmt.Errorf("turn server %q contains an embedded password; storing credentials in configuration is forbidden", raw)
+			}
 			srv := webrtc.ICEServer{
 				URLs: []string{urlNoUser},
 			}
 			if username != "" {
 				srv.Username = username
-				if pwd != "" {
-					srv.Credential = pwd
-					srv.CredentialType = webrtc.ICECredentialTypePassword
-				} else {
-					cred, err := cs.GetTurnCredential(urlNoUser, username)
-					if err != nil && !errors.Is(err, config.ErrSecretStoreUnavailable) {
-						cred, err = cs.GetTurnCredential(raw, username)
-					}
-					if err != nil {
-						if errors.Is(err, config.ErrSecretStoreUnavailable) {
-							return nil, fmt.Errorf("turn server %q requires credentials but protected secret store is unavailable: %w", raw, err)
-						}
-						return nil, fmt.Errorf("turn credential not found for %s (user %s): %w", raw, username, err)
-					}
-					srv.Credential = string(cred)
-					srv.CredentialType = webrtc.ICECredentialTypePassword
+				cred, err := cs.GetTurnCredential(urlNoUser, username)
+				if err != nil && !errors.Is(err, config.ErrSecretStoreUnavailable) {
+					cred, err = cs.GetTurnCredential(raw, username)
 				}
+				if err != nil {
+					if errors.Is(err, config.ErrSecretStoreUnavailable) {
+						return nil, fmt.Errorf("turn server %q requires credentials but protected secret store is unavailable: %w", raw, err)
+					}
+					return nil, fmt.Errorf("turn credential not found for %s (user %s): %w", raw, username, err)
+				}
+				srv.Credential = string(cred)
+				srv.CredentialType = webrtc.ICECredentialTypePassword
 			}
 			resolved = append(resolved, srv)
 		} else {
@@ -731,20 +720,21 @@ func (s *TransferService) DiscardAllInterrupted(outDir string) error {
 }
 
 // RevealCompleted reveals the verified completed transfer output in the OS file manager.
-// The backend derives the path from trusted transfer state rather than arbitrary frontend input.
+// The backend derives the path and bounds it strictly to the exact trusted destination root
+// recorded upon verified completion.
 func (s *TransferService) RevealCompleted(id string) error {
 	s.mu.Lock()
-	targetPath, ok := s.completedDestinations[id]
+	dest, ok := s.completedDestinations[id]
 	rm := s.revealMgr
 	s.mu.Unlock()
 
-	if !ok || targetPath == "" {
+	if !ok || dest.Path == "" || dest.Root == "" {
 		return fmt.Errorf("no verified completed output found for transfer %q", id)
 	}
 	if rm == nil {
 		rm = lifecycle.NewRevealManager(nil)
 	}
-	return rm.Reveal(targetPath, s.authorizedRoots()...)
+	return rm.Reveal(dest.Path, dest.Root)
 }
 
 // GetConfig returns the desktop persistent configuration.
@@ -774,36 +764,6 @@ func (s *TransferService) ActiveCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.runs)
-}
-
-// OnSuspend handles OS application suspend.
-func (s *TransferService) OnSuspend() {
-	if s.emit != nil {
-		s.emit(TransferEventName, &TransferEvent{
-			Kind:  "lifecycle",
-			Phase: "suspend",
-		})
-	}
-}
-
-// OnResume handles OS application resume from sleep.
-func (s *TransferService) OnResume() {
-	if s.emit != nil {
-		s.emit(TransferEventName, &TransferEvent{
-			Kind:  "lifecycle",
-			Phase: "resume",
-		})
-	}
-}
-
-// OnNetworkChange handles OS network changes.
-func (s *TransferService) OnNetworkChange() {
-	if s.emit != nil {
-		s.emit(TransferEventName, &TransferEvent{
-			Kind:  "lifecycle",
-			Phase: "network_change",
-		})
-	}
 }
 
 // Shutdown gracefully cancels active transfers and waits for bounded teardown.
@@ -1218,8 +1178,11 @@ func (r *transferRun) runReceive(ctx context.Context, code, destDir, server stri
 		outPath = destDir
 	}
 
-	// Record verified completed destination for safe RevealCompleted
-	r.svc.recordCompleted(r.id, outPath)
+	// Record verified completed destination bound strictly to its destination root
+	r.svc.recordCompleted(r.id, completedDestination{
+		Path: outPath,
+		Root: destDir,
+	})
 
 	r.publish("done", func(ev *TransferEvent) {
 		ev.Digest = out.Digest
@@ -1350,8 +1313,11 @@ func (r *transferRun) runResumeReceive(ctx context.Context, transferID, code, de
 		outPath = destDir
 	}
 
-	// Record verified completed destination for safe RevealCompleted
-	r.svc.recordCompleted(r.id, outPath)
+	// Record verified completed destination bound strictly to its destination root
+	r.svc.recordCompleted(r.id, completedDestination{
+		Path: outPath,
+		Root: destDir,
+	})
 
 	r.publish("done", func(ev *TransferEvent) {
 		ev.Digest = out.Digest

--- a/apps/desktop/internal/lifecycle/lifecycle_test.go
+++ b/apps/desktop/internal/lifecycle/lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -234,5 +235,30 @@ func TestNotifiers(t *testing.T) {
 	}
 	if defNotif.BackendName() == "" {
 		t.Errorf("DefaultNotifier.BackendName() is empty")
+	}
+
+	// Platform Notifiers
+	darwinNotif := &DarwinNotifier{}
+	if runtime.GOOS != "darwin" && darwinNotif.IsAvailable() {
+		t.Errorf("DarwinNotifier.IsAvailable() must be false on non-darwin")
+	}
+	if darwinNotif.BackendName() != "darwin-osascript" {
+		t.Errorf("DarwinNotifier.BackendName() = %q, want darwin-osascript", darwinNotif.BackendName())
+	}
+
+	winNotif := &WindowsNotifier{}
+	if runtime.GOOS != "windows" && winNotif.IsAvailable() {
+		t.Errorf("WindowsNotifier.IsAvailable() must be false on non-windows")
+	}
+	if winNotif.BackendName() != "windows-powershell" {
+		t.Errorf("WindowsNotifier.BackendName() = %q, want windows-powershell", winNotif.BackendName())
+	}
+
+	linuxNotif := &LinuxNotifier{}
+	if runtime.GOOS != "linux" && linuxNotif.IsAvailable() {
+		t.Errorf("LinuxNotifier.IsAvailable() must be false on non-linux")
+	}
+	if linuxNotif.BackendName() != "linux-notify-send" {
+		t.Errorf("LinuxNotifier.BackendName() = %q, want linux-notify-send", linuxNotif.BackendName())
 	}
 }

--- a/apps/desktop/internal/lifecycle/notify.go
+++ b/apps/desktop/internal/lifecycle/notify.go
@@ -144,9 +144,13 @@ func (w *WindowsNotifier) NotifyFailure(title, message string) {
 	_ = cmd.Start()
 }
 
-// IsAvailable reports true on Windows.
+// IsAvailable reports true on Windows when PowerShell is available.
 func (w *WindowsNotifier) IsAvailable() bool {
-	return runtime.GOOS == "windows"
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	_, err := exec.LookPath("powershell")
+	return err == nil
 }
 
 // BackendName returns "windows-powershell".

--- a/apps/desktop/main.go
+++ b/apps/desktop/main.go
@@ -83,7 +83,7 @@ func main() {
 			Port: 18123,
 		},
 		Mac: application.MacOptions{
-			ApplicationShouldTerminateAfterLastWindowClosed: true,
+			ApplicationShouldTerminateAfterLastWindowClosed: false,
 		},
 	})
 
@@ -105,7 +105,31 @@ func main() {
 
 	win := app.Window.NewWithOptions(winOpts)
 
-	// Close-to-tray handling where supported
+	// System Tray: provides an authoritative reopen and quit mechanism so close-to-tray
+	// or start-minimized never creates an unreachable or un-restorable application.
+	systemTray := app.SystemTray.New()
+	trayMenu := app.NewMenu()
+	trayMenu.Add("Show SendBeam").OnClick(func(_ *application.Context) {
+		win.Show()
+		win.Focus()
+	})
+	trayMenu.Add("Quit SendBeam").OnClick(func(_ *application.Context) {
+		_ = transferSvc.Shutdown(3 * time.Second)
+		app.Quit()
+	})
+	systemTray.SetMenu(trayMenu)
+	systemTray.OnClick(func() {
+		win.Show()
+		win.Focus()
+	})
+
+	// macOS dock reopen hook
+	app.Event.OnApplicationEvent(events.Mac.ApplicationShouldHandleReopen, func(_ *application.ApplicationEvent) {
+		win.Show()
+		win.Focus()
+	})
+
+	// Close-to-tray handling: hides window into tray rather than destroying active transfers
 	if cfg.CloseToTray {
 		win.OnWindowEvent(events.Common.WindowClosing, func(e *application.WindowEvent) {
 			if cfg.CloseToTray {


### PR DESCRIPTION
## Summary
Completes the PR04 platform lifecycle security and correctness requirements:

- **Windows DPAPI Round-Trip Pipeline:** Corrected the DPAPI Protect/Unprotect pipeline using Base64 stdin/stdout streaming without command-line parameter leakage; added pure encoding/decoding boundary helpers with test coverage.
- **Forbid Plaintext TURN Passwords in Config:** Strictly forbids embedded passwords in `DesktopConfig.ICEServers` during validation and runtime resolution, ensuring credentials come solely from the protected secret store.
- **Trusted Destination Root Bounding:** Binds `RevealCompleted` strictly to the exact verified destination root directory recorded upon receive completion, preventing authority expansion across arbitrary roots.
- **System Tray Reopen & Close-To-Tray Safety:** Wires a system tray menu (`Show SendBeam`, `Quit SendBeam`) and dock reopen hook so close-to-tray and start-minimized maintain recoverable window states.
- **Notifier Availability Checks:** Hardens platform notifier availability detection for Windows and preserves explicit degradation to `SilentNotifier`.