### PR TITLE
fix(desktop): wire native lifecycle hooks correctly

### DIFF
--- a/apps/desktop/internal/lifecycle/coordinator.go
+++ b/apps/desktop/internal/lifecycle/coordinator.go
@@ -1,0 +1,150 @@
+// Package lifecycle provides platform integration for desktop durability, single-instance
+// locking, native notifications, file reveal, and power/window lifecycle coordination.
+package lifecycle
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Shutdownable defines a component that can be gracefully shut down with a timeout.
+type Shutdownable interface {
+	Shutdown(timeout time.Duration) error
+}
+
+// LifecycleEventEmitter is the sink for emitting desktop-wide lifecycle updates.
+type LifecycleEventEmitter func(kind, phase string)
+
+// Coordinator coordinates application window hooks, power sleep/wake events,
+// tray reachability policies, and bounded idempotent teardown.
+type Coordinator struct {
+	mu           sync.Mutex
+	closeToTray  bool
+	isTrayUsable bool
+	shutdownOnce sync.Once
+	shutdownErr  error
+	service      Shutdownable
+	emitter      LifecycleEventEmitter
+	sleepCount   int
+	wakeCount    int
+}
+
+// NewCoordinator creates a new lifecycle coordinator.
+func NewCoordinator(closeToTray bool, svc Shutdownable, emitter LifecycleEventEmitter) *Coordinator {
+	return NewCoordinatorWithPlatform(closeToTray, runtime.GOOS, os.Getenv, svc, emitter)
+}
+
+// NewCoordinatorWithPlatform creates a coordinator with explicit platform and env parameters for unit testing.
+func NewCoordinatorWithPlatform(closeToTray bool, goos string, env func(string) string, svc Shutdownable, emitter LifecycleEventEmitter) *Coordinator {
+	trayUsable := IsTraySupportedOnPlatform(goos, env)
+	return &Coordinator{
+		closeToTray:  closeToTray,
+		isTrayUsable: trayUsable,
+		service:      svc,
+		emitter:      emitter,
+	}
+}
+
+// IsTraySupportedOnPlatform evaluates whether system tray reachability can be reliably trusted.
+// macOS and Windows provide universal system tray and notification area facilities.
+// Linux desktop environments vary widely; hide-to-tray is enabled only where reliable tray host
+// facilities are standard (e.g. KDE, XFCE, Cinnamon, MATE, LXQt), degrading safely to normal
+// window-close behavior on GNOME or environments without confirmed tray host support.
+func IsTraySupportedOnPlatform(goos string, env func(string) string) bool {
+	if env == nil {
+		env = os.Getenv
+	}
+	switch goos {
+	case "darwin", "windows":
+		return true
+	case "linux":
+		desktop := strings.ToUpper(env("XDG_CURRENT_DESKTOP"))
+		if strings.Contains(desktop, "KDE") ||
+			strings.Contains(desktop, "XFCE") ||
+			strings.Contains(desktop, "CINNAMON") ||
+			strings.Contains(desktop, "MATE") ||
+			strings.Contains(desktop, "LXQT") ||
+			strings.Contains(desktop, "UNITY") ||
+			strings.Contains(desktop, "DEEPIN") {
+			return true
+		}
+		if env("KDE_FULL_SESSION") != "" {
+			return true
+		}
+		// GNOME standard session without extensions or unknown desktop sessions degrade conservatively
+		// to false so close-to-tray does not create an unreachable/unrecoverable background process.
+		return false
+	default:
+		return false
+	}
+}
+
+// SetCloseToTray updates the user-configured CloseToTray preference.
+func (c *Coordinator) SetCloseToTray(enabled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closeToTray = enabled
+}
+
+// IsTrayUsable reports whether the current platform supports reachable system tray interaction.
+func (c *Coordinator) IsTrayUsable() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.isTrayUsable
+}
+
+// ShouldHideOnClose reports whether window close events should hide to tray rather than exiting.
+// It requires both that CloseToTray is enabled AND that tray interaction is known usable.
+func (c *Coordinator) ShouldHideOnClose() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closeToTray && c.isTrayUsable
+}
+
+// OnSystemWillSleep handles the Wails events.Common.SystemWillSleep notification.
+// It preserves in-flight durability state, ensures no false completion is emitted,
+// and notifies telemetry/UI.
+func (c *Coordinator) OnSystemWillSleep() {
+	c.mu.Lock()
+	c.sleepCount++
+	emitter := c.emitter
+	c.mu.Unlock()
+
+	if emitter != nil {
+		emitter("lifecycle", "sleep")
+	}
+}
+
+// OnSystemDidWake handles the Wails events.Common.SystemDidWake notification.
+// It triggers UI telemetry refresh while relying on the engine's adaptive transport
+// reconnect supervisor for WebRTC/signaling recovery without creating duplicate sessions.
+func (c *Coordinator) OnSystemDidWake() {
+	c.mu.Lock()
+	c.wakeCount++
+	emitter := c.emitter
+	c.mu.Unlock()
+
+	if emitter != nil {
+		emitter("lifecycle", "wake")
+	}
+}
+
+// SleepWakeCounts returns the total sleep and wake events handled.
+func (c *Coordinator) SleepWakeCounts() (sleeps, wakes int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.sleepCount, c.wakeCount
+}
+
+// Shutdown performs bounded, idempotent application teardown.
+func (c *Coordinator) Shutdown(timeout time.Duration) error {
+	c.shutdownOnce.Do(func() {
+		if c.service != nil {
+			c.shutdownErr = c.service.Shutdown(timeout)
+		}
+	})
+	return c.shutdownErr
+}

--- a/apps/desktop/internal/lifecycle/coordinator.go
+++ b/apps/desktop/internal/lifecycle/coordinator.go
@@ -15,8 +15,8 @@ type Shutdownable interface {
 	Shutdown(timeout time.Duration) error
 }
 
-// LifecycleEventEmitter is the sink for emitting desktop-wide lifecycle updates.
-type LifecycleEventEmitter func(kind, phase string)
+// EventEmitter is the sink for emitting desktop-wide lifecycle updates.
+type EventEmitter func(kind, phase string)
 
 // Coordinator coordinates application window hooks, power sleep/wake events,
 // tray reachability policies, and bounded idempotent teardown.
@@ -27,18 +27,18 @@ type Coordinator struct {
 	shutdownOnce sync.Once
 	shutdownErr  error
 	service      Shutdownable
-	emitter      LifecycleEventEmitter
+	emitter      EventEmitter
 	sleepCount   int
 	wakeCount    int
 }
 
 // NewCoordinator creates a new lifecycle coordinator.
-func NewCoordinator(closeToTray bool, svc Shutdownable, emitter LifecycleEventEmitter) *Coordinator {
+func NewCoordinator(closeToTray bool, svc Shutdownable, emitter EventEmitter) *Coordinator {
 	return NewCoordinatorWithPlatform(closeToTray, runtime.GOOS, os.Getenv, svc, emitter)
 }
 
 // NewCoordinatorWithPlatform creates a coordinator with explicit platform and env parameters for unit testing.
-func NewCoordinatorWithPlatform(closeToTray bool, goos string, env func(string) string, svc Shutdownable, emitter LifecycleEventEmitter) *Coordinator {
+func NewCoordinatorWithPlatform(closeToTray bool, goos string, env func(string) string, svc Shutdownable, emitter EventEmitter) *Coordinator {
 	trayUsable := IsTraySupportedOnPlatform(goos, env)
 	return &Coordinator{
 		closeToTray:  closeToTray,

--- a/apps/desktop/internal/lifecycle/lifecycle_test.go
+++ b/apps/desktop/internal/lifecycle/lifecycle_test.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestSingleInstanceLock(t *testing.T) {
@@ -19,131 +21,124 @@ func TestSingleInstanceLock(t *testing.T) {
 		t.Fatalf("first AcquireSingleInstanceLock failed: %v", err)
 	}
 	if lock1 == nil {
-		t.Fatalf("lock1 is nil")
+		t.Fatalf("first AcquireSingleInstanceLock returned nil lock")
 	}
-	defer func() { _ = lock1.Release() }()
 
-	// 2. Second concurrent acquisition on same lock file must fail with ErrAnotherInstanceRunning
+	// 2. Second acquisition on same path fails with ErrAnotherInstanceRunning
 	lock2, err := AcquireSingleInstanceLock(lockPath)
 	if err == nil || !errors.Is(err, ErrAnotherInstanceRunning) {
-		if lock2 != nil {
-			_ = lock2.Release()
-		}
-		t.Fatalf("second AcquireSingleInstanceLock returned err = %v, want ErrAnotherInstanceRunning", err)
+		t.Fatalf("second AcquireSingleInstanceLock error = %v, want ErrAnotherInstanceRunning", err)
+	}
+	if lock2 != nil {
+		t.Fatalf("second AcquireSingleInstanceLock returned non-nil lock")
 	}
 
 	// 3. Release first lock
 	if err := lock1.Release(); err != nil {
-		t.Fatalf("Release lock1 failed: %v", err)
+		t.Fatalf("Release failed: %v", err)
 	}
 
-	// 4. Third acquisition now succeeds
+	// 4. Acquisition succeeds again after release
 	lock3, err := AcquireSingleInstanceLock(lockPath)
 	if err != nil {
-		t.Fatalf("third AcquireSingleInstanceLock after release failed: %v", err)
+		t.Fatalf("AcquireSingleInstanceLock after release failed: %v", err)
 	}
 	if lock3 == nil {
-		t.Fatalf("lock3 is nil")
+		t.Fatalf("AcquireSingleInstanceLock after release returned nil lock")
 	}
 	_ = lock3.Release()
 }
 
-func TestSingleInstanceLockInvalidPath(t *testing.T) {
-	// Empty path
-	_, err := AcquireSingleInstanceLock("")
-	if err == nil {
-		t.Fatalf("AcquireSingleInstanceLock with empty path expected error, got nil")
-	}
-}
-
-func TestRevealPathValidation(t *testing.T) {
+func TestValidatePathConfinement(t *testing.T) {
 	dir := t.TempDir()
-	file1 := filepath.Join(dir, "hello.txt")
-	if err := os.WriteFile(file1, []byte("hello"), 0o600); err != nil {
-		t.Fatalf("write file: %v", err)
+
+	// Setup authorized root
+	root := filepath.Join(dir, "downloads")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
 	}
 
-	otherDir := t.TempDir()
-	otherFile := filepath.Join(otherDir, "outside.txt")
-	if err := os.WriteFile(otherFile, []byte("outside"), 0o600); err != nil {
-		t.Fatalf("write file: %v", err)
+	// Setup external directory (unauthorized)
+	external := filepath.Join(dir, "external")
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatal(err)
 	}
 
-	// Legitimate dotfile inside dir
-	dotFile := filepath.Join(dir, "..legit.txt")
-	if err := os.WriteFile(dotFile, []byte("dotcontent"), 0o600); err != nil {
-		t.Fatalf("write dotfile: %v", err)
+	// Valid target inside root
+	validFile := filepath.Join(root, "valid.txt")
+	if err := os.WriteFile(validFile, []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
 	}
 
-	// Symlink inside dir pointing to file in otherDir
-	symlinkToOutside := filepath.Join(dir, "symlink_outside.txt")
-	_ = os.Symlink(otherFile, symlinkToOutside)
+	// Valid hidden / dotfile inside root
+	dotFile := filepath.Join(root, ".hidden_data")
+	if err := os.WriteFile(dotFile, []byte("hidden"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// File outside authorized root
+	externalFile := filepath.Join(external, "secret.txt")
+	if err := os.WriteFile(externalFile, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Symlink inside root pointing outside
+	symlinkEscape := filepath.Join(root, "escape_link.txt")
+	_ = os.Symlink(externalFile, symlinkEscape)
 
 	tests := []struct {
-		name         string
-		targetPath   string
-		allowedRoots []string
-		wantErr      error
+		name    string
+		target  string
+		roots   []string
+		wantErr error
 	}{
 		{
-			name:         "empty path",
-			targetPath:   "",
-			allowedRoots: []string{dir},
-			wantErr:      ErrInvalidPath,
+			name:    "valid file within root",
+			target:  validFile,
+			roots:   []string{root},
+			wantErr: nil,
 		},
 		{
-			name:         "control characters",
-			targetPath:   dir + "/\x00evil.txt",
-			allowedRoots: []string{dir},
-			wantErr:      ErrInvalidPath,
+			name:    "valid hidden dotfile within root",
+			target:  dotFile,
+			roots:   []string{root},
+			wantErr: nil,
 		},
 		{
-			name:         "non-existent file",
-			targetPath:   filepath.Join(dir, "missing.txt"),
-			allowedRoots: []string{dir},
-			wantErr:      ErrPathNotFound,
+			name:    "file outside authorized roots",
+			target:  externalFile,
+			roots:   []string{root},
+			wantErr: ErrPathOutsideRoot,
 		},
 		{
-			name:         "file outside allowed root",
-			targetPath:   otherFile,
-			allowedRoots: []string{dir},
-			wantErr:      ErrPathOutsideRoot,
+			name:    "symlink escaping root boundary",
+			target:  symlinkEscape,
+			roots:   []string{root},
+			wantErr: ErrPathOutsideRoot,
 		},
 		{
-			name:         "valid file inside allowed root",
-			targetPath:   file1,
-			allowedRoots: []string{dir},
-			wantErr:      nil,
+			name:    "nonexistent file",
+			target:  filepath.Join(root, "nonexistent.bin"),
+			roots:   []string{root},
+			wantErr: ErrPathNotFound,
 		},
 		{
-			name:         "legitimate dotfile starting with .. inside allowed root",
-			targetPath:   dotFile,
-			allowedRoots: []string{dir},
-			wantErr:      nil,
+			name:    "empty target",
+			target:  "",
+			roots:   []string{root},
+			wantErr: ErrInvalidPath,
 		},
 		{
-			name:         "symlink inside root pointing outside root is rejected",
-			targetPath:   symlinkToOutside,
-			allowedRoots: []string{dir},
-			wantErr:      ErrPathOutsideRoot,
-		},
-		{
-			name:         "valid directory without root restrictions",
-			targetPath:   dir,
-			allowedRoots: nil,
-			wantErr:      nil,
-		},
-		{
-			name:         "traversal attempting escape",
-			targetPath:   filepath.Join(dir, "..", filepath.Base(otherDir), "outside.txt"),
-			allowedRoots: []string{dir},
-			wantErr:      ErrPathOutsideRoot,
+			name:    "no authorized roots",
+			target:  validFile,
+			roots:   nil,
+			wantErr: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ValidatePath(tt.targetPath, tt.allowedRoots...)
+			_, err := ValidatePath(tt.target, tt.roots...)
 			if tt.wantErr == nil {
 				if err != nil {
 					t.Fatalf("ValidatePath unexpected error: %v", err)
@@ -260,5 +255,164 @@ func TestNotifiers(t *testing.T) {
 	}
 	if linuxNotif.BackendName() != "linux-notify-send" {
 		t.Errorf("LinuxNotifier.BackendName() = %q, want linux-notify-send", linuxNotif.BackendName())
+	}
+}
+
+func TestIsTraySupportedOnPlatform(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "macOS is always supported",
+			goos: "darwin",
+			want: true,
+		},
+		{
+			name: "windows is always supported",
+			goos: "windows",
+			want: true,
+		},
+		{
+			name: "linux KDE desktop",
+			goos: "linux",
+			env:  map[string]string{"XDG_CURRENT_DESKTOP": "KDE"},
+			want: true,
+		},
+		{
+			name: "linux XFCE desktop",
+			goos: "linux",
+			env:  map[string]string{"XDG_CURRENT_DESKTOP": "XFCE"},
+			want: true,
+		},
+		{
+			name: "linux MATE desktop",
+			goos: "linux",
+			env:  map[string]string{"XDG_CURRENT_DESKTOP": "MATE"},
+			want: true,
+		},
+		{
+			name: "linux GNOME standard desktop degrades safely",
+			goos: "linux",
+			env:  map[string]string{"XDG_CURRENT_DESKTOP": "GNOME"},
+			want: false,
+		},
+		{
+			name: "linux unknown desktop degrades safely",
+			goos: "linux",
+			env:  map[string]string{"XDG_CURRENT_DESKTOP": "custom-wm"},
+			want: false,
+		},
+		{
+			name: "unsupported OS",
+			goos: "freebsd",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envFn := func(k string) string {
+				if tt.env != nil {
+					return tt.env[k]
+				}
+				return ""
+			}
+			got := IsTraySupportedOnPlatform(tt.goos, envFn)
+			if got != tt.want {
+				t.Errorf("IsTraySupportedOnPlatform(%q) = %v, want %v", tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLifecycleCoordinatorCloseToTrayPolicy(t *testing.T) {
+	// Darwin with CloseToTray = true
+	coordDarwin := NewCoordinatorWithPlatform(true, "darwin", nil, nil, nil)
+	if !coordDarwin.ShouldHideOnClose() {
+		t.Errorf("Darwin with CloseToTray=true should hide on close")
+	}
+
+	// Darwin with CloseToTray = false
+	coordDarwin.SetCloseToTray(false)
+	if coordDarwin.ShouldHideOnClose() {
+		t.Errorf("Darwin with CloseToTray=false should not hide on close")
+	}
+
+	// Linux GNOME (tray unsupported) with CloseToTray = true -> degrades to false
+	coordGnome := NewCoordinatorWithPlatform(true, "linux", func(k string) string {
+		if k == "XDG_CURRENT_DESKTOP" {
+			return "GNOME"
+		}
+		return ""
+	}, nil, nil)
+	if coordGnome.ShouldHideOnClose() {
+		t.Errorf("Linux GNOME should degrade ShouldHideOnClose to false")
+	}
+	if coordGnome.IsTrayUsable() {
+		t.Errorf("Linux GNOME IsTrayUsable() = true, want false")
+	}
+
+	// Linux KDE (tray supported) with CloseToTray = true -> hides
+	coordKDE := NewCoordinatorWithPlatform(true, "linux", func(k string) string {
+		if k == "XDG_CURRENT_DESKTOP" {
+			return "KDE"
+		}
+		return ""
+	}, nil, nil)
+	if !coordKDE.ShouldHideOnClose() {
+		t.Errorf("Linux KDE ShouldHideOnClose() = false, want true")
+	}
+}
+
+type mockShutdownable struct {
+	shutdownCalls int32
+}
+
+func (m *mockShutdownable) Shutdown(_ time.Duration) error {
+	atomic.AddInt32(&m.shutdownCalls, 1)
+	return nil
+}
+
+func TestLifecycleCoordinatorSleepWakeAndShutdown(t *testing.T) {
+	var emittedEvents []string
+	emitter := func(kind, phase string) {
+		emittedEvents = append(emittedEvents, kind+":"+phase)
+	}
+
+	mockSvc := &mockShutdownable{}
+	coord := NewCoordinatorWithPlatform(true, "windows", nil, mockSvc, emitter)
+
+	// 1. Sleep event
+	coord.OnSystemWillSleep()
+	sleeps, wakes := coord.SleepWakeCounts()
+	if sleeps != 1 || wakes != 0 {
+		t.Errorf("SleepWakeCounts after sleep: %d, %d; want 1, 0", sleeps, wakes)
+	}
+
+	// 2. Wake event
+	coord.OnSystemDidWake()
+	sleeps, wakes = coord.SleepWakeCounts()
+	if sleeps != 1 || wakes != 1 {
+		t.Errorf("SleepWakeCounts after wake: %d, %d; want 1, 1", sleeps, wakes)
+	}
+
+	if len(emittedEvents) != 2 || emittedEvents[0] != "lifecycle:sleep" || emittedEvents[1] != "lifecycle:wake" {
+		t.Errorf("emittedEvents = %v, want [lifecycle:sleep lifecycle:wake]", emittedEvents)
+	}
+
+	// 3. Idempotent shutdown
+	if err := coord.Shutdown(time.Second); err != nil {
+		t.Fatalf("first Shutdown failed: %v", err)
+	}
+	if err := coord.Shutdown(time.Second); err != nil {
+		t.Fatalf("second Shutdown failed: %v", err)
+	}
+
+	calls := atomic.LoadInt32(&mockSvc.shutdownCalls)
+	if calls != 1 {
+		t.Errorf("Shutdown was called %d times, want exactly 1 (idempotent)", calls)
 	}
 }

--- a/apps/desktop/main.go
+++ b/apps/desktop/main.go
@@ -18,10 +18,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
+	"github.com/wailsapp/wails/v3/pkg/icons"
 
 	"github.com/sendbeam/desktop/internal/config"
 	"github.com/sendbeam/desktop/internal/engine"
@@ -66,6 +68,21 @@ func main() {
 
 	cfg, _ := transferSvc.GetConfig()
 
+	// Lifecycle Coordinator: manages cancellable window closing hooks,
+	// system power sleep/wake notifications, and bounded idempotent shutdown.
+	lifecycleCoord := lifecycle.NewCoordinator(
+		cfg.CloseToTray,
+		transferSvc,
+		func(kind, phase string) {
+			if app := application.Get(); app != nil && app.Event != nil {
+				app.Event.Emit(engine.TransferEventName, map[string]any{
+					"kind":  kind,
+					"phase": phase,
+				})
+			}
+		},
+	)
+
 	app := application.New(application.Options{
 		Name:        "SendBeam Desktop",
 		Description: "Secure, end-to-end-encrypted, peer-to-peer file transfer",
@@ -106,15 +123,26 @@ func main() {
 	win := app.Window.NewWithOptions(winOpts)
 
 	// System Tray: provides an authoritative reopen and quit mechanism so close-to-tray
-	// or start-minimized never creates an unreachable or un-restorable application.
+	// or start-minimized maintains an easily discoverable and restorable window state.
 	systemTray := app.SystemTray.New()
+	systemTray.SetTooltip("SendBeam")
+
+	if runtime.GOOS == "darwin" {
+		systemTray.SetTemplateIcon(icons.SystrayMacTemplate)
+	} else if runtime.GOOS == "windows" {
+		systemTray.SetIcon(icons.SystrayLight)
+		systemTray.SetDarkModeIcon(icons.SystrayDark)
+	} else {
+		systemTray.SetIcon(icons.SystrayLight)
+	}
+
 	trayMenu := app.NewMenu()
 	trayMenu.Add("Show SendBeam").OnClick(func(_ *application.Context) {
 		win.Show()
 		win.Focus()
 	})
 	trayMenu.Add("Quit SendBeam").OnClick(func(_ *application.Context) {
-		_ = transferSvc.Shutdown(3 * time.Second)
+		_ = lifecycleCoord.Shutdown(3 * time.Second)
 		app.Quit()
 	})
 	systemTray.SetMenu(trayMenu)
@@ -123,21 +151,28 @@ func main() {
 		win.Focus()
 	})
 
-	// macOS dock reopen hook
+	// macOS dock click reopen hook
 	app.Event.OnApplicationEvent(events.Mac.ApplicationShouldHandleReopen, func(_ *application.ApplicationEvent) {
 		win.Show()
 		win.Focus()
 	})
 
-	// Close-to-tray handling: hides window into tray rather than destroying active transfers
-	if cfg.CloseToTray {
-		win.OnWindowEvent(events.Common.WindowClosing, func(e *application.WindowEvent) {
-			if cfg.CloseToTray {
-				win.Hide()
-				e.Cancel()
-			}
-		})
-	}
+	// Wire real system sleep/wake notifications provided by Wails v3
+	app.Event.OnApplicationEvent(events.Common.SystemWillSleep, func(_ *application.ApplicationEvent) {
+		lifecycleCoord.OnSystemWillSleep()
+	})
+	app.Event.OnApplicationEvent(events.Common.SystemDidWake, func(_ *application.ApplicationEvent) {
+		lifecycleCoord.OnSystemDidWake()
+	})
+
+	// Cancellable window closing hook: uses RegisterHook so e.Cancel() properly suppresses window destruction
+	// when CloseToTray is active and tray access is known usable.
+	win.RegisterHook(events.Common.WindowClosing, func(e *application.WindowEvent) {
+		if lifecycleCoord.ShouldHideOnClose() {
+			win.Hide()
+			e.Cancel()
+		}
+	})
 
 	// Forward OS file drops to a new send. Dropped paths are absolute; the
 	// engine's source expansion handles files and folders identically. The
@@ -172,5 +207,5 @@ func main() {
 	}
 
 	// Bounded graceful teardown upon exit: cancel active transfers cleanly
-	_ = transferSvc.Shutdown(3 * time.Second)
+	_ = lifecycleCoord.Shutdown(3 * time.Second)
 }

--- a/apps/desktop/main.go
+++ b/apps/desktop/main.go
@@ -127,12 +127,13 @@ func main() {
 	systemTray := app.SystemTray.New()
 	systemTray.SetTooltip("SendBeam")
 
-	if runtime.GOOS == "darwin" {
+	switch runtime.GOOS {
+	case "darwin":
 		systemTray.SetTemplateIcon(icons.SystrayMacTemplate)
-	} else if runtime.GOOS == "windows" {
+	case "windows":
 		systemTray.SetIcon(icons.SystrayLight)
 		systemTray.SetDarkModeIcon(icons.SystrayDark)
-	} else {
+	default:
 		systemTray.SetIcon(icons.SystrayLight)
 	}
 


### PR DESCRIPTION
## Summary
Completes the PR04 native Wails v3 lifecycle integration and safe close-to-tray/power management:

- **Cancellable Close-To-Tray:** Replaces passive listener with `win.RegisterHook(events.Common.WindowClosing)` so `e.Cancel()` properly intercepts and suppresses window destruction when `CloseToTray` is active.
- **Wails System Sleep & Wake Events:** Connects `events.Common.SystemWillSleep` and `events.Common.SystemDidWake` to the desktop lifecycle coordinator, preserving durable journals across sleep and driving UI telemetry refresh without duplicate sessions upon wake.
- **Reachable System Tray & Branding:** Configures template icons on macOS, adaptive light/dark icons on Windows/Linux, and sets descriptive tooltips and menus (`Show SendBeam`, `Quit SendBeam`).
- **Safe Linux Tray Policy Degradation:** Introduces `IsTraySupportedOnPlatform` to guarantee that `ShouldHideOnClose` only hides on environments with reliable system tray infrastructure, falling back to standard window close on GNOME/unsupported sessions to prevent creating an unreachable process.
- **Idempotent Teardown:** Ensures `Shutdown` is idempotent and cleanly handles tray quits and application exits.