### PR TITLE
fix(distribution): use valid native development versions

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -62,6 +62,10 @@ jobs:
         id: meta
         run: bash ./scripts/version-metadata.sh --github-output
 
+      - name: Test version resolution policy
+        if: matrix.os == 'linux' && matrix.arch == 'amd64'
+        run: bash ./scripts/version-metadata_test.sh
+
       - name: Build CLI binary
         env:
           CGO_ENABLED: 0
@@ -327,8 +331,8 @@ jobs:
           cp build/darwin/icons.icns "$APP_BUNDLE/Contents/Resources/icons.icns"
 
           # Inject authoritative version values into Info.plist
-          plutil -replace CFBundleVersion -string "${{ steps.meta.outputs.numeric_version }}" "$APP_BUNDLE/Contents/Info.plist"
-          plutil -replace CFBundleShortVersionString -string "${{ steps.meta.outputs.display_version }}" "$APP_BUNDLE/Contents/Info.plist"
+          plutil -replace CFBundleVersion -string "${{ steps.meta.outputs.macos_bundle_version }}" "$APP_BUNDLE/Contents/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "${{ steps.meta.outputs.macos_short_version }}" "$APP_BUNDLE/Contents/Info.plist"
           plutil -lint "$APP_BUNDLE/Contents/Info.plist"
 
           codesign --force --deep --sign - "$APP_BUNDLE"
@@ -353,8 +357,19 @@ jobs:
           test -f artifacts/SendBeam-macos-universal.dmg
 
           # Validate Info.plist in the assembled bundle
-          defaults read "$PWD/apps/desktop/bin/SendBeam.app/Contents/Info.plist" CFBundleShortVersionString | grep -q "${{ steps.meta.outputs.display_version }}"
-          defaults read "$PWD/apps/desktop/bin/SendBeam.app/Contents/Info.plist" CFBundleVersion | grep -q "${{ steps.meta.outputs.numeric_version }}"
+          SHORT_VER=$(defaults read "$PWD/apps/desktop/bin/SendBeam.app/Contents/Info.plist" CFBundleShortVersionString)
+          BUNDLE_VER=$(defaults read "$PWD/apps/desktop/bin/SendBeam.app/Contents/Info.plist" CFBundleVersion)
+
+          echo "macOS CFBundleShortVersionString: $SHORT_VER"
+          echo "macOS CFBundleVersion: $BUNDLE_VER"
+
+          # Assert exact values match authoritative policy
+          test "$SHORT_VER" = "${{ steps.meta.outputs.macos_short_version }}"
+          test "$BUNDLE_VER" = "${{ steps.meta.outputs.macos_bundle_version }}"
+
+          # Validate Apple numeric dotted-version shape (X.Y.Z)
+          echo "$SHORT_VER" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
+          echo "$BUNDLE_VER" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
 
           # Mount DMG and verify structure
           MOUNT_POINT=$(mktemp -d)

--- a/apps/desktop/build/darwin/Info.plist
+++ b/apps/desktop/build/darwin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleVersion</key>
 	<string>0.0.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>dev</string>
+	<string>0.0.0</string>
 	<key>CFBundleIconFile</key>
 	<string>icons.icns</string>
 	<key>LSMinimumSystemVersion</key>

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -45,7 +45,7 @@ The SendBeam Desktop application packages the Go transfer engine with native pla
 
 ## Authoritative Version Resolution Policy
 
-Build and packaging metadata is resolved deterministically through [scripts/version-metadata.sh](file:///home/akshay/Desktop/agy/SendArc/scripts/version-metadata.sh) across all CLI and desktop platforms:
+Build and packaging metadata is resolved deterministically through [scripts/version-metadata.sh](scripts/version-metadata.sh) across all CLI and desktop platforms:
 
 | Version Field                | Untagged / Development / PR Builds | Tagged Release Builds (`vX.Y.Z`) | Description                                                          |
 | :--------------------------- | :--------------------------------- | :------------------------------- | :------------------------------------------------------------------- |

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -45,15 +45,17 @@ The SendBeam Desktop application packages the Go transfer engine with native pla
 
 ## Authoritative Version Resolution Policy
 
-Build and packaging metadata is resolved deterministically through a single unified policy across all CLI and desktop platforms:
+Build and packaging metadata is resolved deterministically through [scripts/version-metadata.sh](file:///home/akshay/Desktop/agy/SendArc/scripts/version-metadata.sh) across all CLI and desktop platforms:
 
-| Version Category       | Untagged / Development Builds | Tagged Release Builds (`vX.Y.Z`) |
-| :--------------------- | :---------------------------- | :------------------------------- |
-| **Semantic / Display** | `dev`                         | `X.Y.Z`                          |
-| **Numeric Platform**   | `0.0.0`                       | `X.Y.Z`                          |
-| **Windows Fixed File** | `0.0.0.0`                     | `X.Y.Z.0`                        |
-| **Debian Package**     | `0.0.0~dev+git.<shortsha>`    | `X.Y.Z`                          |
-| **Git Commit**         | Exact 40-character commit SHA | Exact 40-character commit SHA    |
+| Version Field                | Untagged / Development / PR Builds | Tagged Release Builds (`vX.Y.Z`) | Description                                                          |
+| :--------------------------- | :--------------------------------- | :------------------------------- | :------------------------------------------------------------------- |
+| **Internal Product Version** | `dev`                              | `X.Y.Z`                          | Go `-ldflags` embedded product build version (`ProductVersion`)      |
+| **Display Version**          | `dev`                              | `X.Y.Z`                          | Human-facing CLI version UX and installer display string             |
+| **macOS Short Version**      | `0.0.0`                            | `X.Y.Z`                          | `CFBundleShortVersionString` (strictly `[0-9]+(\.[0-9]+)*`)          |
+| **macOS Bundle Version**     | `0.0.0`                            | `X.Y.Z`                          | `CFBundleVersion` (strictly numeric dotted version)                  |
+| **Windows Fixed Version**    | `0.0.0.0`                          | `X.Y.Z.0`                        | 4-part numeric PE `FixedFileInfo` (`FileVersion` / `ProductVersion`) |
+| **Debian Package Version**   | `0.0.0~dev+git.<shortsha>`         | `X.Y.Z`                          | Debian-compliant package version string                              |
+| **Git Commit**               | Exact 40-character commit SHA      | Exact 40-character commit SHA    | Full git commit SHA embedded via `-ldflags`                          |
 
 Wire protocol versioning remains immutable (`sendbeam/1`) and is decoupled from product release versions.
 

--- a/scripts/version-metadata.sh
+++ b/scripts/version-metadata.sh
@@ -10,6 +10,8 @@
 #     product_version        = dev
 #     display_version        = dev
 #     numeric_version        = 0.0.0
+#     macos_short_version    = 0.0.0
+#     macos_bundle_version   = 0.0.0
 #     windows_fixed_version  = 0.0.0.0
 #     win_major              = 0
 #     win_minor              = 0
@@ -21,6 +23,8 @@
 #     product_version        = X.Y.Z
 #     display_version        = X.Y.Z
 #     numeric_version        = X.Y.Z
+#     macos_short_version    = X.Y.Z
+#     macos_bundle_version   = X.Y.Z
 #     windows_fixed_version  = X.Y.Z.0
 #     win_major              = X
 #     win_minor              = Y
@@ -35,12 +39,14 @@ REF_NAME="${GITHUB_REF_NAME:-}"
 SHA="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo "0000000000000000000000000000000000000000")}"
 SHORT_SHA="${SHA:0:12}"
 
-if [ "${REF_TYPE}" = "tag" ] && [[ "${REF_NAME}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-  # Strip leading 'v' if present
+if [ "${REF_TYPE}" = "tag" ] && [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  # Strip leading 'v'
   RAW_VER="${REF_NAME#v}"
   PRODUCT_VERSION="${RAW_VER}"
   DISPLAY_VERSION="${RAW_VER}"
   NUMERIC_VERSION="${RAW_VER}"
+  MACOS_SHORT_VERSION="${RAW_VER}"
+  MACOS_BUNDLE_VERSION="${RAW_VER}"
   DEB_VERSION="${RAW_VER}"
 
   # Parse semver components for Windows FixedFileInfo
@@ -54,6 +60,8 @@ else
   PRODUCT_VERSION="dev"
   DISPLAY_VERSION="dev"
   NUMERIC_VERSION="0.0.0"
+  MACOS_SHORT_VERSION="0.0.0"
+  MACOS_BUNDLE_VERSION="0.0.0"
   DEB_VERSION="0.0.0~dev+git.${SHORT_SHA}"
 
   WIN_MAJOR="0"
@@ -70,6 +78,8 @@ if [ "${OUTPUT_MODE}" = "--github-output" ] && [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "version=${PRODUCT_VERSION}"
     echo "display_version=${DISPLAY_VERSION}"
     echo "numeric_version=${NUMERIC_VERSION}"
+    echo "macos_short_version=${MACOS_SHORT_VERSION}"
+    echo "macos_bundle_version=${MACOS_BUNDLE_VERSION}"
     echo "windows_fixed_version=${WINDOWS_FIXED_VERSION}"
     echo "win_major=${WIN_MAJOR}"
     echo "win_minor=${WIN_MINOR}"
@@ -86,6 +96,8 @@ cat <<EOF
 version=${PRODUCT_VERSION}
 display_version=${DISPLAY_VERSION}
 numeric_version=${NUMERIC_VERSION}
+macos_short_version=${MACOS_SHORT_VERSION}
+macos_bundle_version=${MACOS_BUNDLE_VERSION}
 windows_fixed_version=${WINDOWS_FIXED_VERSION}
 win_major=${WIN_MAJOR}
 win_minor=${WIN_MINOR}

--- a/scripts/version-metadata_test.sh
+++ b/scripts/version-metadata_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# scripts/version-metadata_test.sh
+# Unit tests for authoritative version resolver (scripts/version-metadata.sh)
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${DIR}/version-metadata.sh"
+
+test_case() {
+  local ref_type="$1"
+  local ref_name="$2"
+  local exp_ver="$3"
+  local exp_macos_short="$4"
+  local exp_macos_bundle="$5"
+  local exp_win_fixed="$6"
+  local exp_deb="$7"
+
+  local output
+  output="$(GITHUB_REF_TYPE="${ref_type}" GITHUB_REF_NAME="${ref_name}" GITHUB_SHA="9908855a5e5f9d410700eedaceb970994cd785ec" "${SCRIPT}" --stdout)"
+
+  local ver macos_short macos_bundle win_fixed deb
+  ver="$(echo "${output}" | grep "^version=" | cut -d= -f2)"
+  macos_short="$(echo "${output}" | grep "^macos_short_version=" | cut -d= -f2)"
+  macos_bundle="$(echo "${output}" | grep "^macos_bundle_version=" | cut -d= -f2)"
+  win_fixed="$(echo "${output}" | grep "^windows_fixed_version=" | cut -d= -f2)"
+  deb="$(echo "${output}" | grep "^deb_version=" | cut -d= -f2)"
+
+  if [ "${ver}" != "${exp_ver}" ]; then
+    echo "FAIL [${ref_type}:${ref_name}] expected version=${exp_ver}, got ${ver}"
+    exit 1
+  fi
+  if [ "${macos_short}" != "${exp_macos_short}" ]; then
+    echo "FAIL [${ref_type}:${ref_name}] expected macos_short_version=${exp_macos_short}, got ${macos_short}"
+    exit 1
+  fi
+  if [ "${macos_bundle}" != "${exp_macos_bundle}" ]; then
+    echo "FAIL [${ref_type}:${ref_name}] expected macos_bundle_version=${exp_macos_bundle}, got ${macos_bundle}"
+    exit 1
+  fi
+  if [ "${win_fixed}" != "${exp_win_fixed}" ]; then
+    echo "FAIL [${ref_type}:${ref_name}] expected windows_fixed_version=${exp_win_fixed}, got ${win_fixed}"
+    exit 1
+  fi
+  if [ "${deb}" != "${exp_deb}" ]; then
+    echo "FAIL [${ref_type}:${ref_name}] expected deb_version=${exp_deb}, got ${deb}"
+    exit 1
+  fi
+
+  echo "PASS [${ref_type}:${ref_name}] => ver=${ver}, macos=${macos_short}, win=${win_fixed}, deb=${deb}"
+}
+
+echo "=== Running version-metadata test suite ==="
+
+# 1. Exact valid release tags (vX.Y.Z)
+test_case "tag" "v1.4.0" "1.4.0" "1.4.0" "1.4.0" "1.4.0.0" "1.4.0"
+test_case "tag" "v12.3.45" "12.3.45" "12.3.45" "12.3.45" "12.3.45.0" "12.3.45"
+
+# 2. Invalid or non-conforming tags (must resolve to development)
+test_case "tag" "1.4.0" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f"
+test_case "tag" "v1.4.0foo" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f"
+test_case "tag" "v1.4" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f"
+test_case "tag" "v1.4.0-rc1" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f"
+
+# 3. Branches / untagged builds (must resolve to development)
+test_case "branch" "main" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f"
+test_case "branch" "feat/something" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f"
+test_case "" "" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f"
+
+echo "=== All 9 version-metadata test cases passed ==="


### PR DESCRIPTION
## Description
- Enforce Apple's numeric version format (`0.0.0` for development, `X.Y.Z` for tagged releases) for macOS `CFBundleShortVersionString` and `CFBundleVersion`.
- Maintain internal SendBeam product/build channel identity as `dev` and `GitCommit` via Go build `-ldflags`.
- Anchor version-tag regex in `scripts/version-metadata.sh` to `^v[0-9]+\.[0-9]+\.[0-9]+$` to strictly enforce `vX.Y.Z` tag convention and prevent invalid prefix matching.
- Add comprehensive test suite `scripts/version-metadata_test.sh` verifying tag parsing and environment resolution across release tags, non-conforming tags, and branch builds.
- Strengthen macOS CI distribution validation to assert `CFBundleShortVersionString` and `CFBundleVersion` numeric formatting.
- Update distribution documentation to document internal build identity vs native platform package metadata.

## Validation
- `scripts/version-metadata_test.sh` unit tests pass 100%.
- Local `just lint`, `just typecheck`, and formatting checks pass.