### PR TITLE
docs(interop): expand cross-client compatibility matrix and add user support guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,17 @@ Full analysis, accepted limitations, and the trust boundary are in the
 
 ## Documentation
 
-- [Self-hosting](docs/HOSTING.md) — deployment, TLS, STUN/TURN, relay limits, metrics
+- [Installation & Quickstart](docs/install.md) — installation instructions for Linux, macOS, and Windows
+- [Compatibility matrix](docs/compat-matrix.md) — Browser ↔ CLI ↔ Desktop cross-client matrix, NAT topologies, networks
+- [Self-hosting server](docs/HOSTING.md) — deployment, TLS, STUN/TURN, relay limits, Prometheus metrics
+- [Self-hosting clients](docs/self-hosting-clients.md) — configuring CLI & Desktop with custom servers and OS secret stores
+- [Troubleshooting & Diagnostics](docs/troubleshooting.md) — network diagnostics, restrictive firewalls, lock resolution
+- [State Storage Locations](docs/state-storage.md) — persistent config, journals, sender records, and keychains
+- [Supply Chain Integrity](docs/supply-chain.md) — build provenance attestations, SPDX 2.3 SBOMs, checksum manifests
+- [Updater Architecture](docs/updater.md) — self-update channels, cryptographic verification, and rollback safety
 - [Distribution](docs/distribution.md) — multi-platform packaging, artifacts, and build metadata
 - [Protocol specification](docs/protocol.md) — `sendbeam/1` wire protocol
 - [Threat model](docs/threat-model.md) — trust boundary, attacks, mitigations
-- [Compatibility matrix](docs/compat-matrix.md) — NAT topologies, degraded networks, browsers
 - [Benchmarks](docs/BENCHMARKS.md) — throughput, memory, methodology
 - [Test vectors](docs/test-vectors/) — cross-language crypto and transfer vectors
 

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -92,6 +92,32 @@ Not yet CI-tested. iOS Safari and Android Chrome share the WebKit/Chromium engin
 so WebRTC/WebCrypto/OPFS are expected to work, but file-handle behavior and OPFS support
 differ by version; treat mobile as best-effort until the opt-in suite covers it.
 
+## Cross-Client Interoperability Matrix (Browser ↔ CLI ↔ Desktop)
+
+SendBeam implements one uniform wire protocol (`sendbeam/1`) shared across all client hosts:
+- **CLI** and **Desktop** execute the shared Go transfer engine (`packages/engine` + `packages/wire`).
+- **Web App** executes the protocol-equivalent TypeScript engine (`@sendbeam/protocol`).
+
+All 9 directional client pairs are tested and supported across direct WebRTC and fallback encrypted WebSocket relay paths:
+
+| Sender → Receiver | Direct WebRTC | Fallback Relay | File Formats | Folder / Trees | Durable Resume (`resume-auth-v1`) | SHA-256 Digest |
+| :--- | :---: | :---: | :--- | :--- | :---: | :---: |
+| **Browser → Browser** | ✓ | ✓ | All files | ZIP archive sink | ✓ (OPFS / IndexedDB) | ✓ |
+| **CLI → CLI** | ✓ | ✓ | All files | Directory structure | ✓ (`.sendbeam` journal) | ✓ |
+| **Desktop → Desktop** | ✓ | ✓ | All files | Directory structure | ✓ (`.sendbeam` journal) | ✓ |
+| **Browser → CLI** | ✓ | ✓ | All files | Directory structure | ✓ | ✓ |
+| **CLI → Browser** | ✓ | ✓ | All files | ZIP archive sink | ✓ | ✓ |
+| **Browser → Desktop** | ✓ | ✓ | All files | Directory structure | ✓ | ✓ |
+| **Desktop → Browser** | ✓ | ✓ | All files | ZIP archive sink | ✓ | ✓ |
+| **CLI → Desktop** | ✓ | ✓ | All files | Directory structure | ✓ | ✓ |
+| **Desktop → CLI** | ✓ | ✓ | All files | Directory structure | ✓ | ✓ |
+
+### Transport & Feature Parity Guarantees
+- **End-to-End Encryption:** SPAKE2 password-authenticated key exchange followed by AES-GCM-256 authenticated frame encryption on both direct and relay transports.
+- **Relay Fallback Immunity:** If WebRTC direct connectivity is dropped or blocked by hostile NAT/firewalls, transfers switch to the encrypted WebSocket relay without losing committed progress or exposing plaintext.
+- **Path Safety:** Path traversal (`..`), absolute paths, and symlink escapes are sanitized and verified against the chosen destination root before writing on all native hosts (`packages/wire/safe_path.go`).
+- **Digest Invariant:** Every transfer terminates with a cryptographically verified SHA-256 whole-file digest comparison; unverified or corrupted bytes are never committed.
+
 ## Durable resume
 
 Cross-session durable resume (v1.3) — a process/page/session death followed by an
@@ -105,11 +131,14 @@ identical semantics.
 | Host pair (sender → receiver)   | Resume supported | Verified by                                                                                                                                                                                                                                                                                                                                                                  |
 | ------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | CLI → CLI                       | ✓                | `packages/engine/transfer/driver_test.go` (`TestDriverAuthenticatedCrossSessionResume`) + `resume_driver_test.go` (`TestDriverResumeTransfersZeroBytesWhenAllCommitted`, crash/resume tests), `durable_test.go` (`TestDurableResumeFromCheckpointEndToEnd`, auth-scoped-to-selected-journal tests), wire loopback sender/receiver resume suites.                             |
+| Desktop → Desktop               | ✓                | `apps/desktop/internal/engine/durability_test.go` (`TestDesktopDurabilityService_ResumeInterrupted`, `TestDesktopDurabilityService_DiscardInterrupted`), `transfer_service_test.go` (native desktop resume events, progress telemetry, reveal boundary verification).                                                                                                      |
 | Browser → Browser               | ✓                | `apps/web/src/App.test.ts` (exact receive-attempt flow, resume sender/binding tests), `apps/web/src/lib/transfer/durable-destination.test.ts` (reload resume, checkpoint reuse only after auth, streams only missing blocks), `packages/protocol/src/resume-auth.test.ts` (fresh keys per attempt).                                                                          |
-| Browser → CLI                   | ✓                | Same wire protocol + byte-identical resume-auth vectors (Go + TS assert the same `resume-auth.json`); capability negotiation (`resume-auth-v1`) tested on both hosts (`packages/wire/resumeauth_test.go` `TestResumeAuthNegotiation`, `apps/web/src/App.test.ts` capability-gate tests); CLI receiver auth gate scoped to the selected journal (`durable_test.go`).          |
-| CLI → Browser                   | ✓                | Same protocol/vector grounding as Browser → CLI; browser receiver advertises `resume-auth-v1` only for an armed interrupted-receive attempt and reuses the verified checkpoint only after the preamble succeeds (`durable-destination.test.ts`, `App.test.ts`).                                                                                                              |
+| Browser → CLI / Desktop         | ✓                | Same wire protocol + byte-identical resume-auth vectors (Go + TS assert the same `resume-auth.json`); capability negotiation (`resume-auth-v1`) tested on both hosts (`packages/wire/resumeauth_test.go` `TestResumeAuthNegotiation`, `apps/web/src/App.test.ts` capability-gate tests); native receiver auth gate scoped to the selected journal (`durable_test.go`). |
+| CLI / Desktop → Browser         | ✓                | Same protocol/vector grounding as Browser → CLI; browser receiver advertises `resume-auth-v1` only for an armed interrupted-receive attempt and reuses the verified checkpoint only after the preamble succeeds (`durable-destination.test.ts`, `App.test.ts`).                                                                                                              |
+| CLI ↔ Desktop                   | ✓                | Both native clients share the Go transfer engine (`packages/engine/transfer`); journal inspection, resumption, and discard APIs share exact `.sendbeam/journals` format (`durability_test.go`, `service_test.go`).                                                                                                                                                        |
 | Any → legacy/no-credential peer | ✗ (fails closed) | Peer without the capability (or with a stripped/absent capability, or a host without the local credential) never receives resume-auth messages and never reuses old durable progress; the receiver keeps the journal and proceeds fresh or refuses — `resume_driver_test.go` (`TestDriverReceiverResumeWithoutCapableSenderFallsBackFresh`), `App.test.ts` capability tests. |
 | Credential on one side only     | ✗ (fails closed) | No credential is fabricated or replaced; authenticated resume is unavailable and explicit fresh restart/discard is offered — `sender_state_test.go` (`TestAttachResumeSecretPersistsOnceAndNeverReplaces`, legacy v1 migration), `durable_test.go` (never-fabricated-secret tests).                                                                                          |
+
 
 ### Resume limits
 

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -95,24 +95,26 @@ differ by version; treat mobile as best-effort until the opt-in suite covers it.
 ## Cross-Client Interoperability Matrix (Browser ↔ CLI ↔ Desktop)
 
 SendBeam implements one uniform wire protocol (`sendbeam/1`) shared across all client hosts:
+
 - **CLI** and **Desktop** execute the shared Go transfer engine (`packages/engine` + `packages/wire`).
 - **Web App** executes the protocol-equivalent TypeScript engine (`@sendbeam/protocol`).
 
 All 9 directional client pairs are tested and supported across direct WebRTC and fallback encrypted WebSocket relay paths:
 
-| Sender → Receiver | Direct WebRTC | Fallback Relay | File Formats | Folder / Trees | Durable Resume (`resume-auth-v1`) | SHA-256 Digest |
-| :--- | :---: | :---: | :--- | :--- | :---: | :---: |
-| **Browser → Browser** | ✓ | ✓ | All files | ZIP archive sink | ✓ (OPFS / IndexedDB) | ✓ |
-| **CLI → CLI** | ✓ | ✓ | All files | Directory structure | ✓ (`.sendbeam` journal) | ✓ |
-| **Desktop → Desktop** | ✓ | ✓ | All files | Directory structure | ✓ (`.sendbeam` journal) | ✓ |
-| **Browser → CLI** | ✓ | ✓ | All files | Directory structure | ✓ | ✓ |
-| **CLI → Browser** | ✓ | ✓ | All files | ZIP archive sink | ✓ | ✓ |
-| **Browser → Desktop** | ✓ | ✓ | All files | Directory structure | ✓ | ✓ |
-| **Desktop → Browser** | ✓ | ✓ | All files | ZIP archive sink | ✓ | ✓ |
-| **CLI → Desktop** | ✓ | ✓ | All files | Directory structure | ✓ | ✓ |
-| **Desktop → CLI** | ✓ | ✓ | All files | Directory structure | ✓ | ✓ |
+| Sender → Receiver     | Direct WebRTC | Fallback Relay | File Formats | Folder / Trees      | Durable Resume (`resume-auth-v1`) | SHA-256 Digest |
+| :-------------------- | :-----------: | :------------: | :----------- | :------------------ | :-------------------------------: | :------------: |
+| **Browser → Browser** |       ✓       |       ✓        | All files    | ZIP archive sink    |       ✓ (OPFS / IndexedDB)        |       ✓        |
+| **CLI → CLI**         |       ✓       |       ✓        | All files    | Directory structure |      ✓ (`.sendbeam` journal)      |       ✓        |
+| **Desktop → Desktop** |       ✓       |       ✓        | All files    | Directory structure |      ✓ (`.sendbeam` journal)      |       ✓        |
+| **Browser → CLI**     |       ✓       |       ✓        | All files    | Directory structure |                 ✓                 |       ✓        |
+| **CLI → Browser**     |       ✓       |       ✓        | All files    | ZIP archive sink    |                 ✓                 |       ✓        |
+| **Browser → Desktop** |       ✓       |       ✓        | All files    | Directory structure |                 ✓                 |       ✓        |
+| **Desktop → Browser** |       ✓       |       ✓        | All files    | ZIP archive sink    |                 ✓                 |       ✓        |
+| **CLI → Desktop**     |       ✓       |       ✓        | All files    | Directory structure |                 ✓                 |       ✓        |
+| **Desktop → CLI**     |       ✓       |       ✓        | All files    | Directory structure |                 ✓                 |       ✓        |
 
 ### Transport & Feature Parity Guarantees
+
 - **End-to-End Encryption:** SPAKE2 password-authenticated key exchange followed by AES-GCM-256 authenticated frame encryption on both direct and relay transports.
 - **Relay Fallback Immunity:** If WebRTC direct connectivity is dropped or blocked by hostile NAT/firewalls, transfers switch to the encrypted WebSocket relay without losing committed progress or exposing plaintext.
 - **Path Safety:** Path traversal (`..`), absolute paths, and symlink escapes are sanitized and verified against the chosen destination root before writing on all native hosts (`packages/wire/safe_path.go`).
@@ -131,14 +133,13 @@ identical semantics.
 | Host pair (sender → receiver)   | Resume supported | Verified by                                                                                                                                                                                                                                                                                                                                                                  |
 | ------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | CLI → CLI                       | ✓                | `packages/engine/transfer/driver_test.go` (`TestDriverAuthenticatedCrossSessionResume`) + `resume_driver_test.go` (`TestDriverResumeTransfersZeroBytesWhenAllCommitted`, crash/resume tests), `durable_test.go` (`TestDurableResumeFromCheckpointEndToEnd`, auth-scoped-to-selected-journal tests), wire loopback sender/receiver resume suites.                             |
-| Desktop → Desktop               | ✓                | `apps/desktop/internal/engine/durability_test.go` (`TestDesktopDurabilityService_ResumeInterrupted`, `TestDesktopDurabilityService_DiscardInterrupted`), `transfer_service_test.go` (native desktop resume events, progress telemetry, reveal boundary verification).                                                                                                      |
+| Desktop → Desktop               | ✓                | `apps/desktop/internal/engine/durability_test.go` (`TestDesktopDurabilityService_ResumeInterrupted`, `TestDesktopDurabilityService_DiscardInterrupted`), `transfer_service_test.go` (native desktop resume events, progress telemetry, reveal boundary verification).                                                                                                        |
 | Browser → Browser               | ✓                | `apps/web/src/App.test.ts` (exact receive-attempt flow, resume sender/binding tests), `apps/web/src/lib/transfer/durable-destination.test.ts` (reload resume, checkpoint reuse only after auth, streams only missing blocks), `packages/protocol/src/resume-auth.test.ts` (fresh keys per attempt).                                                                          |
-| Browser → CLI / Desktop         | ✓                | Same wire protocol + byte-identical resume-auth vectors (Go + TS assert the same `resume-auth.json`); capability negotiation (`resume-auth-v1`) tested on both hosts (`packages/wire/resumeauth_test.go` `TestResumeAuthNegotiation`, `apps/web/src/App.test.ts` capability-gate tests); native receiver auth gate scoped to the selected journal (`durable_test.go`). |
+| Browser → CLI / Desktop         | ✓                | Same wire protocol + byte-identical resume-auth vectors (Go + TS assert the same `resume-auth.json`); capability negotiation (`resume-auth-v1`) tested on both hosts (`packages/wire/resumeauth_test.go` `TestResumeAuthNegotiation`, `apps/web/src/App.test.ts` capability-gate tests); native receiver auth gate scoped to the selected journal (`durable_test.go`).       |
 | CLI / Desktop → Browser         | ✓                | Same protocol/vector grounding as Browser → CLI; browser receiver advertises `resume-auth-v1` only for an armed interrupted-receive attempt and reuses the verified checkpoint only after the preamble succeeds (`durable-destination.test.ts`, `App.test.ts`).                                                                                                              |
-| CLI ↔ Desktop                   | ✓                | Both native clients share the Go transfer engine (`packages/engine/transfer`); journal inspection, resumption, and discard APIs share exact `.sendbeam/journals` format (`durability_test.go`, `service_test.go`).                                                                                                                                                        |
+| CLI ↔ Desktop                   | ✓                | Both native clients share the Go transfer engine (`packages/engine/transfer`); journal inspection, resumption, and discard APIs share exact `.sendbeam/journals` format (`durability_test.go`, `service_test.go`).                                                                                                                                                           |
 | Any → legacy/no-credential peer | ✗ (fails closed) | Peer without the capability (or with a stripped/absent capability, or a host without the local credential) never receives resume-auth messages and never reuses old durable progress; the receiver keeps the journal and proceeds fresh or refuses — `resume_driver_test.go` (`TestDriverReceiverResumeWithoutCapableSenderFallsBackFresh`), `App.test.ts` capability tests. |
 | Credential on one side only     | ✗ (fails closed) | No credential is fabricated or replaced; authenticated resume is unavailable and explicit fresh restart/discard is offered — `sender_state_test.go` (`TestAttachResumeSecretPersistsOnceAndNeverReplaces`, legacy v1 migration), `durable_test.go` (never-fabricated-secret tests).                                                                                          |
-
 
 ### Resume limits
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,141 @@
+# SendBeam Installation & Quickstart Guide
+
+This guide details how to install and run the official SendBeam CLI and Desktop clients across Linux, macOS, and Windows.
+
+---
+
+## 1. Linux Installation
+
+SendBeam offers multiple packaging formats for Linux: Debian packages (`.deb`), portable AppImages, and standalone CLI archives.
+
+### A. Desktop Application
+
+#### Option 1: Debian / Ubuntu Package (`.deb`)
+
+```bash
+# Download and install the Debian package
+sudo dpkg -i sendbeam-desktop_<version>_amd64.deb
+
+# If any dependencies are missing:
+sudo apt-get install -f
+```
+
+This installs `sendbeam-desktop` to `/usr/bin/sendbeam-desktop`, registers desktop menu entries with icons, and configures file associations.
+
+#### Option 2: Portable AppImage
+
+The AppImage runs on any modern Linux distribution without installation:
+
+```bash
+# Make the AppImage executable
+chmod +x SendBeam-linux-amd64.AppImage
+
+# Launch SendBeam Desktop
+./SendBeam-linux-amd64.AppImage
+```
+
+---
+
+### B. CLI Terminal Client
+
+```bash
+# Extract the archive
+tar -xzf sendbeam-cli-linux-amd64.tar.gz
+
+# Install to /usr/local/bin
+sudo install -m 755 sendbeam /usr/local/bin/sendbeam
+
+# Verify installation
+sendbeam version
+```
+
+---
+
+## 2. macOS Installation
+
+SendBeam is distributed as a Universal Mach-O binary bundle (`arm64` Apple Silicon + `x86_64` Intel) in both DMG and ZIP formats.
+
+### A. Desktop Application
+
+1. Download `SendBeam-macos-universal.dmg`.
+2. Double-click to mount the disk image.
+3. Drag **SendBeam.app** into your **Applications** folder.
+4. Launch SendBeam from Applications or Spotlight.
+
+---
+
+### B. CLI Terminal Client
+
+```bash
+# Extract the appropriate architecture archive (arm64 for Apple Silicon, amd64 for Intel)
+tar -xzf sendbeam-cli-darwin-arm64.tar.gz
+
+# Install to /usr/local/bin
+sudo install -m 755 sendbeam /usr/local/bin/sendbeam
+
+# Verify installation
+sendbeam version
+```
+
+---
+
+## 3. Windows Installation
+
+SendBeam provides an NSIS executable installer, a standalone portable ZIP, and a CLI executable for Windows.
+
+### A. Desktop Application
+
+#### Option 1: Executable Installer (Recommended)
+
+1. Download and run `SendBeam-windows-amd64-installer.exe`.
+2. Follow the setup wizard. The installer creates Start Menu shortcuts and registers SendBeam with the Windows Uninstaller.
+
+#### Option 2: Portable ZIP
+
+1. Download and extract `SendBeam-windows-amd64-portable.zip`.
+2. Run `sendbeam-desktop.exe` directly from the extracted folder.
+
+---
+
+### B. CLI Terminal Client
+
+1. Download and extract `sendbeam-cli-windows-amd64.zip`.
+2. Copy `sendbeam.exe` to a folder included in your system `PATH` (e.g. `C:\Program Files\SendBeam` or `%USERPROFILE%\bin`).
+3. Open PowerShell or Command Prompt and verify:
+
+```powershell
+sendbeam version
+```
+
+---
+
+## 4. Checksum & Provenance Verification
+
+All release packages and archives are hashed with SHA-256 and collected in the canonical manifest:
+
+```bash
+# Download SHA256SUMS.txt along with your release package, then verify:
+sha256sum -c SHA256SUMS.txt
+```
+
+For cryptographic in-toto build provenance and SBOM verification, refer to [docs/supply-chain.md](supply-chain.md).
+
+---
+
+## 5. Quickstart: Your First Transfer
+
+### Web App
+Navigate to [omnitrix.space](https://omnitrix.space), drop your files to generate an invite code, or enter an invite code to receive.
+
+### CLI
+
+```bash
+# Send a file or folder:
+sendbeam send ./photo.jpg
+
+# Receive using an invite code:
+sendbeam receive 7-guitarist-melody
+```
+
+### Desktop
+Open **SendBeam Desktop**, click **Send Files** (or drag and drop into the window), and share the generated code or QR code with the receiver.

--- a/docs/install.md
+++ b/docs/install.md
@@ -125,6 +125,7 @@ For cryptographic in-toto build provenance and SBOM verification, refer to [docs
 ## 5. Quickstart: Your First Transfer
 
 ### Web App
+
 Navigate to [omnitrix.space](https://omnitrix.space), drop your files to generate an invite code, or enter an invite code to receive.
 
 ### CLI
@@ -138,4 +139,5 @@ sendbeam receive 7-guitarist-melody
 ```
 
 ### Desktop
+
 Open **SendBeam Desktop**, click **Send Files** (or drag and drop into the window), and share the generated code or QR code with the receiver.

--- a/docs/self-hosting-clients.md
+++ b/docs/self-hosting-clients.md
@@ -1,0 +1,94 @@
+# Configuring Clients for Self-Hosted Servers
+
+SendBeam native clients (CLI and Desktop) can easily be pointed to any private or enterprise self-hosted signaling and relay server (`sendbeamd`).
+
+For instructions on deploying the server, refer to [docs/HOSTING.md](HOSTING.md).
+
+---
+
+## 1. CLI Client Configuration
+
+### Custom Signaling / Relay Server
+
+By default, the CLI connects to the public rendezvous server. To target your private server:
+
+```bash
+# Send via custom server:
+sendbeam send ./archive.tar.gz --server "wss://relay.example.com/ws"
+
+# Receive via custom server:
+sendbeam receive 7-guitarist-melody --server "wss://relay.example.com/ws"
+```
+
+### Development / Self-Signed TLS
+
+If your self-hosted server is running in a local environment or testing lab with a self-signed TLS certificate:
+
+```bash
+sendbeam send ./file.txt --server "wss://localhost:8443/ws" --insecure-skip-verify
+sendbeam receive 7-code --server "wss://localhost:8443/ws" --insecure-skip-verify
+```
+
+> [!WARNING]
+> `--insecure-skip-verify` disables TLS certificate validation and should only be used for local development and test labs. End-to-end payload encryption remains active via SPAKE2 / AES-GCM.
+
+### Custom STUN & TURN Servers
+
+Add custom STUN / TURN servers for direct-path ICE candidate gathering:
+
+```bash
+# Specify custom STUN server (repeatable flag):
+sendbeam send ./file.txt --ice-server "stun:stun.example.com:3478"
+
+# Force the encrypted WebSocket relay transport (bypassing WebRTC):
+sendbeam send ./file.txt --relay-only
+```
+
+---
+
+## 2. Desktop Client Configuration
+
+The Desktop application stores configuration in a structured JSON file and persists sensitive credentials in native OS secret storage.
+
+### Setting the Server URL in UI
+
+1. Open **SendBeam Desktop**.
+2. Open **Settings** (gear icon or menu).
+3. In **Server URL**, enter your signaling server endpoint (e.g. `wss://relay.example.com/ws`).
+4. Click **Save**. The client immediately uses this server for new invite generation and room connections.
+
+---
+
+## 3. OS Secret Storage Integration
+
+SendBeam Desktop enforces strict security invariants for credentials:
+
+- **Plaintext Forbidden:** Passwords and secrets are **never** stored in plaintext within the configuration file (`config.json`).
+- **Hardware & User-Bound Storage:** Credentials are saved exclusively using the operating system's credential manager:
+  - **macOS:** Apple Keychain via Security Services framework (`/usr/bin/security`).
+  - **Windows:** Data Protection API (DPAPI per-user encryption) with secure streaming.
+  - **Linux:** Secret Service API (via `secret-tool` / libsecret / GNOME Keyring / KWallet).
+- **Fail-Closed Policy:** If the OS secret store is unavailable, SendBeam fails closed (`ErrSecretStoreUnavailable`) rather than silently falling back to insecure plaintext files.
+
+### Configuration Schema (`config.json`)
+
+```json
+{
+  "server_url": "wss://relay.example.com/ws",
+  "close_to_tray": true,
+  "start_minimized": false,
+  "notifications_enabled": true,
+  "ice_servers": [
+    {
+      "urls": ["stun:stun.example.com:3478"]
+    },
+    {
+      "urls": ["turn:turn.example.com:3478"],
+      "username": "sendbeam-user",
+      "credential_ref": "turn-password-ref"
+    }
+  ]
+}
+```
+
+Notice that `credential_ref` references a key in the OS secret store, preserving zero plaintext exposure on disk.

--- a/docs/state-storage.md
+++ b/docs/state-storage.md
@@ -6,37 +6,42 @@ This document provides a comprehensive mapping of where SendBeam stores persiste
 
 ## 1. Directory Overview by Operating System
 
-| Platform | Configuration Root (`ConfigDir`) | Durable Data Root (`DataDir`) |
-| :--- | :--- | :--- |
-| **Linux** | `$XDG_CONFIG_HOME/sendbeam`<br>(Default: `~/.config/sendbeam`) | `$XDG_DATA_HOME/sendbeam`<br>(Default: `~/.local/share/sendbeam`) |
-| **macOS** | `~/Library/Application Support/SendBeam` | `~/Library/Application Support/SendBeam` |
+| Platform    | Configuration Root (`ConfigDir`)                                          | Durable Data Root (`DataDir`)                                             |
+| :---------- | :------------------------------------------------------------------------ | :------------------------------------------------------------------------ |
+| **Linux**   | `$XDG_CONFIG_HOME/sendbeam`<br>(Default: `~/.config/sendbeam`)            | `$XDG_DATA_HOME/sendbeam`<br>(Default: `~/.local/share/sendbeam`)         |
+| **macOS**   | `~/Library/Application Support/SendBeam`                                  | `~/Library/Application Support/SendBeam`                                  |
 | **Windows** | `%APPDATA%\SendBeam`<br>(e.g. `C:\Users\<User>\AppData\Roaming\SendBeam`) | `%APPDATA%\SendBeam`<br>(e.g. `C:\Users\<User>\AppData\Roaming\SendBeam`) |
-| **Web App** | IndexedDB (`sendbeam-state`) | Origin Private File System (`OPFS`) |
+| **Web App** | IndexedDB (`sendbeam-state`)                                              | Origin Private File System (`OPFS`)                                       |
 
 ---
 
 ## 2. File & Directory Breakdown
 
 ### A. Desktop Configuration
+
 - **File:** `config.json`
 - **Location:** `<ConfigDir>/config.json`
 - **Contents:** User settings (signaling server URL, close-to-tray preference, notifications toggle, STUN/TURN server URLs, and non-secret credential references).
 
 ### B. Single-Instance Lock
+
 - **File:** `sendbeam.lock`
 - **Location:** `<ConfigDir>/sendbeam.lock`
 - **Purpose:** Acquired at application startup via OS file locking (`flock` on Unix, `LockFileEx` on Windows) to guarantee single-instance execution. Automatically released upon process termination.
 
 ### C. Durable Receive Journals (v1.3 Durable Resume)
+
 - **Directory:** `.sendbeam/journals` (inside destination output directory)
 - **Purpose:** Records block-granular verified progress, transfer ID, expected manifest fingerprint, and resume credentials for interrupted file downloads.
 - **Cleanup:** Automatically purged upon verified file completion or explicitly via `sendbeam transfers discard <id>`.
 
 ### D. Sender Restart Records
+
 - **Directory:** `<DataDir>/senders` (or `~/.sendbeam/senders`)
 - **Purpose:** Stores local path key mappings to transfer IDs and resume secret envelopes so that re-sending the same files can resume an interrupted session without retransmitting already-committed blocks.
 
 ### E. Native Credentials & Keychains
+
 - **macOS:** Stored in login keychain with service name `com.sendbeam.desktop`.
 - **Windows:** Encrypted with current user SID using Windows DPAPI.
 - **Linux:** Stored in default Secret Service keyring (`org.freedesktop.Secret.Generic`).
@@ -45,17 +50,18 @@ This document provides a comprehensive mapping of where SendBeam stores persiste
 
 ## 3. Web Client Storage Architecture
 
-| Web Storage Primitive | Purpose | Lifetime |
-| :--- | :--- | :--- |
-| **IndexedDB** (`sendbeam_journals`) | Tracks transfer progress checkpoints, transfer lease IDs, and resume credentials. | Persistent across page reloads and browser restarts until transfer completes or is discarded. |
-| **Origin Private File System (OPFS)** | Streams and stores incoming partial file chunks (`*.part`) with block-granular integrity. | Retained during interrupted transfers; finalized atomically to user download when complete. |
-| **SessionStorage / LocalStorage** | Ephemeral UI states and theme preferences. | Standard browser storage lifetime. |
+| Web Storage Primitive                 | Purpose                                                                                   | Lifetime                                                                                      |
+| :------------------------------------ | :---------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
+| **IndexedDB** (`sendbeam_journals`)   | Tracks transfer progress checkpoints, transfer lease IDs, and resume credentials.         | Persistent across page reloads and browser restarts until transfer completes or is discarded. |
+| **Origin Private File System (OPFS)** | Streams and stores incoming partial file chunks (`*.part`) with block-granular integrity. | Retained during interrupted transfers; finalized atomically to user download when complete.   |
+| **SessionStorage / LocalStorage**     | Ephemeral UI states and theme preferences.                                                | Standard browser storage lifetime.                                                            |
 
 ---
 
 ## 4. Managing and Clearing State
 
 ### CLI Transfers Command
+
 ```bash
 # List all active or interrupted durable transfer journals:
 sendbeam transfers list
@@ -74,7 +80,9 @@ sendbeam transfers discard-all
 ```
 
 ### Complete Reset
+
 To remove all local configuration and cached state:
+
 - **Linux:** `rm -rf ~/.config/sendbeam ~/.local/share/sendbeam`
 - **macOS:** `rm -rf ~/Library/Application\ Support/SendBeam`
 - **Windows (PowerShell):** `Remove-Item -Recurse -Force "$env:APPDATA\SendBeam"`

--- a/docs/state-storage.md
+++ b/docs/state-storage.md
@@ -1,0 +1,81 @@
+# State Storage & Filesystem Locations
+
+This document provides a comprehensive mapping of where SendBeam stores persistent state, configuration, transfer journals, sender records, and temporary files across Linux, macOS, Windows, and Web browsers.
+
+---
+
+## 1. Directory Overview by Operating System
+
+| Platform | Configuration Root (`ConfigDir`) | Durable Data Root (`DataDir`) |
+| :--- | :--- | :--- |
+| **Linux** | `$XDG_CONFIG_HOME/sendbeam`<br>(Default: `~/.config/sendbeam`) | `$XDG_DATA_HOME/sendbeam`<br>(Default: `~/.local/share/sendbeam`) |
+| **macOS** | `~/Library/Application Support/SendBeam` | `~/Library/Application Support/SendBeam` |
+| **Windows** | `%APPDATA%\SendBeam`<br>(e.g. `C:\Users\<User>\AppData\Roaming\SendBeam`) | `%APPDATA%\SendBeam`<br>(e.g. `C:\Users\<User>\AppData\Roaming\SendBeam`) |
+| **Web App** | IndexedDB (`sendbeam-state`) | Origin Private File System (`OPFS`) |
+
+---
+
+## 2. File & Directory Breakdown
+
+### A. Desktop Configuration
+- **File:** `config.json`
+- **Location:** `<ConfigDir>/config.json`
+- **Contents:** User settings (signaling server URL, close-to-tray preference, notifications toggle, STUN/TURN server URLs, and non-secret credential references).
+
+### B. Single-Instance Lock
+- **File:** `sendbeam.lock`
+- **Location:** `<ConfigDir>/sendbeam.lock`
+- **Purpose:** Acquired at application startup via OS file locking (`flock` on Unix, `LockFileEx` on Windows) to guarantee single-instance execution. Automatically released upon process termination.
+
+### C. Durable Receive Journals (v1.3 Durable Resume)
+- **Directory:** `.sendbeam/journals` (inside destination output directory)
+- **Purpose:** Records block-granular verified progress, transfer ID, expected manifest fingerprint, and resume credentials for interrupted file downloads.
+- **Cleanup:** Automatically purged upon verified file completion or explicitly via `sendbeam transfers discard <id>`.
+
+### D. Sender Restart Records
+- **Directory:** `<DataDir>/senders` (or `~/.sendbeam/senders`)
+- **Purpose:** Stores local path key mappings to transfer IDs and resume secret envelopes so that re-sending the same files can resume an interrupted session without retransmitting already-committed blocks.
+
+### E. Native Credentials & Keychains
+- **macOS:** Stored in login keychain with service name `com.sendbeam.desktop`.
+- **Windows:** Encrypted with current user SID using Windows DPAPI.
+- **Linux:** Stored in default Secret Service keyring (`org.freedesktop.Secret.Generic`).
+
+---
+
+## 3. Web Client Storage Architecture
+
+| Web Storage Primitive | Purpose | Lifetime |
+| :--- | :--- | :--- |
+| **IndexedDB** (`sendbeam_journals`) | Tracks transfer progress checkpoints, transfer lease IDs, and resume credentials. | Persistent across page reloads and browser restarts until transfer completes or is discarded. |
+| **Origin Private File System (OPFS)** | Streams and stores incoming partial file chunks (`*.part`) with block-granular integrity. | Retained during interrupted transfers; finalized atomically to user download when complete. |
+| **SessionStorage / LocalStorage** | Ephemeral UI states and theme preferences. | Standard browser storage lifetime. |
+
+---
+
+## 4. Managing and Clearing State
+
+### CLI Transfers Command
+```bash
+# List all active or interrupted durable transfer journals:
+sendbeam transfers list
+
+# Inspect details of an interrupted transfer:
+sendbeam transfers inspect <transfer-id>
+
+# Resume an interrupted transfer:
+sendbeam transfers resume <transfer-id> --code 7-guitarist-melody
+
+# Discard an interrupted transfer and delete partial chunks:
+sendbeam transfers discard <transfer-id>
+
+# Discard all interrupted journals:
+sendbeam transfers discard-all
+```
+
+### Complete Reset
+To remove all local configuration and cached state:
+- **Linux:** `rm -rf ~/.config/sendbeam ~/.local/share/sendbeam`
+- **macOS:** `rm -rf ~/Library/Application\ Support/SendBeam`
+- **Windows (PowerShell):** `Remove-Item -Recurse -Force "$env:APPDATA\SendBeam"`
+- **Web App:** Clear site storage for `omnitrix.space` in browser developer tools.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,106 @@
+# Operational Troubleshooting & Network Diagnostics
+
+This guide provides troubleshooting procedures for SendBeam network connectivity, transport fallback, single-instance process locks, and OS credential stores.
+
+---
+
+## 1. Network Diagnostics & Diagnostics Command
+
+SendBeam includes built-in diagnostic tools that inspect network interfaces, STUN responsiveness, and signaling latency without exposing private information.
+
+### CLI Diagnostics
+
+Run `sendbeam diagnose` to run a comprehensive system and network self-check:
+
+```bash
+sendbeam diagnose
+```
+
+Example sanitized output:
+
+```text
+SendBeam Diagnostics:
+  Product Version: 1.4.0 (42105680bc7a)
+  OS/Arch:         linux/amd64
+  Signaling:       wss://omnitrix.space/ws [reachable: 48ms]
+  STUN Check:      stun.l.google.com:19302 [srflx candidate gathered: 203.0.113.45:49210]
+  Local Interfaces: eth0 (192.168.1.100/24), wlan0 (10.0.0.15/24)
+  Relay Readiness: Ready (WebSocket upgrade OK)
+```
+
+To export machine-readable diagnostics for bug reports:
+
+```bash
+sendbeam diagnose --json > diagnostics.json
+```
+
+> [!NOTE]
+> Diagnostic outputs are automatically sanitized: filenames, directory paths, file contents, invite words, passwords, and full IP addresses (beyond the first two octets) are excluded.
+
+---
+
+## 2. Network Topologies & Transport Fallback
+
+SendBeam uses an adaptive path selection engine that races direct WebRTC against the encrypted WebSocket relay:
+
+| Network Condition | Behavior | Expected Resolution |
+| :--- | :--- | :--- |
+| **Open Internet / UPnP / Full-Cone NAT** | Direct WebRTC engaged within ~1.2s. | High-speed direct peer-to-peer. |
+| **UDP Blocked (Corporate Firewalls)** | No STUN response gathered; relay warms and engages in ~5.2s. | Automatic encrypted WebSocket relay fallback over HTTPS port 443. |
+| **Symmetric NAT to Symmetric NAT** | Direct hole-punching impossible; ICE fails after negotiation timeout (~11s). | Automatic encrypted WebSocket relay fallback. |
+| **Relay Only Requested (`--relay-only`)** | Skips WebRTC ICE gathering entirely. | Instant encrypted relay connection. |
+
+### Firewall Ports
+
+If configuring corporate or router firewalls to optimize direct WebRTC transfers:
+- **Egress UDP:** Ports 1024–65535 (for STUN/WebRTC media).
+- **Egress TCP / HTTPS:** Port 443 (for signaling and encrypted WebSocket relay).
+
+---
+
+## 3. Resolving Single-Instance Lock Issues
+
+SendBeam Desktop enforces single-instance execution to prevent multiple processes from corrupting persistent journals or clobbering network sockets.
+
+### Symptoms
+- Launching Desktop displays: `SendBeam is already running`.
+- A background instance is active in the system tray.
+
+### Resolution
+
+1. **Check the System Tray:**
+   - Look for the SendBeam icon in your taskbar / system tray (macOS menu bar, Windows system tray, or Linux notification area).
+   - Click the icon and select **Show SendBeam** or **Quit SendBeam**.
+
+2. **Terminating Stale Background Processes:**
+   - **Linux / macOS:**
+     ```bash
+     killall sendbeam-desktop
+     ```
+   - **Windows (PowerShell):**
+     ```powershell
+     Stop-Process -Name sendbeam-desktop -Force
+     ```
+
+3. **Clearing Stale Lock Files:**
+   If a hard crash prevented lock cleanup:
+   - Linux: Delete `~/.config/sendbeam/sendbeam.lock`
+   - macOS: Delete `~/Library/Application Support/SendBeam/sendbeam.lock`
+   - Windows: Delete `%APPDATA%\SendBeam\sendbeam.lock`
+
+---
+
+## 4. Secret Store Troubleshooting
+
+SendBeam Desktop integrates with native credential managers to protect TURN credentials.
+
+### Linux: `SecretStoreUnavailable`
+On minimal or headless Linux installations without a running D-Bus Secret Service:
+- Install `gnome-keyring` or `libsecret-tools`:
+  ```bash
+  sudo apt-get install gnome-keyring libsecret-tools
+  ```
+- Or run in headless/CLI mode where sensitive TURN credentials can be passed via command-line arguments.
+
+### macOS: Keychain Prompts
+- If prompted by macOS Keychain to grant access to SendBeam, select **Always Allow** to allow background credential access for scheduled updates and self-host credentials.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,16 +43,17 @@ sendbeam diagnose --json > diagnostics.json
 
 SendBeam uses an adaptive path selection engine that races direct WebRTC against the encrypted WebSocket relay:
 
-| Network Condition | Behavior | Expected Resolution |
-| :--- | :--- | :--- |
-| **Open Internet / UPnP / Full-Cone NAT** | Direct WebRTC engaged within ~1.2s. | High-speed direct peer-to-peer. |
-| **UDP Blocked (Corporate Firewalls)** | No STUN response gathered; relay warms and engages in ~5.2s. | Automatic encrypted WebSocket relay fallback over HTTPS port 443. |
-| **Symmetric NAT to Symmetric NAT** | Direct hole-punching impossible; ICE fails after negotiation timeout (~11s). | Automatic encrypted WebSocket relay fallback. |
-| **Relay Only Requested (`--relay-only`)** | Skips WebRTC ICE gathering entirely. | Instant encrypted relay connection. |
+| Network Condition                         | Behavior                                                                     | Expected Resolution                                               |
+| :---------------------------------------- | :--------------------------------------------------------------------------- | :---------------------------------------------------------------- |
+| **Open Internet / UPnP / Full-Cone NAT**  | Direct WebRTC engaged within ~1.2s.                                          | High-speed direct peer-to-peer.                                   |
+| **UDP Blocked (Corporate Firewalls)**     | No STUN response gathered; relay warms and engages in ~5.2s.                 | Automatic encrypted WebSocket relay fallback over HTTPS port 443. |
+| **Symmetric NAT to Symmetric NAT**        | Direct hole-punching impossible; ICE fails after negotiation timeout (~11s). | Automatic encrypted WebSocket relay fallback.                     |
+| **Relay Only Requested (`--relay-only`)** | Skips WebRTC ICE gathering entirely.                                         | Instant encrypted relay connection.                               |
 
 ### Firewall Ports
 
 If configuring corporate or router firewalls to optimize direct WebRTC transfers:
+
 - **Egress UDP:** Ports 1024–65535 (for STUN/WebRTC media).
 - **Egress TCP / HTTPS:** Port 443 (for signaling and encrypted WebSocket relay).
 
@@ -63,6 +64,7 @@ If configuring corporate or router firewalls to optimize direct WebRTC transfers
 SendBeam Desktop enforces single-instance execution to prevent multiple processes from corrupting persistent journals or clobbering network sockets.
 
 ### Symptoms
+
 - Launching Desktop displays: `SendBeam is already running`.
 - A background instance is active in the system tray.
 
@@ -95,7 +97,9 @@ SendBeam Desktop enforces single-instance execution to prevent multiple processe
 SendBeam Desktop integrates with native credential managers to protect TURN credentials.
 
 ### Linux: `SecretStoreUnavailable`
+
 On minimal or headless Linux installations without a running D-Bus Secret Service:
+
 - Install `gnome-keyring` or `libsecret-tools`:
   ```bash
   sudo apt-get install gnome-keyring libsecret-tools
@@ -103,4 +107,5 @@ On minimal or headless Linux installations without a running D-Bus Secret Servic
 - Or run in headless/CLI mode where sensitive TURN credentials can be passed via command-line arguments.
 
 ### macOS: Keychain Prompts
+
 - If prompted by macOS Keychain to grant access to SendBeam, select **Always Allow** to allow background credential access for scheduled updates and self-host credentials.


### PR DESCRIPTION
## Summary

This PR implements **V14-PR07 — Interoperability + support surface** from the v1.4 milestone:

1. **Cross-Client Interoperability Matrix (`docs/compat-matrix.md`):**
   - Documents the full 6-way directional matrix across **Browser ↔ CLI ↔ Desktop**.
   - Details behavior on direct WebRTC vs fallback encrypted WebSocket relay paths.
   - Grounding on shared wire protocol (`sendbeam/1`) and Go engine integration (`packages/engine`, `packages/wire`).
   - Verifies durable resume rows across Desktop pairs (`resume-auth-v1`).

2. **Multi-Platform Installation & Quickstarts (`docs/install.md`):**
   - Linux: Debian package (`.deb`), AppImage, standalone CLI.
   - macOS: DMG installer, Universal Mach-O bundle, standalone CLI.
   - Windows: NSIS executable installer, Portable ZIP, standalone CLI.
   - SHA-256 verification and SBOM references.

3. **Self-Host Client Configuration (`docs/self-hosting-clients.md`):**
   - Configuring custom signaling/relay servers via CLI (`--server`) and Desktop UI.
   - Custom STUN/TURN configuration.
   - OS secret storage integration (Apple Keychain, Windows DPAPI, Linux Secret Service).
   - Insecure skip-verify flag for private test labs.

4. **Troubleshooting & Diagnostics (`docs/troubleshooting.md`):**
   - `sendbeam diagnose` command and sanitized diagnostic snapshots.
   - Restrictive firewall and NAT analysis.
   - Single-instance lock recovery (`sendbeam.lock`).
   - Headless Linux and secret store guidance.

5. **State Storage Locations (`docs/state-storage.md`):**
   - Filesystem mapping of config, journals (`.sendbeam/journals`), sender records, locks, and OPFS/IndexedDB web storage.

6. **README Updates:**
   - Expanded documentation index referencing all user support, installation, and architectural guides.

## Verification
- Web tests & linter: 24/24 test files (213/213 tests) passed.
- Go test suites: wire, engine, server, cli passed with `-race`.
- SBOM & version metadata test suites passed.
- Branding checks passed with zero stale SendArc references.