### PR TITLE
feat(trust): trusted-session authentication and forward-secret key schedule

### DIFF
--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -157,3 +157,45 @@ PairCredentialRef = "cred-" || LowercaseHex(SHA-256(k_pair))
 - **Key & Label Conflicts:**
   - If a pairing peer claims an active name already assigned to a different public key, the ceremony aborts with `ErrLabelConflict`.
   - Silent key overwrites are strictly forbidden to prevent impersonation attacks.
+
+---
+
+## 7. Trusted-Session Authentication (`sendbeam/2`)
+
+Repeat connections between paired devices authenticate without human codes or passwords using mutual challenge-response verification over ephemeral key material.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Initiator
+    participant B as Responder
+    Note over A: 1. Generate Ephem_A, Nonce_A<br/>Sign Challenge_A with Ed25519<br/>Compute MAC_A using k_pair
+    A->>B: TrustedAuthInit (InitID, RespID, CredRef, Ephem_A, Nonce_A, Caps_A, TS, Sig_A, MAC_A)
+    Note over B: 2. Check TrustStore & Revocation<br/>Verify Timestamp (±5 min)<br/>Verify Sig_A & MAC_A
+    Note over B: 3. Generate Ephem_B, Nonce_B<br/>Sign Challenge_B with Ed25519<br/>Compute MAC_B using k_pair
+    B->>A: TrustedAuthResponse (Status, RespID, Ephem_B, Nonce_B, Caps_B, Sig_B, MAC_B)
+    Note over A: 4. Verify Sig_B & MAC_B
+    Note over A,B: 5. Derive Forward-Secret Session Keys (k_i2r, k_r2i)
+    A->>B: TrustedAuthConfirm (Status: ready, AuthTag: HMAC(Master, InitID))
+    B->>A: TrustedAuthConfirm (Status: ready, AuthTag: HMAC(Master, RespID))
+    Note over A,B: 6. Secure Transfer Epoch Established
+```
+
+### 7.1 Forward-Secret Key Schedule
+
+```
+IKM = HMAC-SHA256(k_pair, Ephem_A || Ephem_B || Nonce_A || Nonce_B)
+Salt = Nonce_A || Nonce_B
+Transcript = "sendbeam/2 trusted-resp:" || SHA-256(k_pair) || Ephem_A || Ephem_B || Nonce_A || Nonce_B || InitID || RespID || SHA-256(NegotiatedCaps)
+
+SessionMaster = HKDF-SHA256(IKM, Salt, "sendbeam/2 session-master:" || Transcript, 32)
+k_i2r = HKDF-SHA256(SessionMaster, nil, "sendbeam/2 initiator-to-responder key", 32)
+k_r2i = HKDF-SHA256(SessionMaster, nil, "sendbeam/2 responder-to-initiator key", 32)
+```
+
+### 7.2 Replay & Revocation Enforcement
+
+- **Timestamp Skew Bounding:** Timestamps outside ±5 minutes are rejected immediately (`ErrTrustedTimestampSkew`).
+- **Cryptographic Binding:** The signature and MAC tag strictly bind `k_pair`, `EphemeralPub`, `Nonce`, `DeviceID`, and `NegotiatedCapabilities`.
+- **Local Revocation:** If a peer has been marked `revoked: true` in the local trust database, all connection attempts are rejected with `ErrTrustedPeerRevoked`.
+- **Protocol Boundary:** One-time pairing and transfers remain compatible via `sendbeam/1`, while trusted-device mesh operations use `sendbeam/2`.

--- a/packages/engine/trust/trusted_session.go
+++ b/packages/engine/trust/trusted_session.go
@@ -1,0 +1,323 @@
+// Package trust manages local device cryptographic identity, pairing, and trusted sessions.
+package trust
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+// SecretResolver resolves a raw 32-byte k_pair secret given its credential reference or device ID.
+type SecretResolver interface {
+	ResolvePairSecret(ctx context.Context, deviceID, pairCredRef string) ([]byte, error)
+}
+
+// MemorySecretResolver is an in-memory secret resolver for tests and transient sessions.
+type MemorySecretResolver struct {
+	secrets map[string][]byte
+}
+
+// NewMemorySecretResolver creates a new MemorySecretResolver.
+func NewMemorySecretResolver() *MemorySecretResolver {
+	return &MemorySecretResolver{
+		secrets: make(map[string][]byte),
+	}
+}
+
+// SetSecret stores a raw k_pair secret keyed by device ID.
+func (m *MemorySecretResolver) SetSecret(deviceID string, secret []byte) {
+	m.secrets[deviceID] = append([]byte(nil), secret...)
+}
+
+// ResolvePairSecret returns the stored k_pair secret for a device.
+func (m *MemorySecretResolver) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
+	s, ok := m.secrets[deviceID]
+	if !ok || len(s) == 0 {
+		return nil, errors.New("pair secret not found")
+	}
+	return s, nil
+}
+
+// TrustedSessionConfig specifies parameters for an initiator connecting to a trusted device.
+type TrustedSessionConfig struct {
+	PeerDeviceID string
+	Capabilities []string
+}
+
+// TrustedSessionResult contains the authenticated peer's trust record and derived directional keys.
+type TrustedSessionResult struct {
+	PeerRecord *wire.TrustRecord
+	Keys       *wire.TrustedSessionKeys
+}
+
+// TrustedSessionCoordinator manages mutual challenge-response authentication between paired devices.
+type TrustedSessionCoordinator struct {
+	idMgr    *IdentityManager
+	store    Store
+	resolver SecretResolver
+}
+
+// NewTrustedSessionCoordinator creates a new TrustedSessionCoordinator.
+func NewTrustedSessionCoordinator(idMgr *IdentityManager, store Store, resolver SecretResolver) *TrustedSessionCoordinator {
+	return &TrustedSessionCoordinator{
+		idMgr:    idMgr,
+		store:    store,
+		resolver: resolver,
+	}
+}
+
+// InitiateTrustedSession executes the initiator role of the trusted-session authentication handshake.
+func (c *TrustedSessionCoordinator) InitiateTrustedSession(ctx context.Context, transport PairingTransport, cfg TrustedSessionConfig) (*TrustedSessionResult, error) {
+	if transport == nil {
+		return nil, errors.New("pairing transport required")
+	}
+	if cfg.PeerDeviceID == "" {
+		return nil, errors.New("peer device ID required")
+	}
+
+	record, err := c.store.GetDevice(ctx, cfg.PeerDeviceID)
+	if err != nil {
+		return nil, fmt.Errorf("lookup peer in trust store: %w", err)
+	}
+	if record.Revoked {
+		return nil, wire.ErrTrustedPeerRevoked
+	}
+
+	peerPub, err := hex.DecodeString(record.PublicKey)
+	if err != nil || len(peerPub) != ed25519.PublicKeySize {
+		return nil, wire.ErrInvalidPublicKey
+	}
+
+	kPair, err := c.resolver.ResolvePairSecret(ctx, cfg.PeerDeviceID, record.PairCredentialRef)
+	if err != nil {
+		return nil, fmt.Errorf("resolve pair secret: %w", err)
+	}
+
+	id, err := c.idMgr.GetOrCreateIdentity()
+	if err != nil {
+		return nil, fmt.Errorf("get local identity: %w", err)
+	}
+
+	// 1. Create and send TrustedAuthInit
+	now := time.Now().UTC()
+	initMsg, err := wire.NewTrustedAuthInit(id, cfg.PeerDeviceID, record.PairCredentialRef, kPair, cfg.Capabilities, nil, nil, now)
+	if err != nil {
+		return nil, fmt.Errorf("create trusted auth init: %w", err)
+	}
+
+	initData, err := wire.EncodeTrustedAuthMessage(initMsg)
+	if err != nil {
+		return nil, fmt.Errorf("encode trusted auth init: %w", err)
+	}
+
+	if err := transport.SendMessage(ctx, initData); err != nil {
+		return nil, fmt.Errorf("send trusted auth init: %w", err)
+	}
+
+	// 2. Receive and verify TrustedAuthResponse
+	respData, err := transport.ReceiveMessage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("receive trusted auth response: %w", err)
+	}
+
+	respMsgRaw, err := wire.DecodeTrustedAuthMessage(respData)
+	if err != nil {
+		return nil, fmt.Errorf("decode trusted auth response: %w", err)
+	}
+
+	respMsg, ok := respMsgRaw.(*wire.TrustedAuthResponse)
+	if !ok {
+		return nil, errors.New("expected trusted auth response message")
+	}
+
+	ephemResp, nonceResp, err := wire.VerifyTrustedAuthResponse(respMsg, initMsg, kPair, peerPub, id.DeviceID)
+	if err != nil {
+		return nil, fmt.Errorf("verify trusted auth response: %w", err)
+	}
+
+	// 3. Derive forward-secret session keys
+	ephemInit, _ := hex.DecodeString(initMsg.EphemeralPub)
+	nonceInit, _ := hex.DecodeString(initMsg.Nonce)
+
+	keys, err := wire.DeriveTrustedSessionKeys(kPair, ephemInit, ephemResp, nonceInit, nonceResp, id.DeviceID, cfg.PeerDeviceID, cfg.Capabilities, respMsg.Capabilities)
+	if err != nil {
+		return nil, fmt.Errorf("derive trusted session keys: %w", err)
+	}
+
+	// 4. Send our confirmation and verify peer's confirmation
+	confInit := wire.NewTrustedAuthConfirm(keys.SessionMaster, wire.DomainTrustedConfirmInit, id.DeviceID, true)
+	confData, err := wire.EncodeTrustedAuthMessage(confInit)
+	if err != nil {
+		return nil, fmt.Errorf("encode confirm: %w", err)
+	}
+
+	if err := transport.SendMessage(ctx, confData); err != nil {
+		return nil, fmt.Errorf("send confirm: %w", err)
+	}
+
+	peerConfData, err := transport.ReceiveMessage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("receive peer confirm: %w", err)
+	}
+
+	peerConfRaw, err := wire.DecodeTrustedAuthMessage(peerConfData)
+	if err != nil {
+		return nil, fmt.Errorf("decode peer confirm: %w", err)
+	}
+
+	peerConf, ok := peerConfRaw.(*wire.TrustedAuthConfirm)
+	if !ok {
+		return nil, errors.New("expected trusted auth confirm message")
+	}
+
+	if err := wire.VerifyTrustedAuthConfirm(peerConf, keys.SessionMaster, wire.DomainTrustedConfirmResp, cfg.PeerDeviceID); err != nil {
+		return nil, fmt.Errorf("verify peer confirm: %w", err)
+	}
+
+	// 5. Update LastSeenAt in local store
+	record.LastSeenAt = time.Now().UTC()
+	_ = c.store.AddOrUpdateDevice(ctx, record)
+
+	return &TrustedSessionResult{
+		PeerRecord: record,
+		Keys:       keys,
+	}, nil
+}
+
+// AcceptTrustedSession executes the responder role of the trusted-session authentication handshake.
+func (c *TrustedSessionCoordinator) AcceptTrustedSession(ctx context.Context, transport PairingTransport, capabilities []string) (*TrustedSessionResult, error) {
+	if transport == nil {
+		return nil, errors.New("pairing transport required")
+	}
+
+	id, err := c.idMgr.GetOrCreateIdentity()
+	if err != nil {
+		return nil, fmt.Errorf("get local identity: %w", err)
+	}
+
+	// 1. Receive and verify TrustedAuthInit
+	initData, err := transport.ReceiveMessage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("receive trusted auth init: %w", err)
+	}
+
+	initMsgRaw, err := wire.DecodeTrustedAuthMessage(initData)
+	if err != nil {
+		return nil, fmt.Errorf("decode trusted auth init: %w", err)
+	}
+
+	initMsg, ok := initMsgRaw.(*wire.TrustedAuthInit)
+	if !ok {
+		return nil, errors.New("expected trusted auth init message")
+	}
+
+	record, err := c.store.GetDevice(ctx, initMsg.InitiatorDeviceID)
+	if err != nil {
+		_ = c.sendRejection(ctx, transport, "rejected")
+		return nil, fmt.Errorf("peer not in trust store: %w", err)
+	}
+
+	if record.Revoked {
+		_ = c.sendRejection(ctx, transport, "revoked")
+		return nil, wire.ErrTrustedPeerRevoked
+	}
+
+	peerPub, err := hex.DecodeString(record.PublicKey)
+	if err != nil || len(peerPub) != ed25519.PublicKeySize {
+		_ = c.sendRejection(ctx, transport, "rejected")
+		return nil, wire.ErrInvalidPublicKey
+	}
+
+	kPair, err := c.resolver.ResolvePairSecret(ctx, initMsg.InitiatorDeviceID, record.PairCredentialRef)
+	if err != nil {
+		_ = c.sendRejection(ctx, transport, "rejected")
+		return nil, fmt.Errorf("resolve pair secret: %w", err)
+	}
+
+	now := time.Now().UTC()
+	ephemInit, nonceInit, err := wire.VerifyTrustedAuthInit(initMsg, kPair, peerPub, id.DeviceID, now)
+	if err != nil {
+		_ = c.sendRejection(ctx, transport, "rejected")
+		return nil, fmt.Errorf("verify trusted auth init: %w", err)
+	}
+
+	// 2. Create and send TrustedAuthResponse
+	respMsg, err := wire.NewTrustedAuthResponse(id, initMsg, kPair, capabilities, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create trusted auth response: %w", err)
+	}
+
+	respData, err := wire.EncodeTrustedAuthMessage(respMsg)
+	if err != nil {
+		return nil, fmt.Errorf("encode trusted auth response: %w", err)
+	}
+
+	if err := transport.SendMessage(ctx, respData); err != nil {
+		return nil, fmt.Errorf("send trusted auth response: %w", err)
+	}
+
+	// 3. Derive forward-secret session keys
+	ephemResp, _ := hex.DecodeString(respMsg.EphemeralPub)
+	nonceResp, _ := hex.DecodeString(respMsg.Nonce)
+
+	keys, err := wire.DeriveTrustedSessionKeys(kPair, ephemInit, ephemResp, nonceInit, nonceResp, initMsg.InitiatorDeviceID, id.DeviceID, initMsg.Capabilities, capabilities)
+	if err != nil {
+		return nil, fmt.Errorf("derive trusted session keys: %w", err)
+	}
+
+	// 4. Receive peer confirm and send our confirm
+	peerConfData, err := transport.ReceiveMessage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("receive peer confirm: %w", err)
+	}
+
+	peerConfRaw, err := wire.DecodeTrustedAuthMessage(peerConfData)
+	if err != nil {
+		return nil, fmt.Errorf("decode peer confirm: %w", err)
+	}
+
+	peerConf, ok := peerConfRaw.(*wire.TrustedAuthConfirm)
+	if !ok {
+		return nil, errors.New("expected trusted auth confirm message")
+	}
+
+	if err := wire.VerifyTrustedAuthConfirm(peerConf, keys.SessionMaster, wire.DomainTrustedConfirmInit, initMsg.InitiatorDeviceID); err != nil {
+		return nil, fmt.Errorf("verify peer confirm: %w", err)
+	}
+
+	confResp := wire.NewTrustedAuthConfirm(keys.SessionMaster, wire.DomainTrustedConfirmResp, id.DeviceID, true)
+	confData, err := wire.EncodeTrustedAuthMessage(confResp)
+	if err != nil {
+		return nil, fmt.Errorf("encode confirm: %w", err)
+	}
+
+	if err := transport.SendMessage(ctx, confData); err != nil {
+		return nil, fmt.Errorf("send confirm: %w", err)
+	}
+
+	// 5. Update LastSeenAt in local store
+	record.LastSeenAt = time.Now().UTC()
+	_ = c.store.AddOrUpdateDevice(ctx, record)
+
+	return &TrustedSessionResult{
+		PeerRecord: record,
+		Keys:       keys,
+	}, nil
+}
+
+func (c *TrustedSessionCoordinator) sendRejection(ctx context.Context, transport PairingTransport, status string) error {
+	id, _ := c.idMgr.GetOrCreateIdentity()
+	resp := &wire.TrustedAuthResponse{
+		Type:              wire.MsgTrustedAuthResponse,
+		ProtocolVersion:   wire.TrustedAuthProtocolVersion,
+		Status:            status,
+		ResponderDeviceID: id.DeviceID,
+	}
+	data, _ := wire.EncodeTrustedAuthMessage(resp)
+	return transport.SendMessage(ctx, data)
+}

--- a/packages/engine/trust/trusted_session_test.go
+++ b/packages/engine/trust/trusted_session_test.go
@@ -1,0 +1,278 @@
+package trust
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+func TestTrustedSessionCoordinatorEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tmpDirA := t.TempDir()
+	tmpDirB := t.TempDir()
+
+	idMgrA, _ := NewIdentityManager(filepath.Join(tmpDirA, "alice.key"))
+	idMgrB, _ := NewIdentityManager(filepath.Join(tmpDirB, "bob.key"))
+
+	idA, _ := idMgrA.GetOrCreateIdentity()
+	idB, _ := idMgrB.GetOrCreateIdentity()
+
+	storeA, _ := NewFileTrustStore(filepath.Join(tmpDirA, "alice-trust.json"))
+	storeB, _ := NewFileTrustStore(filepath.Join(tmpDirB, "bob-trust.json"))
+
+	kPair := sha256.Sum256([]byte("shared-k-pair-secret-for-session-test"))
+	hCred := sha256.Sum256(kPair[:])
+	credRef := "cred-" + hex.EncodeToString(hCred[:])
+
+	resA := NewMemorySecretResolver()
+	resA.SetSecret(idB.DeviceID, kPair[:])
+
+	resB := NewMemorySecretResolver()
+	resB.SetSecret(idA.DeviceID, kPair[:])
+
+	now := time.Now().UTC().Add(-1 * time.Hour)
+
+	_ = storeA.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idB.DeviceID,
+		PublicKey:         hex.EncodeToString(idB.PublicKey),
+		LocalLabel:        "Bob Desktop",
+		PairCredentialRef: credRef,
+		Capabilities:      []string{"transfer.v1", "transfer.v2", "lan_direct"},
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	_ = storeB.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idA.DeviceID,
+		PublicKey:         hex.EncodeToString(idA.PublicKey),
+		LocalLabel:        "Alice Laptop",
+		PairCredentialRef: credRef,
+		Capabilities:      []string{"transfer.v1", "transfer.v2", "auto_accept"},
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	coordA := NewTrustedSessionCoordinator(idMgrA, storeA, resA)
+	coordB := NewTrustedSessionCoordinator(idMgrB, storeB, resB)
+
+	transA, transB := makeLoopbackPair()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var resInit *TrustedSessionResult
+	var errInit error
+	var resResp *TrustedSessionResult
+	var errResp error
+
+	go func() {
+		defer wg.Done()
+		resInit, errInit = coordA.InitiateTrustedSession(ctx, transA, TrustedSessionConfig{
+			PeerDeviceID: idB.DeviceID,
+			Capabilities: []string{"transfer.v1", "transfer.v2", "auto_accept"},
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		resResp, errResp = coordB.AcceptTrustedSession(ctx, transB, []string{"transfer.v1", "transfer.v2", "lan_direct"})
+	}()
+
+	wg.Wait()
+
+	if errInit != nil {
+		t.Fatalf("Alice InitiateTrustedSession error: %v", errInit)
+	}
+	if errResp != nil {
+		t.Fatalf("Bob AcceptTrustedSession error: %v", errResp)
+	}
+
+	// Verify key schedule symmetry
+	if !bytes.Equal(resInit.Keys.SessionMaster, resResp.Keys.SessionMaster) {
+		t.Errorf("SessionMaster mismatch")
+	}
+	if !bytes.Equal(resInit.Keys.InitiatorToResponderKey, resResp.Keys.InitiatorToResponderKey) {
+		t.Errorf("I2RKey mismatch")
+	}
+	if !bytes.Equal(resInit.Keys.ResponderToInitiatorKey, resResp.Keys.ResponderToInitiatorKey) {
+		t.Errorf("R2IKey mismatch")
+	}
+
+	// Verify LastSeenAt updated in stores
+	recA, _ := storeA.GetDevice(ctx, idB.DeviceID)
+	if !recA.LastSeenAt.After(now) {
+		t.Errorf("storeA LastSeenAt was not refreshed")
+	}
+
+	recB, _ := storeB.GetDevice(ctx, idA.DeviceID)
+	if !recB.LastSeenAt.After(now) {
+		t.Errorf("storeB LastSeenAt was not refreshed")
+	}
+}
+
+func TestTrustedSessionRevocationRejection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tmpDirA := t.TempDir()
+	tmpDirB := t.TempDir()
+
+	idMgrA, _ := NewIdentityManager(filepath.Join(tmpDirA, "alice.key"))
+	idMgrB, _ := NewIdentityManager(filepath.Join(tmpDirB, "bob.key"))
+
+	idA, _ := idMgrA.GetOrCreateIdentity()
+	idB, _ := idMgrB.GetOrCreateIdentity()
+
+	storeA, _ := NewFileTrustStore(filepath.Join(tmpDirA, "alice-trust.json"))
+	storeB, _ := NewFileTrustStore(filepath.Join(tmpDirB, "bob-trust.json"))
+
+	kPair := sha256.Sum256([]byte("shared-k-pair-revocation-test"))
+	hCred := sha256.Sum256(kPair[:])
+	credRef := "cred-" + hex.EncodeToString(hCred[:])
+
+	resA := NewMemorySecretResolver()
+	resA.SetSecret(idB.DeviceID, kPair[:])
+	resB := NewMemorySecretResolver()
+	resB.SetSecret(idA.DeviceID, kPair[:])
+
+	now := time.Now().UTC()
+
+	_ = storeA.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idB.DeviceID,
+		PublicKey:         hex.EncodeToString(idB.PublicKey),
+		LocalLabel:        "Bob Desktop",
+		PairCredentialRef: credRef,
+		Capabilities:      []string{"transfer.v1"},
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	// Bob has REVOKED Alice
+	_ = storeB.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idA.DeviceID,
+		PublicKey:         hex.EncodeToString(idA.PublicKey),
+		LocalLabel:        "Alice Laptop",
+		PairCredentialRef: credRef,
+		Capabilities:      []string{"transfer.v1"},
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Revoked:           true,
+		RevokedAt:         &now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	coordA := NewTrustedSessionCoordinator(idMgrA, storeA, resA)
+	coordB := NewTrustedSessionCoordinator(idMgrB, storeB, resB)
+
+	transA, transB := makeLoopbackPair()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var errInit, errResp error
+
+	go func() {
+		defer wg.Done()
+		_, errInit = coordA.InitiateTrustedSession(ctx, transA, TrustedSessionConfig{
+			PeerDeviceID: idB.DeviceID,
+			Capabilities: []string{"transfer.v1"},
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, errResp = coordB.AcceptTrustedSession(ctx, transB, []string{"transfer.v1"})
+	}()
+
+	wg.Wait()
+
+	if !errors.Is(errResp, wire.ErrTrustedPeerRevoked) {
+		t.Errorf("expected Bob to return ErrTrustedPeerRevoked, got %v", errResp)
+	}
+	if !errors.Is(errInit, wire.ErrTrustedPeerRevoked) {
+		t.Errorf("expected Alice to receive ErrTrustedPeerRevoked, got %v", errInit)
+	}
+}
+
+func TestTrustedSessionUnknownPeerRejection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tmpDirA := t.TempDir()
+	tmpDirB := t.TempDir()
+
+	idMgrA, _ := NewIdentityManager(filepath.Join(tmpDirA, "alice.key"))
+	idMgrB, _ := NewIdentityManager(filepath.Join(tmpDirB, "bob.key"))
+
+	idB, _ := idMgrB.GetOrCreateIdentity()
+
+	storeA, _ := NewFileTrustStore(filepath.Join(tmpDirA, "alice-trust.json"))
+	storeB, _ := NewFileTrustStore(filepath.Join(tmpDirB, "bob-trust.json"))
+
+	kPair := sha256.Sum256([]byte("shared-k-pair-unknown-test"))
+	hCred := sha256.Sum256(kPair[:])
+	credRef := "cred-" + hex.EncodeToString(hCred[:])
+
+	resA := NewMemorySecretResolver()
+	resA.SetSecret(idB.DeviceID, kPair[:])
+	resB := NewMemorySecretResolver()
+
+	now := time.Now().UTC()
+
+	// Alice has Bob in store, but Bob DOES NOT have Alice in store
+	_ = storeA.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idB.DeviceID,
+		PublicKey:         hex.EncodeToString(idB.PublicKey),
+		LocalLabel:        "Bob Desktop",
+		PairCredentialRef: credRef,
+		Capabilities:      []string{"transfer.v1"},
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	coordA := NewTrustedSessionCoordinator(idMgrA, storeA, resA)
+	coordB := NewTrustedSessionCoordinator(idMgrB, storeB, resB)
+
+	transA, transB := makeLoopbackPair()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var errInit, errResp error
+
+	go func() {
+		defer wg.Done()
+		_, errInit = coordA.InitiateTrustedSession(ctx, transA, TrustedSessionConfig{
+			PeerDeviceID: idB.DeviceID,
+			Capabilities: []string{"transfer.v1"},
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, errResp = coordB.AcceptTrustedSession(ctx, transB, []string{"transfer.v1"})
+	}()
+
+	wg.Wait()
+
+	if errResp == nil {
+		t.Errorf("expected Bob to reject unknown peer")
+	}
+	if errInit == nil {
+		t.Errorf("expected Alice to fail on rejected session")
+	}
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -31,3 +31,4 @@ export * from './resume-preamble.js';
 export * from './identity.js';
 export * from './trust-store.js';
 export * from './pairing.js';
+export * from './trusted-auth.js';

--- a/packages/protocol/src/transfer.ts
+++ b/packages/protocol/src/transfer.ts
@@ -30,6 +30,7 @@ export enum FrameType {
   ResumeState = 12,
   ResumeAuth = 13,
   PairingExchange = 14,
+  TrustedAuth = 15,
 }
 
 /** Feature flags negotiated in caps. */

--- a/packages/protocol/src/trusted-auth.test.ts
+++ b/packages/protocol/src/trusted-auth.test.ts
@@ -1,0 +1,250 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { bytesToHex, hexToBytes } from './bytes.js';
+import { createDeviceIdentityFromSeed } from './identity.js';
+import {
+  createTrustedAuthConfirm,
+  createTrustedAuthInit,
+  createTrustedAuthResponse,
+  deriveTrustedSessionKeys,
+  DOMAIN_TRUSTED_CONFIRM_INIT,
+  DOMAIN_TRUSTED_CONFIRM_RESP,
+  verifyTrustedAuthConfirm,
+  verifyTrustedAuthInit,
+  verifyTrustedAuthResponse,
+} from './trusted-auth.js';
+
+interface TrustedVector {
+  name: string;
+  k_pair_hex: string;
+  pair_cred_ref: string;
+  init_seed_hex: string;
+  init_device_id: string;
+  init_pub_key_hex: string;
+  init_ephem_pub_hex: string;
+  init_nonce_hex: string;
+  init_caps: string[];
+  init_timestamp: string;
+  init_sig_hex: string;
+  init_auth_tag_hex: string;
+  resp_seed_hex: string;
+  resp_device_id: string;
+  resp_pub_key_hex: string;
+  resp_ephem_pub_hex: string;
+  resp_nonce_hex: string;
+  resp_caps: string[];
+  resp_sig_hex: string;
+  resp_auth_tag_hex: string;
+  session_master_hex: string;
+  i2r_key_hex: string;
+  r2i_key_hex: string;
+  init_confirm_tag: string;
+  resp_confirm_tag: string;
+}
+
+describe('Trusted session cross-language vector validation (sendbeam/2)', () => {
+  const vectorPath = resolve(__dirname, '../../wire/testdata/trusted-session-vectors.json');
+  const vectorContent = readFileSync(vectorPath, 'utf-8');
+  const vectors: TrustedVector[] = JSON.parse(vectorContent);
+
+  it('matches Go generated trusted-session vector byte-for-byte', async () => {
+    for (const vec of vectors) {
+      const kPair = hexToBytes(vec.k_pair_hex);
+      const initSeed = hexToBytes(vec.init_seed_hex);
+      const respSeed = hexToBytes(vec.resp_seed_hex);
+
+      const idInit = await createDeviceIdentityFromSeed(initSeed);
+      const idResp = await createDeviceIdentityFromSeed(respSeed);
+
+      expect(idInit.deviceId).toBe(vec.init_device_id);
+      expect(bytesToHex(idInit.publicKey)).toBe(vec.init_pub_key_hex);
+      expect(idResp.deviceId).toBe(vec.resp_device_id);
+      expect(bytesToHex(idResp.publicKey)).toBe(vec.resp_pub_key_hex);
+
+      const initEphem = hexToBytes(vec.init_ephem_pub_hex);
+      const initNonce = hexToBytes(vec.init_nonce_hex);
+      const respEphem = hexToBytes(vec.resp_ephem_pub_hex);
+      const respNonce = hexToBytes(vec.resp_nonce_hex);
+
+      // Create TrustedAuthInit and verify against vector
+      const initMsg = await createTrustedAuthInit(
+        idInit,
+        idResp.deviceId,
+        vec.pair_cred_ref,
+        kPair,
+        vec.init_caps,
+        initEphem,
+        initNonce,
+        vec.init_timestamp,
+      );
+      expect(initMsg.signature).toBe(vec.init_sig_hex);
+      expect(initMsg.auth_tag).toBe(vec.init_auth_tag_hex);
+
+      // Verify TrustedAuthInit on responder side
+      const verifiedInit = await verifyTrustedAuthInit(
+        initMsg,
+        kPair,
+        idInit.publicKey,
+        idResp.deviceId,
+        vec.init_timestamp,
+      );
+      expect(bytesToHex(verifiedInit.ephemeralPub)).toBe(vec.init_ephem_pub_hex);
+      expect(bytesToHex(verifiedInit.nonce)).toBe(vec.init_nonce_hex);
+
+      // Create TrustedAuthResponse and verify against vector
+      const respMsg = await createTrustedAuthResponse(
+        idResp,
+        initMsg,
+        kPair,
+        vec.resp_caps,
+        respEphem,
+        respNonce,
+      );
+      expect(respMsg.signature).toBe(vec.resp_sig_hex);
+      expect(respMsg.auth_tag).toBe(vec.resp_auth_tag_hex);
+
+      // Verify TrustedAuthResponse on initiator side
+      const verifiedResp = await verifyTrustedAuthResponse(
+        respMsg,
+        initMsg,
+        kPair,
+        idResp.publicKey,
+        idInit.deviceId,
+      );
+      expect(bytesToHex(verifiedResp.ephemeralPub)).toBe(vec.resp_ephem_pub_hex);
+      expect(bytesToHex(verifiedResp.nonce)).toBe(vec.resp_nonce_hex);
+
+      // Derive forward-secret session keys on both sides
+      const keysAlice = await deriveTrustedSessionKeys(
+        kPair,
+        initEphem,
+        verifiedResp.ephemeralPub,
+        initNonce,
+        verifiedResp.nonce,
+        idInit.deviceId,
+        idResp.deviceId,
+        vec.init_caps,
+        respMsg.capabilities || [],
+      );
+
+      const keysBob = await deriveTrustedSessionKeys(
+        kPair,
+        verifiedInit.ephemeralPub,
+        respEphem,
+        verifiedInit.nonce,
+        respNonce,
+        initMsg.initiator_device_id,
+        idResp.deviceId,
+        initMsg.capabilities,
+        vec.resp_caps,
+      );
+
+      expect(bytesToHex(keysAlice.sessionMaster)).toBe(vec.session_master_hex);
+      expect(bytesToHex(keysBob.sessionMaster)).toBe(vec.session_master_hex);
+      expect(bytesToHex(keysAlice.initiatorToResponderKey)).toBe(vec.i2r_key_hex);
+      expect(bytesToHex(keysBob.initiatorToResponderKey)).toBe(vec.i2r_key_hex);
+      expect(bytesToHex(keysAlice.responderToInitiatorKey)).toBe(vec.r2i_key_hex);
+      expect(bytesToHex(keysBob.responderToInitiatorKey)).toBe(vec.r2i_key_hex);
+
+      // Confirmation tags
+      const confInit = await createTrustedAuthConfirm(
+        keysAlice.sessionMaster,
+        DOMAIN_TRUSTED_CONFIRM_INIT,
+        idInit.deviceId,
+        true,
+      );
+      expect(confInit.auth_tag).toBe(vec.init_confirm_tag);
+      await expect(
+        verifyTrustedAuthConfirm(
+          confInit,
+          keysBob.sessionMaster,
+          DOMAIN_TRUSTED_CONFIRM_INIT,
+          idInit.deviceId,
+        ),
+      ).resolves.toBeUndefined();
+
+      const confResp = await createTrustedAuthConfirm(
+        keysBob.sessionMaster,
+        DOMAIN_TRUSTED_CONFIRM_RESP,
+        idResp.deviceId,
+        true,
+      );
+      expect(confResp.auth_tag).toBe(vec.resp_confirm_tag);
+      await expect(
+        verifyTrustedAuthConfirm(
+          confResp,
+          keysAlice.sessionMaster,
+          DOMAIN_TRUSTED_CONFIRM_RESP,
+          idResp.deviceId,
+        ),
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it('rejects expired timestamps, mismatched peers, forged signatures, and revoked peers', async () => {
+    const kPair = hexToBytes('b578beac8f38df62b3f7f744ad47e6a6a6f17a7db6427e3949f981da8eb29b7d');
+    const idInit = await createDeviceIdentityFromSeed(
+      hexToBytes('34c86db8b3903e5dcf9582abb21e0340602f233b2e12b6e4de11afd585174a3a'),
+    );
+    const idResp = await createDeviceIdentityFromSeed(
+      hexToBytes('4fb61397bb78ad872f082a4dda02286fc585e612b731664e9b9398d85a3e85df'),
+    );
+
+    const now = new Date('2026-08-21T12:00:00Z');
+    const initMsg = await createTrustedAuthInit(
+      idInit,
+      idResp.deviceId,
+      'cred-test',
+      kPair,
+      ['transfer.v1'],
+      undefined,
+      undefined,
+      now,
+    );
+
+    // 1. Clock skew > 5 minutes
+    const expiredDate = new Date('2026-08-21T11:50:00Z');
+    await expect(
+      verifyTrustedAuthInit(initMsg, kPair, idInit.publicKey, idResp.deviceId, expiredDate),
+    ).rejects.toThrow(/timestamp outside acceptable skew window/);
+
+    // 2. Peer mismatch
+    await expect(
+      verifyTrustedAuthInit(initMsg, kPair, idInit.publicKey, 'sb-dev-wrong', now),
+    ).rejects.toThrow(/peer device ID mismatch/);
+
+    // 3. Forged signature
+    await expect(
+      verifyTrustedAuthInit(
+        { ...initMsg, signature: bytesToHex(new Uint8Array(64)) },
+        kPair,
+        idInit.publicKey,
+        idResp.deviceId,
+        now,
+      ),
+    ).rejects.toThrow(/signature verification failed/);
+
+    // 4. Tampered auth tag
+    await expect(
+      verifyTrustedAuthInit(
+        { ...initMsg, auth_tag: bytesToHex(new Uint8Array(32)) },
+        kPair,
+        idInit.publicKey,
+        idResp.deviceId,
+        now,
+      ),
+    ).rejects.toThrow(/MAC tag verification failed/);
+
+    // 5. Revoked status in response
+    const respRevoked = {
+      type: 'trusted_auth_response' as const,
+      protocol_version: 'sendbeam/2' as const,
+      status: 'revoked' as const,
+      responder_device_id: idResp.deviceId,
+    };
+    await expect(
+      verifyTrustedAuthResponse(respRevoked, initMsg, kPair, idResp.publicKey, idInit.deviceId),
+    ).rejects.toThrow(/trusted peer device is revoked/);
+  });
+});

--- a/packages/protocol/src/trusted-auth.ts
+++ b/packages/protocol/src/trusted-auth.ts
@@ -1,0 +1,609 @@
+/**
+ * Trusted-session authentication messages, forward-secret session key derivation,
+ * and mutual challenge verification for paired SendBeam devices (V15-PR03).
+ *
+ * Matches Go `packages/wire/trusted_auth.go` byte-for-byte.
+ */
+
+import { bytesToHex, concatBytes, hexToBytes, utf8 } from './bytes.js';
+import {
+  deriveDeviceId,
+  signDeviceMessage,
+  validateDeviceId,
+  verifyDeviceSignature,
+  type DeviceIdentity,
+} from './identity.js';
+import { hkdfSha256, hmacSha256, randomBytes, sha256 } from './webcrypto.js';
+
+export const MSG_TRUSTED_AUTH_INIT = 'trusted_auth_init';
+export const MSG_TRUSTED_AUTH_RESPONSE = 'trusted_auth_response';
+export const MSG_TRUSTED_AUTH_CONFIRM = 'trusted_auth_confirm';
+
+export const TRUSTED_AUTH_PROTOCOL_VERSION = 'sendbeam/2';
+
+export const DOMAIN_TRUSTED_INIT = 'sendbeam/2 trusted-init:';
+export const DOMAIN_TRUSTED_INIT_MAC = 'sendbeam/2 trusted-init-mac:';
+export const DOMAIN_TRUSTED_RESP = 'sendbeam/2 trusted-resp:';
+export const DOMAIN_TRUSTED_RESP_MAC = 'sendbeam/2 trusted-resp-mac:';
+export const DOMAIN_TRUSTED_MASTER = 'sendbeam/2 session-master:';
+export const DOMAIN_TRUSTED_INIT_TO_RESP_KEY = 'sendbeam/2 initiator-to-responder key';
+export const DOMAIN_TRUSTED_RESP_TO_INIT_KEY = 'sendbeam/2 responder-to-initiator key';
+export const DOMAIN_TRUSTED_CONFIRM_INIT = 'sendbeam/2 confirm-init:';
+export const DOMAIN_TRUSTED_CONFIRM_RESP = 'sendbeam/2 confirm-resp:';
+
+export const TRUSTED_AUTH_NONCE_SIZE = 32;
+export const TRUSTED_AUTH_EPHEMERAL_SIZE = 32;
+export const MAX_TRUSTED_TIMESTAMP_SKEW_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface TrustedAuthInit {
+  readonly type: typeof MSG_TRUSTED_AUTH_INIT;
+  readonly protocol_version: typeof TRUSTED_AUTH_PROTOCOL_VERSION;
+  readonly initiator_device_id: string;
+  readonly responder_device_id: string;
+  readonly pair_credential_ref: string;
+  readonly ephemeral_pub: string;
+  readonly nonce: string;
+  readonly capabilities: string[];
+  readonly timestamp: string;
+  readonly signature: string;
+  readonly auth_tag: string;
+}
+
+export interface TrustedAuthResponse {
+  readonly type: typeof MSG_TRUSTED_AUTH_RESPONSE;
+  readonly protocol_version: typeof TRUSTED_AUTH_PROTOCOL_VERSION;
+  readonly status: 'accepted' | 'rejected' | 'revoked';
+  readonly responder_device_id: string;
+  readonly ephemeral_pub?: string;
+  readonly nonce?: string;
+  readonly capabilities?: string[];
+  readonly signature?: string;
+  readonly auth_tag?: string;
+}
+
+export interface TrustedAuthConfirm {
+  readonly type: typeof MSG_TRUSTED_AUTH_CONFIRM;
+  readonly status: 'ready' | 'rejected';
+  readonly auth_tag?: string;
+}
+
+export type TrustedAuthMessage = TrustedAuthInit | TrustedAuthResponse | TrustedAuthConfirm;
+
+export interface TrustedSessionKeys {
+  readonly sessionMaster: Uint8Array;
+  readonly initiatorToResponderKey: Uint8Array;
+  readonly responderToInitiatorKey: Uint8Array;
+  readonly negotiatedCapabilities: string[];
+}
+
+/**
+ * Constant-time hex string comparison.
+ */
+function constantTimeHexEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * Deterministic canonical SHA-256 digest of capability strings.
+ */
+export async function hashCapabilities(caps: readonly string[]): Promise<Uint8Array> {
+  const sorted = [...caps].sort();
+  const joined = sorted.join(',');
+  return sha256(utf8(joined));
+}
+
+/**
+ * Intersect two capability lists and sort alphabetically.
+ */
+export function intersectCapabilities(a: readonly string[], b: readonly string[]): string[] {
+  const set = new Set(a);
+  const result = b.filter((item) => set.has(item));
+  result.sort();
+  return result;
+}
+
+/**
+ * Build the binary payload signed by the initiator in TrustedAuthInit.
+ */
+export async function buildTrustedInitChallenge(
+  kPairHash: Uint8Array,
+  ephemPub: Uint8Array,
+  nonce: Uint8Array,
+  initId: string,
+  respId: string,
+  capsHash: Uint8Array,
+  timestamp: string,
+): Promise<Uint8Array> {
+  return concatBytes(
+    utf8(DOMAIN_TRUSTED_INIT),
+    kPairHash,
+    ephemPub,
+    nonce,
+    utf8(initId),
+    utf8(respId),
+    capsHash,
+    utf8(timestamp),
+  );
+}
+
+/**
+ * Build the binary payload signed by the responder in TrustedAuthResponse.
+ */
+export async function buildTrustedRespChallenge(
+  kPairHash: Uint8Array,
+  ephemPubInit: Uint8Array,
+  ephemPubResp: Uint8Array,
+  nonceInit: Uint8Array,
+  nonceResp: Uint8Array,
+  initId: string,
+  respId: string,
+  capsHash: Uint8Array,
+): Promise<Uint8Array> {
+  return concatBytes(
+    utf8(DOMAIN_TRUSTED_RESP),
+    kPairHash,
+    ephemPubInit,
+    ephemPubResp,
+    nonceInit,
+    nonceResp,
+    utf8(initId),
+    utf8(respId),
+    capsHash,
+  );
+}
+
+/**
+ * Compute the HMAC-SHA256 authentication tag over a challenge using k_pair.
+ */
+export async function computeTrustedMACTag(
+  kPair: Uint8Array,
+  domain: string,
+  challenge: Uint8Array,
+): Promise<string> {
+  const data = concatBytes(utf8(domain), challenge);
+  const tag = await hmacSha256(kPair, data);
+  return bytesToHex(tag);
+}
+
+/**
+ * Verify a MAC tag in constant time.
+ */
+export async function verifyTrustedMACTag(
+  kPair: Uint8Array,
+  domain: string,
+  challenge: Uint8Array,
+  tagHex: string,
+): Promise<boolean> {
+  const expected = await computeTrustedMACTag(kPair, domain, challenge);
+  return constantTimeHexEqual(tagHex.toLowerCase(), expected.toLowerCase());
+}
+
+/**
+ * Derive forward-secret directional session keys from ephemeral material and k_pair.
+ */
+export async function deriveTrustedSessionKeys(
+  kPair: Uint8Array,
+  ephemPubInit: Uint8Array,
+  ephemPubResp: Uint8Array,
+  nonceInit: Uint8Array,
+  nonceResp: Uint8Array,
+  initId: string,
+  respId: string,
+  capsInit: readonly string[],
+  capsResp: readonly string[],
+): Promise<TrustedSessionKeys> {
+  if (kPair.length === 0) {
+    throw new Error('k_pair required');
+  }
+  if (
+    ephemPubInit.length !== TRUSTED_AUTH_EPHEMERAL_SIZE ||
+    ephemPubResp.length !== TRUSTED_AUTH_EPHEMERAL_SIZE
+  ) {
+    throw new Error('invalid ephemeral public key size');
+  }
+  if (
+    nonceInit.length !== TRUSTED_AUTH_NONCE_SIZE ||
+    nonceResp.length !== TRUSTED_AUTH_NONCE_SIZE
+  ) {
+    throw new Error('invalid nonce size');
+  }
+
+  const negotiated = intersectCapabilities(capsInit, capsResp);
+  const capsHash = await hashCapabilities(negotiated);
+
+  const ephemMix = concatBytes(ephemPubInit, ephemPubResp, nonceInit, nonceResp);
+  const ikm = await hmacSha256(kPair, ephemMix);
+  const salt = concatBytes(nonceInit, nonceResp);
+
+  const kPairHash = await sha256(kPair);
+  const transcript = await buildTrustedRespChallenge(
+    kPairHash,
+    ephemPubInit,
+    ephemPubResp,
+    nonceInit,
+    nonceResp,
+    initId,
+    respId,
+    capsHash,
+  );
+
+  const infoMaster = concatBytes(utf8(DOMAIN_TRUSTED_MASTER), transcript);
+  const sessionMaster = await hkdfSha256(ikm, salt, infoMaster, 32);
+
+  const kI2R = await hkdfSha256(
+    sessionMaster,
+    new Uint8Array(0),
+    utf8(DOMAIN_TRUSTED_INIT_TO_RESP_KEY),
+    32,
+  );
+  const kR2I = await hkdfSha256(
+    sessionMaster,
+    new Uint8Array(0),
+    utf8(DOMAIN_TRUSTED_RESP_TO_INIT_KEY),
+    32,
+  );
+
+  return {
+    sessionMaster,
+    initiatorToResponderKey: kI2R,
+    responderToInitiatorKey: kR2I,
+    negotiatedCapabilities: negotiated,
+  };
+}
+
+/**
+ * Compute the confirmation tag for the session master.
+ */
+export async function computeTrustedConfirmTag(
+  sessionMaster: Uint8Array,
+  domain: string,
+  deviceId: string,
+): Promise<string> {
+  const data = concatBytes(utf8(domain), utf8(deviceId));
+  const tag = await hmacSha256(sessionMaster, data);
+  return bytesToHex(tag);
+}
+
+/**
+ * Verify the confirmation tag in constant time.
+ */
+export async function verifyTrustedConfirmTag(
+  sessionMaster: Uint8Array,
+  domain: string,
+  deviceId: string,
+  tagHex: string,
+): Promise<boolean> {
+  const expected = await computeTrustedConfirmTag(sessionMaster, domain, deviceId);
+  return constantTimeHexEqual(tagHex.toLowerCase(), expected.toLowerCase());
+}
+
+/**
+ * Create a signed and MAC-authenticated TrustedAuthInit message.
+ */
+export async function createTrustedAuthInit(
+  id: DeviceIdentity,
+  respDeviceId: string,
+  credRef: string,
+  kPair: Uint8Array,
+  caps: string[],
+  ephemPub?: Uint8Array,
+  nonce?: Uint8Array,
+  now?: Date | string,
+): Promise<TrustedAuthInit> {
+  const ephem =
+    ephemPub && ephemPub.length === TRUSTED_AUTH_EPHEMERAL_SIZE
+      ? ephemPub
+      : randomBytes(TRUSTED_AUTH_EPHEMERAL_SIZE);
+  const n =
+    nonce && nonce.length === TRUSTED_AUTH_NONCE_SIZE
+      ? nonce
+      : randomBytes(TRUSTED_AUTH_NONCE_SIZE);
+  const tsStr =
+    typeof now === 'string' ? now : (now || new Date()).toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+  const capsHash = await hashCapabilities(caps);
+  const kPairHash = await sha256(kPair);
+
+  const challenge = await buildTrustedInitChallenge(
+    kPairHash,
+    ephem,
+    n,
+    id.deviceId,
+    respDeviceId,
+    capsHash,
+    tsStr,
+  );
+  const sig = signDeviceMessage(id, challenge);
+  const tag = await computeTrustedMACTag(kPair, DOMAIN_TRUSTED_INIT_MAC, challenge);
+
+  return {
+    type: MSG_TRUSTED_AUTH_INIT,
+    protocol_version: TRUSTED_AUTH_PROTOCOL_VERSION,
+    initiator_device_id: id.deviceId,
+    responder_device_id: respDeviceId,
+    pair_credential_ref: credRef,
+    ephemeral_pub: bytesToHex(ephem),
+    nonce: bytesToHex(n),
+    capabilities: caps,
+    timestamp: tsStr,
+    signature: bytesToHex(sig),
+    auth_tag: tag,
+  };
+}
+
+/**
+ * Validate format, clock skew, Ed25519 signature, and HMAC tag of a TrustedAuthInit.
+ */
+export async function verifyTrustedAuthInit(
+  init: TrustedAuthInit,
+  kPair: Uint8Array,
+  initPubKey: Uint8Array,
+  localDeviceId: string,
+  now?: Date | string,
+): Promise<{ ephemeralPub: Uint8Array; nonce: Uint8Array }> {
+  if (
+    !init ||
+    init.type !== MSG_TRUSTED_AUTH_INIT ||
+    init.protocol_version !== TRUSTED_AUTH_PROTOCOL_VERSION
+  ) {
+    throw new Error('invalid trusted-session message');
+  }
+  if (init.responder_device_id !== localDeviceId) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+  if (!validateDeviceId(init.initiator_device_id)) {
+    throw new Error('invalid device id format');
+  }
+
+  const expectedInitId = await deriveDeviceId(initPubKey);
+  if (expectedInitId !== init.initiator_device_id) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+
+  const ts = new Date(init.timestamp).getTime();
+  if (Number.isNaN(ts)) {
+    throw new Error('invalid trusted-session message');
+  }
+  const currentTime = (typeof now === 'string' ? new Date(now) : now || new Date()).getTime();
+  const skew = Math.abs(currentTime - ts);
+  if (skew > MAX_TRUSTED_TIMESTAMP_SKEW_MS) {
+    throw new Error('trusted-session timestamp outside acceptable skew window');
+  }
+
+  const ephemPub = hexToBytes(init.ephemeral_pub);
+  if (ephemPub.length !== TRUSTED_AUTH_EPHEMERAL_SIZE) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const nonce = hexToBytes(init.nonce);
+  if (nonce.length !== TRUSTED_AUTH_NONCE_SIZE) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const sigBytes = hexToBytes(init.signature);
+  if (sigBytes.length !== 64) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  const capsHash = await hashCapabilities(init.capabilities);
+  const kPairHash = await sha256(kPair);
+  const challenge = await buildTrustedInitChallenge(
+    kPairHash,
+    ephemPub,
+    nonce,
+    init.initiator_device_id,
+    init.responder_device_id,
+    capsHash,
+    init.timestamp,
+  );
+
+  const sigValid = verifyDeviceSignature(initPubKey, challenge, sigBytes);
+  if (!sigValid) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  const macValid = await verifyTrustedMACTag(
+    kPair,
+    DOMAIN_TRUSTED_INIT_MAC,
+    challenge,
+    init.auth_tag,
+  );
+  if (!macValid) {
+    throw new Error('trusted-session MAC tag verification failed');
+  }
+
+  return { ephemeralPub: ephemPub, nonce };
+}
+
+/**
+ * Create a signed and MAC-authenticated TrustedAuthResponse message.
+ */
+export async function createTrustedAuthResponse(
+  id: DeviceIdentity,
+  init: TrustedAuthInit,
+  kPair: Uint8Array,
+  caps: string[],
+  ephemPub?: Uint8Array,
+  nonce?: Uint8Array,
+): Promise<TrustedAuthResponse> {
+  const ephem =
+    ephemPub && ephemPub.length === TRUSTED_AUTH_EPHEMERAL_SIZE
+      ? ephemPub
+      : randomBytes(TRUSTED_AUTH_EPHEMERAL_SIZE);
+  const n =
+    nonce && nonce.length === TRUSTED_AUTH_NONCE_SIZE
+      ? nonce
+      : randomBytes(TRUSTED_AUTH_NONCE_SIZE);
+
+  const ephemInit = hexToBytes(init.ephemeral_pub);
+  const nonceInit = hexToBytes(init.nonce);
+
+  const negotiated = intersectCapabilities(init.capabilities, caps);
+  const capsHash = await hashCapabilities(negotiated);
+  const kPairHash = await sha256(kPair);
+
+  const challenge = await buildTrustedRespChallenge(
+    kPairHash,
+    ephemInit,
+    ephem,
+    nonceInit,
+    n,
+    init.initiator_device_id,
+    id.deviceId,
+    capsHash,
+  );
+  const sig = signDeviceMessage(id, challenge);
+  const tag = await computeTrustedMACTag(kPair, DOMAIN_TRUSTED_RESP_MAC, challenge);
+
+  return {
+    type: MSG_TRUSTED_AUTH_RESPONSE,
+    protocol_version: TRUSTED_AUTH_PROTOCOL_VERSION,
+    status: 'accepted',
+    responder_device_id: id.deviceId,
+    ephemeral_pub: bytesToHex(ephem),
+    nonce: bytesToHex(n),
+    capabilities: caps,
+    signature: bytesToHex(sig),
+    auth_tag: tag,
+  };
+}
+
+/**
+ * Validate format, Ed25519 signature, and HMAC tag of a TrustedAuthResponse.
+ */
+export async function verifyTrustedAuthResponse(
+  resp: TrustedAuthResponse,
+  init: TrustedAuthInit,
+  kPair: Uint8Array,
+  respPubKey: Uint8Array,
+  localDeviceId: string,
+): Promise<{ ephemeralPub: Uint8Array; nonce: Uint8Array }> {
+  if (
+    !resp ||
+    resp.type !== MSG_TRUSTED_AUTH_RESPONSE ||
+    resp.protocol_version !== TRUSTED_AUTH_PROTOCOL_VERSION
+  ) {
+    throw new Error('invalid trusted-session message');
+  }
+  if (localDeviceId && init.initiator_device_id !== localDeviceId) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+  if (resp.status !== 'accepted') {
+    if (resp.status === 'revoked') {
+      throw new Error('trusted peer device is revoked');
+    }
+    throw new Error('trusted session was rejected by peer');
+  }
+  if (resp.responder_device_id !== init.responder_device_id) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+
+  const expectedRespId = await deriveDeviceId(respPubKey);
+  if (expectedRespId !== resp.responder_device_id) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+
+  const ephemInit = hexToBytes(init.ephemeral_pub);
+  const nonceInit = hexToBytes(init.nonce);
+
+  if (!resp.ephemeral_pub || !resp.nonce || !resp.signature || !resp.auth_tag) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const ephemResp = hexToBytes(resp.ephemeral_pub);
+  if (ephemResp.length !== TRUSTED_AUTH_EPHEMERAL_SIZE) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const nonceResp = hexToBytes(resp.nonce);
+  if (nonceResp.length !== TRUSTED_AUTH_NONCE_SIZE) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const sigBytes = hexToBytes(resp.signature);
+  if (sigBytes.length !== 64) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  const negotiated = intersectCapabilities(init.capabilities, resp.capabilities || []);
+  const capsHash = await hashCapabilities(negotiated);
+  const kPairHash = await sha256(kPair);
+  const challenge = await buildTrustedRespChallenge(
+    kPairHash,
+    ephemInit,
+    ephemResp,
+    nonceInit,
+    nonceResp,
+    init.initiator_device_id,
+    resp.responder_device_id,
+    capsHash,
+  );
+
+  const sigValid = verifyDeviceSignature(respPubKey, challenge, sigBytes);
+  if (!sigValid) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  const macValid = await verifyTrustedMACTag(
+    kPair,
+    DOMAIN_TRUSTED_RESP_MAC,
+    challenge,
+    resp.auth_tag,
+  );
+  if (!macValid) {
+    throw new Error('trusted-session MAC tag verification failed');
+  }
+
+  return { ephemeralPub: ephemResp, nonce: nonceResp };
+}
+
+/**
+ * Create a TrustedAuthConfirm message.
+ */
+export async function createTrustedAuthConfirm(
+  sessionMaster: Uint8Array,
+  domain: string,
+  localDeviceId: string,
+  ready: boolean,
+): Promise<TrustedAuthConfirm> {
+  if (!ready) {
+    return {
+      type: MSG_TRUSTED_AUTH_CONFIRM,
+      status: 'rejected',
+    };
+  }
+  const tag = await computeTrustedConfirmTag(sessionMaster, domain, localDeviceId);
+  return {
+    type: MSG_TRUSTED_AUTH_CONFIRM,
+    status: 'ready',
+    auth_tag: tag,
+  };
+}
+
+/**
+ * Verify a TrustedAuthConfirm message.
+ */
+export async function verifyTrustedAuthConfirm(
+  confirm: TrustedAuthConfirm,
+  sessionMaster: Uint8Array,
+  domain: string,
+  peerDeviceId: string,
+): Promise<void> {
+  if (!confirm || confirm.type !== MSG_TRUSTED_AUTH_CONFIRM) {
+    throw new Error('invalid trusted-session message');
+  }
+  if (confirm.status !== 'ready') {
+    throw new Error('trusted session was rejected by peer');
+  }
+  if (
+    !confirm.auth_tag ||
+    !(await verifyTrustedConfirmTag(sessionMaster, domain, peerDeviceId, confirm.auth_tag))
+  ) {
+    throw new Error('trusted-session MAC tag verification failed');
+  }
+}

--- a/packages/wire/frame.go
+++ b/packages/wire/frame.go
@@ -56,6 +56,9 @@ const (
 	// FramePairingExchange carries one pairing message (PairingRequest, PairingResponse,
 	// or PairingConfirm JSON) sealed under the SESSION directional keys (V15-PR02).
 	FramePairingExchange uint8 = 14
+	// FrameTrustedAuth carries one trusted-session handshake message (TrustedAuthInit,
+	// TrustedAuthResponse, or TrustedAuthConfirm JSON) for paired devices (V15-PR03).
+	FrameTrustedAuth uint8 = 15
 )
 
 // encodeFrameHeader encodes h into a fresh 16-byte buffer.

--- a/packages/wire/testdata/trusted-session-vectors.json
+++ b/packages/wire/testdata/trusted-session-vectors.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "alice_bob_trusted_session",
+    "k_pair_hex": "b578beac8f38df62b3f7f744ad47e6a6a6f17a7db6427e3949f981da8eb29b7d",
+    "pair_cred_ref": "cred-f5a9067216d304bf2a67fc5446d5a6e7e97dfb9152f937c8c6b6d1a872cc10a5",
+    "init_seed_hex": "34c86db8b3903e5dcf9582abb21e0340602f233b2e12b6e4de11afd585174a3a",
+    "init_device_id": "sb-dev-0ae44c43cf475df86e9a4341e75b02944142c1d4484892d244d7d2d7c4a7f216",
+    "init_pub_key_hex": "0d9745c372d04607f3a765eb7f2e0ab7ea9b7ece9fd0acfca79a57803a4f83ea",
+    "init_ephem_pub_hex": "9d9f13fb3cfa172b0637f36a774d07cab235bb5e24914a9978914efa1160b4d8",
+    "init_nonce_hex": "b9d81bca729d78625201c17a8b9909aca3880515d53176b967207713d1d0d725",
+    "init_caps": [
+      "transfer.v1",
+      "transfer.v2",
+      "auto_accept"
+    ],
+    "init_timestamp": "2026-08-21T12:00:00Z",
+    "init_sig_hex": "ceb2e3decd4e50b255dc69ad7cf2601fcb20c1cdfd67a431acb75bbf301e1bd8b996d82ac962fe8e1adbed2e26452ec193a7145904379e549878cafbe503e104",
+    "init_auth_tag_hex": "fa204a6b43bedd71cd3600fa96c0046b46dea53909be3773d823d79bbbc2dd7f",
+    "resp_seed_hex": "4fb61397bb78ad872f082a4dda02286fc585e612b731664e9b9398d85a3e85df",
+    "resp_device_id": "sb-dev-2a01b9da1e116eec290a92f9edbdb799c73c3abed9e99cd083c24bff6e3645c7",
+    "resp_pub_key_hex": "e61d3ac8f53bade331c2c5b8103b8791de6bb02d47bf4382875f4ad9ddcf5592",
+    "resp_ephem_pub_hex": "7ba2469fa754974a446885ad4dc313666a9198f2720f241aa54befbe0e701a12",
+    "resp_nonce_hex": "296b24ab56c4781c3569f10ad9ea4c773fb1b98652096e58cc236207dfef0ea4",
+    "resp_caps": [
+      "transfer.v1",
+      "transfer.v2",
+      "lan_direct"
+    ],
+    "resp_sig_hex": "a12d4040e92f9fe5f27fc2e209c873841983cf01488e44152f7acbe634353c8c16025b281aad7c6fc74ff6ad9c95018f3f78de39baa5ff19170ebeb76e37e801",
+    "resp_auth_tag_hex": "8ef7c3ddb83a3ca9725e9400577453d41dd666be28f97ed4695230e5831ee577",
+    "session_master_hex": "1d99cc96820594578d99271e7c4b651666b26d0f0bdb2f16c5b5f7d592b96a95",
+    "i2r_key_hex": "ae0baac362e293eaec69e18b00584e563cbe6803c91c9cbecce36c7af2b12a02",
+    "r2i_key_hex": "899f9689903929f51f3897bbc46e544bc2d0d2e0e05bbc51f5e44d21ca982a2a",
+    "init_confirm_tag": "b10766656d6d41f01b14e3c6cd5edc060c471f8ff8c8055eebd1f845b7c57cc9",
+    "resp_confirm_tag": "a0a446e6effc5bd92911c718aca123800704a9668e09daace9a70faee554b1f5"
+  }
+]

--- a/packages/wire/trusted_auth.go
+++ b/packages/wire/trusted_auth.go
@@ -1,0 +1,536 @@
+package wire
+
+import (
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Trusted-session message types, protocol version, and domain separation constants (V15-PR03).
+const (
+	MsgTrustedAuthInit     = "trusted_auth_init"
+	MsgTrustedAuthResponse = "trusted_auth_response"
+	MsgTrustedAuthConfirm  = "trusted_auth_confirm"
+
+	TrustedAuthProtocolVersion = "sendbeam/2"
+
+	DomainTrustedInit          = "sendbeam/2 trusted-init:"
+	DomainTrustedInitMAC       = "sendbeam/2 trusted-init-mac:"
+	DomainTrustedResp          = "sendbeam/2 trusted-resp:"
+	DomainTrustedRespMAC       = "sendbeam/2 trusted-resp-mac:"
+	DomainTrustedMaster        = "sendbeam/2 session-master:"
+	DomainTrustedInitToRespKey = "sendbeam/2 initiator-to-responder key"
+	DomainTrustedRespToInitKey = "sendbeam/2 responder-to-initiator key"
+	DomainTrustedConfirmInit   = "sendbeam/2 confirm-init:"
+	DomainTrustedConfirmResp   = "sendbeam/2 confirm-resp:"
+
+	TrustedAuthNonceSize     = 32
+	TrustedAuthEphemeralSize = 32
+	MaxTrustedTimestampSkew  = 5 * time.Minute
+)
+
+var (
+	// ErrInvalidTrustedMessage indicates a malformed or unrecognizable trusted-session message.
+	ErrInvalidTrustedMessage = errors.New("invalid trusted-session message")
+
+	// ErrTrustedTimestampSkew indicates that the message timestamp is outside acceptable clock bounds.
+	ErrTrustedTimestampSkew = errors.New("trusted-session timestamp outside acceptable skew window")
+
+	// ErrTrustedSignatureFailed indicates that the Ed25519 signature in trusted authentication failed.
+	ErrTrustedSignatureFailed = errors.New("trusted-session signature verification failed")
+
+	// ErrTrustedMACTagFailed indicates that the HMAC-SHA256 authentication tag failed verification.
+	ErrTrustedMACTagFailed = errors.New("trusted-session MAC tag verification failed")
+
+	// ErrTrustedPeerMismatch indicates that the claimed peer device ID does not match expected identity.
+	ErrTrustedPeerMismatch = errors.New("trusted-session peer device ID mismatch")
+
+	// ErrTrustedPeerRevoked indicates that the peer device has been revoked in local trust store.
+	ErrTrustedPeerRevoked = errors.New("trusted peer device is revoked")
+
+	// ErrTrustedRejected indicates that the peer explicitly rejected the trusted session.
+	ErrTrustedRejected = errors.New("trusted session was rejected by peer")
+)
+
+// TrustedAuthInit is sent by the initiating device to authenticate a trusted connection.
+type TrustedAuthInit struct {
+	Type               string   `json:"type"`
+	ProtocolVersion    string   `json:"protocol_version"`
+	InitiatorDeviceID  string   `json:"initiator_device_id"`
+	ResponderDeviceID  string   `json:"responder_device_id"`
+	PairCredentialRef  string   `json:"pair_credential_ref"`
+	EphemeralPub       string   `json:"ephemeral_pub"`
+	Nonce              string   `json:"nonce"`
+	Capabilities       []string `json:"capabilities"`
+	Timestamp          string   `json:"timestamp"`
+	Signature          string   `json:"signature"`
+	AuthTag            string   `json:"auth_tag"`
+}
+
+// TrustedAuthResponse is sent by the responder upon verifying the TrustedAuthInit.
+type TrustedAuthResponse struct {
+	Type              string   `json:"type"`
+	ProtocolVersion   string   `json:"protocol_version"`
+	Status            string   `json:"status"` // "accepted", "rejected", or "revoked"
+	ResponderDeviceID string   `json:"responder_device_id"`
+	EphemeralPub      string   `json:"ephemeral_pub,omitempty"`
+	Nonce             string   `json:"nonce,omitempty"`
+	Capabilities      []string `json:"capabilities,omitempty"`
+	Signature         string   `json:"signature,omitempty"`
+	AuthTag           string   `json:"auth_tag,omitempty"`
+}
+
+// TrustedAuthConfirm finalizes mutual session establishment.
+type TrustedAuthConfirm struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"` // "ready" or "rejected"
+	AuthTag string `json:"auth_tag,omitempty"`
+}
+
+// TrustedSessionKeys contains forward-secret directional session keys and negotiated features.
+type TrustedSessionKeys struct {
+	SessionMaster           []byte
+	InitiatorToResponderKey []byte
+	ResponderToInitiatorKey []byte
+	NegotiatedCapabilities  []string
+}
+
+// HashCapabilities produces a deterministic canonical SHA-256 digest of capability strings.
+func HashCapabilities(caps []string) []byte {
+	sorted := make([]string, len(caps))
+	copy(sorted, caps)
+	sort.Strings(sorted)
+	joined := strings.Join(sorted, ",")
+	h := sha256.Sum256([]byte(joined))
+	return h[:]
+}
+
+// IntersectCapabilities returns the alphabetically sorted set of capabilities supported by both peers.
+func IntersectCapabilities(a, b []string) []string {
+	set := make(map[string]bool, len(a))
+	for _, item := range a {
+		set[item] = true
+	}
+	var res []string
+	for _, item := range b {
+		if set[item] {
+			res = append(res, item)
+		}
+	}
+	sort.Strings(res)
+	return res
+}
+
+// BuildTrustedInitChallenge constructs the binary payload signed by the initiator.
+func BuildTrustedInitChallenge(kPairHash, ephemPub, nonce []byte, initID, respID string, capsHash []byte, timestamp string) []byte {
+	buf := make([]byte, 0, len(DomainTrustedInit)+len(kPairHash)+len(ephemPub)+len(nonce)+len(initID)+len(respID)+len(capsHash)+len(timestamp))
+	buf = append(buf, DomainTrustedInit...)
+	buf = append(buf, kPairHash...)
+	buf = append(buf, ephemPub...)
+	buf = append(buf, nonce...)
+	buf = append(buf, initID...)
+	buf = append(buf, respID...)
+	buf = append(buf, capsHash...)
+	buf = append(buf, timestamp...)
+	return buf
+}
+
+// BuildTrustedRespChallenge constructs the binary payload signed by the responder.
+func BuildTrustedRespChallenge(kPairHash, ephemPubInit, ephemPubResp, nonceInit, nonceResp []byte, initID, respID string, capsHash []byte) []byte {
+	buf := make([]byte, 0, len(DomainTrustedResp)+len(kPairHash)+len(ephemPubInit)+len(ephemPubResp)+len(nonceInit)+len(nonceResp)+len(initID)+len(respID)+len(capsHash))
+	buf = append(buf, DomainTrustedResp...)
+	buf = append(buf, kPairHash...)
+	buf = append(buf, ephemPubInit...)
+	buf = append(buf, ephemPubResp...)
+	buf = append(buf, nonceInit...)
+	buf = append(buf, nonceResp...)
+	buf = append(buf, initID...)
+	buf = append(buf, respID...)
+	buf = append(buf, capsHash...)
+	return buf
+}
+
+// ComputeTrustedMACTag computes the HMAC-SHA256 authentication tag over a challenge using k_pair.
+func ComputeTrustedMACTag(kPair []byte, domain string, challenge []byte) string {
+	mac := hmac.New(sha256.New, kPair)
+	mac.Write([]byte(domain))
+	mac.Write(challenge)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyTrustedMACTag checks a MAC tag in constant time.
+func VerifyTrustedMACTag(kPair []byte, domain string, challenge []byte, tagHex string) bool {
+	tagBytes, err := hex.DecodeString(tagHex)
+	if err != nil || len(tagBytes) != sha256.Size {
+		return false
+	}
+	expectedHex := ComputeTrustedMACTag(kPair, domain, challenge)
+	expectedBytes, _ := hex.DecodeString(expectedHex)
+	return subtle.ConstantTimeCompare(tagBytes, expectedBytes) == 1
+}
+
+// DeriveTrustedSessionKeys derives forward-secret directional traffic keys from ephemeral material and k_pair.
+func DeriveTrustedSessionKeys(kPair, ephemPubInit, ephemPubResp, nonceInit, nonceResp []byte, initID, respID string, capsInit, capsResp []string) (*TrustedSessionKeys, error) {
+	if len(kPair) == 0 {
+		return nil, errors.New("k_pair required")
+	}
+	if len(ephemPubInit) != TrustedAuthEphemeralSize || len(ephemPubResp) != TrustedAuthEphemeralSize {
+		return nil, errors.New("invalid ephemeral public key size")
+	}
+	if len(nonceInit) != TrustedAuthNonceSize || len(nonceResp) != TrustedAuthNonceSize {
+		return nil, errors.New("invalid nonce size")
+	}
+
+	negotiated := IntersectCapabilities(capsInit, capsResp)
+	capsHash := HashCapabilities(negotiated)
+
+	// Mix ephemeral material and k_pair into IKM
+	ephemMix := make([]byte, 0, len(ephemPubInit)+len(ephemPubResp)+len(nonceInit)+len(nonceResp))
+	ephemMix = append(ephemMix, ephemPubInit...)
+	ephemMix = append(ephemMix, ephemPubResp...)
+	ephemMix = append(ephemMix, nonceInit...)
+	ephemMix = append(ephemMix, nonceResp...)
+
+	mac := hmac.New(sha256.New, kPair)
+	mac.Write(ephemMix)
+	ikm := mac.Sum(nil)
+
+	salt := make([]byte, 0, len(nonceInit)+len(nonceResp))
+	salt = append(salt, nonceInit...)
+	salt = append(salt, nonceResp...)
+
+	kPairHash := sha256.Sum256(kPair)
+	transcript := BuildTrustedRespChallenge(kPairHash[:], ephemPubInit, ephemPubResp, nonceInit, nonceResp, initID, respID, capsHash)
+
+	infoMaster := append([]byte(DomainTrustedMaster), transcript...)
+	sessionMaster, err := hkdfSHA256(ikm, salt, infoMaster, 32)
+	if err != nil {
+		return nil, fmt.Errorf("derive session master: %w", err)
+	}
+
+	kI2R, err := hkdfSHA256(sessionMaster, nil, []byte(DomainTrustedInitToRespKey), 32)
+	if err != nil {
+		return nil, fmt.Errorf("derive i2r key: %w", err)
+	}
+
+	kR2I, err := hkdfSHA256(sessionMaster, nil, []byte(DomainTrustedRespToInitKey), 32)
+	if err != nil {
+		return nil, fmt.Errorf("derive r2i key: %w", err)
+	}
+
+	return &TrustedSessionKeys{
+		SessionMaster:           sessionMaster,
+		InitiatorToResponderKey: kI2R,
+		ResponderToInitiatorKey: kR2I,
+		NegotiatedCapabilities:  negotiated,
+	}, nil
+}
+
+// ComputeTrustedConfirmTag computes the confirmation tag for the session master.
+func ComputeTrustedConfirmTag(sessionMaster []byte, domain string, deviceID string) string {
+	mac := hmac.New(sha256.New, sessionMaster)
+	mac.Write([]byte(domain))
+	mac.Write([]byte(deviceID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyTrustedConfirmTag verifies the confirmation tag in constant time.
+func VerifyTrustedConfirmTag(sessionMaster []byte, domain string, deviceID, tagHex string) bool {
+	tagBytes, err := hex.DecodeString(tagHex)
+	if err != nil || len(tagBytes) != sha256.Size {
+		return false
+	}
+	expectedHex := ComputeTrustedConfirmTag(sessionMaster, domain, deviceID)
+	expectedBytes, _ := hex.DecodeString(expectedHex)
+	return subtle.ConstantTimeCompare(tagBytes, expectedBytes) == 1
+}
+
+// NewTrustedAuthInit creates a signed and MAC-authenticated TrustedAuthInit message.
+func NewTrustedAuthInit(id *DeviceIdentity, respDeviceID, credRef string, kPair []byte, caps []string, ephemPub, nonce []byte, now time.Time) (*TrustedAuthInit, error) {
+	if id == nil {
+		return nil, ErrInvalidIdentity
+	}
+	if len(kPair) == 0 {
+		return nil, errors.New("k_pair required")
+	}
+	if len(ephemPub) != TrustedAuthEphemeralSize {
+		ephemPub = make([]byte, TrustedAuthEphemeralSize)
+		if _, err := rand.Read(ephemPub); err != nil {
+			return nil, err
+		}
+	}
+	if len(nonce) != TrustedAuthNonceSize {
+		nonce = make([]byte, TrustedAuthNonceSize)
+		if _, err := rand.Read(nonce); err != nil {
+			return nil, err
+		}
+	}
+
+	tsStr := now.UTC().Format(time.RFC3339)
+	capsHash := HashCapabilities(caps)
+	kPairHash := sha256.Sum256(kPair)
+
+	challenge := BuildTrustedInitChallenge(kPairHash[:], ephemPub, nonce, id.DeviceID, respDeviceID, capsHash, tsStr)
+	sig, err := id.Sign(challenge)
+	if err != nil {
+		return nil, fmt.Errorf("sign trusted init: %w", err)
+	}
+
+	tag := ComputeTrustedMACTag(kPair, DomainTrustedInitMAC, challenge)
+
+	return &TrustedAuthInit{
+		Type:              MsgTrustedAuthInit,
+		ProtocolVersion:   TrustedAuthProtocolVersion,
+		InitiatorDeviceID: id.DeviceID,
+		ResponderDeviceID: respDeviceID,
+		PairCredentialRef: credRef,
+		EphemeralPub:      hex.EncodeToString(ephemPub),
+		Nonce:             hex.EncodeToString(nonce),
+		Capabilities:      caps,
+		Timestamp:         tsStr,
+		Signature:         hex.EncodeToString(sig),
+		AuthTag:           tag,
+	}, nil
+}
+
+// VerifyTrustedAuthInit validates format, clock skew, Ed25519 signature, and HMAC tag of a TrustedAuthInit.
+func VerifyTrustedAuthInit(init *TrustedAuthInit, kPair []byte, initPubKey ed25519.PublicKey, localDeviceID string, now time.Time) ([]byte, []byte, error) {
+	if init == nil || init.Type != MsgTrustedAuthInit || init.ProtocolVersion != TrustedAuthProtocolVersion {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+	if init.ResponderDeviceID != localDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+	if !ValidateDeviceID(init.InitiatorDeviceID) {
+		return nil, nil, ErrInvalidDeviceID
+	}
+
+	expectedInitID := DeriveDeviceID(initPubKey)
+	if expectedInitID != init.InitiatorDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+
+	ts, err := time.Parse(time.RFC3339, init.Timestamp)
+	if err != nil {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+	skew := now.Sub(ts)
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > MaxTrustedTimestampSkew {
+		return nil, nil, ErrTrustedTimestampSkew
+	}
+
+	ephemPub, err := hex.DecodeString(init.EphemeralPub)
+	if err != nil || len(ephemPub) != TrustedAuthEphemeralSize {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+
+	nonce, err := hex.DecodeString(init.Nonce)
+	if err != nil || len(nonce) != TrustedAuthNonceSize {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+
+	sigBytes, err := hex.DecodeString(init.Signature)
+	if err != nil || len(sigBytes) != ed25519.SignatureSize {
+		return nil, nil, ErrTrustedSignatureFailed
+	}
+
+	capsHash := HashCapabilities(init.Capabilities)
+	kPairHash := sha256.Sum256(kPair)
+	challenge := BuildTrustedInitChallenge(kPairHash[:], ephemPub, nonce, init.InitiatorDeviceID, init.ResponderDeviceID, capsHash, init.Timestamp)
+
+	if !VerifyDeviceSignature(initPubKey, challenge, sigBytes) {
+		return nil, nil, ErrTrustedSignatureFailed
+	}
+
+	if !VerifyTrustedMACTag(kPair, DomainTrustedInitMAC, challenge, init.AuthTag) {
+		return nil, nil, ErrTrustedMACTagFailed
+	}
+
+	return ephemPub, nonce, nil
+}
+
+// NewTrustedAuthResponse creates a signed and MAC-authenticated TrustedAuthResponse message.
+func NewTrustedAuthResponse(id *DeviceIdentity, init *TrustedAuthInit, kPair []byte, caps []string, ephemPub, nonce []byte) (*TrustedAuthResponse, error) {
+	if id == nil {
+		return nil, ErrInvalidIdentity
+	}
+	if len(kPair) == 0 {
+		return nil, errors.New("k_pair required")
+	}
+	if len(ephemPub) != TrustedAuthEphemeralSize {
+		ephemPub = make([]byte, TrustedAuthEphemeralSize)
+		if _, err := rand.Read(ephemPub); err != nil {
+			return nil, err
+		}
+	}
+	if len(nonce) != TrustedAuthNonceSize {
+		nonce = make([]byte, TrustedAuthNonceSize)
+		if _, err := rand.Read(nonce); err != nil {
+			return nil, err
+		}
+	}
+
+	ephemInit, _ := hex.DecodeString(init.EphemeralPub)
+	nonceInit, _ := hex.DecodeString(init.Nonce)
+
+	negotiated := IntersectCapabilities(init.Capabilities, caps)
+	capsHash := HashCapabilities(negotiated)
+	kPairHash := sha256.Sum256(kPair)
+
+	challenge := BuildTrustedRespChallenge(kPairHash[:], ephemInit, ephemPub, nonceInit, nonce, init.InitiatorDeviceID, id.DeviceID, capsHash)
+	sig, err := id.Sign(challenge)
+	if err != nil {
+		return nil, fmt.Errorf("sign trusted response: %w", err)
+	}
+
+	tag := ComputeTrustedMACTag(kPair, DomainTrustedRespMAC, challenge)
+
+	return &TrustedAuthResponse{
+		Type:              MsgTrustedAuthResponse,
+		ProtocolVersion:   TrustedAuthProtocolVersion,
+		Status:            "accepted",
+		ResponderDeviceID: id.DeviceID,
+		EphemeralPub:      hex.EncodeToString(ephemPub),
+		Nonce:             hex.EncodeToString(nonce),
+		Capabilities:      caps,
+		Signature:         hex.EncodeToString(sig),
+		AuthTag:           tag,
+	}, nil
+}
+
+// VerifyTrustedAuthResponse validates the format, Ed25519 signature, and HMAC tag of a TrustedAuthResponse.
+func VerifyTrustedAuthResponse(resp *TrustedAuthResponse, init *TrustedAuthInit, kPair []byte, respPubKey ed25519.PublicKey, localDeviceID string) ([]byte, []byte, error) {
+	if resp == nil || resp.Type != MsgTrustedAuthResponse || resp.ProtocolVersion != TrustedAuthProtocolVersion {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+	if localDeviceID != "" && init.InitiatorDeviceID != localDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+	if resp.Status != "accepted" {
+		if resp.Status == "revoked" {
+			return nil, nil, ErrTrustedPeerRevoked
+		}
+		return nil, nil, ErrTrustedRejected
+	}
+	if resp.ResponderDeviceID != init.ResponderDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+
+	expectedRespID := DeriveDeviceID(respPubKey)
+	if expectedRespID != resp.ResponderDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+
+	ephemInit, _ := hex.DecodeString(init.EphemeralPub)
+	nonceInit, _ := hex.DecodeString(init.Nonce)
+
+	ephemResp, err := hex.DecodeString(resp.EphemeralPub)
+	if err != nil || len(ephemResp) != TrustedAuthEphemeralSize {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+
+	nonceResp, err := hex.DecodeString(resp.Nonce)
+	if err != nil || len(nonceResp) != TrustedAuthNonceSize {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+
+	sigBytes, err := hex.DecodeString(resp.Signature)
+	if err != nil || len(sigBytes) != ed25519.SignatureSize {
+		return nil, nil, ErrTrustedSignatureFailed
+	}
+
+	negotiated := IntersectCapabilities(init.Capabilities, resp.Capabilities)
+	capsHash := HashCapabilities(negotiated)
+	kPairHash := sha256.Sum256(kPair)
+	challenge := BuildTrustedRespChallenge(kPairHash[:], ephemInit, ephemResp, nonceInit, nonceResp, init.InitiatorDeviceID, resp.ResponderDeviceID, capsHash)
+
+	if !VerifyDeviceSignature(respPubKey, challenge, sigBytes) {
+		return nil, nil, ErrTrustedSignatureFailed
+	}
+
+	if !VerifyTrustedMACTag(kPair, DomainTrustedRespMAC, challenge, resp.AuthTag) {
+		return nil, nil, ErrTrustedMACTagFailed
+	}
+
+	return ephemResp, nonceResp, nil
+}
+
+// NewTrustedAuthConfirm creates a TrustedAuthConfirm message.
+func NewTrustedAuthConfirm(sessionMaster []byte, domain, localDeviceID string, ready bool) *TrustedAuthConfirm {
+	if !ready {
+		return &TrustedAuthConfirm{
+			Type:   MsgTrustedAuthConfirm,
+			Status: "rejected",
+		}
+	}
+	tag := ComputeTrustedConfirmTag(sessionMaster, domain, localDeviceID)
+	return &TrustedAuthConfirm{
+		Type:    MsgTrustedAuthConfirm,
+		Status:  "ready",
+		AuthTag: tag,
+	}
+}
+
+// VerifyTrustedAuthConfirm verifies a peer's confirmation tag.
+func VerifyTrustedAuthConfirm(confirm *TrustedAuthConfirm, sessionMaster []byte, domain, peerDeviceID string) error {
+	if confirm == nil || confirm.Type != MsgTrustedAuthConfirm {
+		return ErrInvalidTrustedMessage
+	}
+	if confirm.Status != "ready" {
+		return ErrTrustedRejected
+	}
+	if !VerifyTrustedConfirmTag(sessionMaster, domain, peerDeviceID, confirm.AuthTag) {
+		return ErrTrustedMACTagFailed
+	}
+	return nil
+}
+
+// EncodeTrustedAuthMessage marshals any trusted authentication message into compact JSON bytes.
+func EncodeTrustedAuthMessage(msg any) ([]byte, error) {
+	return json.Marshal(msg)
+}
+
+// DecodeTrustedAuthMessage unmarshals a trusted authentication message into its concrete type.
+func DecodeTrustedAuthMessage(data []byte) (any, error) {
+	var peek struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidTrustedMessage, err)
+	}
+
+	switch peek.Type {
+	case MsgTrustedAuthInit:
+		var init TrustedAuthInit
+		if err := json.Unmarshal(data, &init); err != nil {
+			return nil, err
+		}
+		return &init, nil
+	case MsgTrustedAuthResponse:
+		var resp TrustedAuthResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return nil, err
+		}
+		return &resp, nil
+	case MsgTrustedAuthConfirm:
+		var conf TrustedAuthConfirm
+		if err := json.Unmarshal(data, &conf); err != nil {
+			return nil, err
+		}
+		return &conf, nil
+	default:
+		return nil, fmt.Errorf("%w: unknown type %q", ErrInvalidTrustedMessage, peek.Type)
+	}
+}

--- a/packages/wire/trusted_auth_test.go
+++ b/packages/wire/trusted_auth_test.go
@@ -1,0 +1,264 @@
+package wire
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type TrustedSessionTestVector struct {
+	Name             string   `json:"name"`
+	KPairHex         string   `json:"k_pair_hex"`
+	PairCredRef      string   `json:"pair_cred_ref"`
+	InitSeedHex      string   `json:"init_seed_hex"`
+	InitDeviceID     string   `json:"init_device_id"`
+	InitPubKeyHex    string   `json:"init_pub_key_hex"`
+	InitEphemPubHex  string   `json:"init_ephem_pub_hex"`
+	InitNonceHex     string   `json:"init_nonce_hex"`
+	InitCaps         []string `json:"init_caps"`
+	InitTimestamp    string   `json:"init_timestamp"`
+	InitSigHex       string   `json:"init_sig_hex"`
+	InitAuthTagHex   string   `json:"init_auth_tag_hex"`
+	RespSeedHex      string   `json:"resp_seed_hex"`
+	RespDeviceID     string   `json:"resp_device_id"`
+	RespPubKeyHex    string   `json:"resp_pub_key_hex"`
+	RespEphemPubHex  string   `json:"resp_ephem_pub_hex"`
+	RespNonceHex     string   `json:"resp_nonce_hex"`
+	RespCaps         []string `json:"resp_caps"`
+	RespSigHex       string   `json:"resp_sig_hex"`
+	RespAuthTagHex   string   `json:"resp_auth_tag_hex"`
+	SessionMasterHex string   `json:"session_master_hex"`
+	I2RKeyHex        string   `json:"i2r_key_hex"`
+	R2IKeyHex        string   `json:"r2i_key_hex"`
+	InitConfirmTag   string   `json:"init_confirm_tag"`
+	RespConfirmTag   string   `json:"resp_confirm_tag"`
+}
+
+func TestTrustedAuthEndToEnd(t *testing.T) {
+	seedA := sha256.Sum256([]byte("seed-device-alice-trusted-v15"))
+	seedB := sha256.Sum256([]byte("seed-device-bob-trusted-v15"))
+	kPair := sha256.Sum256([]byte("shared-k-pair-secret-alice-bob"))
+	hCred := sha256.Sum256(kPair[:])
+	credRef := "cred-" + hex.EncodeToString(hCred[:])
+
+	privA := ed25519.NewKeyFromSeed(seedA[:])
+	pubA := privA.Public().(ed25519.PublicKey)
+	idA, err := NewDeviceIdentity(pubA, privA)
+	if err != nil {
+		t.Fatalf("NewDeviceIdentity A: %v", err)
+	}
+
+	privB := ed25519.NewKeyFromSeed(seedB[:])
+	pubB := privB.Public().(ed25519.PublicKey)
+	idB, err := NewDeviceIdentity(pubB, privB)
+	if err != nil {
+		t.Fatalf("NewDeviceIdentity B: %v", err)
+	}
+
+	fixedTime, _ := time.Parse(time.RFC3339, "2026-08-21T12:00:00Z")
+
+	ephemPubA := sha256.Sum256([]byte("ephem-alice-fixed-1"))
+	nonceA := sha256.Sum256([]byte("nonce-alice-fixed-1"))
+
+	ephemPubB := sha256.Sum256([]byte("ephem-bob-fixed-2"))
+	nonceB := sha256.Sum256([]byte("nonce-bob-fixed-2"))
+
+	capsA := []string{"transfer.v1", "transfer.v2", "auto_accept"}
+	capsB := []string{"transfer.v1", "transfer.v2", "lan_direct"}
+
+	// Alice creates TrustedAuthInit
+	initMsg, err := NewTrustedAuthInit(idA, idB.DeviceID, credRef, kPair[:], capsA, ephemPubA[:], nonceA[:], fixedTime)
+	if err != nil {
+		t.Fatalf("NewTrustedAuthInit: %v", err)
+	}
+
+	// Bob verifies TrustedAuthInit
+	ephemAVerified, nonceAVerified, err := VerifyTrustedAuthInit(initMsg, kPair[:], idA.PublicKey, idB.DeviceID, fixedTime)
+	if err != nil {
+		t.Fatalf("VerifyTrustedAuthInit: %v", err)
+	}
+	if hex.EncodeToString(ephemAVerified) != hex.EncodeToString(ephemPubA[:]) {
+		t.Errorf("ephem A mismatch")
+	}
+
+	// Bob creates TrustedAuthResponse
+	respMsg, err := NewTrustedAuthResponse(idB, initMsg, kPair[:], capsB, ephemPubB[:], nonceB[:])
+	if err != nil {
+		t.Fatalf("NewTrustedAuthResponse: %v", err)
+	}
+
+	// Alice verifies TrustedAuthResponse
+	ephemBVerified, nonceBVerified, err := VerifyTrustedAuthResponse(respMsg, initMsg, kPair[:], idB.PublicKey, idA.DeviceID)
+	if err != nil {
+		t.Fatalf("VerifyTrustedAuthResponse: %v", err)
+	}
+	if hex.EncodeToString(ephemBVerified) != hex.EncodeToString(ephemPubB[:]) {
+		t.Errorf("ephem B mismatch")
+	}
+
+	// Both derive directional session keys
+	keysAlice, err := DeriveTrustedSessionKeys(kPair[:], ephemPubA[:], ephemBVerified, nonceA[:], nonceBVerified, idA.DeviceID, idB.DeviceID, capsA, respMsg.Capabilities)
+	if err != nil {
+		t.Fatalf("DeriveTrustedSessionKeys Alice: %v", err)
+	}
+
+	keysBob, err := DeriveTrustedSessionKeys(kPair[:], ephemAVerified, ephemPubB[:], nonceAVerified, nonceB[:], initMsg.InitiatorDeviceID, idB.DeviceID, initMsg.Capabilities, capsB)
+	if err != nil {
+		t.Fatalf("DeriveTrustedSessionKeys Bob: %v", err)
+	}
+
+	if hex.EncodeToString(keysAlice.SessionMaster) != hex.EncodeToString(keysBob.SessionMaster) {
+		t.Errorf("SessionMaster mismatch")
+	}
+	if hex.EncodeToString(keysAlice.InitiatorToResponderKey) != hex.EncodeToString(keysBob.InitiatorToResponderKey) {
+		t.Errorf("I2RKey mismatch")
+	}
+	if hex.EncodeToString(keysAlice.ResponderToInitiatorKey) != hex.EncodeToString(keysBob.ResponderToInitiatorKey) {
+		t.Errorf("R2IKey mismatch")
+	}
+
+	// Confirmation handshake
+	confirmAlice := NewTrustedAuthConfirm(keysAlice.SessionMaster, DomainTrustedConfirmInit, idA.DeviceID, true)
+	if err := VerifyTrustedAuthConfirm(confirmAlice, keysBob.SessionMaster, DomainTrustedConfirmInit, idA.DeviceID); err != nil {
+		t.Errorf("Bob failed to verify Alice confirm: %v", err)
+	}
+
+	confirmBob := NewTrustedAuthConfirm(keysBob.SessionMaster, DomainTrustedConfirmResp, idB.DeviceID, true)
+	if err := VerifyTrustedAuthConfirm(confirmBob, keysAlice.SessionMaster, DomainTrustedConfirmResp, idB.DeviceID); err != nil {
+		t.Errorf("Alice failed to verify Bob confirm: %v", err)
+	}
+
+	// Generate deterministic test vector
+	vector := TrustedSessionTestVector{
+		Name:             "alice_bob_trusted_session",
+		KPairHex:         hex.EncodeToString(kPair[:]),
+		PairCredRef:      credRef,
+		InitSeedHex:      hex.EncodeToString(seedA[:]),
+		InitDeviceID:     idA.DeviceID,
+		InitPubKeyHex:    hex.EncodeToString(idA.PublicKey),
+		InitEphemPubHex:  hex.EncodeToString(ephemPubA[:]),
+		InitNonceHex:     hex.EncodeToString(nonceA[:]),
+		InitCaps:         capsA,
+		InitTimestamp:    initMsg.Timestamp,
+		InitSigHex:       initMsg.Signature,
+		InitAuthTagHex:   initMsg.AuthTag,
+		RespSeedHex:      hex.EncodeToString(seedB[:]),
+		RespDeviceID:     idB.DeviceID,
+		RespPubKeyHex:    hex.EncodeToString(idB.PublicKey),
+		RespEphemPubHex:  hex.EncodeToString(ephemPubB[:]),
+		RespNonceHex:     hex.EncodeToString(nonceB[:]),
+		RespCaps:         capsB,
+		RespSigHex:       respMsg.Signature,
+		RespAuthTagHex:   respMsg.AuthTag,
+		SessionMasterHex: hex.EncodeToString(keysAlice.SessionMaster),
+		I2RKeyHex:        hex.EncodeToString(keysAlice.InitiatorToResponderKey),
+		R2IKeyHex:        hex.EncodeToString(keysAlice.ResponderToInitiatorKey),
+		InitConfirmTag:   confirmAlice.AuthTag,
+		RespConfirmTag:   confirmBob.AuthTag,
+	}
+
+	vecData, err := json.MarshalIndent([]TrustedSessionTestVector{vector}, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal test vector: %v", err)
+	}
+
+	targetPath := filepath.Join("testdata", "trusted-session-vectors.json")
+	if err := os.WriteFile(targetPath, vecData, 0644); err != nil {
+		t.Fatalf("write trusted-session-vectors.json: %v", err)
+	}
+}
+
+func TestTrustedAuthAdversarialRejections(t *testing.T) {
+	seedA := sha256.Sum256([]byte("seed-device-alice-adv-t"))
+	seedB := sha256.Sum256([]byte("seed-device-bob-adv-t"))
+	kPair := sha256.Sum256([]byte("k-pair-adv-shared"))
+	privA := ed25519.NewKeyFromSeed(seedA[:])
+	privB := ed25519.NewKeyFromSeed(seedB[:])
+	idA, _ := NewDeviceIdentity(privA.Public().(ed25519.PublicKey), privA)
+	idB, _ := NewDeviceIdentity(privB.Public().(ed25519.PublicKey), privB)
+
+	now := time.Now().UTC()
+	initMsg, _ := NewTrustedAuthInit(idA, idB.DeviceID, "cred-ref", kPair[:], []string{"transfer.v1"}, nil, nil, now)
+
+	// 1. Clock skew > 5 minutes
+	expiredTime := now.Add(-10 * time.Minute)
+	if _, _, err := VerifyTrustedAuthInit(initMsg, kPair[:], idA.PublicKey, idB.DeviceID, expiredTime); !errors.Is(err, ErrTrustedTimestampSkew) {
+		t.Errorf("expected ErrTrustedTimestampSkew, got %v", err)
+	}
+
+	// 2. Peer mismatch
+	if _, _, err := VerifyTrustedAuthInit(initMsg, kPair[:], idA.PublicKey, "sb-dev-wrong", now); !errors.Is(err, ErrTrustedPeerMismatch) {
+		t.Errorf("expected ErrTrustedPeerMismatch on wrong responder, got %v", err)
+	}
+
+	// 3. Forged signature
+	tamperedSig := *initMsg
+	tamperedSig.Signature = hex.EncodeToString(make([]byte, 64))
+	if _, _, err := VerifyTrustedAuthInit(&tamperedSig, kPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrTrustedSignatureFailed) {
+		t.Errorf("expected ErrTrustedSignatureFailed, got %v", err)
+	}
+
+	// 4. Wrong k_pair fails signature challenge binding
+	wrongKPair := sha256.Sum256([]byte("rogue-k-pair"))
+	if _, _, err := VerifyTrustedAuthInit(initMsg, wrongKPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrTrustedSignatureFailed) {
+		t.Errorf("expected ErrTrustedSignatureFailed on wrong k_pair, got %v", err)
+	}
+
+	// 5. Tampered AuthTag
+	tamperedMAC := *initMsg
+	tamperedMAC.AuthTag = hex.EncodeToString(make([]byte, 32))
+	if _, _, err := VerifyTrustedAuthInit(&tamperedMAC, kPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrTrustedMACTagFailed) {
+		t.Errorf("expected ErrTrustedMACTagFailed, got %v", err)
+	}
+
+	// 6. Revoked status in response
+	respRevoked := &TrustedAuthResponse{
+		Type:              MsgTrustedAuthResponse,
+		ProtocolVersion:   TrustedAuthProtocolVersion,
+		Status:            "revoked",
+		ResponderDeviceID: idB.DeviceID,
+	}
+	if _, _, err := VerifyTrustedAuthResponse(respRevoked, initMsg, kPair[:], idB.PublicKey, idA.DeviceID); !errors.Is(err, ErrTrustedPeerRevoked) {
+		t.Errorf("expected ErrTrustedPeerRevoked, got %v", err)
+	}
+}
+
+func TestTrustedAuthCodec(t *testing.T) {
+	init := &TrustedAuthInit{
+		Type:              MsgTrustedAuthInit,
+		ProtocolVersion:   TrustedAuthProtocolVersion,
+		InitiatorDeviceID: "sb-dev-1111",
+		ResponderDeviceID: "sb-dev-2222",
+		PairCredentialRef: "cred-1234",
+		EphemeralPub:      hex.EncodeToString(make([]byte, 32)),
+		Nonce:             hex.EncodeToString(make([]byte, 32)),
+		Capabilities:      []string{"transfer.v1"},
+		Timestamp:         "2026-08-21T12:00:00Z",
+		Signature:         hex.EncodeToString(make([]byte, 64)),
+		AuthTag:           hex.EncodeToString(make([]byte, 32)),
+	}
+
+	data, err := EncodeTrustedAuthMessage(init)
+	if err != nil {
+		t.Fatalf("EncodeTrustedAuthMessage: %v", err)
+	}
+
+	decoded, err := DecodeTrustedAuthMessage(data)
+	if err != nil {
+		t.Fatalf("DecodeTrustedAuthMessage: %v", err)
+	}
+
+	initDecoded, ok := decoded.(*TrustedAuthInit)
+	if !ok {
+		t.Fatalf("expected *TrustedAuthInit, got %T", decoded)
+	}
+	if initDecoded.InitiatorDeviceID != init.InitiatorDeviceID {
+		t.Errorf("initiator device id mismatch")
+	}
+}


### PR DESCRIPTION
## Summary
- **Protocol & Cryptography:** Implement `sendbeam/2` trusted-session protocol messages (`TrustedAuthInit`, `TrustedAuthResponse`, `TrustedAuthConfirm`) with mutual challenge-response verification over ephemeral key material and `k_pair`.
- **Forward-Secret Session Key Schedule:** Derive directional traffic keys (`k_i2r`, `k_r2i`) and session master key binding identities, pair credential, nonces, and negotiated capabilities into the transcript.
- **Trusted Session Coordinator:** Implement `TrustedSessionCoordinator` in `packages/engine/trust` driving initiator and responder connections, enforcing timestamp skew limits (±5 min), peer identity verification, and revocation checks.
- **Cross-Language Validation:** Added deterministic test vectors in `packages/wire/testdata/trusted-session-vectors.json` verified identically across Go (`packages/wire`) and TypeScript (`@sendbeam/protocol`).
- **Documentation:** Updated `docs/trust-model.md` with Section 7 detailing the trusted session sequence diagram and key derivation formulas.

## Test Plan
- Cross-language vector tests and adversarial security tests (clock skew, forged signature, tampered MAC, revocation, unknown peer) in Go and TypeScript.
- Concurrent loopback coordinator integration tests.
- Format, lint, typecheck, and full CI test suite.