### PR TITLE
feat(presence): privacy-preserving remote presence and blinded LAN discovery

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -160,3 +160,8 @@ Cross-language vector tests keep the TypeScript and Go implementations byte-iden
 the test-vector suite (KATs + a full transfer vector) is published under
 `docs/test-vectors/` for independent reimplementation. Before public release the crypto
 and server are security-reviewed and the JS/Go dependencies audited.
+
+## Remote Presence & Blinded Discovery Metadata Boundaries (v1.5)
+
+- **Opaque Rendezvous Handles:** Pairwise handles are derived via `HMAC-SHA256(k_pair, "sendbeam/2 rendezvous-handle:" || epoch)` rotating every 15 minutes. The signaling server sees connection attempts for a random-looking 32-byte hex string, but cannot link distinct handles across epochs, determine the underlying device identities, or associate them with account records.
+- **Blinded LAN Beacons:** UDP broadcast/multicast beacons contain only ephemeral random nonces, port numbers, and truncated 16-byte HMAC tags (`HMAC(k_pair, nonce || epoch)`). Passive network observers on the local Wi-Fi see pseudorandom beacons without plaintext device names, fingerprints, or transfer metadata.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -199,3 +199,35 @@ k_r2i = HKDF-SHA256(SessionMaster, nil, "sendbeam/2 responder-to-initiator key",
 - **Cryptographic Binding:** The signature and MAC tag strictly bind `k_pair`, `EphemeralPub`, `Nonce`, `DeviceID`, and `NegotiatedCapabilities`.
 - **Local Revocation:** If a peer has been marked `revoked: true` in the local trust database, all connection attempts are rejected with `ErrTrustedPeerRevoked`.
 - **Protocol Boundary:** One-time pairing and transfers remain compatible via `sendbeam/1`, while trusted-device mesh operations use `sendbeam/2`.
+
+---
+
+## 8. Privacy-Preserving Remote Presence & LAN Discovery
+
+SendBeam allows paired devices to discover each other across the internet and local networks without leaking device identities, filenames, user accounts, or global directories.
+
+### 8.1 Opaque Epoch-Rotated Rendezvous Handles
+
+To discover peers over the signaling server without creating a global directory or publishing device IDs:
+
+- **Pairwise Time-Windowed Handle Derivation:**
+  ```
+  epochIndex = floor(unixTimestampSeconds / 900)  // 15-minute epoch window
+  handle = HMAC-SHA256(k_pair, "sendbeam/2 rendezvous-handle:" || epochIndex)
+  ```
+- **Clock Drift Tolerance:** Clients compute candidate handles for `[epochIndex-1, epochIndex, epochIndex+1]` to tolerate clock skew.
+- **Server Privacy:** The signaling server matches connections solely on exact handle equality. The server cannot determine which devices share a handle or link different epoch handles together.
+
+### 8.2 Blinded LAN Discovery Beacons
+
+For local network (Wi-Fi/LAN) direct transfer without internet roundtrips:
+
+- **Beacon Frame Format:**
+  - Header (32 bytes): Magic `"SB2B"`, Version `1`, TCP Listening Port (2 bytes), Timestamp (8 bytes), Nonce (16 bytes), Tag Count (1 byte).
+  - Tags: Up to 32 truncated 16-byte blinded tags.
+- **Blinded Tag Formula:**
+  ```
+  tag = HMAC-SHA256(k_pair, "sendbeam/2 lan-beacon:" || Nonce || epochIndex)[0:16]
+  ```
+- **Local Matching:** Listening nodes compute candidate tags using `k_pair` secrets from their local trust stores. Unpaired third parties on the LAN only see pseudorandom bytes.
+- **Direct LAN Connection:** When a peer is matched on LAN, nodes connect directly via TCP/TLS, bypassing internet signaling and relay.

--- a/packages/engine/discovery/lan_discovery.go
+++ b/packages/engine/discovery/lan_discovery.go
@@ -1,0 +1,267 @@
+// Package discovery implements privacy-preserving local network (LAN) peer discovery using blinded beacons.
+package discovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+// DiscoveredPeer represents a trusted paired peer discovered directly over LAN.
+type DiscoveredPeer struct {
+	DeviceID string
+	IP       net.IP
+	Port     uint16
+	LastSeen time.Time
+}
+
+// Config defines options for the LAN discovery service.
+type Config struct {
+	ListenAddr     string
+	BroadcastAddr  string
+	AdvertisePort  uint16
+	BeaconInterval time.Duration
+	EpochWindow    time.Duration
+}
+
+// LanDiscoveryService broadcasts blinded beacons and discovers local paired peers.
+type LanDiscoveryService struct {
+	cfg      Config
+	store    trust.Store
+	resolver trust.SecretResolver
+
+	mu       sync.RWMutex
+	peers    map[string]*DiscoveredPeer
+	handlers []func(peer DiscoveredPeer)
+
+	conn   net.PacketConn
+	isConnManaged bool
+}
+
+// NewLanDiscoveryService creates a new LanDiscoveryService.
+func NewLanDiscoveryService(cfg Config, store trust.Store, resolver trust.SecretResolver) *LanDiscoveryService {
+	if cfg.BeaconInterval <= 0 {
+		cfg.BeaconInterval = 3 * time.Second
+	}
+	if cfg.EpochWindow <= 0 {
+		cfg.EpochWindow = wire.DefaultLanBeaconEpochWindow
+	}
+	return &LanDiscoveryService{
+		cfg:      cfg,
+		store:    store,
+		resolver: resolver,
+		peers:    make(map[string]*DiscoveredPeer),
+	}
+}
+
+// SetPacketConn overrides the UDP packet connection (useful for unit testing).
+func (s *LanDiscoveryService) SetPacketConn(conn net.PacketConn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conn = conn
+	s.isConnManaged = false
+}
+
+// OnPeerDiscovered registers a callback invoked when a paired peer is seen on LAN.
+func (s *LanDiscoveryService) OnPeerDiscovered(handler func(peer DiscoveredPeer)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.handlers = append(s.handlers, handler)
+}
+
+// GetDiscoveredPeers returns a snapshot of currently discovered LAN peers.
+func (s *LanDiscoveryService) GetDiscoveredPeers() []DiscoveredPeer {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	res := make([]DiscoveredPeer, 0, len(s.peers))
+	for _, p := range s.peers {
+		res = append(res, *p)
+	}
+	return res
+}
+
+// Start launches the background advertiser and listener routines.
+func (s *LanDiscoveryService) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.conn == nil {
+		listenAddr := s.cfg.ListenAddr
+		if listenAddr == "" {
+			listenAddr = fmt.Sprintf(":%d", wire.DefaultLanBeaconPort)
+		}
+		c, err := net.ListenPacket("udp4", listenAddr)
+		if err != nil {
+			s.mu.Unlock()
+			return fmt.Errorf("listen udp: %w", err)
+		}
+		s.conn = c
+		s.isConnManaged = true
+	}
+	conn := s.conn
+	s.mu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Listener loop
+	go func() {
+		defer wg.Done()
+		s.listenLoop(ctx, conn)
+	}()
+
+	// Advertiser loop
+	go func() {
+		defer wg.Done()
+		s.advertiseLoop(ctx, conn)
+	}()
+
+	<-ctx.Done()
+	if s.isConnManaged && conn != nil {
+		_ = conn.Close()
+	}
+	wg.Wait()
+	return nil
+}
+
+func (s *LanDiscoveryService) listenLoop(ctx context.Context, conn net.PacketConn) {
+	buf := make([]byte, 1024)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		n, addr, err := conn.ReadFrom(buf)
+		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				continue
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			continue
+		}
+
+		beacon, err := wire.DecodeLanBeacon(buf[:n])
+		if err != nil {
+			continue
+		}
+
+		var udpIP net.IP
+		if udpAddr, ok := addr.(*net.UDPAddr); ok {
+			udpIP = udpAddr.IP
+		}
+
+		s.processBeacon(ctx, beacon, udpIP)
+	}
+}
+
+func (s *LanDiscoveryService) processBeacon(ctx context.Context, beacon *wire.LanBeacon, ip net.IP) {
+	devices, err := s.store.ListDevices(ctx)
+	if err != nil || len(devices) == 0 {
+		return
+	}
+
+	localPairs := make(map[string][]byte, len(devices))
+	for _, dev := range devices {
+		if dev.Revoked {
+			continue
+		}
+		kPair, err := s.resolver.ResolvePairSecret(ctx, dev.DeviceID, dev.PairCredentialRef)
+		if err == nil && len(kPair) > 0 {
+			localPairs[dev.DeviceID] = kPair
+		}
+	}
+
+	now := time.Now().UTC()
+	matched := wire.MatchLanBeacon(beacon, localPairs, now, s.cfg.EpochWindow)
+	if len(matched) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, devID := range matched {
+		peer := &DiscoveredPeer{
+			DeviceID: devID,
+			IP:       ip,
+			Port:     beacon.Port,
+			LastSeen: now,
+		}
+		s.peers[devID] = peer
+		for _, h := range s.handlers {
+			go h(*peer)
+		}
+	}
+}
+
+func (s *LanDiscoveryService) advertiseLoop(ctx context.Context, conn net.PacketConn) {
+	ticker := time.NewTicker(s.cfg.BeaconInterval)
+	defer ticker.Stop()
+
+	// Initial send immediately
+	s.sendBeacon(ctx, conn)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sendBeacon(ctx, conn)
+		}
+	}
+}
+
+func (s *LanDiscoveryService) sendBeacon(ctx context.Context, conn net.PacketConn) {
+	devices, err := s.store.ListDevices(ctx)
+	if err != nil || len(devices) == 0 {
+		return
+	}
+
+	var kPairs [][]byte
+	for _, dev := range devices {
+		if dev.Revoked {
+			continue
+		}
+		kPair, err := s.resolver.ResolvePairSecret(ctx, dev.DeviceID, dev.PairCredentialRef)
+		if err == nil && len(kPair) > 0 {
+			kPairs = append(kPairs, kPair)
+		}
+	}
+
+	if len(kPairs) == 0 {
+		return
+	}
+
+	now := time.Now().UTC()
+	beacon, err := wire.NewLanBeacon(s.cfg.AdvertisePort, kPairs, now, s.cfg.EpochWindow)
+	if err != nil {
+		return
+	}
+
+	data, err := beacon.Encode()
+	if err != nil {
+		return
+	}
+
+	dstAddrStr := s.cfg.BroadcastAddr
+	if dstAddrStr == "" {
+		dstAddrStr = fmt.Sprintf("255.255.255.255:%d", wire.DefaultLanBeaconPort)
+	}
+
+	dst, err := net.ResolveUDPAddr("udp4", dstAddrStr)
+	if err != nil {
+		return
+	}
+
+	_, _ = conn.WriteTo(data, dst)
+}

--- a/packages/engine/discovery/lan_discovery_test.go
+++ b/packages/engine/discovery/lan_discovery_test.go
@@ -1,0 +1,215 @@
+package discovery
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+// pipePacketConn is an in-memory bi-directional PacketConn for testing.
+type pipePacketConn struct {
+	localAddr net.Addr
+	peer      *pipePacketConn
+	incoming  chan packet
+	closed    chan struct{}
+	once      sync.Once
+}
+
+type packet struct {
+	data []byte
+	addr net.Addr
+}
+
+func newPipePacketPair() (*pipePacketConn, *pipePacketConn) {
+	addrA := &net.UDPAddr{IP: net.ParseIP("192.168.1.10"), Port: 53317}
+	addrB := &net.UDPAddr{IP: net.ParseIP("192.168.1.20"), Port: 53317}
+
+	a := &pipePacketConn{
+		localAddr: addrA,
+		incoming:  make(chan packet, 32),
+		closed:    make(chan struct{}),
+	}
+	b := &pipePacketConn{
+		localAddr: addrB,
+		incoming:  make(chan packet, 32),
+		closed:    make(chan struct{}),
+	}
+	a.peer = b
+	b.peer = a
+	return a, b
+}
+
+func (p *pipePacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	select {
+	case <-p.closed:
+		return 0, nil, net.ErrClosed
+	case pkt, ok := <-p.incoming:
+		if !ok {
+			return 0, nil, net.ErrClosed
+		}
+		n := copy(b, pkt.data)
+		return n, pkt.addr, nil
+	}
+}
+
+func (p *pipePacketConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+	select {
+	case <-p.closed:
+		return 0, net.ErrClosed
+	default:
+	}
+	data := append([]byte(nil), b...)
+	if p.peer != nil {
+		select {
+		case p.peer.incoming <- packet{data: data, addr: p.localAddr}:
+		default:
+		}
+	}
+	return len(b), nil
+}
+
+func (p *pipePacketConn) Close() error {
+	p.once.Do(func() {
+		close(p.closed)
+	})
+	return nil
+}
+
+func (p *pipePacketConn) LocalAddr() net.Addr                { return p.localAddr }
+func (p *pipePacketConn) SetDeadline(_ time.Time) error      { return nil }
+func (p *pipePacketConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (p *pipePacketConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func TestLanDiscoveryEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	tmpDirA := t.TempDir()
+	tmpDirB := t.TempDir()
+
+	storeA, _ := trust.NewFileTrustStore(filepath.Join(tmpDirA, "alice-trust.json"))
+	storeB, _ := trust.NewFileTrustStore(filepath.Join(tmpDirB, "bob-trust.json"))
+
+	resA := trust.NewMemorySecretResolver()
+	resB := trust.NewMemorySecretResolver()
+
+	kPair := sha256.Sum256([]byte("shared-k-pair-lan-discovery-test"))
+	hCred := sha256.Sum256(kPair[:])
+	credRef := "cred-" + hex.EncodeToString(hCred[:])
+
+	pubA, _, _ := ed25519.GenerateKey(nil)
+	pubB, _, _ := ed25519.GenerateKey(nil)
+
+	devAlice := wire.DeriveDeviceID(pubA)
+	devBob := wire.DeriveDeviceID(pubB)
+
+	now := time.Now().UTC()
+	errA := storeA.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devBob,
+		PublicKey:         hex.EncodeToString(pubB),
+		LocalLabel:        "Bob",
+		PairCredentialRef: credRef,
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	if errA != nil {
+		t.Fatalf("storeA AddOrUpdateDevice: %v", errA)
+	}
+	resA.SetSecret(devBob, kPair[:])
+
+	errB := storeB.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devAlice,
+		PublicKey:         hex.EncodeToString(pubA),
+		LocalLabel:        "Alice",
+		PairCredentialRef: credRef,
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	if errB != nil {
+		t.Fatalf("storeB AddOrUpdateDevice: %v", errB)
+	}
+	resB.SetSecret(devAlice, kPair[:])
+
+	connA, connB := newPipePacketPair()
+
+	cfgA := Config{
+		AdvertisePort:  8081,
+		BeaconInterval: 100 * time.Millisecond,
+		EpochWindow:    15 * time.Minute,
+	}
+	cfgB := Config{
+		AdvertisePort:  8082,
+		BeaconInterval: 100 * time.Millisecond,
+		EpochWindow:    15 * time.Minute,
+	}
+
+	serviceA := NewLanDiscoveryService(cfgA, storeA, resA)
+	serviceA.SetPacketConn(connA)
+
+	serviceB := NewLanDiscoveryService(cfgB, storeB, resB)
+	serviceB.SetPacketConn(connB)
+
+	discoveredChA := make(chan DiscoveredPeer, 4)
+	serviceA.OnPeerDiscovered(func(p DiscoveredPeer) {
+		discoveredChA <- p
+	})
+
+	discoveredChB := make(chan DiscoveredPeer, 4)
+	serviceB.OnPeerDiscovered(func(p DiscoveredPeer) {
+		discoveredChB <- p
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_ = serviceA.Start(ctx)
+	}()
+
+	go func() {
+		defer wg.Done()
+		_ = serviceB.Start(ctx)
+	}()
+
+	// Wait for mutual discovery
+	select {
+	case peer := <-discoveredChA:
+		if peer.DeviceID != devBob {
+			t.Errorf("Alice discovered wrong peer: %v", peer.DeviceID)
+		}
+		if peer.Port != 8082 {
+			t.Errorf("Alice discovered wrong port: %v", peer.Port)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for Alice to discover Bob")
+	}
+
+	select {
+	case peer := <-discoveredChB:
+		if peer.DeviceID != devAlice {
+			t.Errorf("Bob discovered wrong peer: %v", peer.DeviceID)
+		}
+		if peer.Port != 8081 {
+			t.Errorf("Bob discovered wrong port: %v", peer.Port)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for Bob to discover Alice")
+	}
+
+	cancel()
+	_ = connA.Close()
+	_ = connB.Close()
+	wg.Wait()
+}

--- a/packages/engine/rendezvous/presence_coordinator.go
+++ b/packages/engine/rendezvous/presence_coordinator.go
@@ -1,0 +1,84 @@
+// Package rendezvous provides room-based signaling and privacy-preserving opaque presence coordination.
+package rendezvous
+
+import (
+	"context"
+	"time"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+// PresenceCoordinator manages opaque handle calculation and inbound presence verification.
+type PresenceCoordinator struct {
+	store       trust.Store
+	resolver    trust.SecretResolver
+	epochWindow time.Duration
+}
+
+// NewPresenceCoordinator creates a new PresenceCoordinator.
+func NewPresenceCoordinator(store trust.Store, resolver trust.SecretResolver, epochWindow time.Duration) *PresenceCoordinator {
+	if epochWindow <= 0 {
+		epochWindow = wire.DefaultRendezvousEpochWindow
+	}
+	return &PresenceCoordinator{
+		store:       store,
+		resolver:    resolver,
+		epochWindow: epochWindow,
+	}
+}
+
+// GetActiveHandles returns a mapping of DeviceID to candidate handles for all trusted paired devices.
+func (c *PresenceCoordinator) GetActiveHandles(ctx context.Context, now time.Time) (map[string][]string, error) {
+	devices, err := c.store.ListDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[string][]string)
+	for _, dev := range devices {
+		if dev.Revoked {
+			continue
+		}
+		kPair, err := c.resolver.ResolvePairSecret(ctx, dev.DeviceID, dev.PairCredentialRef)
+		if err != nil || len(kPair) == 0 {
+			continue
+		}
+		handles := wire.DeriveRendezvousHandlesWithSkew(kPair, now, c.epochWindow)
+		res[dev.DeviceID] = handles
+	}
+	return res, nil
+}
+
+// MatchInboundPresence tests an incoming opaque handle and proof against stored paired devices.
+func (c *PresenceCoordinator) MatchInboundPresence(ctx context.Context, handle string, nonce []byte, proof string, now time.Time) (string, bool) {
+	if !wire.ValidateRendezvousHandle(handle) {
+		return "", false
+	}
+
+	devices, err := c.store.ListDevices(ctx)
+	if err != nil || len(devices) == 0 {
+		return "", false
+	}
+
+	for _, dev := range devices {
+		if dev.Revoked {
+			continue
+		}
+		kPair, err := c.resolver.ResolvePairSecret(ctx, dev.DeviceID, dev.PairCredentialRef)
+		if err != nil || len(kPair) == 0 {
+			continue
+		}
+
+		if wire.MatchRendezvousHandle(kPair, handle, now, c.epochWindow) {
+			if len(proof) > 0 && len(nonce) > 0 {
+				if wire.VerifyPresenceProof(kPair, handle, nonce, proof) {
+					return dev.DeviceID, true
+				}
+			} else {
+				return dev.DeviceID, true
+			}
+		}
+	}
+	return "", false
+}

--- a/packages/engine/rendezvous/presence_coordinator_test.go
+++ b/packages/engine/rendezvous/presence_coordinator_test.go
@@ -1,0 +1,86 @@
+package rendezvous
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+func TestPresenceCoordinator(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	store, _ := trust.NewFileTrustStore(filepath.Join(tmpDir, "presence-trust.json"))
+	resolver := trust.NewMemorySecretResolver()
+
+	kPairAlice := sha256.Sum256([]byte("kpair-alice-presence"))
+	kPairBob := sha256.Sum256([]byte("kpair-bob-presence"))
+
+	pubA, _, _ := ed25519.GenerateKey(nil)
+	pubB, _, _ := ed25519.GenerateKey(nil)
+
+	devAlice := wire.DeriveDeviceID(pubA)
+	devBob := wire.DeriveDeviceID(pubB)
+
+	now := time.Now().UTC()
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devAlice,
+		PublicKey:         hex.EncodeToString(pubA),
+		LocalLabel:        "Alice",
+		PairCredentialRef: "cred-alice",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	resolver.SetSecret(devAlice, kPairAlice[:])
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devBob,
+		PublicKey:         hex.EncodeToString(pubB),
+		LocalLabel:        "Bob",
+		PairCredentialRef: "cred-bob",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Revoked:           true, // Revoked
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	resolver.SetSecret(devBob, kPairBob[:])
+
+	coord := NewPresenceCoordinator(store, resolver, 15*time.Minute)
+
+	handles, err := coord.GetActiveHandles(ctx, now)
+	if err != nil {
+		t.Fatalf("GetActiveHandles: %v", err)
+	}
+
+	if _, ok := handles[devAlice]; !ok {
+		t.Errorf("Alice handles missing")
+	}
+	if _, ok := handles[devBob]; ok {
+		t.Errorf("Revoked Bob should not have active handles")
+	}
+
+	// Inbound presence verification
+	handleAlice := wire.DeriveRendezvousHandleForTime(kPairAlice[:], now, 15*time.Minute)
+	nonce := sha256.Sum256([]byte("inbound-nonce-1"))
+	proofAlice := wire.DerivePresenceProof(kPairAlice[:], handleAlice, nonce[:])
+
+	matchedID, valid := coord.MatchInboundPresence(ctx, handleAlice, nonce[:], proofAlice, now)
+	if !valid || matchedID != devAlice {
+		t.Errorf("expected match %s, got %v (valid: %v)", devAlice, matchedID, valid)
+	}
+
+	// Tampered proof
+	_, validTampered := coord.MatchInboundPresence(ctx, handleAlice, nonce[:], hex.EncodeToString(make([]byte, 32)), now)
+	if validTampered {
+		t.Errorf("tampered proof should not be valid")
+	}
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -32,3 +32,4 @@ export * from './identity.js';
 export * from './trust-store.js';
 export * from './pairing.js';
 export * from './trusted-auth.js';
+export * from './presence.js';

--- a/packages/protocol/src/presence.test.ts
+++ b/packages/protocol/src/presence.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { bytesToHex, hexToBytes } from './bytes.js';
+import {
+  DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+  deriveLanBeaconTag,
+  derivePresenceProof,
+  deriveRendezvousHandle,
+  deriveRendezvousHandlesWithSkew,
+  matchLanBeaconTag,
+  verifyPresenceProof,
+} from './presence.js';
+
+interface PresenceVector {
+  name: string;
+  k_pair_hex: string;
+  timestamp: string;
+  epoch_index: number;
+  rendezvous_handle: string;
+  skew_handles: string[];
+  presence_nonce_hex: string;
+  presence_proof_hex: string;
+  beacon_nonce_hex: string;
+  beacon_tag_hex: string;
+}
+
+describe('Presence and LAN discovery cross-language vector validation (sendbeam/2)', () => {
+  const vectorPath = resolve(__dirname, '../../wire/testdata/presence-vectors.json');
+  const vectorContent = readFileSync(vectorPath, 'utf-8');
+  const vectors: PresenceVector[] = JSON.parse(vectorContent);
+
+  it('matches Go generated presence vector byte-for-byte', async () => {
+    for (const vec of vectors) {
+      const kPair = hexToBytes(vec.k_pair_hex);
+      const presenceNonce = hexToBytes(vec.presence_nonce_hex);
+      const beaconNonce = hexToBytes(vec.beacon_nonce_hex);
+
+      // Derive rendezvous handle
+      const handle = await deriveRendezvousHandle(kPair, vec.epoch_index);
+      expect(handle).toBe(vec.rendezvous_handle);
+
+      // Derive skew handles
+      const date = new Date(vec.timestamp);
+      const skewHandles = await deriveRendezvousHandlesWithSkew(
+        kPair,
+        date,
+        DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+      );
+      expect(skewHandles).toEqual(vec.skew_handles);
+
+      // Presence proof
+      const proof = await derivePresenceProof(kPair, handle, presenceNonce);
+      expect(proof).toBe(vec.presence_proof_hex);
+      expect(await verifyPresenceProof(kPair, handle, presenceNonce, proof)).toBe(true);
+
+      // Blinded LAN beacon tag
+      const tag = await deriveLanBeaconTag(kPair, beaconNonce, vec.epoch_index);
+      expect(bytesToHex(tag)).toBe(vec.beacon_tag_hex);
+
+      // Match beacon tag
+      const matched = await matchLanBeaconTag(
+        kPair,
+        beaconNonce,
+        tag,
+        date.getTime(),
+        date.getTime(),
+        DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+      );
+      expect(matched).toBe(true);
+    }
+  });
+
+  it('rejects stale beacon tags and invalid proofs', async () => {
+    const kPair = hexToBytes('8b4c642283597de370a8313836bcc86ca6718f0d71fa4f301134d3f049da2848');
+    const nonce = hexToBytes('c83888c50dc690cbf88691633df49122');
+    const now = Date.now();
+    const tag = await deriveLanBeaconTag(
+      kPair,
+      nonce,
+      Math.floor(now / DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS),
+    );
+
+    // Stale timestamp (> 2 windows)
+    const staleTime = now + 4 * DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS;
+    const matchedStale = await matchLanBeaconTag(kPair, nonce, tag, now, staleTime);
+    expect(matchedStale).toBe(false);
+
+    // Wrong proof
+    const proofValid = await verifyPresenceProof(
+      kPair,
+      'handle-1',
+      nonce,
+      bytesToHex(new Uint8Array(32)),
+    );
+    expect(proofValid).toBe(false);
+  });
+});

--- a/packages/protocol/src/presence.ts
+++ b/packages/protocol/src/presence.ts
@@ -1,0 +1,159 @@
+/**
+ * Remote presence handles, opaque rendezvous discovery, and blinded LAN beacon tags (V15-PR04).
+ *
+ * Matches Go `packages/wire/presence.go` and `packages/wire/lan_beacon.go` byte-for-byte.
+ */
+
+import { bytesToHex, concatBytes, utf8 } from './bytes.js';
+import { hmacSha256 } from './webcrypto.js';
+
+export const DOMAIN_RENDEZVOUS_HANDLE = 'sendbeam/2 rendezvous-handle:';
+export const DOMAIN_PRESENCE_PROOF = 'sendbeam/2 presence-proof:';
+export const DOMAIN_LAN_BEACON_TAG = 'sendbeam/2 lan-beacon:';
+
+export const DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+export const LAN_BEACON_TAG_SIZE = 16;
+export const LAN_BEACON_NONCE_SIZE = 16;
+
+/**
+ * Constant-time hex string comparison.
+ */
+function constantTimeHexEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * Derive a 32-byte opaque rendezvous handle for a specific epoch index.
+ */
+export async function deriveRendezvousHandle(
+  kPair: Uint8Array,
+  epochIndex: number | bigint,
+): Promise<string> {
+  const epochStr = epochIndex.toString();
+  const data = concatBytes(utf8(DOMAIN_RENDEZVOUS_HANDLE), utf8(epochStr));
+  const tag = await hmacSha256(kPair, data);
+  return bytesToHex(tag);
+}
+
+/**
+ * Derive the opaque handle for a given timestamp and window.
+ */
+export async function deriveRendezvousHandleForTime(
+  kPair: Uint8Array,
+  t?: Date | number,
+  windowMs = DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+): Promise<string> {
+  const timeMs = t instanceof Date ? t.getTime() : typeof t === 'number' ? t : Date.now();
+  const epochIndex = Math.floor(timeMs / windowMs);
+  return deriveRendezvousHandle(kPair, epochIndex);
+}
+
+/**
+ * Derive current, previous, and next epoch handles to tolerate clock drift.
+ */
+export async function deriveRendezvousHandlesWithSkew(
+  kPair: Uint8Array,
+  t?: Date | number,
+  windowMs = DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+): Promise<string[]> {
+  const timeMs = t instanceof Date ? t.getTime() : typeof t === 'number' ? t : Date.now();
+  const epochIndex = Math.floor(timeMs / windowMs);
+  return Promise.all([
+    deriveRendezvousHandle(kPair, epochIndex - 1),
+    deriveRendezvousHandle(kPair, epochIndex),
+    deriveRendezvousHandle(kPair, epochIndex + 1),
+  ]);
+}
+
+/**
+ * Compute an HMAC proof of possession for registering or polling a handle.
+ */
+export async function derivePresenceProof(
+  kPair: Uint8Array,
+  handle: string,
+  nonce: Uint8Array,
+): Promise<string> {
+  const data = concatBytes(utf8(DOMAIN_PRESENCE_PROOF), utf8(handle), nonce);
+  const tag = await hmacSha256(kPair, data);
+  return bytesToHex(tag);
+}
+
+/**
+ * Verify an HMAC proof of possession in constant time.
+ */
+export async function verifyPresenceProof(
+  kPair: Uint8Array,
+  handle: string,
+  nonce: Uint8Array,
+  proofHex: string,
+): Promise<boolean> {
+  const expected = await derivePresenceProof(kPair, handle, nonce);
+  return constantTimeHexEqual(proofHex.toLowerCase(), expected.toLowerCase());
+}
+
+/**
+ * Derive a 16-byte truncated blinded tag for a paired device in a LAN beacon.
+ */
+export async function deriveLanBeaconTag(
+  kPair: Uint8Array,
+  nonce: Uint8Array,
+  epochIndex: number | bigint,
+): Promise<Uint8Array> {
+  const epochStr = epochIndex.toString();
+  const data = concatBytes(utf8(DOMAIN_LAN_BEACON_TAG), nonce, utf8(epochStr));
+  const full = await hmacSha256(kPair, data);
+  return full.slice(0, LAN_BEACON_TAG_SIZE);
+}
+
+/**
+ * Compute candidate LAN beacon tags for [epoch-1, epoch, epoch+1].
+ */
+export async function deriveLanBeaconTagsForDevice(
+  kPair: Uint8Array,
+  nonce: Uint8Array,
+  t?: Date | number,
+  windowMs = DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+): Promise<Uint8Array[]> {
+  const timeMs = t instanceof Date ? t.getTime() : typeof t === 'number' ? t : Date.now();
+  const epochIndex = Math.floor(timeMs / windowMs);
+  return Promise.all([
+    deriveLanBeaconTag(kPair, nonce, epochIndex - 1),
+    deriveLanBeaconTag(kPair, nonce, epochIndex),
+    deriveLanBeaconTag(kPair, nonce, epochIndex + 1),
+  ]);
+}
+
+/**
+ * Match a candidate beacon against known paired device secrets.
+ */
+export async function matchLanBeaconTag(
+  kPair: Uint8Array,
+  beaconNonce: Uint8Array,
+  advertisedTag: Uint8Array,
+  beaconTimestampMs: number,
+  nowMs = Date.now(),
+  windowMs = DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+): Promise<boolean> {
+  const skew = Math.abs(nowMs - beaconTimestampMs);
+  if (skew > 2 * windowMs) {
+    return false;
+  }
+  const candidates = await deriveLanBeaconTagsForDevice(
+    kPair,
+    beaconNonce,
+    beaconTimestampMs,
+    windowMs,
+  );
+  const advHex = bytesToHex(advertisedTag);
+  for (const cand of candidates) {
+    if (constantTimeHexEqual(bytesToHex(cand), advHex)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/wire/lan_beacon.go
+++ b/packages/wire/lan_beacon.go
@@ -1,0 +1,214 @@
+package wire
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Blinded LAN beacon constants (V15-PR04).
+const (
+	LanBeaconMagic   = "SB2B"
+	LanBeaconVersion = 1
+
+	LanBeaconHeaderSize = 32
+	LanBeaconNonceSize  = 16
+	LanBeaconTagSize    = 16
+	MaxLanBeaconTags    = 32
+
+	DomainLanBeaconTag = "sendbeam/2 lan-beacon:"
+
+	DefaultLanBeaconEpochWindow = 15 * time.Minute
+	DefaultLanBeaconMulticast   = "239.255.77.88:53317"
+	DefaultLanBeaconPort        = 53317
+)
+
+var (
+	// ErrInvalidLanBeacon indicates a corrupted or invalid LAN discovery beacon packet.
+	ErrInvalidLanBeacon = errors.New("invalid LAN discovery beacon")
+)
+
+// LanBeacon represents a decoded privacy-preserving LAN discovery beacon.
+type LanBeacon struct {
+	Version     uint8
+	Port        uint16
+	Timestamp   time.Time
+	BeaconNonce []byte   // 16 bytes
+	Tags        [][]byte // Slice of 16-byte blinded tags
+}
+
+// DeriveLanBeaconTag derives a 16-byte truncated blinded tag for a paired device.
+func DeriveLanBeaconTag(kPair, nonce []byte, epochIndex int64) []byte {
+	epochStr := strconv.FormatInt(epochIndex, 10)
+	mac := hmac.New(sha256.New, kPair)
+	mac.Write([]byte(DomainLanBeaconTag))
+	mac.Write(nonce)
+	mac.Write([]byte(epochStr))
+	full := mac.Sum(nil)
+	tag := make([]byte, LanBeaconTagSize)
+	copy(tag, full[:LanBeaconTagSize])
+	return tag
+}
+
+// DeriveLanBeaconTagsForDevice computes candidate tags for [epoch-1, epoch, epoch+1].
+func DeriveLanBeaconTagsForDevice(kPair, nonce []byte, t time.Time, window time.Duration) [][]byte {
+	if window <= 0 {
+		window = DefaultLanBeaconEpochWindow
+	}
+	epochIndex := t.UTC().Unix() / int64(window.Seconds())
+	return [][]byte{
+		DeriveLanBeaconTag(kPair, nonce, epochIndex-1),
+		DeriveLanBeaconTag(kPair, nonce, epochIndex),
+		DeriveLanBeaconTag(kPair, nonce, epochIndex+1),
+	}
+}
+
+// NewLanBeacon constructs a LanBeacon with fresh nonce and blinded tags for the provided paired secrets.
+func NewLanBeacon(port uint16, kPairs [][]byte, now time.Time, window time.Duration) (*LanBeacon, error) {
+	if len(kPairs) > MaxLanBeaconTags {
+		kPairs = kPairs[:MaxLanBeaconTags]
+	}
+	if window <= 0 {
+		window = DefaultLanBeaconEpochWindow
+	}
+
+	nonce := make([]byte, LanBeaconNonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate beacon nonce: %w", err)
+	}
+
+	epochIndex := now.UTC().Unix() / int64(window.Seconds())
+	tags := make([][]byte, 0, len(kPairs))
+	for _, kPair := range kPairs {
+		if len(kPair) == 0 {
+			continue
+		}
+		tag := DeriveLanBeaconTag(kPair, nonce, epochIndex)
+		tags = append(tags, tag)
+	}
+
+	return &LanBeacon{
+		Version:     LanBeaconVersion,
+		Port:        port,
+		Timestamp:   now.UTC().Truncate(time.Second),
+		BeaconNonce: nonce,
+		Tags:        tags,
+	}, nil
+}
+
+// Encode serializes the LanBeacon into a binary datagram.
+func (b *LanBeacon) Encode() ([]byte, error) {
+	if b == nil || len(b.BeaconNonce) != LanBeaconNonceSize {
+		return nil, ErrInvalidLanBeacon
+	}
+	if len(b.Tags) > MaxLanBeaconTags {
+		return nil, ErrInvalidLanBeacon
+	}
+
+	totalLen := LanBeaconHeaderSize + (len(b.Tags) * LanBeaconTagSize)
+	buf := make([]byte, totalLen)
+
+	copy(buf[0:4], LanBeaconMagic)
+	buf[4] = b.Version
+	binary.BigEndian.PutUint16(buf[5:7], b.Port)
+	binary.BigEndian.PutUint64(buf[7:15], uint64(b.Timestamp.Unix()))
+	copy(buf[15:31], b.BeaconNonce)
+	buf[31] = uint8(len(b.Tags))
+
+	offset := LanBeaconHeaderSize
+	for _, tag := range b.Tags {
+		if len(tag) != LanBeaconTagSize {
+			return nil, ErrInvalidLanBeacon
+		}
+		copy(buf[offset:offset+LanBeaconTagSize], tag)
+		offset += LanBeaconTagSize
+	}
+
+	return buf, nil
+}
+
+// DecodeLanBeacon parses a raw binary datagram into a LanBeacon.
+func DecodeLanBeacon(data []byte) (*LanBeacon, error) {
+	if len(data) < LanBeaconHeaderSize {
+		return nil, ErrInvalidLanBeacon
+	}
+	if string(data[0:4]) != LanBeaconMagic {
+		return nil, ErrInvalidLanBeacon
+	}
+	ver := data[4]
+	if ver != LanBeaconVersion {
+		return nil, fmt.Errorf("%w: unsupported version %d", ErrInvalidLanBeacon, ver)
+	}
+
+	port := binary.BigEndian.Uint16(data[5:7])
+	tsSec := int64(binary.BigEndian.Uint64(data[7:15]))
+	nonce := make([]byte, LanBeaconNonceSize)
+	copy(nonce, data[15:31])
+	tagCount := int(data[31])
+
+	expectedLen := LanBeaconHeaderSize + (tagCount * LanBeaconTagSize)
+	if len(data) != expectedLen {
+		return nil, ErrInvalidLanBeacon
+	}
+
+	tags := make([][]byte, tagCount)
+	offset := LanBeaconHeaderSize
+	for i := 0; i < tagCount; i++ {
+		tag := make([]byte, LanBeaconTagSize)
+		copy(tag, data[offset:offset+LanBeaconTagSize])
+		tags[i] = tag
+		offset += LanBeaconTagSize
+	}
+
+	return &LanBeacon{
+		Version:     ver,
+		Port:        port,
+		Timestamp:   time.Unix(tsSec, 0).UTC(),
+		BeaconNonce: nonce,
+		Tags:        tags,
+	}, nil
+}
+
+// MatchLanBeacon checks which paired devices in localPairs match any tags in the beacon.
+func MatchLanBeacon(b *LanBeacon, localPairs map[string][]byte, now time.Time, window time.Duration) []string {
+	if b == nil || len(b.Tags) == 0 || len(localPairs) == 0 {
+		return nil
+	}
+	if window <= 0 {
+		window = DefaultLanBeaconEpochWindow
+	}
+
+	// Reject beacons with timestamp skewed more than 2 windows
+	skew := now.Sub(b.Timestamp)
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > 2*window {
+		return nil
+	}
+
+	var matched []string
+	for devID, kPair := range localPairs {
+		candidates := DeriveLanBeaconTagsForDevice(kPair, b.BeaconNonce, b.Timestamp, window)
+		found := false
+		for _, cand := range candidates {
+			for _, advertised := range b.Tags {
+				if subtle.ConstantTimeCompare(cand, advertised) == 1 {
+					matched = append(matched, devID)
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+	}
+	return matched
+}

--- a/packages/wire/lan_beacon_test.go
+++ b/packages/wire/lan_beacon_test.go
@@ -1,0 +1,69 @@
+package wire
+
+import (
+	"crypto/sha256"
+	"testing"
+	"time"
+)
+
+func TestLanBeaconEncodeDecode(t *testing.T) {
+	kPair1 := sha256.Sum256([]byte("kpair-device-1"))
+	kPair2 := sha256.Sum256([]byte("kpair-device-2"))
+
+	now := time.Now().UTC().Truncate(time.Second)
+	beacon, err := NewLanBeacon(53317, [][]byte{kPair1[:], kPair2[:]}, now, 15*time.Minute)
+	if err != nil {
+		t.Fatalf("NewLanBeacon error: %v", err)
+	}
+
+	data, err := beacon.Encode()
+	if err != nil {
+		t.Fatalf("beacon.Encode error: %v", err)
+	}
+
+	decoded, err := DecodeLanBeacon(data)
+	if err != nil {
+		t.Fatalf("DecodeLanBeacon error: %v", err)
+	}
+
+	if decoded.Port != 53317 {
+		t.Errorf("port mismatch: got %d, want 53317", decoded.Port)
+	}
+	if !decoded.Timestamp.Equal(now) {
+		t.Errorf("timestamp mismatch: got %v, want %v", decoded.Timestamp, now)
+	}
+	if len(decoded.Tags) != 2 {
+		t.Fatalf("tag count mismatch: got %d, want 2", len(decoded.Tags))
+	}
+}
+
+func TestLanBeaconMatching(t *testing.T) {
+	kPairAlice := sha256.Sum256([]byte("kpair-alice-tag"))
+	kPairBob := sha256.Sum256([]byte("kpair-bob-tag"))
+	kPairCharlie := sha256.Sum256([]byte("kpair-charlie-tag"))
+
+	now := time.Now().UTC()
+	// Transmitter is Bob advertising to Alice and Charlie
+	beacon, err := NewLanBeacon(4000, [][]byte{kPairAlice[:], kPairCharlie[:]}, now, 15*time.Minute)
+	if err != nil {
+		t.Fatalf("NewLanBeacon error: %v", err)
+	}
+
+	// Alice's trust store has Bob and Charlie
+	localPairs := map[string][]byte{
+		"sb-dev-bob":     kPairAlice[:],   // shared secret with Bob
+		"sb-dev-stranger": kPairBob[:],     // stranger
+	}
+
+	matched := MatchLanBeacon(beacon, localPairs, now, 15*time.Minute)
+	if len(matched) != 1 || matched[0] != "sb-dev-bob" {
+		t.Errorf("expected matched [sb-dev-bob], got %v", matched)
+	}
+
+	// Stale beacon (> 30 min) should NOT match
+	oldTime := now.Add(45 * time.Minute)
+	matchedStale := MatchLanBeacon(beacon, localPairs, oldTime, 15*time.Minute)
+	if len(matchedStale) != 0 {
+		t.Errorf("stale beacon should not match, got %v", matchedStale)
+	}
+}

--- a/packages/wire/presence.go
+++ b/packages/wire/presence.go
@@ -1,0 +1,107 @@
+package wire
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"time"
+)
+
+// Remote presence and opaque rendezvous handle constants (V15-PR04).
+const (
+	DomainRendezvousHandle = "sendbeam/2 rendezvous-handle:"
+	DomainPresenceProof    = "sendbeam/2 presence-proof:"
+
+	DefaultRendezvousEpochWindow = 15 * time.Minute
+	RendezvousHandleHexLength    = 64 // 32 bytes hex encoded
+)
+
+var (
+	// ErrInvalidHandle indicates a malformed rendezvous handle.
+	ErrInvalidHandle = errors.New("invalid rendezvous handle")
+
+	// ErrInvalidProof indicates an invalid presence proof tag.
+	ErrInvalidProof = errors.New("invalid presence proof")
+)
+
+// DeriveRendezvousHandle derives a 32-byte opaque rendezvous handle for a specific epoch index.
+func DeriveRendezvousHandle(kPair []byte, epochIndex int64) string {
+	epochStr := strconv.FormatInt(epochIndex, 10)
+	mac := hmac.New(sha256.New, kPair)
+	mac.Write([]byte(DomainRendezvousHandle))
+	mac.Write([]byte(epochStr))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// DeriveRendezvousHandleForTime derives the opaque handle for a given timestamp and window.
+func DeriveRendezvousHandleForTime(kPair []byte, t time.Time, window time.Duration) string {
+	if window <= 0 {
+		window = DefaultRendezvousEpochWindow
+	}
+	epochIndex := t.UTC().Unix() / int64(window.Seconds())
+	return DeriveRendezvousHandle(kPair, epochIndex)
+}
+
+// DeriveRendezvousHandlesWithSkew derives current, previous, and next epoch handles to tolerate clock drift.
+func DeriveRendezvousHandlesWithSkew(kPair []byte, t time.Time, window time.Duration) []string {
+	if window <= 0 {
+		window = DefaultRendezvousEpochWindow
+	}
+	epochIndex := t.UTC().Unix() / int64(window.Seconds())
+	return []string{
+		DeriveRendezvousHandle(kPair, epochIndex-1),
+		DeriveRendezvousHandle(kPair, epochIndex),
+		DeriveRendezvousHandle(kPair, epochIndex+1),
+	}
+}
+
+// DerivePresenceProof computes an HMAC proof of possession for registering or polling a handle.
+func DerivePresenceProof(kPair []byte, handle string, nonce []byte) string {
+	mac := hmac.New(sha256.New, kPair)
+	mac.Write([]byte(DomainPresenceProof))
+	mac.Write([]byte(handle))
+	mac.Write(nonce)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyPresenceProof validates an HMAC proof of possession in constant time.
+func VerifyPresenceProof(kPair []byte, handle string, nonce []byte, proofHex string) bool {
+	proofBytes, err := hex.DecodeString(proofHex)
+	if err != nil || len(proofBytes) != sha256.Size {
+		return false
+	}
+	expectedHex := DerivePresenceProof(kPair, handle, nonce)
+	expectedBytes, _ := hex.DecodeString(expectedHex)
+	return subtle.ConstantTimeCompare(proofBytes, expectedBytes) == 1
+}
+
+// ValidateRendezvousHandle checks whether a handle string is a valid 64-character lowercase hex string.
+func ValidateRendezvousHandle(handle string) bool {
+	if len(handle) != RendezvousHandleHexLength {
+		return false
+	}
+	for i := 0; i < len(handle); i++ {
+		c := handle[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchRendezvousHandle checks if a given handle matches any candidate epoch for k_pair.
+func MatchRendezvousHandle(kPair []byte, handle string, t time.Time, window time.Duration) bool {
+	if !ValidateRendezvousHandle(handle) {
+		return false
+	}
+	candidates := DeriveRendezvousHandlesWithSkew(kPair, t, window)
+	for _, cand := range candidates {
+		if subtle.ConstantTimeCompare([]byte(cand), []byte(handle)) == 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/wire/presence_test.go
+++ b/packages/wire/presence_test.go
@@ -1,0 +1,91 @@
+package wire
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type PresenceTestVector struct {
+	Name            string   `json:"name"`
+	KPairHex        string   `json:"k_pair_hex"`
+	Timestamp       string   `json:"timestamp"`
+	EpochIndex      int64    `json:"epoch_index"`
+	RendezvousHandle string  `json:"rendezvous_handle"`
+	SkewHandles     []string `json:"skew_handles"`
+	PresenceNonceHex string  `json:"presence_nonce_hex"`
+	PresenceProofHex string  `json:"presence_proof_hex"`
+	BeaconNonceHex  string   `json:"beacon_nonce_hex"`
+	BeaconTagHex    string   `json:"beacon_tag_hex"`
+}
+
+func TestPresenceAndLanBeaconVectors(t *testing.T) {
+	kPair := sha256.Sum256([]byte("shared-k-pair-presence-vectors-v15"))
+	fixedTime, _ := time.Parse(time.RFC3339, "2026-08-21T12:00:00Z")
+	window := 15 * time.Minute
+	epochIndex := fixedTime.Unix() / int64(window.Seconds())
+
+	handle := DeriveRendezvousHandle(kPair[:], epochIndex)
+	skewHandles := DeriveRendezvousHandlesWithSkew(kPair[:], fixedTime, window)
+
+	presenceNonce := sha256.Sum256([]byte("fixed-presence-nonce-1"))
+	proof := DerivePresenceProof(kPair[:], handle, presenceNonce[:])
+
+	if !VerifyPresenceProof(kPair[:], handle, presenceNonce[:], proof) {
+		t.Fatalf("VerifyPresenceProof failed")
+	}
+
+	beaconNonce := sha256.Sum256([]byte("fixed-beacon-nonce-1"))
+	beaconTag := DeriveLanBeaconTag(kPair[:], beaconNonce[:16], epochIndex)
+
+	vector := PresenceTestVector{
+		Name:             "alice_bob_presence_and_beacon",
+		KPairHex:         hex.EncodeToString(kPair[:]),
+		Timestamp:        fixedTime.Format(time.RFC3339),
+		EpochIndex:       epochIndex,
+		RendezvousHandle: handle,
+		SkewHandles:      skewHandles,
+		PresenceNonceHex: hex.EncodeToString(presenceNonce[:]),
+		PresenceProofHex: proof,
+		BeaconNonceHex:   hex.EncodeToString(beaconNonce[:16]),
+		BeaconTagHex:     hex.EncodeToString(beaconTag),
+	}
+
+	vecData, err := json.MarshalIndent([]PresenceTestVector{vector}, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal test vector: %v", err)
+	}
+
+	targetPath := filepath.Join("testdata", "presence-vectors.json")
+	if err := os.WriteFile(targetPath, vecData, 0644); err != nil {
+		t.Fatalf("write presence-vectors.json: %v", err)
+	}
+}
+
+func TestPresenceHandleSkewMatching(t *testing.T) {
+	kPair := sha256.Sum256([]byte("shared-k-pair-presence-skew"))
+	now := time.Now().UTC()
+	window := 15 * time.Minute
+
+	handleNow := DeriveRendezvousHandleForTime(kPair[:], now, window)
+	if !MatchRendezvousHandle(kPair[:], handleNow, now, window) {
+		t.Errorf("handleNow did not match current time")
+	}
+
+	// Boundary test: time 10 minutes earlier (within same or adjacent epoch)
+	timePast := now.Add(-10 * time.Minute)
+	if !MatchRendezvousHandle(kPair[:], handleNow, timePast, window) {
+		t.Errorf("handleNow should match within 10 min window")
+	}
+
+	// Wrong handle should not match
+	wrongKPair := sha256.Sum256([]byte("wrong-k-pair"))
+	wrongHandle := DeriveRendezvousHandleForTime(wrongKPair[:], now, window)
+	if MatchRendezvousHandle(kPair[:], wrongHandle, now, window) {
+		t.Errorf("wrongHandle should not match")
+	}
+}

--- a/packages/wire/testdata/presence-vectors.json
+++ b/packages/wire/testdata/presence-vectors.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "alice_bob_presence_and_beacon",
+    "k_pair_hex": "8b4c642283597de370a8313836bcc86ca6718f0d71fa4f301134d3f049da2848",
+    "timestamp": "2026-08-21T12:00:00Z",
+    "epoch_index": 1985904,
+    "rendezvous_handle": "edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428",
+    "skew_handles": [
+      "21281a90dd17ca4e970d4ac0340eed1a5990e76d84e7a16427f650b06b29e4c1",
+      "edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428",
+      "fd2f12fa6f7d5c496f03ed08f360476773bbb30855d5c80fc2fc21bae4c9754e"
+    ],
+    "presence_nonce_hex": "4d6338b3f7ac53122d614db533e20a7b0e4cf6cc7567d447d4db256e49bb4251",
+    "presence_proof_hex": "e30a17e362961905e53228ac82e4c72a4478c170f8fba02ba8655a9dda7225a4",
+    "beacon_nonce_hex": "c83888c50dc690cbf88691633df49122",
+    "beacon_tag_hex": "f8bd0174d09e9392354a71fa9b629b76"
+  }
+]


### PR DESCRIPTION
## Summary
- **Remote Presence Handles:** Implement epoch-rotated (15-minute window) opaque rendezvous handles (`HMAC(k_pair, "sendbeam/2 rendezvous-handle:" || epoch)`) and proof verification in `packages/wire` and `@sendbeam/protocol`.
- **Blinded LAN Discovery Beacons:** Implement privacy-preserving LAN discovery beacons (`SB2B` magic, 16-byte HMAC blinded tags) in `packages/wire` and `packages/engine/discovery/lan_discovery.go` for direct local network peer discovery without leaking device identities or transfer metadata to third parties on the LAN.
- **Presence Coordination:** Implement `PresenceCoordinator` in `packages/engine/rendezvous` for deriving active handles and validating inbound presence proofs.
- **Cross-Language Validation:** Added deterministic test vectors in `packages/wire/testdata/presence-vectors.json` verified identically across Go (`packages/wire`) and TypeScript (`@sendbeam/protocol`).
- **Documentation:** Updated `docs/trust-model.md` (Section 8: Remote Presence & LAN Discovery) and `docs/threat-model.md` (Remote Presence & Blinded Discovery Metadata Boundaries).

## Test Plan
- Cross-language vector tests and negative adversarial tests in Go (`packages/wire`) and TypeScript (`@sendbeam/protocol`).
- In-memory bi-directional packet connection LAN discovery tests (`packages/engine/discovery`).
- Format, lint, typecheck, and full CI test suite.