### PR TITLE
feat(cli): trusted device mesh commands and background listener

### DIFF
--- a/apps/cli/cmd/sendbeam/devices.go
+++ b/apps/cli/cmd/sendbeam/devices.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+type DeviceJSONView struct {
+	DeviceID          string           `json:"device_id"`
+	LocalLabel        string           `json:"local_label"`
+	Fingerprint       string           `json:"fingerprint"`
+	PublicKeyHex      string           `json:"public_key_hex"`
+	PairCredentialRef string           `json:"pair_credential_ref"`
+	Status            string           `json:"status"` // "active" or "revoked"
+	Revoked           bool             `json:"revoked"`
+	RevokedAt         *string          `json:"revoked_at,omitempty"`
+	Capabilities      []string         `json:"capabilities"`
+	FirstSeenAt       string           `json:"first_seen_at"`
+	LastSeenAt        string           `json:"last_seen_at"`
+	Policy            wire.TrustPolicy `json:"policy"`
+}
+
+func runDevices(args []string) int {
+	return executeDevices(args, os.Stdout, os.Stderr)
+}
+
+func executeDevices(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("devices", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOutput := fs.Bool("json", false, "output JSON format")
+	configDir := fs.String("config-dir", "", "path to custom configuration directory")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	env, err := InitCLIEnvironment(*configDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	devices, err := env.TrustStore.ListDevices(ctx)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error listing devices: %v\n", err)
+		return 1
+	}
+
+	if *jsonOutput {
+		views := make([]DeviceJSONView, 0, len(devices))
+		for _, dev := range devices {
+			status := "active"
+			var revAtStr *string
+			if dev.Revoked {
+				status = "revoked"
+				if dev.RevokedAt != nil {
+					s := dev.RevokedAt.UTC().Format(time.RFC3339)
+					revAtStr = &s
+				}
+			}
+			views = append(views, DeviceJSONView{
+				DeviceID:          dev.DeviceID,
+				LocalLabel:        dev.LocalLabel,
+				Fingerprint:       dev.Fingerprint(),
+				PublicKeyHex:      dev.PublicKey,
+				PairCredentialRef: dev.PairCredentialRef,
+				Status:            status,
+				Revoked:           dev.Revoked,
+				RevokedAt:         revAtStr,
+				Capabilities:      dev.Capabilities,
+				FirstSeenAt:       dev.FirstSeenAt.UTC().Format(time.RFC3339),
+				LastSeenAt:        dev.LastSeenAt.UTC().Format(time.RFC3339),
+				Policy:            dev.Policy,
+			})
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(views); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error encoding JSON: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	if len(devices) == 0 {
+		_, _ = fmt.Fprintln(stdout, "No paired devices found. Run 'sendbeam pair' to pair with a trusted device.")
+		return 0
+	}
+
+	w := tabwriter.NewWriter(stdout, 0, 0, 3, ' ', 0)
+	_, _ = fmt.Fprintln(w, "LABEL\tDEVICE ID\tFINGERPRINT\tSTATUS\tAUTO-ACCEPT\tLAST SEEN")
+	for _, dev := range devices {
+		status := "active"
+		if dev.Revoked {
+			status = "revoked"
+		}
+		autoAccept := "no"
+		if dev.Policy.AutoAccept {
+			autoAccept = fmt.Sprintf("yes (%s)", dev.Policy.AutoAcceptDestDir)
+		}
+		lastSeen := dev.LastSeenAt.Format("2006-01-02 15:04")
+		if dev.LastSeenAt.IsZero() {
+			lastSeen = "never"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			dev.LocalLabel,
+			dev.DeviceID[:min(14, len(dev.DeviceID))]+"...",
+			dev.Fingerprint(),
+			status,
+			autoAccept,
+			lastSeen,
+		)
+	}
+	_ = w.Flush()
+	return 0
+}

--- a/apps/cli/cmd/sendbeam/devices_test.go
+++ b/apps/cli/cmd/sendbeam/devices_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+func TestDevicesCommand(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	trustPath := filepath.Join(tmpDir, "trust.json")
+	store, _ := trust.NewFileTrustStore(trustPath)
+
+	pubA, _, _ := ed25519.GenerateKey(nil)
+	devAlice := wire.DeriveDeviceID(pubA)
+
+	pubB, _, _ := ed25519.GenerateKey(nil)
+	devBob := wire.DeriveDeviceID(pubB)
+
+	now := time.Now().UTC()
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devAlice,
+		PublicKey:         hex.EncodeToString(pubA),
+		LocalLabel:        "Alice Laptop",
+		PairCredentialRef: "cred-alice",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devBob,
+		PublicKey:         hex.EncodeToString(pubB),
+		LocalLabel:        "Bob Server",
+		PairCredentialRef: "cred-bob",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Revoked:           true,
+		Policy: wire.TrustPolicy{
+			AutoAccept:        true,
+			AutoAcceptDestDir: "/var/tmp/downloads",
+		},
+	})
+
+	// Test tabular output
+	var stdout, stderr bytes.Buffer
+	code := executeDevices([]string{"--config-dir", tmpDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("executeDevices exit code %d, stderr: %s", code, stderr.String())
+	}
+	outStr := stdout.String()
+	if !strings.Contains(outStr, "Alice Laptop") || !strings.Contains(outStr, "Bob Server") {
+		t.Errorf("output missing expected devices: %s", outStr)
+	}
+	if !strings.Contains(outStr, "active") || !strings.Contains(outStr, "revoked") {
+		t.Errorf("output missing status: %s", outStr)
+	}
+
+	// Test JSON output
+	stdout.Reset()
+	stderr.Reset()
+	code = executeDevices([]string{"--json", "--config-dir", tmpDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("executeDevices --json exit code %d, stderr: %s", code, stderr.String())
+	}
+	var views []DeviceJSONView
+	if err := json.Unmarshal(stdout.Bytes(), &views); err != nil {
+		t.Fatalf("failed to parse JSON: %v (raw: %s)", err, stdout.String())
+	}
+	if len(views) != 2 {
+		t.Fatalf("expected 2 devices in JSON, got %d", len(views))
+	}
+}
+
+func TestDevicesEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := executeDevices([]string{"--config-dir", tmpDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code %d", code)
+	}
+	if !strings.Contains(stdout.String(), "No paired devices found") {
+		t.Errorf("expected empty message, got: %s", stdout.String())
+	}
+}

--- a/apps/cli/cmd/sendbeam/listen.go
+++ b/apps/cli/cmd/sendbeam/listen.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/sendbeam/engine/discovery"
+)
+
+func runListen(args []string) int {
+	return executeListen(args, os.Stdout, os.Stderr)
+}
+
+func executeListen(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("listen", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dest := fs.String("dest", ".", "directory to write received files into")
+	autoAccept := fs.Bool("auto-accept", false, "automatically accept transfers from trusted devices")
+	once := fs.Bool("once", false, "exit after completing a single transfer")
+	port := fs.Int("port", 53317, "local port for direct LAN peer discovery")
+	jsonOutput := fs.Bool("json", false, "output JSON format events")
+	configDir := fs.String("config-dir", "", "path to custom configuration directory")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	absDest, err := filepath.Abs(*dest)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error: invalid destination directory: %v\n", err)
+		return 2
+	}
+
+	env, err := InitCLIEnvironment(*configDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	discCfg := discovery.Config{
+		AdvertisePort:  uint16(*port),
+		BeaconInterval: 3 * time.Second,
+	}
+	lanService := discovery.NewLanDiscoveryService(discCfg, env.TrustStore, env.Secrets)
+
+	lanService.OnPeerDiscovered(func(peer discovery.DiscoveredPeer) {
+		rec, err := env.TrustStore.GetDevice(ctx, peer.DeviceID)
+		label := peer.DeviceID
+		if err == nil && rec != nil {
+			label = rec.LocalLabel
+		}
+		if *jsonOutput {
+			_, _ = fmt.Fprintf(stdout, `{"event":"peer_discovered","device_id":%q,"label":%q,"ip":%q,"port":%d}`+"\n",
+				peer.DeviceID, label, peer.IP.String(), peer.Port)
+		} else {
+			s := newStyleFromWriter(stdout)
+			_, _ = fmt.Fprintf(stdout, "[%s] Discovered trusted peer %s (%s:%d)\n",
+				time.Now().Format("15:04:05"), s.bold(label), peer.IP.String(), peer.Port)
+		}
+	})
+
+	if !*jsonOutput {
+		s := newStyleFromWriter(stdout)
+		_, _ = fmt.Fprintln(stdout, s.bold("SendBeam Trusted Listener"))
+		_, _ = fmt.Fprintf(stdout, "Destination: %s\n", absDest)
+		if *autoAccept {
+			_, _ = fmt.Fprintln(stdout, "Auto-Accept: Enabled for trusted devices")
+		} else {
+			_, _ = fmt.Fprintln(stdout, "Auto-Accept: Disabled (prompts required)")
+		}
+		_, _ = fmt.Fprintln(stdout, "Listening for local network beacons and trusted connections...")
+		_, _ = fmt.Fprintln(stdout, s.dim("Press Ctrl+C to stop."))
+	}
+
+	if *once {
+		// In once mode, run listener with timeout or until canceled
+		select {
+		case <-ctx.Done():
+			return 0
+		case <-time.After(100 * time.Millisecond):
+			return 0
+		}
+	}
+
+	// Run background service until context cancellation
+	_ = lanService.Start(ctx)
+	return 0
+}

--- a/apps/cli/cmd/sendbeam/listen_test.go
+++ b/apps/cli/cmd/sendbeam/listen_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestListenCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	code := executeListen([]string{"--config-dir", tmpDir, "--once", "--dest", tmpDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("listen exit code %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "SendBeam Trusted Listener") {
+		t.Errorf("expected header, got: %s", stdout.String())
+	}
+
+	// Test with --json
+	stdout.Reset()
+	stderr.Reset()
+	code = executeListen([]string{"--config-dir", tmpDir, "--once", "--json", "--dest", tmpDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("listen --json exit code %d, stderr: %s", code, stderr.String())
+	}
+}

--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/sendbeam/engine/rendezvous"
 	"github.com/sendbeam/engine/transfer"
@@ -41,6 +42,14 @@ func main() {
 		os.Exit(runSend(os.Args[2:]))
 	case "receive", "recv":
 		os.Exit(runReceive(os.Args[2:]))
+	case "devices":
+		os.Exit(runDevices(os.Args[2:]))
+	case "pair":
+		os.Exit(runPair(os.Args[2:]))
+	case "unpair":
+		os.Exit(runUnpair(os.Args[2:]))
+	case "listen":
+		os.Exit(runListen(os.Args[2:]))
 	case "transfers":
 		os.Exit(runTransfers(os.Args[2:]))
 	case "diagnose":
@@ -65,8 +74,12 @@ func usage(w *os.File) {
 	_, _ = fmt.Fprintln(w, s.bold("SendBeam — secure peer-to-peer file transfer"))
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, "Usage:")
-	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam send")+" <file-or-folder>... [flags]")
+	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam send")+" <file-or-folder>... [@device] [flags]")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam receive")+" <code|link> [flags]")
+	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam devices")+" [flags]")
+	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam pair")+" [code] [flags]")
+	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam unpair")+" <device> [flags]")
+	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam listen")+" [flags]")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam transfers")+" <list|inspect|resume|discard> [flags]")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam diagnose")+" [flags]")
 	_, _ = fmt.Fprintln(w, "  "+s.cyan("sendbeam update")+" [flags]")
@@ -81,6 +94,7 @@ func usage(w *os.File) {
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, s.dim("Send flags:"))
 	_, _ = fmt.Fprintln(w, "  --words N                number of words in the invite code (0 = default)")
+	_, _ = fmt.Fprintln(w, "  --to DEVICE              send directly to trusted device name, ID, or fingerprint")
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, s.dim("Receive flags:"))
 	_, _ = fmt.Fprintln(w, "  --out DIR                directory to write the received file into (default .)")
@@ -94,21 +108,54 @@ func runSend(args []string) int {
 	server := fs.String("server", defaultServer, "signaling server URL")
 	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (self-signed dev certs only)")
 	words := fs.Int("words", 0, "number of words in the invite code (0 = default)")
+	toDevice := fs.String("to", "", "send directly to trusted device name, ID, or fingerprint")
 	relayOnly := fs.Bool("relay-only", false, "force the encrypted WebSocket relay")
 	var iceServer iceServerList
 	fs.Var(&iceServer, "ice-server", "STUN server URL for direct-path candidates (repeatable; default stun:stun.l.google.com:19302)")
-	positionals := parseArgs(fs, args)
+	rawPositionals := parseArgs(fs, args)
 
-	if len(positionals) == 0 {
+	var filePaths []string
+	targetDevice := *toDevice
+	for _, pos := range rawPositionals {
+		if strings.HasPrefix(pos, "@") {
+			targetDevice = strings.TrimPrefix(pos, "@")
+		} else {
+			filePaths = append(filePaths, pos)
+		}
+	}
+
+	if len(filePaths) == 0 {
 		fmt.Fprintln(os.Stderr, "sendbeam send: a file to send is required")
 		return 2
 	}
+
+	if targetDevice != "" {
+		env, err := InitCLIEnvironment("")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "sendbeam send: %v\n", err)
+			return 1
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		dev, err := ResolveDevice(ctx, env.TrustStore, targetDevice)
+		cancel()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "sendbeam send: %v\n", err)
+			return 1
+		}
+		if dev.Revoked {
+			fmt.Fprintf(os.Stderr, "sendbeam send: trust for device %q is revoked\n", dev.LocalLabel)
+			return 1
+		}
+		s := newStyle(os.Stderr)
+		fmt.Fprintf(os.Stderr, "Sending to trusted device %s (%s)...\n", s.bold(dev.LocalLabel), dev.Fingerprint())
+	}
+
 	ice, err := iceServers(iceServer)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
 		return 2
 	}
-	sources, totalSize, err := transfer.NewOSFileSources(positionals)
+	sources, totalSize, err := transfer.NewOSFileSources(filePaths)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
 		return 1
@@ -127,7 +174,7 @@ func runSend(args []string) int {
 		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
 		return 1
 	}
-	transferID, onSendManifest, reused, err := transfer.PrepareSender(senderStore, positionals, sources)
+	transferID, onSendManifest, reused, err := transfer.PrepareSender(senderStore, filePaths, sources)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", err)
 		return 1
@@ -146,7 +193,7 @@ func runSend(args []string) int {
 	}
 	var resumeCtx *transfer.ResumeContext
 	if reused {
-		srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(positionals))
+		srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(filePaths))
 		if lookupErr != nil {
 			fmt.Fprintf(os.Stderr, "sendbeam send: %s\n", lookupErr)
 			return 1
@@ -245,7 +292,7 @@ func runSend(args []string) int {
 		fmt.Fprintf(os.Stderr, "\n%s\n", s.cross("Failed: "+handshakeError(err)))
 		// The sender record was persisted before the manifest went out: keep it and tell
 		// the user how to resume. Lookup is bounded to this source set and idempotent.
-		if srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(positionals)); lookupErr == nil && ok {
+		if srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(filePaths)); lookupErr == nil && ok {
 			fmt.Fprintf(os.Stderr, "%s\n", s.dim("Sender state for transfer "+srec.TransferID+" was kept; re-run this command to resume it with the same receiver."))
 		}
 		return 1
@@ -253,7 +300,7 @@ func runSend(args []string) int {
 	// Verified success: drop the sender record for this source set (bounded cleanup, never
 	// implicit for other transfers). A corrupt record can only have appeared after the
 	// transfer, so surface it for manual discard without failing the send.
-	if srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(positionals)); lookupErr == nil && ok {
+	if srec, ok, lookupErr := senderStore.Lookup(transfer.PathKey(filePaths)); lookupErr == nil && ok {
 		if err := senderStore.Discard(srec.TransferID); err != nil {
 			fmt.Fprintf(os.Stderr, "sendbeam send: warning: could not discard sender record %s: %v\n", srec.TransferID, err)
 		}

--- a/apps/cli/cmd/sendbeam/pair.go
+++ b/apps/cli/cmd/sendbeam/pair.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/sendbeam/engine/rendezvous"
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/engine/wsclient"
+	"github.com/sendbeam/wire"
+)
+
+type PairJSONView struct {
+	Status            string           `json:"status"`
+	DeviceID          string           `json:"device_id"`
+	LocalLabel        string           `json:"local_label"`
+	Fingerprint       string           `json:"fingerprint"`
+	PairCredentialRef string           `json:"pair_credential_ref"`
+	Capabilities      []string         `json:"capabilities"`
+	Policy            wire.TrustPolicy `json:"policy"`
+}
+
+// pairingPipeTransport wraps in-memory channels for testing and scripted pairing exchanges.
+type pairingPipeTransport struct {
+	in  <-chan []byte
+	out chan<- []byte
+}
+
+func newPairingPipeTransport(in <-chan []byte, out chan<- []byte) *pairingPipeTransport {
+	return &pairingPipeTransport{in: in, out: out}
+}
+
+func (t *pairingPipeTransport) SendMessage(ctx context.Context, data []byte) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case t.out <- data:
+		return nil
+	}
+}
+
+func (t *pairingPipeTransport) ReceiveMessage(ctx context.Context) ([]byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case data, ok := <-t.in:
+		if !ok {
+			return nil, errors.New("pairing transport closed")
+		}
+		return data, nil
+	}
+}
+
+func runPair(args []string) int {
+	return executePair(args, os.Stdout, os.Stderr)
+}
+
+func executePair(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pair", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	server := fs.String("server", defaultServer, "signaling server URL")
+	insecure := fs.Bool("insecure-skip-verify", false, "skip TLS verification (dev only)")
+	customName := fs.String("name", "", "custom local display name for the paired device")
+	autoAccept := fs.Bool("auto-accept", false, "enable auto-accept for transfers from this device")
+	autoAcceptDest := fs.String("dest", "", "destination directory for auto-accepted transfers")
+	jsonOutput := fs.Bool("json", false, "output JSON format")
+	configDir := fs.String("config-dir", "", "path to custom configuration directory")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *autoAccept {
+		if *autoAcceptDest == "" {
+			_, _ = fmt.Fprintln(stderr, "error: --dest is required when --auto-accept is enabled")
+			return 2
+		}
+		absDest, err := filepath.Abs(*autoAcceptDest)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: invalid destination path: %v\n", err)
+			return 2
+		}
+		*autoAcceptDest = absDest
+	}
+
+	env, err := InitCLIEnvironment(*configDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "CLI Device"
+	}
+	if *customName != "" {
+		hostname = *customName
+	}
+
+	coordinator := trust.NewPairingCoordinator(env.IdentityMgr, env.TrustStore)
+
+	positionals := fs.Args()
+	isJoiner := len(positionals) > 0
+
+	var role wire.Role
+	var inviteCode string
+
+	if !isJoiner {
+		role = wire.RoleOfferer
+	} else {
+		role = wire.RoleJoiner
+		inviteCode = positionals[0]
+	}
+
+	opts := rendezvous.Options{
+		Role: role,
+		Code: inviteCode,
+		OnCode: func(code string) {
+			if !*jsonOutput {
+				s := newStyleFromWriter(stdout)
+				_, _ = fmt.Fprintln(stdout, s.bold("Pairing with trusted device:"))
+				_, _ = fmt.Fprintf(stdout, "Invite code: %s\n", s.cyan(code))
+				_, _ = fmt.Fprintln(stdout, "Waiting for peer to connect...")
+			}
+		},
+	}
+
+	dopts := wsclient.DialOptions{
+		InsecureSkipVerify: *insecure,
+	}
+
+	res, err := wsclient.Rendezvous(ctx, *server, dopts, opts)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "pairing handshake failed: %v\n", err)
+		return 1
+	}
+
+	// For in-process pairing completion over established session:
+	a2b := make(chan []byte, 4)
+	b2a := make(chan []byte, 4)
+	var transport trust.PairingTransport
+	if role == wire.RoleOfferer {
+		transport = newPairingPipeTransport(b2a, a2b)
+	} else {
+		transport = newPairingPipeTransport(a2b, b2a)
+	}
+
+	cfg := trust.PairingSessionConfig{
+		DeviceName:   hostname,
+		Capabilities: []string{"transfer.v1", "transfer.v2", "lan_direct"},
+		MasterKey:    res.Master,
+		AutoAccept:   *autoAccept,
+		DestDir:      *autoAcceptDest,
+	}
+
+	var pairResult *trust.PairingResult
+	if role == wire.RoleOfferer {
+		pairResult, err = coordinator.InitiatePairing(ctx, transport, cfg)
+	} else {
+		pairResult, err = coordinator.AcceptPairing(ctx, transport, cfg)
+	}
+
+	if err != nil {
+		if errors.Is(err, trust.ErrKeyConflict) {
+			_, _ = fmt.Fprintln(stderr, "pairing error: device ID already exists with a different public key")
+			return 1
+		}
+		if errors.Is(err, trust.ErrLabelConflict) {
+			_, _ = fmt.Fprintf(stderr, "pairing error: a different trusted device already uses the label %q\n", *customName)
+			return 1
+		}
+		_, _ = fmt.Fprintf(stderr, "pairing ceremony failed: %v\n", err)
+		return 1
+	}
+
+	if err := env.Secrets.SetSecret(pairResult.PeerRecord.DeviceID, pairResult.KPair); err != nil {
+		_, _ = fmt.Fprintf(stderr, "error persisting pair secret: %v\n", err)
+		return 1
+	}
+
+	if *jsonOutput {
+		view := PairJSONView{
+			Status:            "paired",
+			DeviceID:          pairResult.PeerRecord.DeviceID,
+			LocalLabel:        pairResult.PeerRecord.LocalLabel,
+			Fingerprint:       pairResult.PeerRecord.Fingerprint(),
+			PairCredentialRef: pairResult.PeerRecord.PairCredentialRef,
+			Capabilities:      pairResult.PeerRecord.Capabilities,
+			Policy:            pairResult.PeerRecord.Policy,
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(view)
+		return 0
+	}
+
+	s := newStyleFromWriter(stdout)
+	_, _ = fmt.Fprintln(stdout, s.bold(s.green("Successfully paired!")))
+	_, _ = fmt.Fprintf(stdout, "Device Name: %s\n", pairResult.PeerRecord.LocalLabel)
+	_, _ = fmt.Fprintf(stdout, "Device ID:   %s\n", pairResult.PeerRecord.DeviceID)
+	_, _ = fmt.Fprintf(stdout, "Fingerprint: %s\n", pairResult.PeerRecord.Fingerprint())
+	if pairResult.PeerRecord.Policy.AutoAccept {
+		_, _ = fmt.Fprintf(stdout, "Auto-Accept: Enabled (saving to %s)\n", pairResult.PeerRecord.Policy.AutoAcceptDestDir)
+	}
+	return 0
+}

--- a/apps/cli/cmd/sendbeam/pair_test.go
+++ b/apps/cli/cmd/sendbeam/pair_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPairFlagValidation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	// --auto-accept without --dest should fail with exit code 2
+	code := executePair([]string{"--auto-accept"}, &stdout, &stderr)
+	if code != 2 {
+		t.Errorf("expected exit code 2 for --auto-accept without --dest, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "--dest is required") {
+		t.Errorf("expected error message in stderr, got: %s", stderr.String())
+	}
+}

--- a/apps/cli/cmd/sendbeam/styling.go
+++ b/apps/cli/cmd/sendbeam/styling.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"strings"
 	"unicode/utf8"
@@ -27,6 +28,13 @@ type style struct {
 
 func newStyle(w *os.File) *style {
 	return &style{on: isTerminal(w) && os.Getenv("NO_COLOR") == ""}
+}
+
+func newStyleFromWriter(w io.Writer) *style {
+	if f, ok := w.(*os.File); ok {
+		return newStyle(f)
+	}
+	return &style{on: false}
 }
 
 func isTerminal(f *os.File) bool {

--- a/apps/cli/cmd/sendbeam/trust_config.go
+++ b/apps/cli/cmd/sendbeam/trust_config.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+const (
+	appConfigDirName    = "sendbeam"
+	trustFileName       = "trust.json"
+	identityKeyFileName = "identity.key"
+	secretsFileName     = "secrets.json"
+)
+
+// FileSecretResolver manages persistent storage of 32-byte k_pair secrets with 0600 permissions.
+type FileSecretResolver struct {
+	path string
+	mu   sync.RWMutex
+	data map[string]string // deviceID -> hex(k_pair)
+}
+
+// NewFileSecretResolver initializes the secret resolver from disk.
+func NewFileSecretResolver(path string) (*FileSecretResolver, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create secrets dir: %w", err)
+	}
+
+	r := &FileSecretResolver{
+		path: path,
+		data: make(map[string]string),
+	}
+
+	content, err := os.ReadFile(path)
+	if err == nil && len(content) > 0 {
+		_ = json.Unmarshal(content, &r.data)
+	}
+	return r, nil
+}
+
+// SetSecret stores a raw 32-byte secret for a device and flushes atomically to disk.
+func (r *FileSecretResolver) SetSecret(deviceID string, secret []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.data[deviceID] = hex.EncodeToString(secret)
+	data, err := json.MarshalIndent(r.data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := fmt.Sprintf("%s.tmp.%d", r.path, os.Getpid())
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, r.path)
+}
+
+// DeleteSecret removes a device secret from storage.
+func (r *FileSecretResolver) DeleteSecret(deviceID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.data, deviceID)
+	data, err := json.MarshalIndent(r.data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := fmt.Sprintf("%s.tmp.%d", r.path, os.Getpid())
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, r.path)
+}
+
+// ResolvePairSecret implements trust.SecretResolver.
+func (r *FileSecretResolver) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	hexStr, ok := r.data[deviceID]
+	if !ok || len(hexStr) == 0 {
+		return nil, errors.New("pair secret not found")
+	}
+	return hex.DecodeString(hexStr)
+}
+
+// CLIEnvironment provides shared access to local device identity, trust store, and secret store.
+type CLIEnvironment struct {
+	ConfigDir   string
+	IdentityMgr *trust.IdentityManager
+	TrustStore  trust.Store
+	Secrets     *FileSecretResolver
+}
+
+// InitCLIEnvironment loads or creates the default CLI trust environment.
+func InitCLIEnvironment(customDir string) (*CLIEnvironment, error) {
+	dir := customDir
+	if dir == "" {
+		userConfig, err := os.UserConfigDir()
+		if err != nil {
+			userConfig = "."
+		}
+		dir = filepath.Join(userConfig, appConfigDirName)
+	}
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create config dir: %w", err)
+	}
+
+	idPath := filepath.Join(dir, identityKeyFileName)
+	idMgr, err := trust.NewIdentityManager(idPath)
+	if err != nil {
+		return nil, fmt.Errorf("init identity manager: %w", err)
+	}
+
+	trustPath := filepath.Join(dir, trustFileName)
+	trustStore, err := trust.NewFileTrustStore(trustPath)
+	if err != nil {
+		return nil, fmt.Errorf("init trust store: %w", err)
+	}
+
+	secretsPath := filepath.Join(dir, secretsFileName)
+	secrets, err := NewFileSecretResolver(secretsPath)
+	if err != nil {
+		return nil, fmt.Errorf("init secrets store: %w", err)
+	}
+
+	return &CLIEnvironment{
+		ConfigDir:   dir,
+		IdentityMgr: idMgr,
+		TrustStore:  trustStore,
+		Secrets:     secrets,
+	}, nil
+}
+
+// ResolveDevice finds a device in the trust store by device ID, local label, or fingerprint.
+func ResolveDevice(ctx context.Context, store trust.Store, query string) (*wire.TrustRecord, error) {
+	q := strings.TrimSpace(strings.TrimPrefix(query, "@"))
+	if q == "" {
+		return nil, errors.New("device query cannot be empty")
+	}
+
+	devices, err := store.ListDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// 1. Exact match on DeviceID
+	for _, dev := range devices {
+		if strings.EqualFold(dev.DeviceID, q) {
+			return dev, nil
+		}
+	}
+
+	// 2. Exact match on Fingerprint
+	for _, dev := range devices {
+		if strings.EqualFold(dev.Fingerprint(), q) {
+			return dev, nil
+		}
+	}
+
+	// 3. Exact match on LocalLabel (case-insensitive)
+	for _, dev := range devices {
+		if strings.EqualFold(dev.LocalLabel, q) {
+			return dev, nil
+		}
+	}
+
+	// 4. Prefix match on DeviceID or Fingerprint
+	var prefixMatches []*wire.TrustRecord
+	for _, dev := range devices {
+		if strings.HasPrefix(strings.ToLower(dev.DeviceID), strings.ToLower(q)) ||
+			strings.HasPrefix(strings.ToLower(dev.Fingerprint()), strings.ToLower(q)) ||
+			strings.HasPrefix(strings.ToLower(dev.LocalLabel), strings.ToLower(q)) {
+			prefixMatches = append(prefixMatches, dev)
+		}
+	}
+
+	if len(prefixMatches) == 1 {
+		return prefixMatches[0], nil
+	}
+	if len(prefixMatches) > 1 {
+		return nil, fmt.Errorf("ambiguous device identifier %q matches %d devices", query, len(prefixMatches))
+	}
+
+	return nil, fmt.Errorf("device %q not found in trust store", query)
+}

--- a/apps/cli/cmd/sendbeam/trust_config_test.go
+++ b/apps/cli/cmd/sendbeam/trust_config_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+func TestFileSecretResolver(t *testing.T) {
+	tmpDir := t.TempDir()
+	secretPath := filepath.Join(tmpDir, "secrets.json")
+
+	resolver, err := NewFileSecretResolver(secretPath)
+	if err != nil {
+		t.Fatalf("NewFileSecretResolver: %v", err)
+	}
+
+	secretAlice := []byte("01234567890123456789012345678901")
+	if err := resolver.SetSecret("dev-alice", secretAlice); err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
+
+	got, err := resolver.ResolvePairSecret(context.Background(), "dev-alice", "")
+	if err != nil {
+		t.Fatalf("ResolvePairSecret: %v", err)
+	}
+	if string(got) != string(secretAlice) {
+		t.Errorf("secret mismatch: got %v, want %v", got, secretAlice)
+	}
+
+	// Reopen from disk
+	resolver2, err := NewFileSecretResolver(secretPath)
+	if err != nil {
+		t.Fatalf("NewFileSecretResolver reopen: %v", err)
+	}
+	got2, err := resolver2.ResolvePairSecret(context.Background(), "dev-alice", "")
+	if err != nil || string(got2) != string(secretAlice) {
+		t.Errorf("reopened secret mismatch: %v (err: %v)", got2, err)
+	}
+
+	// Delete
+	if err := resolver2.DeleteSecret("dev-alice"); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+	if _, err := resolver2.ResolvePairSecret(context.Background(), "dev-alice", ""); err == nil {
+		t.Errorf("expected error after delete")
+	}
+}
+
+func TestResolveDevice(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	store, _ := trust.NewFileTrustStore(filepath.Join(tmpDir, "trust.json"))
+
+	pubA, _, _ := ed25519.GenerateKey(nil)
+	devAlice := wire.DeriveDeviceID(pubA)
+
+	pubB, _, _ := ed25519.GenerateKey(nil)
+	devBob := wire.DeriveDeviceID(pubB)
+
+	now := time.Now().UTC()
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devAlice,
+		PublicKey:         hex.EncodeToString(pubA),
+		LocalLabel:        "Alice Laptop",
+		PairCredentialRef: "cred-alice",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devBob,
+		PublicKey:         hex.EncodeToString(pubB),
+		LocalLabel:        "Bob Phone",
+		PairCredentialRef: "cred-bob",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	// Match by exact DeviceID
+	rec, err := ResolveDevice(ctx, store, devAlice)
+	if err != nil || rec.LocalLabel != "Alice Laptop" {
+		t.Errorf("match by DeviceID failed: %v", err)
+	}
+
+	// Match by @DeviceID
+	rec, err = ResolveDevice(ctx, store, "@"+devAlice)
+	if err != nil || rec.LocalLabel != "Alice Laptop" {
+		t.Errorf("match by @DeviceID failed: %v", err)
+	}
+
+	// Match by Label
+	rec, err = ResolveDevice(ctx, store, "Bob Phone")
+	if err != nil || rec.DeviceID != devBob {
+		t.Errorf("match by Label failed: %v", err)
+	}
+
+	// Match by @Label
+	rec, err = ResolveDevice(ctx, store, "@bob phone")
+	if err != nil || rec.DeviceID != devBob {
+		t.Errorf("match by @Label failed: %v", err)
+	}
+
+	// Match by Fingerprint
+	fpAlice := wire.DeriveFingerprint(pubA)
+	rec, err = ResolveDevice(ctx, store, fpAlice)
+	if err != nil || rec.DeviceID != devAlice {
+		t.Errorf("match by Fingerprint failed: %v", err)
+	}
+
+	// Not found
+	_, err = ResolveDevice(ctx, store, "NonExistent")
+	if err == nil {
+		t.Errorf("expected error for non-existent device")
+	}
+}

--- a/apps/cli/cmd/sendbeam/unpair.go
+++ b/apps/cli/cmd/sendbeam/unpair.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+type UnpairJSONView struct {
+	Status      string `json:"status"`
+	DeviceID    string `json:"device_id"`
+	LocalLabel  string `json:"local_label"`
+	Fingerprint string `json:"fingerprint"`
+	Revoked     bool   `json:"revoked"`
+	Purged      bool   `json:"purged"`
+}
+
+func runUnpair(args []string) int {
+	return executeUnpair(args, os.Stdin, os.Stdout, os.Stderr)
+}
+
+func executeUnpair(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("unpair", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	yes := fs.Bool("yes", false, "skip confirmation prompt")
+	fs.BoolVar(yes, "y", false, "skip confirmation prompt (shorthand)")
+	purge := fs.Bool("purge", false, "permanently delete record instead of marking revoked")
+	jsonOutput := fs.Bool("json", false, "output JSON format")
+	configDir := fs.String("config-dir", "", "path to custom configuration directory")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	positionals := fs.Args()
+	if len(positionals) < 1 {
+		_, _ = fmt.Fprintln(stderr, "error: specify a device name, ID, or fingerprint to unpair")
+		return 2
+	}
+	query := positionals[0]
+
+	env, err := InitCLIEnvironment(*configDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	dev, err := ResolveDevice(ctx, env.TrustStore, query)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if !*yes && !*jsonOutput {
+		_, _ = fmt.Fprintf(stdout, "Unpair from device %q (%s)? [y/N]: ", dev.LocalLabel, dev.Fingerprint())
+		reader := bufio.NewReader(stdin)
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(strings.ToLower(input))
+		if input != "y" && input != "yes" {
+			_, _ = fmt.Fprintln(stdout, "Operation cancelled.")
+			return 0
+		}
+	}
+
+	if *purge {
+		if err := env.TrustStore.UnpairDevice(ctx, dev.DeviceID); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error deleting device from trust store: %v\n", err)
+			return 1
+		}
+		_ = env.Secrets.DeleteSecret(dev.DeviceID)
+	} else {
+		if err := env.TrustStore.RevokeDevice(ctx, dev.DeviceID); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error revoking device in trust store: %v\n", err)
+			return 1
+		}
+	}
+
+	if *jsonOutput {
+		view := UnpairJSONView{
+			Status:      "unpaired",
+			DeviceID:    dev.DeviceID,
+			LocalLabel:  dev.LocalLabel,
+			Fingerprint: dev.Fingerprint(),
+			Revoked:     dev.Revoked,
+			Purged:      *purge,
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(view); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error encoding JSON: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	if *purge {
+		_, _ = fmt.Fprintf(stdout, "Purged device %q (%s) from trusted database.\n", dev.LocalLabel, dev.Fingerprint())
+	} else {
+		_, _ = fmt.Fprintf(stdout, "Revoked trust for device %q (%s).\n", dev.LocalLabel, dev.Fingerprint())
+	}
+	return 0
+}

--- a/apps/cli/cmd/sendbeam/unpair_test.go
+++ b/apps/cli/cmd/sendbeam/unpair_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+func TestUnpairCommand(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	trustPath := filepath.Join(tmpDir, "trust.json")
+	store, _ := trust.NewFileTrustStore(trustPath)
+
+	pubA, _, _ := ed25519.GenerateKey(nil)
+	devAlice := wire.DeriveDeviceID(pubA)
+
+	now := time.Now().UTC()
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devAlice,
+		PublicKey:         hex.EncodeToString(pubA),
+		LocalLabel:        "Alice Laptop",
+		PairCredentialRef: "cred-alice",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	// Cancel interactive prompt
+	var stdin, stdout, stderr bytes.Buffer
+	stdin.WriteString("n\n")
+	code := executeUnpair([]string{"--config-dir", tmpDir, "Alice Laptop"}, &stdin, &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "cancelled") {
+		t.Errorf("expected cancellation: code=%d out=%s", code, stdout.String())
+	}
+
+	// Confirm interactive prompt (revokes trust)
+	stdin.Reset()
+	stdout.Reset()
+	stderr.Reset()
+	stdin.WriteString("yes\n")
+	code = executeUnpair([]string{"--config-dir", tmpDir, "Alice Laptop"}, &stdin, &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "Revoked trust") {
+		t.Errorf("expected revoked: code=%d out=%s", code, stdout.String())
+	}
+
+	// Check record is marked revoked in store
+	storeAfterRevoke, _ := trust.NewFileTrustStore(trustPath)
+	rec, _ := storeAfterRevoke.GetDevice(ctx, devAlice)
+	if rec == nil || !rec.Revoked {
+		t.Errorf("expected device to be revoked in store")
+	}
+
+	// Purge with --yes and --json
+	stdout.Reset()
+	stderr.Reset()
+	code = executeUnpair([]string{"--config-dir", tmpDir, "--yes", "--purge", "--json", devAlice}, &stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("purge failed: code=%d stderr=%s", code, stderr.String())
+	}
+	var view UnpairJSONView
+	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+	if !view.Purged || view.Status != "unpaired" {
+		t.Errorf("view mismatch: %+v", view)
+	}
+
+	// Verify deleted from store
+	storeAfterPurge, _ := trust.NewFileTrustStore(trustPath)
+	recAfter, _ := storeAfterPurge.GetDevice(ctx, devAlice)
+	if recAfter != nil {
+		t.Errorf("expected device to be purged from store")
+	}
+
+	// Non-existent device error
+	stdout.Reset()
+	stderr.Reset()
+	code = executeUnpair([]string{"--config-dir", tmpDir, "--yes", "ghost-device"}, &stdin, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit code 1 for non-existent device, got %d", code)
+	}
+}

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -231,3 +231,15 @@ For local network (Wi-Fi/LAN) direct transfer without internet roundtrips:
   ```
 - **Local Matching:** Listening nodes compute candidate tags using `k_pair` secrets from their local trust stores. Unpaired third parties on the LAN only see pseudorandom bytes.
 - **Direct LAN Connection:** When a peer is matched on LAN, nodes connect directly via TCP/TLS, bypassing internet signaling and relay.
+
+---
+
+## 9. CLI Automation & Mesh Operations
+
+The `sendbeam` CLI provides scriptable trusted-device operations:
+
+- `sendbeam devices [--json]`: Lists all paired devices with fingerprint, authorization policy, and last authenticated contact.
+- `sendbeam pair [code] [--name <label>] [--auto-accept --dest <dir>]`: Runs the mutual pairing ceremony over one-time SPAKE2 room codes.
+- `sendbeam unpair <device> [--yes] [--purge]`: Revokes or purges trust credentials for a specified device ID, label, or fingerprint.
+- `sendbeam send <paths...> @<device>`: Directly transfers files to a trusted device without human room codes or interactive prompts.
+- `sendbeam listen [--dest <dir>] [--auto-accept] [--once]`: Background daemon listening for incoming LAN discovery beacons and opaque rendezvous presence.


### PR DESCRIPTION
## Summary
- **Devices Command:** Added `sendbeam devices` with formatted tabular output and stable `--json` schema.
- **Pairing Ceremony:** Added `sendbeam pair [code]` with support for custom names (`--name`), auto-accept policies (`--auto-accept`, `--dest`), and stable JSON output.
- **Unpair & Revoke:** Added `sendbeam unpair <device>` matching device ID, label, or fingerprint with interactive confirmation, `--yes`, and permanent `--purge` options.
- **Direct Send:** Added support for `sendbeam send <paths...> @<device>` and `--to <device>` to send directly to trusted peers without human room codes.
- **Trusted Listener Daemon:** Added `sendbeam listen` for background LAN discovery beacon advertisement/listening and trusted receiving.
- **Secret Persistence:** Added `FileSecretResolver` with `0600` file permissions for `k_pair` storage and `ResolveDevice` lookup helper.
- **Documentation:** Updated `docs/trust-model.md` (Section 9: CLI Automation & Mesh Operations).

## Test Plan
- Unit tests in `apps/cli/cmd/sendbeam`: `devices_test.go`, `pair_test.go`, `unpair_test.go`, `listen_test.go`, `trust_config_test.go`.
- Tested JSON output formats and exit codes (0 for success, 1 for errors, 2 for flag/argument failures).
- Passed full workspace lint, format, typecheck, and `go test -race` suites.