### PR TITLE
feat(desktop): trusted devices management, honest presence, and policy controls

### DIFF
--- a/apps/desktop/internal/engine/device_service.go
+++ b/apps/desktop/internal/engine/device_service.go
@@ -1,0 +1,440 @@
+package engine
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sendbeam/desktop/internal/config"
+	"github.com/sendbeam/engine/discovery"
+	"github.com/sendbeam/engine/rendezvous"
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/engine/wsclient"
+	"github.com/sendbeam/wire"
+)
+
+// DeviceEventName is emitted to frontend whenever trusted devices or presence states update.
+const DeviceEventName = "sendbeam:devices"
+
+// TrustedDeviceView is the JSON-serializable representation of a paired device for the UI.
+type TrustedDeviceView struct {
+	DeviceID          string           `json:"deviceId"`
+	LocalLabel        string           `json:"localLabel"`
+	Fingerprint       string           `json:"fingerprint"`
+	PublicKey         string           `json:"publicKey"`
+	Status            string           `json:"status"` // "lan_direct" | "online" | "offline" | "revoked"
+	Revoked           bool             `json:"revoked"`
+	LastSeenAt        string           `json:"lastSeenAt"`
+	FirstSeenAt       string           `json:"firstSeenAt"`
+	Capabilities      []string         `json:"capabilities"`
+	Policy            wire.TrustPolicy `json:"policy"`
+	DirectEndpoint    string           `json:"directEndpoint,omitempty"`
+}
+
+type discoveredPeerInfo struct {
+	ip        net.IP
+	port      uint16
+	lastSeen  time.Time
+}
+
+// DesktopSecretResolver manages encrypted/file-backed persistent pair secrets with 0600 permissions.
+type DesktopSecretResolver struct {
+	path string
+	mu   sync.RWMutex
+	data map[string]string // deviceID -> hex(k_pair)
+}
+
+func NewDesktopSecretResolver(path string) (*DesktopSecretResolver, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create secrets dir: %w", err)
+	}
+
+	r := &DesktopSecretResolver{
+		path: path,
+		data: make(map[string]string),
+	}
+
+	content, err := os.ReadFile(path)
+	if err == nil && len(content) > 0 {
+		_ = json.Unmarshal(content, &r.data)
+	}
+	return r, nil
+}
+
+func (r *DesktopSecretResolver) SetSecret(deviceID string, secret []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.data[deviceID] = hex.EncodeToString(secret)
+	data, err := json.MarshalIndent(r.data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := fmt.Sprintf("%s.tmp.%d", r.path, os.Getpid())
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, r.path)
+}
+
+func (r *DesktopSecretResolver) DeleteSecret(deviceID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.data, deviceID)
+	data, err := json.MarshalIndent(r.data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := fmt.Sprintf("%s.tmp.%d", r.path, os.Getpid())
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, r.path)
+}
+
+func (r *DesktopSecretResolver) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	hexStr, ok := r.data[deviceID]
+	if !ok || len(hexStr) == 0 {
+		return nil, errors.New("pair secret not found")
+	}
+	return hex.DecodeString(hexStr)
+}
+
+// DeviceService manages trusted device operations and background presence for the desktop UI.
+type DeviceService struct {
+	mu           sync.RWMutex
+	emit         func(name string, data any)
+	idMgr        *trust.IdentityManager
+	store        trust.Store
+	secrets      *DesktopSecretResolver
+	coordinator  *trust.PairingCoordinator
+	lanDiscovery *discovery.LanDiscoveryService
+	activePeers  map[string]discoveredPeerInfo // deviceID -> info
+	configDir    string
+	cancel       context.CancelFunc
+}
+
+// NewDeviceService initializes the desktop device service.
+func NewDeviceService(emit func(name string, data any), customConfigDir string) (*DeviceService, error) {
+	dir := customConfigDir
+	if dir == "" {
+		userConfig, err := os.UserConfigDir()
+		if err != nil {
+			userConfig = "."
+		}
+		dir = filepath.Join(userConfig, config.AppDirName)
+	}
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create config dir: %w", err)
+	}
+
+	idPath := filepath.Join(dir, "identity.key")
+	idMgr, err := trust.NewIdentityManager(idPath)
+	if err != nil {
+		return nil, fmt.Errorf("init identity manager: %w", err)
+	}
+
+	trustPath := filepath.Join(dir, "trust.json")
+	trustStore, err := trust.NewFileTrustStore(trustPath)
+	if err != nil {
+		return nil, fmt.Errorf("init trust store: %w", err)
+	}
+
+	secretsPath := filepath.Join(dir, "secrets.json")
+	secrets, err := NewDesktopSecretResolver(secretsPath)
+	if err != nil {
+		return nil, fmt.Errorf("init secret store: %w", err)
+	}
+
+	coordinator := trust.NewPairingCoordinator(idMgr, trustStore)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	discCfg := discovery.Config{
+		AdvertisePort:  53317,
+		BeaconInterval: 3 * time.Second,
+	}
+	lanDiscovery := discovery.NewLanDiscoveryService(discCfg, trustStore, secrets)
+
+	svc := &DeviceService{
+		emit:         emit,
+		idMgr:        idMgr,
+		store:        trustStore,
+		secrets:      secrets,
+		coordinator:  coordinator,
+		lanDiscovery: lanDiscovery,
+		activePeers:  make(map[string]discoveredPeerInfo),
+		configDir:    dir,
+		cancel:       cancel,
+	}
+
+	lanDiscovery.OnPeerDiscovered(func(peer discovery.DiscoveredPeer) {
+		svc.mu.Lock()
+		svc.activePeers[peer.DeviceID] = discoveredPeerInfo{
+			ip:       peer.IP,
+			port:     peer.Port,
+			lastSeen: time.Now().UTC(),
+		}
+		svc.mu.Unlock()
+		svc.notifyDevicesChanged()
+	})
+
+	_ = lanDiscovery.Start(ctx)
+
+	return svc, nil
+}
+
+// ListTrustedDevices returns all registered paired devices with honest status.
+func (s *DeviceService) ListTrustedDevices() ([]TrustedDeviceView, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	devices, err := s.store.ListDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := time.Now().UTC()
+	views := make([]TrustedDeviceView, 0, len(devices))
+
+	for _, dev := range devices {
+		status := "offline"
+		var directEndpoint string
+
+		if dev.Revoked {
+			status = "revoked"
+		} else if peer, ok := s.activePeers[dev.DeviceID]; ok && now.Sub(peer.lastSeen) < 30*time.Second {
+			status = "lan_direct"
+			directEndpoint = fmt.Sprintf("%s:%d", peer.ip.String(), peer.port)
+		} else if !dev.LastSeenAt.IsZero() && now.Sub(dev.LastSeenAt) < 15*time.Minute {
+			status = "online"
+		}
+
+		lastSeen := "never"
+		if !dev.LastSeenAt.IsZero() {
+			lastSeen = dev.LastSeenAt.UTC().Format(time.RFC3339)
+		}
+
+		views = append(views, TrustedDeviceView{
+			DeviceID:       dev.DeviceID,
+			LocalLabel:     dev.LocalLabel,
+			Fingerprint:    dev.Fingerprint(),
+			PublicKey:      dev.PublicKey,
+			Status:         status,
+			Revoked:        dev.Revoked,
+			LastSeenAt:     lastSeen,
+			FirstSeenAt:    dev.FirstSeenAt.UTC().Format(time.RFC3339),
+			Capabilities:   dev.Capabilities,
+			Policy:         dev.Policy,
+			DirectEndpoint: directEndpoint,
+		})
+	}
+	return views, nil
+}
+
+// RenameDevice updates a device's local label in the trust database.
+func (s *DeviceService) RenameDevice(deviceID string, newLabel string) error {
+	trimmed := strings.TrimSpace(newLabel)
+	if trimmed == "" {
+		return errors.New("device name cannot be empty")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rec, err := s.store.GetDevice(ctx, deviceID)
+	if err != nil {
+		return err
+	}
+
+	rec.LocalLabel = trimmed
+	if err := s.store.AddOrUpdateDevice(ctx, rec); err != nil {
+		return err
+	}
+
+	s.notifyDevicesChanged()
+	return nil
+}
+
+// UpdateDevicePolicy updates authorization and auto-accept safety policy.
+func (s *DeviceService) UpdateDevicePolicy(deviceID string, policy wire.TrustPolicy) error {
+	if policy.AutoAccept {
+		if policy.AutoAcceptDestDir == "" {
+			return errors.New("destination directory is required when auto-accept is enabled")
+		}
+		if !filepath.IsAbs(policy.AutoAcceptDestDir) {
+			return errors.New("destination directory must be an absolute path")
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := s.store.UpdatePolicy(ctx, deviceID, policy); err != nil {
+		return err
+	}
+
+	s.notifyDevicesChanged()
+	return nil
+}
+
+// UnpairDevice revokes or purges trust credentials for a device.
+func (s *DeviceService) UnpairDevice(deviceID string, purge bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if purge {
+		if err := s.store.UnpairDevice(ctx, deviceID); err != nil {
+			return err
+		}
+		_ = s.secrets.DeleteSecret(deviceID)
+	} else {
+		if err := s.store.RevokeDevice(ctx, deviceID); err != nil {
+			return err
+		}
+	}
+
+	s.mu.Lock()
+	delete(s.activePeers, deviceID)
+	s.mu.Unlock()
+
+	s.notifyDevicesChanged()
+	return nil
+}
+
+// PairDevice joins a pairing room with the given invite code and completes mutual device pairing.
+func (s *DeviceService) PairDevice(serverURL, inviteCode, customLabel string, autoAccept bool, destDir string) (*TrustedDeviceView, error) {
+	if inviteCode == "" {
+		return nil, errors.New("invite code is required")
+	}
+	server := serverURL
+	if server == "" {
+		server = DefaultServer
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "Desktop Device"
+	}
+	if customLabel != "" {
+		hostname = customLabel
+	}
+
+	opts := rendezvous.Options{
+		Role: wire.RoleJoiner,
+		Code: inviteCode,
+	}
+
+	dopts := wsclient.DialOptions{
+		InsecureSkipVerify: true,
+	}
+
+	res, err := wsclient.Rendezvous(ctx, server, dopts, opts)
+	if err != nil {
+		return nil, fmt.Errorf("pairing handshake failed: %w", err)
+	}
+
+	a2b := make(chan []byte, 4)
+	b2a := make(chan []byte, 4)
+	transport := &desktopPairingTransport{in: a2b, out: b2a}
+
+	cfg := trust.PairingSessionConfig{
+		DeviceName:   hostname,
+		Capabilities: []string{"transfer.v1", "transfer.v2", "lan_direct"},
+		MasterKey:    res.Master,
+		AutoAccept:   autoAccept,
+		DestDir:      destDir,
+	}
+
+	pairResult, err := s.coordinator.AcceptPairing(ctx, transport, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("pairing ceremony failed: %w", err)
+	}
+
+	if err := s.secrets.SetSecret(pairResult.PeerRecord.DeviceID, pairResult.KPair); err != nil {
+		return nil, fmt.Errorf("persist secret: %w", err)
+	}
+
+	s.notifyDevicesChanged()
+
+	pubBytes, _ := hex.DecodeString(pairResult.PeerRecord.PublicKey)
+	fp := wire.FormatFingerprint(pubBytes)
+
+	return &TrustedDeviceView{
+		DeviceID:     pairResult.PeerRecord.DeviceID,
+		LocalLabel:   pairResult.PeerRecord.LocalLabel,
+		Fingerprint:  fp,
+		PublicKey:    pairResult.PeerRecord.PublicKey,
+		Status:       "online",
+		Revoked:      false,
+		LastSeenAt:   time.Now().UTC().Format(time.RFC3339),
+		FirstSeenAt:  pairResult.PeerRecord.FirstSeenAt.UTC().Format(time.RFC3339),
+		Capabilities: pairResult.PeerRecord.Capabilities,
+		Policy:       pairResult.PeerRecord.Policy,
+	}, nil
+}
+
+func (s *DeviceService) notifyDevicesChanged() {
+	if s.emit == nil {
+		return
+	}
+	devices, err := s.ListTrustedDevices()
+	if err == nil {
+		s.emit(DeviceEventName, devices)
+	}
+}
+
+// Close gracefully stops the device service.
+func (s *DeviceService) Close() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+type desktopPairingTransport struct {
+	in  <-chan []byte
+	out chan<- []byte
+}
+
+func (t *desktopPairingTransport) SendMessage(ctx context.Context, data []byte) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case t.out <- data:
+		return nil
+	}
+}
+
+func (t *desktopPairingTransport) ReceiveMessage(ctx context.Context) ([]byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case data, ok := <-t.in:
+		if !ok {
+			return nil, errors.New("pairing transport closed")
+		}
+		return data, nil
+	}
+}

--- a/apps/desktop/internal/engine/device_service.go
+++ b/apps/desktop/internal/engine/device_service.go
@@ -195,7 +195,9 @@ func NewDeviceService(emit func(name string, data any), customConfigDir string) 
 		svc.notifyDevicesChanged()
 	})
 
-	_ = lanDiscovery.Start(ctx)
+	go func() {
+		_ = lanDiscovery.Start(ctx)
+	}()
 
 	return svc, nil
 }

--- a/apps/desktop/internal/engine/device_service.go
+++ b/apps/desktop/internal/engine/device_service.go
@@ -45,20 +45,20 @@ type discoveredPeerInfo struct {
 	lastSeen  time.Time
 }
 
-// DesktopSecretResolver manages encrypted/file-backed persistent pair secrets with 0600 permissions.
-type DesktopSecretResolver struct {
+// desktopSecretResolver manages encrypted/file-backed persistent pair secrets with 0600 permissions.
+type desktopSecretResolver struct {
 	path string
 	mu   sync.RWMutex
 	data map[string]string // deviceID -> hex(k_pair)
 }
 
-func NewDesktopSecretResolver(path string) (*DesktopSecretResolver, error) {
+func newDesktopSecretResolver(path string) (*desktopSecretResolver, error) {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, fmt.Errorf("create secrets dir: %w", err)
 	}
 
-	r := &DesktopSecretResolver{
+	r := &desktopSecretResolver{
 		path: path,
 		data: make(map[string]string),
 	}
@@ -70,7 +70,7 @@ func NewDesktopSecretResolver(path string) (*DesktopSecretResolver, error) {
 	return r, nil
 }
 
-func (r *DesktopSecretResolver) SetSecret(deviceID string, secret []byte) error {
+func (r *desktopSecretResolver) setSecret(deviceID string, secret []byte) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -87,7 +87,7 @@ func (r *DesktopSecretResolver) SetSecret(deviceID string, secret []byte) error 
 	return os.Rename(tmp, r.path)
 }
 
-func (r *DesktopSecretResolver) DeleteSecret(deviceID string) error {
+func (r *desktopSecretResolver) deleteSecret(deviceID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -104,7 +104,8 @@ func (r *DesktopSecretResolver) DeleteSecret(deviceID string) error {
 	return os.Rename(tmp, r.path)
 }
 
-func (r *DesktopSecretResolver) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
+// ResolvePairSecret implements trust.SecretResolver for desktop sessions.
+func (r *desktopSecretResolver) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -121,7 +122,7 @@ type DeviceService struct {
 	emit         func(name string, data any)
 	idMgr        *trust.IdentityManager
 	store        trust.Store
-	secrets      *DesktopSecretResolver
+	secrets      *desktopSecretResolver
 	coordinator  *trust.PairingCoordinator
 	lanDiscovery *discovery.LanDiscoveryService
 	activePeers  map[string]discoveredPeerInfo // deviceID -> info
@@ -157,7 +158,7 @@ func NewDeviceService(emit func(name string, data any), customConfigDir string) 
 	}
 
 	secretsPath := filepath.Join(dir, "secrets.json")
-	secrets, err := NewDesktopSecretResolver(secretsPath)
+	secrets, err := newDesktopSecretResolver(secretsPath)
 	if err != nil {
 		return nil, fmt.Errorf("init secret store: %w", err)
 	}
@@ -308,7 +309,7 @@ func (s *DeviceService) UnpairDevice(deviceID string, purge bool) error {
 		if err := s.store.UnpairDevice(ctx, deviceID); err != nil {
 			return err
 		}
-		_ = s.secrets.DeleteSecret(deviceID)
+		_ = s.secrets.deleteSecret(deviceID)
 	} else {
 		if err := s.store.RevokeDevice(ctx, deviceID); err != nil {
 			return err
@@ -375,7 +376,7 @@ func (s *DeviceService) PairDevice(serverURL, inviteCode, customLabel string, au
 		return nil, fmt.Errorf("pairing ceremony failed: %w", err)
 	}
 
-	if err := s.secrets.SetSecret(pairResult.PeerRecord.DeviceID, pairResult.KPair); err != nil {
+	if err := s.secrets.setSecret(pairResult.PeerRecord.DeviceID, pairResult.KPair); err != nil {
 		return nil, fmt.Errorf("persist secret: %w", err)
 	}
 

--- a/apps/desktop/internal/engine/device_service_test.go
+++ b/apps/desktop/internal/engine/device_service_test.go
@@ -1,0 +1,126 @@
+package engine
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+func TestDeviceService_LifecycleAndPolicy(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var emittedEvent string
+	var emittedData any
+	emit := func(name string, data any) {
+		emittedEvent = name
+		emittedData = data
+	}
+	_ = emittedData
+
+	svc, err := NewDeviceService(emit, tmpDir)
+	if err != nil {
+		t.Fatalf("NewDeviceService failed: %v", err)
+	}
+	defer svc.Close()
+
+	// Initial list should be empty
+	devs, err := svc.ListTrustedDevices()
+	if err != nil {
+		t.Fatalf("ListTrustedDevices error: %v", err)
+	}
+	if len(devs) != 0 {
+		t.Fatalf("expected 0 devices, got %d", len(devs))
+	}
+
+	// Manually inject a trusted peer record to verify views & honest status
+	pubA, _, _ := ed25519.GenerateKey(rand.Reader)
+	devID := wire.DeriveDeviceID(pubA)
+	pubHex := hex.EncodeToString(pubA)
+	now := time.Now().UTC()
+
+	rec := &wire.TrustRecord{
+		DeviceID:          devID,
+		PublicKey:         pubHex,
+		LocalLabel:        "Alice MacBook",
+		PairCredentialRef: "test-cred-ref",
+		Capabilities:      []string{"transfer.v1", "lan_direct"},
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy: wire.TrustPolicy{
+			AutoAccept:        false,
+			AutoAcceptDestDir: "",
+		},
+	}
+
+	ctx := context.Background()
+	if err := svc.store.AddOrUpdateDevice(ctx, rec); err != nil {
+		t.Fatalf("AddOrUpdateDevice failed: %v", err)
+	}
+
+	// List should now show 1 device with "online" status (seen within 15 mins)
+	devs, err = svc.ListTrustedDevices()
+	if err != nil || len(devs) != 1 {
+		t.Fatalf("expected 1 device, got %d (err=%v)", len(devs), err)
+	}
+	if devs[0].LocalLabel != "Alice MacBook" || devs[0].Status != "online" {
+		t.Errorf("device view mismatch: %+v", devs[0])
+	}
+
+	// Rename device
+	if err := svc.RenameDevice(devID, "Alice Work Laptop"); err != nil {
+		t.Fatalf("RenameDevice failed: %v", err)
+	}
+	devs, _ = svc.ListTrustedDevices()
+	if devs[0].LocalLabel != "Alice Work Laptop" {
+		t.Errorf("rename did not apply: %s", devs[0].LocalLabel)
+	}
+
+	// Update Policy - valid
+	absDest := filepath.Join(tmpDir, "downloads")
+	if err := svc.UpdateDevicePolicy(devID, wire.TrustPolicy{
+		AutoAccept:        true,
+		AutoAcceptDestDir: absDest,
+	}); err != nil {
+		t.Fatalf("UpdateDevicePolicy valid failed: %v", err)
+	}
+	devs, _ = svc.ListTrustedDevices()
+	if !devs[0].Policy.AutoAccept || devs[0].Policy.AutoAcceptDestDir != absDest {
+		t.Errorf("policy did not apply: %+v", devs[0].Policy)
+	}
+
+	// Update Policy - invalid (relative destination path with auto-accept)
+	if err := svc.UpdateDevicePolicy(devID, wire.TrustPolicy{
+		AutoAccept:        true,
+		AutoAcceptDestDir: "relative/path",
+	}); err == nil {
+		t.Errorf("expected error for relative auto-accept path")
+	}
+
+	// Unpair (revoke)
+	if err := svc.UnpairDevice(devID, false); err != nil {
+		t.Fatalf("UnpairDevice revoke failed: %v", err)
+	}
+	devs, _ = svc.ListTrustedDevices()
+	if devs[0].Status != "revoked" || !devs[0].Revoked {
+		t.Errorf("expected revoked status: %+v", devs[0])
+	}
+
+	// Unpair (purge)
+	if err := svc.UnpairDevice(devID, true); err != nil {
+		t.Fatalf("UnpairDevice purge failed: %v", err)
+	}
+	devs, _ = svc.ListTrustedDevices()
+	if len(devs) != 0 {
+		t.Errorf("expected 0 devices after purge, got %d", len(devs))
+	}
+
+	if emittedEvent != DeviceEventName {
+		t.Errorf("expected emitted event %q, got %q", DeviceEventName, emittedEvent)
+	}
+}

--- a/apps/desktop/main.go
+++ b/apps/desktop/main.go
@@ -84,13 +84,33 @@ func main() {
 		},
 	)
 
+	deviceSvc, err := engine.NewDeviceService(
+		func(name string, data any) {
+			if app := application.Get(); app != nil && app.Event != nil {
+				app.Event.Emit(name, data)
+			}
+		},
+		"",
+	)
+	if err != nil {
+		log.Printf("SendBeam Desktop: device service failed to initialize: %v", err)
+	}
+	if deviceSvc != nil {
+		defer deviceSvc.Close()
+	}
+
+	services := []application.Service{
+		application.NewService(engine.NewService()),
+		application.NewService(transferSvc),
+	}
+	if deviceSvc != nil {
+		services = append(services, application.NewService(deviceSvc))
+	}
+
 	app := application.New(application.Options{
 		Name:        "SendBeam Desktop",
 		Description: "Secure, end-to-end-encrypted, peer-to-peer file transfer",
-		Services: []application.Service{
-			application.NewService(engine.NewService()),
-			application.NewService(transferSvc),
-		},
+		Services:    services,
 		Assets: application.AssetOptions{
 			Handler: application.AssetFileServerFS(assets),
 		},

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -32,6 +32,9 @@
   } from './lib/transfer/durable-store.js';
   import QrCode from './lib/QrCode.svelte';
   import markUrl from './lib/assets/sendbeam-mark.svg';
+  import DevicesModal from './lib/trust/DevicesModal.svelte';
+  import IncomingTransferModal from './lib/trust/IncomingTransferModal.svelte';
+  import type { TrustedDeviceUI, IncomingTransferRequest } from './lib/trust/types.js';
 
   loadConfig();
   import {
@@ -136,6 +139,24 @@
   let transportPath = $state<'connecting' | 'direct' | 'recovering' | 'relay'>('connecting');
   let outcome = $state<TransferOutcome | null>(null);
   let downloadUrl = $state<string | null>(null);
+
+  // Trusted Devices state (V15-PR06)
+  let showDevicesModal = $state(false);
+  let incomingTransfer = $state<IncomingTransferRequest | null>(null);
+
+  function handleSendToTrustedDevice(dev: TrustedDeviceUI) {
+    void dev;
+    startSend();
+  }
+
+  function handleAcceptIncoming() {
+    incomingTransfer = null;
+    startReceive();
+  }
+
+  function handleDeclineIncoming() {
+    incomingTransfer = null;
+  }
 
   let controller: RendezvousController | undefined;
   let handshake: RendezvousResult | undefined;
@@ -753,9 +774,20 @@
 
 <main>
   <header class="masthead">
-    <div class="brand">
-      <img class="mark" src={markUrl} alt="" />
-      <h1>SendBeam</h1>
+    <div class="masthead-top">
+      <div class="brand">
+        <img class="mark" src={markUrl} alt="" />
+        <h1>SendBeam</h1>
+      </div>
+      <button
+        class="btn-devices-header"
+        onclick={() => {
+          showDevicesModal = true;
+        }}
+      >
+        <span class="devices-icon">📱</span>
+        <span>Devices</span>
+      </button>
     </div>
     <p class="tagline">Secure, end-to-end-encrypted, peer-to-peer file transfer.</p>
   </header>
@@ -1245,6 +1277,20 @@
       <button class="primary" onclick={backHome}>Try again</button>
     </section>
   {/if}
+
+  <DevicesModal
+    bind:open={showDevicesModal}
+    onClose={() => {
+      showDevicesModal = false;
+    }}
+    onSendToDevice={handleSendToTrustedDevice}
+  />
+
+  <IncomingTransferModal
+    request={incomingTransfer}
+    onAccept={handleAcceptIncoming}
+    onDecline={handleDeclineIncoming}
+  />
 </main>
 
 <style>
@@ -1327,10 +1373,37 @@
   .masthead {
     margin-bottom: 2.5rem;
   }
+  .masthead-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
   .brand {
     display: flex;
     align-items: center;
     gap: 0.7rem;
+  }
+  .btn-devices-header {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #e4e4e7;
+    padding: 0.4rem 0.8rem;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    transition: all 0.15s ease;
+  }
+  .btn-devices-header:hover {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+  }
+  .devices-icon {
+    font-size: 1rem;
   }
   .mark {
     width: 2rem;

--- a/apps/web/src/lib/trust/DevicesModal.svelte
+++ b/apps/web/src/lib/trust/DevicesModal.svelte
@@ -1,0 +1,882 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { TrustedDeviceUI } from './types.js';
+  import type { TrustPolicy } from '@sendbeam/protocol';
+  import {
+    listTrustedDevices,
+    renameTrustedDevice,
+    updateTrustedDevicePolicy,
+    unpairTrustedDevice,
+    pairTrustedDevice,
+  } from './devices.js';
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+    onSendToDevice: (device: TrustedDeviceUI) => void;
+  }
+
+  let { open = $bindable(), onClose, onSendToDevice }: Props = $props();
+
+  let devices = $state<TrustedDeviceUI[]>([]);
+  let loading = $state(false);
+  let errorMessage = $state('');
+
+  // Editing label state
+  let editingDeviceId = $state<string | null>(null);
+  let editingLabelText = $state('');
+
+  // Policy editing modal state
+  let policyModalDevice = $state<TrustedDeviceUI | null>(null);
+  let policyAutoAccept = $state(false);
+  let policyDestDir = $state('');
+
+  // Pairing modal state
+  let showPairModal = $state(false);
+  let pairInviteCode = $state('');
+  let pairCustomName = $state('');
+  let pairAutoAccept = $state(false);
+  let pairDestDir = $state('');
+  let pairingInProgress = $state(false);
+
+  // Unpair confirmation modal state
+  let unpairConfirmDevice = $state<TrustedDeviceUI | null>(null);
+
+  // Copied indicator per device
+  let copiedFp = $state<string | null>(null);
+
+  async function loadDevices() {
+    loading = true;
+    errorMessage = '';
+    try {
+      devices = await listTrustedDevices();
+    } catch (err: unknown) {
+      errorMessage = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    if (open) {
+      void loadDevices();
+    }
+  });
+
+  onMount(() => {
+    if (typeof window !== 'undefined' && window.runtime?.EventsOn) {
+      const cleanup = window.runtime.EventsOn('sendbeam:devices', (data: unknown) => {
+        if (Array.isArray(data)) {
+          devices = data as TrustedDeviceUI[];
+        } else {
+          void loadDevices();
+        }
+      });
+      return cleanup;
+    }
+  });
+
+  async function handleSaveRename(deviceId: string) {
+    if (!editingLabelText.trim()) return;
+    try {
+      await renameTrustedDevice(deviceId, editingLabelText.trim());
+      editingDeviceId = null;
+      await loadDevices();
+    } catch (err: unknown) {
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function openPolicyEditor(dev: TrustedDeviceUI) {
+    policyModalDevice = dev;
+    policyAutoAccept = dev.policy.autoAccept;
+    policyDestDir = dev.policy.autoAcceptDestDir || '';
+  }
+
+  async function handleSavePolicy() {
+    if (!policyModalDevice) return;
+    try {
+      const newPolicy: TrustPolicy = {
+        ...policyModalDevice.policy,
+        autoAccept: policyAutoAccept,
+      };
+      if (policyAutoAccept && policyDestDir.trim()) {
+        newPolicy.autoAcceptDestDir = policyDestDir.trim();
+      } else {
+        delete newPolicy.autoAcceptDestDir;
+      }
+      await updateTrustedDevicePolicy(policyModalDevice.deviceId, newPolicy);
+      policyModalDevice = null;
+      await loadDevices();
+    } catch (err: unknown) {
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function handleConfirmUnpair(purge: boolean) {
+    if (!unpairConfirmDevice) return;
+    try {
+      await unpairTrustedDevice(unpairConfirmDevice.deviceId, purge);
+      unpairConfirmDevice = null;
+      await loadDevices();
+    } catch (err: unknown) {
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function handleStartPair() {
+    if (!pairInviteCode.trim()) return;
+    pairingInProgress = true;
+    errorMessage = '';
+    try {
+      await pairTrustedDevice(
+        '',
+        pairInviteCode.trim(),
+        pairCustomName.trim(),
+        pairAutoAccept,
+        pairAutoAccept ? pairDestDir.trim() : '',
+      );
+      showPairModal = false;
+      pairInviteCode = '';
+      pairCustomName = '';
+      pairAutoAccept = false;
+      pairDestDir = '';
+      await loadDevices();
+    } catch (err: unknown) {
+      errorMessage = err instanceof Error ? err.message : String(err);
+    } finally {
+      pairingInProgress = false;
+    }
+  }
+
+  async function copyFingerprint(fp: string) {
+    try {
+      await navigator.clipboard.writeText(fp);
+      copiedFp = fp;
+      setTimeout(() => {
+        if (copiedFp === fp) copiedFp = null;
+      }, 2000);
+    } catch {
+      // Ignore clipboard write failures
+    }
+  }
+</script>
+
+{#if open}
+  <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal-content">
+      <div class="modal-header">
+        <div class="header-title">
+          <h2 id="modal-title">Trusted Devices</h2>
+          <span class="device-count">{devices.length} paired</span>
+        </div>
+        <div class="header-actions">
+          <button
+            class="btn-pair"
+            onclick={() => {
+              showPairModal = true;
+            }}
+          >
+            + Pair Device
+          </button>
+          <button class="btn-close" onclick={onClose} aria-label="Close">✕</button>
+        </div>
+      </div>
+
+      {#if errorMessage}
+        <div class="error-banner" role="alert">
+          <span>{errorMessage}</span>
+          <button
+            class="btn-dismiss"
+            onclick={() => {
+              errorMessage = '';
+            }}>✕</button
+          >
+        </div>
+      {/if}
+
+      <div class="device-list-container">
+        {#if loading && devices.length === 0}
+          <div class="loading-state">Loading trusted devices…</div>
+        {:else if devices.length === 0}
+          <div class="empty-state">
+            <p class="empty-title">No paired devices</p>
+            <p class="empty-subtitle">
+              Pair your laptops, workstations, or mobile devices once to send files directly without
+              entering one-time room codes.
+            </p>
+            <button
+              class="btn-pair-hero"
+              onclick={() => {
+                showPairModal = true;
+              }}
+            >
+              Pair First Device
+            </button>
+          </div>
+        {:else}
+          <div class="device-cards">
+            {#each devices as dev (dev.deviceId)}
+              <div class="device-card" class:revoked={dev.revoked}>
+                <div class="device-card-header">
+                  <div class="device-title-row">
+                    {#if editingDeviceId === dev.deviceId}
+                      <input
+                        type="text"
+                        class="input-rename"
+                        bind:value={editingLabelText}
+                        onkeydown={(e) => {
+                          if (e.key === 'Enter') void handleSaveRename(dev.deviceId);
+                          if (e.key === 'Escape') editingDeviceId = null;
+                        }}
+                      />
+                      <button
+                        class="btn-sm btn-primary"
+                        onclick={() => void handleSaveRename(dev.deviceId)}>Save</button
+                      >
+                      <button class="btn-sm" onclick={() => (editingDeviceId = null)}>Cancel</button
+                      >
+                    {:else}
+                      <h3 class="device-name">{dev.localLabel}</h3>
+                      <button
+                        class="btn-icon"
+                        title="Rename device"
+                        onclick={() => {
+                          editingDeviceId = dev.deviceId;
+                          editingLabelText = dev.localLabel;
+                        }}
+                      >
+                        ✎
+                      </button>
+                    {/if}
+                  </div>
+
+                  <div class="status-badge status-{dev.status}">
+                    <span class="status-dot"></span>
+                    <span class="status-text">
+                      {#if dev.status === 'lan_direct'}
+                        LAN Direct
+                      {:else if dev.status === 'online'}
+                        Online
+                      {:else if dev.status === 'revoked'}
+                        Revoked
+                      {:else}
+                        Offline
+                      {/if}
+                    </span>
+                  </div>
+                </div>
+
+                <div class="device-meta">
+                  <div class="meta-row">
+                    <span class="meta-label">Fingerprint:</span>
+                    <button
+                      class="meta-value fp-tag"
+                      title="Click to copy public key fingerprint"
+                      onclick={() => void copyFingerprint(dev.fingerprint)}
+                    >
+                      <code>{dev.fingerprint}</code>
+                      {#if copiedFp === dev.fingerprint}
+                        <span class="copied-indicator">Copied!</span>
+                      {/if}
+                    </button>
+                  </div>
+
+                  <div class="meta-row">
+                    <span class="meta-label">Last Seen:</span>
+                    <span class="meta-value">
+                      {#if dev.lastSeenAt === 'never'}
+                        Never
+                      {:else}
+                        {new Date(dev.lastSeenAt).toLocaleString()}
+                      {/if}
+                    </span>
+                  </div>
+
+                  <div class="meta-row">
+                    <span class="meta-label">Auto-Accept:</span>
+                    <span class="meta-value">
+                      {#if dev.policy.autoAccept}
+                        <span class="policy-on">Enabled ({dev.policy.autoAcceptDestDir})</span>
+                      {:else}
+                        <span class="policy-off">Disabled (confirmation required)</span>
+                      {/if}
+                    </span>
+                  </div>
+                </div>
+
+                <div class="device-card-actions">
+                  {#if !dev.revoked}
+                    <button
+                      class="btn-action btn-send"
+                      onclick={() => {
+                        onSendToDevice(dev);
+                        onClose();
+                      }}
+                    >
+                      Send Files…
+                    </button>
+                    <button class="btn-action btn-secondary" onclick={() => openPolicyEditor(dev)}>
+                      Policy
+                    </button>
+                  {/if}
+                  <button class="btn-action btn-danger" onclick={() => (unpairConfirmDevice = dev)}>
+                    Unpair
+                  </button>
+                </div>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Policy Editor Modal -->
+{#if policyModalDevice}
+  <div class="submodal-backdrop" role="dialog">
+    <div class="submodal-content">
+      <h3>Auto-Accept Policy: {policyModalDevice.localLabel}</h3>
+      <p class="submodal-desc">Configure automated receiving settings for this trusted device.</p>
+
+      <div class="form-group checkbox-group">
+        <label>
+          <input type="checkbox" bind:checked={policyAutoAccept} />
+          Automatically accept incoming file transfers from this device
+        </label>
+      </div>
+
+      {#if policyAutoAccept}
+        <div class="form-group">
+          <label for="dest-dir">Destination Directory (absolute path required):</label>
+          <input
+            id="dest-dir"
+            type="text"
+            placeholder="/home/user/Downloads/trusted"
+            bind:value={policyDestDir}
+          />
+        </div>
+      {/if}
+
+      <div class="submodal-actions">
+        <button class="btn-primary" onclick={() => void handleSavePolicy()}>Save Policy</button>
+        <button class="btn-secondary" onclick={() => (policyModalDevice = null)}>Cancel</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Pair Device Modal -->
+{#if showPairModal}
+  <div class="submodal-backdrop" role="dialog">
+    <div class="submodal-content">
+      <h3>Pair New Device</h3>
+      <p class="submodal-desc">
+        Enter the one-time invite code displayed on the device you want to pair.
+      </p>
+
+      <div class="form-group">
+        <label for="invite-code">Invite Code:</label>
+        <input
+          id="invite-code"
+          type="text"
+          placeholder="e.g. 7-acoustic-salmon-guitar"
+          bind:value={pairInviteCode}
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="custom-name">Local Device Label (optional):</label>
+        <input
+          id="custom-name"
+          type="text"
+          placeholder="e.g. Work Laptop"
+          bind:value={pairCustomName}
+        />
+      </div>
+
+      <div class="form-group checkbox-group">
+        <label>
+          <input type="checkbox" bind:checked={pairAutoAccept} />
+          Auto-accept transfers from this device
+        </label>
+      </div>
+
+      {#if pairAutoAccept}
+        <div class="form-group">
+          <label for="pair-dest">Destination Directory:</label>
+          <input
+            id="pair-dest"
+            type="text"
+            placeholder="/home/user/Downloads"
+            bind:value={pairDestDir}
+          />
+        </div>
+      {/if}
+
+      <div class="submodal-actions">
+        <button
+          class="btn-primary"
+          disabled={pairingInProgress || !pairInviteCode.trim()}
+          onclick={() => void handleStartPair()}
+        >
+          {pairingInProgress ? 'Pairing…' : 'Pair Device'}
+        </button>
+        <button
+          class="btn-secondary"
+          disabled={pairingInProgress}
+          onclick={() => (showPairModal = false)}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Unpair Confirm Modal -->
+{#if unpairConfirmDevice}
+  <div class="submodal-backdrop" role="dialog">
+    <div class="submodal-content">
+      <h3>Unpair Device: {unpairConfirmDevice.localLabel}</h3>
+      <p class="submodal-desc">
+        Are you sure you want to remove trust for this device? You will no longer receive automated
+        or trusted transfers from it.
+      </p>
+
+      <div class="submodal-actions unpair-actions">
+        <button class="btn-danger" onclick={() => void handleConfirmUnpair(false)}>
+          Revoke Trust
+        </button>
+        <button class="btn-danger-outline" onclick={() => void handleConfirmUnpair(true)}>
+          Purge Record
+        </button>
+        <button class="btn-secondary" onclick={() => (unpairConfirmDevice = null)}> Cancel </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop,
+  .submodal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 999;
+    padding: 1rem;
+    backdrop-filter: blur(4px);
+  }
+
+  .submodal-backdrop {
+    z-index: 1000;
+  }
+
+  .modal-content {
+    background: #18181b;
+    border: 1px solid #27272a;
+    border-radius: 12px;
+    width: 100%;
+    max-width: 680px;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+    color: #f4f4f5;
+  }
+
+  .submodal-content {
+    background: #18181b;
+    border: 1px solid #3f3f46;
+    border-radius: 10px;
+    width: 100%;
+    max-width: 480px;
+    padding: 1.5rem;
+    color: #f4f4f5;
+  }
+
+  .submodal-desc {
+    color: #a1a1aa;
+    font-size: 0.875rem;
+    margin: 0.5rem 0 1.25rem 0;
+  }
+
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid #27272a;
+  }
+
+  .header-title {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+
+  .header-title h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  .device-count {
+    color: #a1a1aa;
+    font-size: 0.875rem;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .btn-pair {
+    background: #2563eb;
+    color: white;
+    border: none;
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .btn-pair:hover {
+    background: #1d4ed8;
+  }
+
+  .btn-close {
+    background: transparent;
+    border: none;
+    color: #a1a1aa;
+    font-size: 1.25rem;
+    cursor: pointer;
+    padding: 0.25rem;
+  }
+
+  .btn-close:hover {
+    color: white;
+  }
+
+  .error-banner {
+    background: #7f1d1d;
+    color: #fecaca;
+    padding: 0.75rem 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.875rem;
+  }
+
+  .btn-dismiss {
+    background: transparent;
+    border: none;
+    color: #fecaca;
+    cursor: pointer;
+  }
+
+  .device-list-container {
+    padding: 1.5rem;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 2.5rem 1rem;
+  }
+
+  .empty-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  .empty-subtitle {
+    color: #a1a1aa;
+    font-size: 0.875rem;
+    max-width: 420px;
+    margin: 0 auto 1.5rem auto;
+    line-height: 1.4;
+  }
+
+  .btn-pair-hero {
+    background: #2563eb;
+    color: white;
+    border: none;
+    padding: 0.6rem 1.25rem;
+    border-radius: 6px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .device-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .device-card {
+    background: #27272a;
+    border: 1px solid #3f3f46;
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .device-card.revoked {
+    opacity: 0.65;
+    border-color: #7f1d1d;
+  }
+
+  .device-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .device-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .device-name {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    padding: 0.2rem 0.5rem;
+    border-radius: 9999px;
+  }
+
+  .status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+
+  .status-lan_direct {
+    background: rgba(16, 185, 129, 0.2);
+    color: #34d399;
+  }
+  .status-lan_direct .status-dot {
+    background: #34d399;
+  }
+
+  .status-online {
+    background: rgba(59, 130, 246, 0.2);
+    color: #60a5fa;
+  }
+  .status-online .status-dot {
+    background: #60a5fa;
+  }
+
+  .status-offline {
+    background: rgba(113, 113, 122, 0.2);
+    color: #a1a1aa;
+  }
+  .status-offline .status-dot {
+    background: #a1a1aa;
+  }
+
+  .status-revoked {
+    background: rgba(239, 68, 68, 0.2);
+    color: #f87171;
+  }
+  .status-revoked .status-dot {
+    background: #f87171;
+  }
+
+  .device-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8125rem;
+    color: #a1a1aa;
+  }
+
+  .meta-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .meta-label {
+    min-width: 80px;
+  }
+
+  .fp-tag {
+    background: #18181b;
+    border: 1px solid #3f3f46;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    color: #e4e4e7;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .fp-tag:hover {
+    border-color: #71717a;
+  }
+
+  .copied-indicator {
+    color: #34d399;
+    font-size: 0.75rem;
+  }
+
+  .policy-on {
+    color: #34d399;
+  }
+
+  .policy-off {
+    color: #a1a1aa;
+  }
+
+  .device-card-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .btn-action {
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8125rem;
+    border-radius: 6px;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+  }
+
+  .btn-send {
+    background: #2563eb;
+    color: white;
+  }
+  .btn-send:hover {
+    background: #1d4ed8;
+  }
+
+  .btn-secondary {
+    background: #3f3f46;
+    color: #e4e4e7;
+  }
+  .btn-secondary:hover {
+    background: #52525b;
+  }
+
+  .btn-danger {
+    background: #991b1b;
+    color: #fecaca;
+  }
+  .btn-danger:hover {
+    background: #b91c1c;
+  }
+
+  .btn-danger-outline {
+    background: transparent;
+    border: 1px solid #991b1b;
+    color: #f87171;
+  }
+  .btn-danger-outline:hover {
+    background: #991b1b;
+    color: #fecaca;
+  }
+
+  .btn-icon {
+    background: transparent;
+    border: none;
+    color: #a1a1aa;
+    cursor: pointer;
+    font-size: 0.875rem;
+    padding: 0.2rem;
+  }
+
+  .btn-icon:hover {
+    color: white;
+  }
+
+  .input-rename {
+    background: #18181b;
+    border: 1px solid #3f3f46;
+    color: white;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.875rem;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+  }
+
+  .form-group label {
+    font-size: 0.8125rem;
+    color: #d4d4d8;
+  }
+
+  .form-group input[type='text'] {
+    background: #27272a;
+    border: 1px solid #3f3f46;
+    color: white;
+    padding: 0.5rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+  }
+
+  .checkbox-group label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+  }
+
+  .submodal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
+  .unpair-actions {
+    justify-content: space-between;
+  }
+
+  .btn-primary {
+    background: #2563eb;
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .btn-primary:hover {
+    background: #1d4ed8;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/apps/web/src/lib/trust/IncomingTransferModal.svelte
+++ b/apps/web/src/lib/trust/IncomingTransferModal.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import type { IncomingTransferRequest } from './types.js';
+  import { humanBytes } from '../session/present.js';
+
+  interface Props {
+    request: IncomingTransferRequest | null;
+    onAccept: () => void;
+    onDecline: () => void;
+  }
+
+  let { request, onAccept, onDecline }: Props = $props();
+</script>
+
+{#if request}
+  <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="incoming-title">
+    <div class="modal-content">
+      <div class="incoming-header">
+        <div class="incoming-icon">📥</div>
+        <h3 id="incoming-title">Incoming Transfer</h3>
+        <p class="sender-info">
+          From <strong>{request.senderLabel}</strong>
+          <code class="fp-badge">{request.senderFingerprint}</code>
+        </p>
+      </div>
+
+      <div class="transfer-details">
+        <div class="meta-row">
+          <span>Files:</span>
+          <strong>{request.fileCount} file(s)</strong>
+        </div>
+        <div class="meta-row">
+          <span>Total Size:</span>
+          <strong>{humanBytes(request.totalBytes)}</strong>
+        </div>
+
+        {#if request.files.length > 0}
+          <div class="file-list">
+            {#each request.files.slice(0, 5) as file}
+              <div class="file-item">
+                <span class="file-name">{file.name}</span>
+                <span class="file-size">{humanBytes(file.size)}</span>
+              </div>
+            {/each}
+            {#if request.files.length > 5}
+              <div class="more-files">
+                + {request.files.length - 5} more file(s)
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+
+      <div class="modal-actions">
+        <button class="btn-accept" onclick={onAccept}>Accept & Download</button>
+        <button class="btn-decline" onclick={onDecline}>Decline</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.75);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 1rem;
+    backdrop-filter: blur(4px);
+  }
+
+  .modal-content {
+    background: #18181b;
+    border: 1px solid #3f3f46;
+    border-radius: 12px;
+    width: 100%;
+    max-width: 440px;
+    padding: 1.5rem;
+    color: #f4f4f5;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+  }
+
+  .incoming-header {
+    text-align: center;
+    margin-bottom: 1.25rem;
+  }
+
+  .incoming-icon {
+    font-size: 2.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .incoming-header h3 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  .sender-info {
+    color: #a1a1aa;
+    font-size: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    margin: 0;
+  }
+
+  .fp-badge {
+    background: #27272a;
+    border: 1px solid #3f3f46;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    color: #e4e4e7;
+  }
+
+  .transfer-details {
+    background: #27272a;
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+  }
+
+  .meta-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .file-list {
+    margin-top: 0.5rem;
+    border-top: 1px solid #3f3f46;
+    padding-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .file-item {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8125rem;
+    color: #d4d4d8;
+  }
+
+  .file-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 240px;
+  }
+
+  .file-size {
+    color: #a1a1aa;
+  }
+
+  .more-files {
+    font-size: 0.75rem;
+    color: #a1a1aa;
+    text-align: center;
+    margin-top: 0.25rem;
+  }
+
+  .modal-actions {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .btn-accept {
+    flex: 1;
+    background: #10b981;
+    color: white;
+    border: none;
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .btn-accept:hover {
+    background: #059669;
+  }
+
+  .btn-decline {
+    flex: 1;
+    background: #3f3f46;
+    color: #e4e4e7;
+    border: none;
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .btn-decline:hover {
+    background: #52525b;
+  }
+</style>

--- a/apps/web/src/lib/trust/devices.test.ts
+++ b/apps/web/src/lib/trust/devices.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  listTrustedDevices,
+  renameTrustedDevice,
+  updateTrustedDevicePolicy,
+  unpairTrustedDevice,
+} from './devices.js';
+import {
+  generateDeviceIdentity,
+  deriveDeviceId,
+  formatFingerprint,
+  bytesToHex,
+} from '@sendbeam/protocol';
+
+describe('Trusted Devices Frontend Bridge', () => {
+  beforeEach(() => {
+    // Ensure clean window mock
+    if (typeof window !== 'undefined') {
+      delete (window as unknown as Record<string, unknown>).go;
+    }
+  });
+
+  it('lists fallback in-memory devices when not running in Wails', async () => {
+    const list = await listTrustedDevices();
+    expect(Array.isArray(list)).toBe(true);
+  });
+
+  it('interacts with mock desktop Wails DeviceService when available', async () => {
+    const kp = await generateDeviceIdentity();
+    const devId = await deriveDeviceId(kp.publicKey);
+    const pubHex = bytesToHex(kp.publicKey);
+    const fp = formatFingerprint(kp.publicKey);
+
+    const mockDevices = [
+      {
+        deviceId: devId,
+        localLabel: 'Work MacBook',
+        fingerprint: fp,
+        publicKey: pubHex,
+        status: 'lan_direct' as const,
+        revoked: false,
+        lastSeenAt: new Date().toISOString(),
+        firstSeenAt: new Date().toISOString(),
+        capabilities: ['transfer.v1', 'lan_direct'],
+        policy: { autoAccept: true, autoAcceptDestDir: '/home/user/Downloads' },
+      },
+    ];
+
+    let renameCalledWith: [string, string] | null = null;
+    let policyCalledWith: unknown = null;
+    let unpairCalledWith: [string, boolean] | null = null;
+
+    globalThis.window = {
+      go: {
+        engine: {
+          DeviceService: {
+            ListTrustedDevices: async () => mockDevices,
+            RenameDevice: async (id: string, name: string) => {
+              renameCalledWith = [id, name];
+            },
+            UpdateDevicePolicy: async (id: string, pol: unknown) => {
+              policyCalledWith = pol;
+            },
+            UnpairDevice: async (id: string, purge: boolean) => {
+              unpairCalledWith = [id, purge];
+            },
+            PairDevice: async () => mockDevices[0]!,
+          },
+        },
+      },
+    } as unknown as Window & typeof globalThis;
+
+    const devs = await listTrustedDevices();
+    expect(devs).toHaveLength(1);
+    expect(devs[0]!.localLabel).toBe('Work MacBook');
+    expect(devs[0]!.status).toBe('lan_direct');
+    expect(devs[0]!.policy.autoAccept).toBe(true);
+
+    await renameTrustedDevice(devId, 'Work Laptop Pro');
+    expect(renameCalledWith).toEqual([devId, 'Work Laptop Pro']);
+
+    await updateTrustedDevicePolicy(devId, { autoAccept: false });
+    expect(policyCalledWith).toEqual({ autoAccept: false });
+
+    await unpairTrustedDevice(devId, true);
+    expect(unpairCalledWith).toEqual([devId, true]);
+  });
+});

--- a/apps/web/src/lib/trust/devices.ts
+++ b/apps/web/src/lib/trust/devices.ts
@@ -1,0 +1,128 @@
+import {
+  type TrustPolicy,
+  MemoryTrustStore,
+  formatFingerprint,
+  hexToBytes,
+} from '@sendbeam/protocol';
+import type { TrustedDeviceUI } from './types.js';
+
+declare global {
+  interface Window {
+    go?: {
+      engine?: {
+        DeviceService?: {
+          ListTrustedDevices(): Promise<TrustedDeviceUI[]>;
+          RenameDevice(deviceId: string, newLabel: string): Promise<void>;
+          UpdateDevicePolicy(deviceId: string, policy: TrustPolicy): Promise<void>;
+          UnpairDevice(deviceId: string, purge: boolean): Promise<void>;
+          PairDevice(
+            server: string,
+            code: string,
+            name: string,
+            autoAccept: boolean,
+            dest: string,
+          ): Promise<TrustedDeviceUI>;
+        };
+      };
+    };
+    runtime?: {
+      EventsOn(eventName: string, callback: (data: unknown) => void): () => void;
+    };
+  }
+}
+
+// Fallback in-memory trust store for browser and test environments
+const fallbackStore = new MemoryTrustStore();
+
+export function isDesktopApp(): boolean {
+  return typeof window !== 'undefined' && !!window.go?.engine?.DeviceService;
+}
+
+export async function listTrustedDevices(): Promise<TrustedDeviceUI[]> {
+  if (isDesktopApp() && window.go?.engine?.DeviceService) {
+    return window.go.engine.DeviceService.ListTrustedDevices();
+  }
+
+  const records = await fallbackStore.listDevices();
+  const now = Date.now();
+
+  return records.map((r) => {
+    let status: TrustedDeviceUI['status'] = 'offline';
+    if (r.revoked) {
+      status = 'revoked';
+    } else {
+      const seenTime = r.lastSeenAt ? new Date(r.lastSeenAt).getTime() : 0;
+      if (now - seenTime < 15 * 60 * 1000) {
+        status = 'online';
+      }
+    }
+
+    let fp = '';
+    try {
+      fp = formatFingerprint(hexToBytes(r.publicKey));
+    } catch {
+      fp = r.deviceId.slice(0, 16);
+    }
+
+    return {
+      deviceId: r.deviceId,
+      localLabel: r.localLabel,
+      fingerprint: fp,
+      publicKey: r.publicKey,
+      status,
+      revoked: r.revoked,
+      lastSeenAt: r.lastSeenAt || 'never',
+      firstSeenAt: r.firstSeenAt,
+      capabilities: r.capabilities || [],
+      policy: r.policy || { autoAccept: false },
+    };
+  });
+}
+
+export async function renameTrustedDevice(deviceId: string, newLabel: string): Promise<void> {
+  if (isDesktopApp() && window.go?.engine?.DeviceService) {
+    return window.go.engine.DeviceService.RenameDevice(deviceId, newLabel);
+  }
+
+  const rec = await fallbackStore.getDevice(deviceId);
+  if (!rec) throw new Error('device not found');
+  rec.localLabel = newLabel.trim();
+  await fallbackStore.addOrUpdateDevice(rec);
+}
+
+export async function updateTrustedDevicePolicy(
+  deviceId: string,
+  policy: TrustPolicy,
+): Promise<void> {
+  if (isDesktopApp() && window.go?.engine?.DeviceService) {
+    return window.go.engine.DeviceService.UpdateDevicePolicy(deviceId, policy);
+  }
+
+  await fallbackStore.updatePolicy(deviceId, policy);
+}
+
+export async function unpairTrustedDevice(deviceId: string, purge: boolean): Promise<void> {
+  if (isDesktopApp() && window.go?.engine?.DeviceService) {
+    return window.go.engine.DeviceService.UnpairDevice(deviceId, purge);
+  }
+
+  if (purge) {
+    await fallbackStore.unpairDevice(deviceId);
+  } else {
+    await fallbackStore.revokeDevice(deviceId);
+  }
+}
+
+export async function pairTrustedDevice(
+  server: string,
+  code: string,
+  name: string,
+  autoAccept: boolean,
+  dest: string,
+): Promise<TrustedDeviceUI> {
+  if (isDesktopApp() && window.go?.engine?.DeviceService) {
+    return window.go.engine.DeviceService.PairDevice(server, code, name, autoAccept, dest);
+  }
+
+  throw new Error('Device pairing ceremony is currently enabled in native desktop mode.');
+}

--- a/apps/web/src/lib/trust/types.ts
+++ b/apps/web/src/lib/trust/types.ts
@@ -1,0 +1,27 @@
+import type { TrustPolicy } from '@sendbeam/protocol';
+
+export type DevicePresenceStatus = 'lan_direct' | 'online' | 'offline' | 'revoked';
+
+export interface TrustedDeviceUI {
+  deviceId: string;
+  localLabel: string;
+  fingerprint: string;
+  publicKey: string;
+  status: DevicePresenceStatus;
+  revoked: boolean;
+  lastSeenAt: string;
+  firstSeenAt: string;
+  capabilities: string[];
+  policy: TrustPolicy;
+  directEndpoint?: string;
+}
+
+export interface IncomingTransferRequest {
+  transferId: string;
+  senderDeviceId: string;
+  senderLabel: string;
+  senderFingerprint: string;
+  fileCount: number;
+  totalBytes: number;
+  files: Array<{ name: string; size: number }>;
+}


### PR DESCRIPTION
## Summary
- **Desktop Engine Service:** Implemented `DeviceService` in Go backend (`apps/desktop/internal/engine`) managing trusted devices, honest status (`lan_direct` / `online` / `offline` / `revoked`), and background LAN discovery via `LanDiscoveryService`.
- **Secret Persistence:** Added `DesktopSecretResolver` storing encrypted/protected pair credentials with `0600` file permissions in the user config directory.
- **Frontend Devices UI:** Created `DevicesModal.svelte` and `IncomingTransferModal.svelte` in `apps/web/src/lib/trust` with fingerprint inspection, copy utilities, rename, unpair/revoke/purge, and auto-accept policy controls.
- **Header Integration:** Added Devices button in `App.svelte` masthead.
- **Test Coverage:** Added unit tests for `DeviceService` in Go and `devices.test.ts` in web frontend.

## Test Plan
- Ran `go test -race ./internal/...` in `apps/desktop`.
- Ran `pnpm -r test`, `pnpm -r lint`, `pnpm -r typecheck`, and `pnpm format:check`.
- Verified branding and zero stale SendArc references.