### PR TITLE
feat(release): zero-cost binary signing and supply-chain verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -558,6 +558,16 @@ jobs:
           bash ./scripts/generate-sbom.sh --target cli --output sboms/sendbeam-cli.spdx.json --version "${{ steps.meta.outputs.version }}" --commit "${{ steps.meta.outputs.commit }}"
           bash ./scripts/generate-sbom.sh --target desktop --output sboms/sendbeam-desktop.spdx.json --version "${{ steps.meta.outputs.version }}" --commit "${{ steps.meta.outputs.commit }}"
 
+      - name: Check Minisign Secret Key availability
+        run: |
+          if [ -z "${{ secrets.MINISIGN_SECRET_KEY }}" ]; then
+            echo "[-] ERROR: MINISIGN_SECRET_KEY secret is required for signing releases!" >&2
+            exit 1
+          fi
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.1
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -572,6 +582,25 @@ jobs:
           cd release-bundle
           sha256sum * > SHA256SUMS.txt
           cat SHA256SUMS.txt
+
+      - name: Sign release manifest (Minisign + Sigstore Cosign)
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+        working-directory: release-bundle
+        run: |
+          echo "Signing SHA256SUMS.txt with Minisign Ed25519..."
+          go run ../scripts/minisign.go sign \
+            -m SHA256SUMS.txt \
+            -p ../minisign.pub \
+            -x SHA256SUMS.txt.minisig \
+            -t "timestamp:$(date +%s) file:SHA256SUMS.txt version:${{ steps.meta.outputs.version }}"
+          test -f SHA256SUMS.txt.minisig
+
+          echo "Signing SHA256SUMS.txt with Sigstore Cosign keyless OIDC..."
+          cosign sign-blob --yes \
+            --bundle SHA256SUMS.txt.sigstore.json \
+            SHA256SUMS.txt
+          test -f SHA256SUMS.txt.sigstore.json
 
       - name: Validate checksums against bundle
         working-directory: release-bundle
@@ -601,12 +630,29 @@ jobs:
           cat <<EOF > release-notes.md
           ## SendBeam ${TAG_VAL}
 
-          ### Release Assets & Checksums
+          ### Cryptographic Verification
 
-          All binaries and installer packages are cryptographically checksummed in \`SHA256SUMS.txt\` and accompanied by in-toto build provenance attestations and SPDX 2.3 Software Bill of Materials (SBOMs).
+          All release binaries and installer packages are cryptographically signed and verifiable end-to-end:
 
+          1. **Minisign (Ed25519):**
           \`\`\`bash
-          # Verify downloaded asset against SHA256SUMS.txt
+          # Verify SHA256SUMS.txt using the official SendBeam public key:
+          minisign -Vm SHA256SUMS.txt -P RWTcyDWHWbxnuo3LVM5mWoZrx0HDwSQzAZvXK1lPRcdtJxshUDxJh+rE
+          \`\`\`
+
+          2. **Sigstore Cosign (Keyless OIDC):**
+          \`\`\`bash
+          # Verify the GitHub Actions OIDC identity attestation:
+          cosign verify-blob \
+            --bundle SHA256SUMS.txt.sigstore.json \
+            --certificate-identity-regexp 'github.com/Akshay7273/sendbeam' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            SHA256SUMS.txt
+          \`\`\`
+
+          3. **SHA-256 Checksums:**
+          \`\`\`bash
+          # Verify downloaded asset checksum against the signed manifest:
           sha256sum -c SHA256SUMS.txt --ignore-missing
           \`\`\`
 
@@ -670,16 +716,18 @@ jobs:
             bash ./scripts/version-metadata.sh --github-output
           fi
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.1
+
       - name: Download release bundle
         uses: actions/download-artifact@v4
         with:
           name: sendbeam-release-bundle-${{ steps.meta.outputs.version }}
           path: bundle
 
-      - name: Verify checksums in bundle
-        working-directory: bundle
+      - name: Run Release Verification Gate (Minisign + Cosign + Checksums)
         run: |
-          sha256sum -c SHA256SUMS.txt
+          bash ./scripts/verify-release.sh --dir bundle --pubkey minisign.pub --strict
 
       - name: Unpack and smoke test Linux CLI binary
         working-directory: bundle

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -50,7 +50,8 @@ Build and packaging metadata is resolved deterministically through [scripts/vers
 | Version Field                | Untagged / Development / PR Builds | Tagged Release Builds (`vX.Y.Z`) | Prerelease Builds (`vX.Y.Z-rcN`) | Description                                                          |
 | :--------------------------- | :--------------------------------- | :------------------------------- | :------------------------------- | :------------------------------------------------------------------- |
 | **Internal Product Version** | `dev`                              | `X.Y.Z`                          | `X.Y.Z-rcN`                      | Go `-ldflags` embedded product build version (`ProductVersion`)      |
-| **Display Version**          | `dev`                              | `X.Y.Z`                          | `X.Y.Z-rcN`                      | Human-facing CLI version UX and installer display string             |
+| **Display Version**          | `unsigned-dev`                     | `X.Y.Z`                          | `X.Y.Z-rcN`                      | Human-facing CLI version UX and installer display string             |
+| **Signing Status**           | `unsigned-dev`                     | `signed`                         | `signed`                         | Cryptographic release signing status indicator                       |
 | **macOS Short Version**      | `0.0.0`                            | `X.Y.Z`                          | `X.Y.Z`                          | `CFBundleShortVersionString` (strictly numeric `[0-9]+(\.[0-9]+)*`)  |
 | **macOS Bundle Version**     | `0.0.0`                            | `X.Y.Z`                          | `X.Y.Z`                          | `CFBundleVersion` (strictly numeric dotted version)                  |
 | **Windows Fixed Version**    | `0.0.0.0`                          | `X.Y.Z.0`                        | `X.Y.Z.0`                        | 4-part numeric PE `FixedFileInfo` (`FileVersion` / `ProductVersion`) |
@@ -64,7 +65,7 @@ Wire protocol versioning remains immutable (`sendbeam/1` and `sendbeam/2`) and i
 ```bash
 # Development build:
 sendbeam version
-# Output: sendbeam dev (1e937f5e07ea)
+# Output: sendbeam dev (1e937f5e07ea) [unsigned-dev]
 
 # Tagged release build:
 sendbeam version
@@ -88,19 +89,23 @@ Packaging is automated across native GitHub-hosted runners in two dedicated work
    - Triggered on push of version tags (`v*`) or manual `workflow_dispatch`.
    - Compiles all 6 CLI platforms and all 4 desktop formats.
    - Generates canonical `SHA256SUMS.txt`, in-toto build provenance attestations, and SPDX 2.3 SBOMs.
+   - Signs `SHA256SUMS.txt` with Minisign Ed25519 (`SHA256SUMS.txt.minisig`) and Sigstore Cosign keyless OIDC (`SHA256SUMS.txt.sigstore.json`).
    - Creates a **Draft GitHub Release** with all assets and checksums attached. Prerelease tags (`v*-rc*`) are marked as pre-releases.
-   - Runs a **Release Verification Gate** job that downloads the release bundle, re-checks SHA-256 sums, smoke tests the native binary, and validates draft status.
+   - Runs a **Release Verification Gate** (`scripts/verify-release.sh`) that downloads the release bundle, re-checks SHA-256 sums, smoke tests the native binary, and validates draft status.
    - Maintainer reviews the draft release notes and publishes the release.
 
 ### Checksum Manifest & Supply Chain Integrity
 
-All produced distribution archives, installers, and SPDX 2.3 SBOM manifests are hashed with SHA-256 and collected into a canonical manifest:
+All produced distribution archives, installers, and SPDX 2.3 SBOM manifests are hashed with SHA-256 and signed:
 
 ```text
 SHA256SUMS.txt
+SHA256SUMS.txt.minisig
+SHA256SUMS.txt.sigstore.json
 ```
 
 - Cryptographic build provenance: attested in CI via `actions/attest-build-provenance@v2`.
 - Software Bill of Materials: generated via `scripts/generate-sbom.sh` (`sendbeam-cli.spdx.json`, `sendbeam-desktop.spdx.json`).
+- Automated release verification: `scripts/verify-release.sh`.
 - Detailed supply chain security model: [docs/supply-chain.md](supply-chain.md).
 - Standalone self-updater architecture & rollback: [docs/updater.md](updater.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,7 +60,23 @@ SendBeam is distributed as a Universal Mach-O binary bundle (`arm64` Apple Silic
 1. Download `SendBeam-macos-universal.dmg`.
 2. Double-click to mount the disk image.
 3. Drag **SendBeam.app** into your **Applications** folder.
-4. Launch SendBeam from Applications or Spotlight.
+4. Launch SendBeam from Applications.
+
+> [!NOTE]
+> **macOS Gatekeeper First Launch ($0 Budget / Unsigned Notice):**
+> SendBeam is free open-source software built on a $0 budget without paid Apple Developer ID certificates ($99/yr). On first launch, macOS Gatekeeper may display a prompt stating the developer cannot be verified.
+>
+> To launch safely after verifying checksums:
+>
+> 1. Right-click (or Control-click) **SendBeam.app** in Applications.
+> 2. Select **Open** from the context menu.
+> 3. Click **Open** in the confirmation dialog.
+>
+> Alternatively, remove the quarantine attribute via terminal:
+>
+> ```bash
+> xattr -d com.apple.quarantine /Applications/SendBeam.app
+> ```
 
 ---
 
@@ -95,6 +111,15 @@ SendBeam provides an NSIS executable installer, a standalone portable ZIP, and a
 1. Download and extract `SendBeam-windows-amd64-portable.zip`.
 2. Run `sendbeam-desktop.exe` directly from the extracted folder.
 
+> [!NOTE]
+> **Windows SmartScreen Prompt ($0 Budget / Unsigned Notice):**
+> SendBeam does not use commercial Microsoft Authenticode certificates ($300+/yr). Windows Defender SmartScreen may display an unknown publisher dialog ("Windows protected your PC").
+>
+> To proceed after verifying checksums:
+>
+> 1. Click **More info**.
+> 2. Click **Run anyway**.
+
 ---
 
 ### B. CLI Terminal Client
@@ -109,16 +134,36 @@ sendbeam version
 
 ---
 
-## 4. Checksum & Provenance Verification
+## 4. Cryptographic Checksum & Signature Verification
 
-All release packages and archives are hashed with SHA-256 and collected in the canonical manifest:
+All release packages and archives are cryptographically signed and hashed in `SHA256SUMS.txt`:
+
+### Option 1: Minisign (Ed25519) Verification
 
 ```bash
-# Download SHA256SUMS.txt along with your release package, then verify:
-sha256sum -c SHA256SUMS.txt
+# Verify SHA256SUMS.txt against the official SendBeam public key:
+minisign -Vm SHA256SUMS.txt -P RWTcyDWHWbxnuo3LVM5mWoZrx0HDwSQzAZvXK1lPRcdtJxshUDxJh+rE
 ```
 
-For cryptographic in-toto build provenance and SBOM verification, refer to [docs/supply-chain.md](supply-chain.md).
+### Option 2: Sigstore Cosign (Keyless OIDC) Verification
+
+```bash
+# Verify the GitHub Actions OIDC build identity attestation:
+cosign verify-blob \
+  --bundle SHA256SUMS.txt.sigstore.json \
+  --certificate-identity-regexp 'github.com/Akshay7273/sendbeam' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS.txt
+```
+
+### Option 3: SHA-256 Checksum Validation
+
+```bash
+# Verify your downloaded release file matches the signed manifest:
+sha256sum -c SHA256SUMS.txt --ignore-missing
+```
+
+For full supply chain details and SBOM verification, refer to [docs/supply-chain.md](supply-chain.md).
 
 ---
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -6,17 +6,50 @@ This document describes SendBeam's software supply chain security architecture, 
 
 ## 1. Threat Model & Security Invariants
 
-| Attack Vector                                            | Countermeasure                                                                                         | Verification Mechanism                                                                        |
-| :------------------------------------------------------- | :----------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
-| **Tampered Build Artifacts**                             | Artifacts built exclusively on ephemeral GitHub-hosted runners; strict linear commit history required. | GitHub Build-Provenance Attestations (`actions/attest-build-provenance@v2`).                  |
-| **Dependency Confusion / Malicious Transitive Packages** | Frozen dependencies in `go.sum` and `pnpm-lock.yaml`; automated SPDX 2.3 SBOM generation.              | SPDX SBOM manifests (`sendbeam-cli.spdx.json`, `sendbeam-desktop.spdx.json`) attested in CI.  |
-| **Forged Checksums**                                     | SHA-256 checksum manifest (`SHA256SUMS.txt`) generated strictly inside the CI manifest workflow.       | Pre-distribution and post-distribution checksum verification gates.                           |
-| **Attribution & Committer Spoofing**                     | Strict CI gate rejecting automated agent attribution trailers and enforcing Conventional Commits.      | `metadata & attribution hygiene` status check in `ci.yml`.                                    |
-| **Over-Privileged CI Workflows**                         | Default `permissions: contents: read` with least-privilege explicit scopes per job.                    | Explicit job-level permissions (`id-token: write`, `attestations: write`, `packages: write`). |
+| Attack Vector                                            | Countermeasure                                                                                         | Verification Mechanism                                                                                |
+| :------------------------------------------------------- | :----------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| **Tampered Build Artifacts**                             | Artifacts built exclusively on ephemeral GitHub-hosted runners; strict linear commit history required. | GitHub Build-Provenance Attestations (`actions/attest-build-provenance@v2`).                          |
+| **Release Manifest Tampering**                           | Checksum manifest signed with Minisign Ed25519 and Sigstore Cosign keyless OIDC.                       | Dual cryptographic signature verification (`SHA256SUMS.txt.minisig`, `SHA256SUMS.txt.sigstore.json`). |
+| **Dependency Confusion / Malicious Transitive Packages** | Frozen dependencies in `go.sum` and `pnpm-lock.yaml`; automated SPDX 2.3 SBOM generation.              | SPDX SBOM manifests (`sendbeam-cli.spdx.json`, `sendbeam-desktop.spdx.json`) attested in CI.          |
+| **Forged Checksums**                                     | SHA-256 checksum manifest (`SHA256SUMS.txt`) generated strictly inside the CI manifest workflow.       | Pre-distribution and post-distribution checksum verification gates.                                   |
+| **Attribution & Committer Spoofing**                     | Strict CI gate rejecting automated agent attribution trailers and enforcing Conventional Commits.      | `metadata & attribution hygiene` status check in `ci.yml`.                                            |
+| **Over-Privileged CI Workflows**                         | Default `permissions: contents: read` with least-privilege explicit scopes per job.                    | Explicit job-level permissions (`id-token: write`, `attestations: write`, `packages: write`).         |
 
 ---
 
-## 2. Cryptographic Build Provenance
+## 2. Zero-Cost Cryptographic Signing Architecture
+
+SendBeam implements a zero-cost, dual-signature model ensuring every release asset is cryptographically authenticated and non-repudiable without commercial code-signing certificate fees:
+
+```mermaid
+flowchart TD
+    A[Ephemeral GitHub Actions Runner] -->|Builds Matrix| B[6x CLI + 4x Desktop Artifacts]
+    B --> C[SHA256SUMS.txt Checksum Manifest]
+    C -->|Minisign Ed25519| D[SHA256SUMS.txt.minisig]
+    C -->|Sigstore Cosign OIDC| E[SHA256SUMS.txt.sigstore.json]
+    B & C & D & E --> F[Draft GitHub Release]
+    F -->|verify-release.sh| G[Automated Release Verification Gate]
+```
+
+### A. Minisign (Ed25519)
+
+- **Release Public Key:**
+  ```text
+  untrusted comment: minisign public key BA67BC598735C8DC
+  RWTcyDWHWbxnuo3LVM5mWoZrx0HDwSQzAZvXK1lPRcdtJxshUDxJh+rE
+  ```
+- **Signing Invariant:** The private key is held exclusively as a GitHub Actions secret (`MINISIGN_SECRET_KEY`). The signature over `SHA256SUMS.txt` cryptographically commits to every release asset.
+- **Fail-Closed CI Policy:** The release packaging workflow (`.github/workflows/release.yml`) fails closed if `MINISIGN_SECRET_KEY` is not present when drafting a release. Non-release CI builds are explicitly labeled `unsigned-dev` in version metadata.
+
+### B. Sigstore Cosign (Keyless OIDC)
+
+- **Identity Attestation:** Uses GitHub Actions OIDC identity token (`actions/attest-build-provenance` / `cosign sign-blob`) binding the artifact manifest directly to the authoritative repository (`github.com/Akshay7273/sendbeam`) and workflow.
+- **Signature Bundle:** Attached to release as `SHA256SUMS.txt.sigstore.json`.
+- **Zero Key Management:** Cryptographic certificates are short-lived and recorded on the public Rekor transparency log.
+
+---
+
+## 3. Cryptographic Build Provenance
 
 SendBeam produces verifiable in-toto build provenance attestations for all compiled binaries, packages, and container images:
 
@@ -31,7 +64,7 @@ SendBeam produces verifiable in-toto build provenance attestations for all compi
 
 ---
 
-## 3. Software Bill of Materials (SBOM)
+## 4. Software Bill of Materials (SBOM)
 
 Standard SPDX 2.3 JSON SBOM documents are generated automatically during CI packaging via `scripts/generate-sbom.sh`:
 
@@ -48,25 +81,38 @@ Each SBOM document includes:
 - Component package information: package name, version, license declaration, repository download location, and supplier identity.
 - Relationship graph: `SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-...` and `SPDXRef-Package-... DEPENDS_ON <dependency>`.
 
-### Verification
+---
+
+## 5. Verification Commands
+
+Users and package maintainers can verify release assets using the following commands:
 
 ```bash
-# Verify SBOM generation locally:
-./scripts/generate-sbom_test.sh
+# 1. Verify Minisign signature over the checksum manifest:
+minisign -Vm SHA256SUMS.txt -P RWTcyDWHWbxnuo3LVM5mWoZrx0HDwSQzAZvXK1lPRcdtJxshUDxJh+rE
+
+# 2. Verify Sigstore Cosign OIDC bundle:
+cosign verify-blob \
+  --bundle SHA256SUMS.txt.sigstore.json \
+  --certificate-identity-regexp 'github.com/Akshay7273/sendbeam' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS.txt
+
+# 3. Verify asset checksums against the signed manifest:
+sha256sum -c SHA256SUMS.txt --ignore-missing
+
+# Or run the automated all-in-one verification script:
+./scripts/verify-release.sh --dir <release-dir> --pubkey minisign.pub
 ```
 
 ---
 
-## 4. Checksum Manifest Invariant
+## 6. Key Rotation & Security Policy
 
-All binary archives, installers, and SBOM documents are hashed with SHA-256 and collected into:
-
-```text
-SHA256SUMS.txt
-```
-
-Verification command:
-
-```bash
-sha256sum -c SHA256SUMS.txt
-```
+1. **Minisign Key Rotation:**
+   - In the event of secret key compromise or scheduled key rotation, a new Ed25519 keypair is generated via `go run ./scripts/minisign.go keygen`.
+   - The updated public key is committed to `minisign.pub` and documented in release notes.
+   - Previous releases remain verifiable against their historical public keys.
+2. **Platform Code Signing Deferral (Authenticode & Apple Notarization):**
+   - Microsoft Authenticode and Apple Developer ID signing/notarization are intentionally deferred until dedicated project funding is established ($0 budget milestone).
+   - Desktop application binaries on macOS and Windows rely on transparent cryptographic checksums, Minisign signatures, and Sigstore OIDC attestations. Users follow standard OS security prompts (macOS Gatekeeper right-click-Open; Windows SmartScreen "More info → Run anyway") after verifying signatures.

--- a/minisign.pub
+++ b/minisign.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key BA67BC598735C8DC
+RWTcyDWHWbxnuo3LVM5mWoZrx0HDwSQzAZvXK1lPRcdtJxshUDxJh+rE

--- a/scripts/minisign.go
+++ b/scripts/minisign.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	sigAlgEd        = "Ed"
+	pubKeyLen       = 42
+	sigPart1Len     = 74
+	sigPart2Len     = 64
+	untrustedPrefix = "untrusted comment: "
+	trustedPrefix   = "trusted comment: "
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	switch cmd {
+	case "keygen":
+		if err := runKeygen(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "minisign keygen error: %v\n", err)
+			os.Exit(1)
+		}
+	case "sign":
+		if err := runSign(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "minisign sign error: %v\n", err)
+			os.Exit(1)
+		}
+	case "verify":
+		if err := runVerify(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "minisign verify error: %v\n", err)
+			os.Exit(1)
+		}
+	case "-h", "--help", "help":
+		printUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Println(`SendBeam Minisign Tool (Ed25519)
+
+Usage:
+  minisign keygen [-p pubkey.pub] [-s secret.key]
+  minisign sign -m <file> [-s <secret-key-or-seed>] [-x <sig-file>] [-t <trusted-comment>]
+  minisign verify -m <file> [-p <pubkey-file-or-key>] [-x <sig-file>] [-q]
+
+Environment Variables:
+  MINISIGN_SECRET_KEY   32-byte hex seed or raw secret key string for signing`)
+}
+
+// runKeygen generates a new minisign Ed25519 keypair.
+func runKeygen(args []string) error {
+	fs := flag.NewFlagSet("keygen", flag.ExitOnError)
+	pubFile := fs.String("p", "minisign.pub", "public key output file")
+	secFile := fs.String("s", "minisign.key", "secret key output file")
+	_ = fs.Parse(args)
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("failed to generate key: %w", err)
+	}
+
+	var keyID [8]byte
+	if _, err := rand.Read(keyID[:]); err != nil {
+		return fmt.Errorf("failed to generate key id: %w", err)
+	}
+
+	keyIDHex := fmt.Sprintf("%016X", binary.LittleEndian.Uint64(keyID[:]))
+	pubB64 := formatPublicKey(keyID[:], pub)
+	pubContent := fmt.Sprintf("%sminisign public key %s\n%s\n", untrustedPrefix, keyIDHex, pubB64)
+
+	if *pubFile != "" {
+		if err := os.WriteFile(*pubFile, []byte(pubContent), 0644); err != nil {
+			return fmt.Errorf("failed to write pubkey file: %w", err)
+		}
+		fmt.Printf("Public key written to %s\n", *pubFile)
+	}
+
+	seedHex := hex.EncodeToString(priv.Seed())
+	secContent := fmt.Sprintf("%sminisign secret key seed (%s)\n%s\n", untrustedPrefix, keyIDHex, seedHex)
+	if *secFile != "" {
+		if err := os.WriteFile(*secFile, []byte(secContent), 0600); err != nil {
+			return fmt.Errorf("failed to write secret key file: %w", err)
+		}
+		fmt.Printf("Secret key seed written to %s (keep secure)\n", *secFile)
+	}
+
+	fmt.Printf("\nKey ID: %s\n", keyIDHex)
+	fmt.Printf("Public Key: %s\n", pubB64)
+	fmt.Printf("Secret Key Seed (hex): %s\n", seedHex)
+	return nil
+}
+
+// runSign signs a message file with a minisign secret key.
+func runSign(args []string) error {
+	fs := flag.NewFlagSet("sign", flag.ExitOnError)
+	msgFile := fs.String("m", "", "file to sign")
+	secInput := fs.String("s", "", "secret key file or 32-byte hex seed")
+	pubInput := fs.String("p", "", "matching public key file (default: minisign.pub if present)")
+	sigFile := fs.String("x", "", "output signature file (default: <file>.minisig)")
+	trustedComment := fs.String("t", "", "trusted comment")
+	_ = fs.Parse(args)
+
+	if *msgFile == "" {
+		return errors.New("missing required -m <file> argument")
+	}
+
+	secretKeyStr := *secInput
+	if secretKeyStr == "" {
+		secretKeyStr = os.Getenv("MINISIGN_SECRET_KEY")
+	}
+	if secretKeyStr == "" {
+		return errors.New("missing secret key: specify via -s or MINISIGN_SECRET_KEY environment variable")
+	}
+
+	privKey, err := parsePrivateKey(secretKeyStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse secret key: %w", err)
+	}
+
+	content, err := os.ReadFile(*msgFile)
+	if err != nil {
+		return fmt.Errorf("failed to read message file: %w", err)
+	}
+
+	pubKey := privKey.Public().(ed25519.PublicKey)
+	var keyID []byte
+
+	pubKeyFile := *pubInput
+	if pubKeyFile == "" {
+		if _, err := os.Stat("minisign.pub"); err == nil {
+			pubKeyFile = "minisign.pub"
+		}
+	}
+	if pubKeyFile != "" {
+		_, pKeyID, err := parsePublicKey(pubKeyFile)
+		if err == nil && len(pKeyID) == 8 {
+			keyID = pKeyID
+		}
+	}
+	if len(keyID) != 8 {
+		derived := deriveKeyID(pubKey)
+		keyID = derived[:]
+	}
+
+	fileSig := ed25519.Sign(privKey, content)
+
+	// Format line 2: 'E', 'd' + keyID (8 bytes) + fileSig (64 bytes)
+	var sig1Raw [sigPart1Len]byte
+	sig1Raw[0] = 'E'
+	sig1Raw[1] = 'd'
+	copy(sig1Raw[2:10], keyID)
+	copy(sig1Raw[10:], fileSig)
+	sig1B64 := base64.StdEncoding.EncodeToString(sig1Raw[:])
+
+	// Format line 3: trusted comment
+	tComment := *trustedComment
+	if tComment == "" {
+		tComment = fmt.Sprintf("timestamp:%d\tfile:%s", time.Now().Unix(), filepath.Base(*msgFile))
+	}
+
+	// Format line 4: global signature over (fileSig + trustedComment)
+	globalData := append(append([]byte(nil), fileSig...), []byte(tComment)...)
+	globalSig := ed25519.Sign(privKey, globalData)
+	globalSigB64 := base64.StdEncoding.EncodeToString(globalSig)
+
+	sigContent := fmt.Sprintf("%ssignature from minisign secret key\n%s\n%s%s\n%s\n",
+		untrustedPrefix, sig1B64, trustedPrefix, tComment, globalSigB64)
+
+	outFile := *sigFile
+	if outFile == "" {
+		outFile = *msgFile + ".minisig"
+	}
+
+	if err := os.WriteFile(outFile, []byte(sigContent), 0644); err != nil {
+		return fmt.Errorf("failed to write signature file: %w", err)
+	}
+
+	fmt.Printf("Signature written to %s\n", outFile)
+	return nil
+}
+
+// runVerify verifies a message file against a minisign signature.
+func runVerify(args []string) error {
+	fs := flag.NewFlagSet("verify", flag.ExitOnError)
+	msgFile := fs.String("m", "", "file to verify")
+	pubInput := fs.String("p", "", "public key file or base64 string (default: minisign.pub)")
+	sigFile := fs.String("x", "", "signature file (default: <file>.minisig)")
+	quiet := fs.Bool("q", false, "quiet mode")
+	_ = fs.Parse(args)
+
+	if *msgFile == "" {
+		return errors.New("missing required -m <file> argument")
+	}
+
+	pubKeyStr := *pubInput
+	if pubKeyStr == "" {
+		if _, err := os.Stat("minisign.pub"); err == nil {
+			pubKeyStr = "minisign.pub"
+		} else {
+			return errors.New("missing public key: specify via -p or provide minisign.pub")
+		}
+	}
+
+	pubKey, expectedKeyID, err := parsePublicKey(pubKeyStr)
+	if err != nil {
+		return fmt.Errorf("invalid public key: %w", err)
+	}
+
+	inFile := *sigFile
+	if inFile == "" {
+		inFile = *msgFile + ".minisig"
+	}
+
+	sigBytes, err := os.ReadFile(inFile)
+	if err != nil {
+		return fmt.Errorf("failed to read signature file %s: %w", inFile, err)
+	}
+
+	content, err := os.ReadFile(*msgFile)
+	if err != nil {
+		return fmt.Errorf("failed to read message file %s: %w", *msgFile, err)
+	}
+
+	sigLines := strings.Split(strings.TrimSpace(string(sigBytes)), "\n")
+	if len(sigLines) < 4 {
+		return fmt.Errorf("malformed signature file: expected 4 lines, got %d", len(sigLines))
+	}
+
+	sig1Raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(sigLines[1]))
+	if err != nil || len(sig1Raw) != sigPart1Len {
+		return fmt.Errorf("invalid signature part 1 format (len=%d)", len(sig1Raw))
+	}
+
+	if sig1Raw[0] != 'E' || sig1Raw[1] != 'd' {
+		return errors.New("unsupported signature algorithm (must be Ed)")
+	}
+
+	sigKeyID := sig1Raw[2:10]
+	if len(expectedKeyID) == 8 && !bytes.Equal(sigKeyID, expectedKeyID) {
+		return fmt.Errorf("key ID mismatch: signature has %x, public key has %x", sigKeyID, expectedKeyID)
+	}
+
+	fileSig := sig1Raw[10:74]
+	if !ed25519.Verify(pubKey, content, fileSig) {
+		return errors.New("file content signature verification failed: signature does not match content")
+	}
+
+	if !strings.HasPrefix(sigLines[2], trustedPrefix) {
+		return errors.New("malformed trusted comment line")
+	}
+	trustedComment := strings.TrimPrefix(sigLines[2], trustedPrefix)
+
+	globalSigRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(sigLines[3]))
+	if err != nil || len(globalSigRaw) != sigPart2Len {
+		return fmt.Errorf("invalid global signature format (len=%d)", len(globalSigRaw))
+	}
+
+	globalData := append(append([]byte(nil), fileSig...), []byte(trustedComment)...)
+	if !ed25519.Verify(pubKey, globalData, globalSigRaw) {
+		return errors.New("trusted comment signature verification failed: signature tampered")
+	}
+
+	if !*quiet {
+		fmt.Printf("Signature and comment verified using public key ID %016X\n", binary.LittleEndian.Uint64(sigKeyID))
+		fmt.Printf("Trusted comment: %s\n", trustedComment)
+		fmt.Println("OK")
+	}
+
+	return nil
+}
+
+func formatPublicKey(keyID []byte, pub ed25519.PublicKey) string {
+	var pubRaw [pubKeyLen]byte
+	pubRaw[0] = 'E'
+	pubRaw[1] = 'd'
+	copy(pubRaw[2:10], keyID)
+	copy(pubRaw[10:], pub)
+	return base64.StdEncoding.EncodeToString(pubRaw[:])
+}
+
+func parsePublicKey(input string) (ed25519.PublicKey, []byte, error) {
+	s := strings.TrimSpace(input)
+	if data, err := os.ReadFile(s); err == nil {
+		s = strings.TrimSpace(string(data))
+	}
+
+	lines := strings.Split(s, "\n")
+	var b64 string
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if !strings.HasPrefix(trimmed, untrustedPrefix) && trimmed != "" {
+			b64 = trimmed
+			break
+		}
+	}
+	if b64 == "" {
+		return nil, nil, errors.New("no public key line found")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("base64 decode failed: %w", err)
+	}
+
+	if len(raw) == 32 {
+		return ed25519.PublicKey(raw), nil, nil
+	}
+	if len(raw) == pubKeyLen {
+		if raw[0] != 'E' || raw[1] != 'd' {
+			return nil, nil, errors.New("unsupported signature algorithm in pubkey")
+		}
+		keyID := raw[2:10]
+		pub := ed25519.PublicKey(raw[10:])
+		return pub, keyID, nil
+	}
+
+	return nil, nil, fmt.Errorf("unexpected public key length: %d", len(raw))
+}
+
+func parsePrivateKey(input string) (ed25519.PrivateKey, error) {
+	s := strings.TrimSpace(input)
+	if data, err := os.ReadFile(s); err == nil {
+		s = strings.TrimSpace(string(data))
+	}
+
+	lines := strings.Split(s, "\n")
+	var keyText string
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if !strings.HasPrefix(trimmed, untrustedPrefix) && trimmed != "" {
+			keyText = trimmed
+			break
+		}
+	}
+	if keyText == "" {
+		return nil, errors.New("no secret key content found")
+	}
+
+	if len(keyText) == 64 {
+		seed, err := hex.DecodeString(keyText)
+		if err == nil && len(seed) == 32 {
+			return ed25519.NewKeyFromSeed(seed), nil
+		}
+	}
+
+	if len(keyText) == 128 {
+		full, err := hex.DecodeString(keyText)
+		if err == nil && len(full) == 64 {
+			return ed25519.PrivateKey(full), nil
+		}
+	}
+
+	if raw, err := base64.StdEncoding.DecodeString(keyText); err == nil {
+		if len(raw) == 32 {
+			return ed25519.NewKeyFromSeed(raw), nil
+		}
+		if len(raw) == 64 {
+			return ed25519.PrivateKey(raw), nil
+		}
+	}
+
+	return nil, errors.New("unrecognized private key format (expected 32-byte hex seed or base64)")
+}
+
+func deriveKeyID(pub ed25519.PublicKey) [8]byte {
+	var id [8]byte
+	copy(id[:], pub[:8])
+	return id
+}

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# SendBeam Release Artifact Verification Script
+#
+# Cryptographically verifies SendBeam release assets against:
+#   1. SHA-256 checksum manifest (SHA256SUMS.txt)
+#   2. Minisign Ed25519 signature (SHA256SUMS.txt.minisig)
+#   3. Sigstore cosign keyless OIDC provenance bundle (SHA256SUMS.txt.sigstore.json)
+#
+# Usage:
+#   ./scripts/verify-release.sh [--dir <release-dir>] [--pubkey <minisign.pub>] [--strict] [--skip-cosign]
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TARGET_DIR="."
+PUBKEY_FILE="${ROOT_DIR}/minisign.pub"
+STRICT_FILES="false"
+SKIP_COSIGN="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir|-d)
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    --pubkey|-p)
+      PUBKEY_FILE="$2"
+      shift 2
+      ;;
+    --strict)
+      STRICT_FILES="true"
+      shift
+      ;;
+    --skip-cosign)
+      SKIP_COSIGN="true"
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: $0 [--dir <release-dir>] [--pubkey <minisign.pub>] [--strict] [--skip-cosign]"
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown option $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+cd "${TARGET_DIR}"
+
+if [[ ! -f "SHA256SUMS.txt" ]]; then
+  echo "[-] ERROR: SHA256SUMS.txt manifest not found in ${TARGET_DIR}" >&2
+  exit 1
+fi
+
+echo "=== SendBeam Release Verification Gate ==="
+echo "Working directory: $(pwd)"
+
+# ------------------------------------------------------------------------------
+# 1. Minisign Signature Verification
+# ------------------------------------------------------------------------------
+echo ""
+echo "--- [1/3] Minisign Ed25519 Signature Verification ---"
+
+if [[ ! -f "SHA256SUMS.txt.minisig" ]]; then
+  echo "[-] WARNING: SHA256SUMS.txt.minisig signature file not found"
+else
+  if [[ ! -f "${PUBKEY_FILE}" ]]; then
+    echo "[-] ERROR: Minisign public key file not found at ${PUBKEY_FILE}" >&2
+    exit 1
+  fi
+
+  if command -v minisign >/dev/null 2>&1; then
+    echo "[+] Verifying with native minisign CLI..."
+    minisign -Vm SHA256SUMS.txt -p "${PUBKEY_FILE}"
+  elif command -v go >/dev/null 2>&1 && [[ -f "${ROOT_DIR}/scripts/minisign.go" ]]; then
+    echo "[+] Verifying with Go minisign tool..."
+    go run "${ROOT_DIR}/scripts/minisign.go" verify -m SHA256SUMS.txt -p "${PUBKEY_FILE}" -x SHA256SUMS.txt.minisig
+  else
+    echo "[-] ERROR: Neither 'minisign' CLI nor Go toolchain available to verify signature" >&2
+    exit 1
+  fi
+  echo "[✓] Minisign signature over SHA256SUMS.txt verified successfully!"
+fi
+
+# ------------------------------------------------------------------------------
+# 2. Sigstore Cosign Keyless OIDC Verification
+# ------------------------------------------------------------------------------
+echo ""
+echo "--- [2/3] Sigstore Cosign OIDC Attestation Verification ---"
+
+if [[ "${SKIP_COSIGN}" == "true" ]]; then
+  echo "[i] Skipped cosign verification (--skip-cosign flag enabled)"
+elif [[ ! -f "SHA256SUMS.txt.sigstore.json" && ! -f "SHA256SUMS.txt.bundle" ]]; then
+  echo "[i] No Sigstore bundle (SHA256SUMS.txt.sigstore.json) present — skipping cosign verification"
+else
+  BUNDLE_FILE="SHA256SUMS.txt.sigstore.json"
+  if [[ ! -f "${BUNDLE_FILE}" ]]; then
+    BUNDLE_FILE="SHA256SUMS.txt.bundle"
+  fi
+
+  if command -v cosign >/dev/null 2>&1; then
+    echo "[+] Verifying Sigstore bundle with cosign CLI..."
+    cosign verify-blob \
+      --bundle "${BUNDLE_FILE}" \
+      --certificate-identity-regexp 'github.com/Akshay7273/sendbeam' \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      SHA256SUMS.txt
+    echo "[✓] Sigstore OIDC keyless signature verified successfully!"
+  else
+    echo "[-] WARNING: cosign CLI not installed; skipping Sigstore bundle verification"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# 3. SHA-256 Digest Validation
+# ------------------------------------------------------------------------------
+echo ""
+echo "--- [3/3] SHA-256 Digest Checksums ---"
+
+if [[ "${STRICT_FILES}" == "true" ]]; then
+  echo "[+] Validating all checksums strictly..."
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c SHA256SUMS.txt
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c SHA256SUMS.txt
+  else
+    echo "[-] ERROR: Neither sha256sum nor shasum available" >&2
+    exit 1
+  fi
+else
+  echo "[+] Validating present release assets against SHA256SUMS.txt..."
+  # Cross-platform ignore-missing verification
+  FAILED=0
+  VERIFIED=0
+  while read -r expected_hash filename; do
+    # Skip comments, blank lines, and signature/bundle files
+    [[ -z "${expected_hash}" || "${expected_hash}" =~ ^# ]] && continue
+    [[ "${filename}" == *.minisig || "${filename}" == *.sigstore.json || "${filename}" == *.bundle ]] && continue
+
+    if [[ -f "${filename}" ]]; then
+      if command -v sha256sum >/dev/null 2>&1; then
+        actual_hash="$(sha256sum "${filename}" | awk '{print $1}')"
+      else
+        actual_hash="$(shasum -a 256 "${filename}" | awk '{print $1}')"
+      fi
+
+      if [[ "${actual_hash}" != "${expected_hash}" ]]; then
+        echo "[-] CHECKSUM MISMATCH for ${filename}!"
+        echo "    Expected: ${expected_hash}"
+        echo "    Actual:   ${actual_hash}"
+        FAILED=$((FAILED + 1))
+      else
+        echo "    [OK] ${filename}"
+        VERIFIED=$((VERIFIED + 1))
+      fi
+    fi
+  done < SHA256SUMS.txt
+
+  if [[ ${FAILED} -gt 0 ]]; then
+    echo "[-] ERROR: ${FAILED} asset(s) failed checksum validation!" >&2
+    exit 1
+  fi
+
+  if [[ ${VERIFIED} -eq 0 ]]; then
+    echo "[-] WARNING: No assets from SHA256SUMS.txt were present in $(pwd)"
+  else
+    echo "[✓] Verified ${VERIFIED} asset(s) matching SHA256SUMS.txt"
+  fi
+fi
+
+echo ""
+echo "========================================================"
+echo "[✓] ALL RELEASE ASSET VERIFICATIONS PASSED"
+echo "========================================================"

--- a/scripts/verify-release_test.sh
+++ b/scripts/verify-release_test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# SendBeam Release Verification Test Suite
+# Tests scripts/verify-release.sh across happy paths and adversarial tamper vectors.
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VERIFY_SCRIPT="${SCRIPT_DIR}/verify-release.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+echo "=== Running Release Verification Test Suite ==="
+
+# 1. Generate test keypair
+TEST_PUBKEY="${TMPDIR}/test-minisign.pub"
+TEST_SECKEY="${TMPDIR}/test-minisign.key"
+go run "${SCRIPT_DIR}/minisign.go" keygen -p "${TEST_PUBKEY}" -s "${TEST_SECKEY}" >/dev/null
+
+TEST_SEED="$(grep -v '^untrusted' "${TEST_SECKEY}" | head -n 1)"
+
+# 2. Setup mock release assets
+WORKDIR="${TMPDIR}/release-test"
+mkdir -p "${WORKDIR}"
+
+echo "binary linux amd64 payload content v1.6.0" > "${WORKDIR}/sendbeam-cli-linux-amd64.tar.gz"
+echo "binary darwin arm64 payload content v1.6.0" > "${WORKDIR}/sendbeam-cli-darwin-arm64.tar.gz"
+echo "desktop deb payload content v1.6.0" > "${WORKDIR}/sendbeam-desktop_1.6.0_amd64.deb"
+
+(
+  cd "${WORKDIR}"
+  sha256sum * > SHA256SUMS.txt
+  MINISIGN_SECRET_KEY="${TEST_SEED}" go run "${SCRIPT_DIR}/minisign.go" sign -m SHA256SUMS.txt -p "${TEST_PUBKEY}" -x SHA256SUMS.txt.minisig >/dev/null
+)
+
+# Test 1: Happy path verification
+echo "--- Test 1: Valid release artifacts and minisign signature ---"
+"${VERIFY_SCRIPT}" --dir "${WORKDIR}" --pubkey "${TEST_PUBKEY}" --strict --skip-cosign >/dev/null
+echo "PASS [Test 1: Happy path passed]"
+
+# Test 2: Tampered file payload
+echo "--- Test 2: Tampered file payload ---"
+CORRUPT_DIR="${TMPDIR}/corrupt-file"
+cp -r "${WORKDIR}" "${CORRUPT_DIR}"
+echo "CORRUPTED BYTE" >> "${CORRUPT_DIR}/sendbeam-cli-linux-amd64.tar.gz"
+
+if "${VERIFY_SCRIPT}" --dir "${CORRUPT_DIR}" --pubkey "${TEST_PUBKEY}" --skip-cosign >/dev/null 2>&1; then
+  echo "FAIL [Test 2: Expected failure on tampered file payload]"
+  exit 1
+fi
+echo "PASS [Test 2: Correctly rejected tampered payload]"
+
+# Test 3: Tampered SHA256SUMS.txt
+echo "--- Test 3: Tampered SHA256SUMS.txt ---"
+CORRUPT_SUMS="${TMPDIR}/corrupt-sums"
+cp -r "${WORKDIR}" "${CORRUPT_SUMS}"
+echo "0000000000000000000000000000000000000000000000000000000000000000  fake-file.tar.gz" >> "${CORRUPT_SUMS}/SHA256SUMS.txt"
+
+if "${VERIFY_SCRIPT}" --dir "${CORRUPT_SUMS}" --pubkey "${TEST_PUBKEY}" --skip-cosign >/dev/null 2>&1; then
+  echo "FAIL [Test 3: Expected failure on tampered SHA256SUMS.txt]"
+  exit 1
+fi
+echo "PASS [Test 3: Correctly rejected tampered checksums manifest]"
+
+# Test 4: Tampered signature file
+echo "--- Test 4: Tampered signature file ---"
+CORRUPT_SIG="${TMPDIR}/corrupt-sig"
+cp -r "${WORKDIR}" "${CORRUPT_SIG}"
+sed -i 's/a/b/g' "${CORRUPT_SIG}/SHA256SUMS.txt.minisig"
+
+if "${VERIFY_SCRIPT}" --dir "${CORRUPT_SIG}" --pubkey "${TEST_PUBKEY}" --skip-cosign >/dev/null 2>&1; then
+  echo "FAIL [Test 4: Expected failure on tampered signature file]"
+  exit 1
+fi
+echo "PASS [Test 4: Correctly rejected tampered signature]"
+
+# Test 5: Wrong public key
+echo "--- Test 5: Wrong public key ---"
+WRONG_PUBKEY="${TMPDIR}/wrong-minisign.pub"
+WRONG_SECKEY="${TMPDIR}/wrong-minisign.key"
+go run "${SCRIPT_DIR}/minisign.go" keygen -p "${WRONG_PUBKEY}" -s "${WRONG_SECKEY}" >/dev/null
+
+if "${VERIFY_SCRIPT}" --dir "${WORKDIR}" --pubkey "${WRONG_PUBKEY}" --skip-cosign >/dev/null 2>&1; then
+  echo "FAIL [Test 5: Expected failure on wrong public key]"
+  exit 1
+fi
+echo "PASS [Test 5: Correctly rejected mismatched public key]"
+
+# Test 6: Missing manifest
+echo "--- Test 6: Missing SHA256SUMS.txt ---"
+EMPTY_DIR="${TMPDIR}/empty"
+mkdir -p "${EMPTY_DIR}"
+
+if "${VERIFY_SCRIPT}" --dir "${EMPTY_DIR}" --pubkey "${TEST_PUBKEY}" --skip-cosign >/dev/null 2>&1; then
+  echo "FAIL [Test 6: Expected failure on missing SHA256SUMS.txt]"
+  exit 1
+fi
+echo "PASS [Test 6: Correctly rejected missing manifest]"
+
+# Test 7: Missing file in strict mode
+echo "--- Test 7: Missing file in strict mode ---"
+MISSING_FILE_DIR="${TMPDIR}/missing-file"
+cp -r "${WORKDIR}" "${MISSING_FILE_DIR}"
+rm "${MISSING_FILE_DIR}/sendbeam-desktop_1.6.0_amd64.deb"
+
+if "${VERIFY_SCRIPT}" --dir "${MISSING_FILE_DIR}" --pubkey "${TEST_PUBKEY}" --strict --skip-cosign >/dev/null 2>&1; then
+  echo "FAIL [Test 7: Expected failure on missing file with --strict]"
+  exit 1
+fi
+echo "PASS [Test 7: Strict mode correctly rejected missing file]"
+
+# Test 8: Partial download in non-strict mode (ignore-missing)
+echo "--- Test 8: Partial download in non-strict mode ---"
+"${VERIFY_SCRIPT}" --dir "${MISSING_FILE_DIR}" --pubkey "${TEST_PUBKEY}" --skip-cosign >/dev/null
+echo "PASS [Test 8: Non-strict mode verified present files]"
+
+echo ""
+echo "=== ALL 8 RELEASE VERIFICATION TESTS PASSED ==="

--- a/scripts/version-metadata.sh
+++ b/scripts/version-metadata.sh
@@ -56,6 +56,8 @@ if [ "${REF_TYPE}" = "tag" ] && [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0
     DEB_VERSION="${RAW_VER}"
   fi
 
+  SIGNING_STATUS="signed"
+
   # Parse semver components for Windows FixedFileInfo
   IFS='.' read -r MAJOR MINOR PATCH_REST <<< "${RAW_VER}"
   WIN_MAJOR="${MAJOR:-0}"
@@ -66,12 +68,13 @@ if [ "${REF_TYPE}" = "tag" ] && [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0
   WINDOWS_FIXED_VERSION="${WIN_MAJOR}.${WIN_MINOR}.${WIN_PATCH}.${WIN_BUILD}"
 else
   PRODUCT_VERSION="dev"
-  DISPLAY_VERSION="dev"
+  DISPLAY_VERSION="unsigned-dev"
   NUMERIC_VERSION="0.0.0"
   MACOS_SHORT_VERSION="0.0.0"
   MACOS_BUNDLE_VERSION="0.0.0"
   DEB_VERSION="0.0.0~dev+git.${SHORT_SHA}"
   IS_PRERELEASE="false"
+  SIGNING_STATUS="unsigned-dev"
 
   WIN_MAJOR="0"
   WIN_MINOR="0"
@@ -96,6 +99,7 @@ if [ "${OUTPUT_MODE}" = "--github-output" ] && [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "win_build=${WIN_BUILD}"
     echo "deb_version=${DEB_VERSION}"
     echo "is_prerelease=${IS_PRERELEASE}"
+    echo "signing_status=${SIGNING_STATUS}"
     echo "commit=${SHA}"
     echo "short_commit=${SHORT_SHA}"
   } >> "${GITHUB_OUTPUT}"
@@ -115,6 +119,7 @@ win_patch=${WIN_PATCH}
 win_build=${WIN_BUILD}
 deb_version=${DEB_VERSION}
 is_prerelease=${IS_PRERELEASE}
+signing_status=${SIGNING_STATUS}
 commit=${SHA}
 short_commit=${SHORT_SHA}
 EOF

--- a/scripts/version-metadata_test.sh
+++ b/scripts/version-metadata_test.sh
@@ -16,20 +16,28 @@ test_case() {
   local exp_win_fixed="$6"
   local exp_deb="$7"
   local exp_prerelease="${8:-false}"
+  local exp_display="${9:-$exp_ver}"
+  local exp_signing="${10:-signed}"
 
   local output
   output="$(GITHUB_REF_TYPE="${ref_type}" GITHUB_REF_NAME="${ref_name}" GITHUB_SHA="9908855a5e5f9d410700eedaceb970994cd785ec" "${SCRIPT}" --stdout)"
 
-  local ver macos_short macos_bundle win_fixed deb is_prerelease
+  local ver display macos_short macos_bundle win_fixed deb is_prerelease signing_status
   ver="$(echo "${output}" | grep "^version=" | cut -d= -f2)"
+  display="$(echo "${output}" | grep "^display_version=" | cut -d= -f2)"
   macos_short="$(echo "${output}" | grep "^macos_short_version=" | cut -d= -f2)"
   macos_bundle="$(echo "${output}" | grep "^macos_bundle_version=" | cut -d= -f2)"
   win_fixed="$(echo "${output}" | grep "^windows_fixed_version=" | cut -d= -f2)"
   deb="$(echo "${output}" | grep "^deb_version=" | cut -d= -f2)"
   is_prerelease="$(echo "${output}" | grep "^is_prerelease=" | cut -d= -f2)"
+  signing_status="$(echo "${output}" | grep "^signing_status=" | cut -d= -f2)"
 
   if [ "${ver}" != "${exp_ver}" ]; then
     echo "FAIL [${ref_type}:${ref_name}] expected version=${exp_ver}, got ${ver}"
+    exit 1
+  fi
+  if [ "${display}" != "${exp_display}" ]; then
+    echo "FAIL [${ref_type}:${ref_name}] expected display_version=${exp_display}, got ${display}"
     exit 1
   fi
   if [ "${macos_short}" != "${exp_macos_short}" ]; then
@@ -52,28 +60,32 @@ test_case() {
     echo "FAIL [${ref_type}:${ref_name}] expected is_prerelease=${exp_prerelease}, got ${is_prerelease}"
     exit 1
   fi
+  if [ "${signing_status}" != "${exp_signing}" ]; then
+    echo "FAIL [${ref_type}:${ref_name}] expected signing_status=${exp_signing}, got ${signing_status}"
+    exit 1
+  fi
 
-  echo "PASS [${ref_type}:${ref_name}] => ver=${ver}, macos=${macos_short}, win=${win_fixed}, deb=${deb}, prerelease=${is_prerelease}"
+  echo "PASS [${ref_type}:${ref_name}] => ver=${ver} (${display}), macos=${macos_short}, win=${win_fixed}, deb=${deb}, prerelease=${is_prerelease}, signing=${signing_status}"
 }
 
 echo "=== Running version-metadata test suite ==="
 
 # 1. Exact valid release tags (vX.Y.Z)
-test_case "tag" "v1.4.0" "1.4.0" "1.4.0" "1.4.0" "1.4.0.0" "1.4.0" "false"
-test_case "tag" "v12.3.45" "12.3.45" "12.3.45" "12.3.45" "12.3.45.0" "12.3.45" "false"
+test_case "tag" "v1.4.0" "1.4.0" "1.4.0" "1.4.0" "1.4.0.0" "1.4.0" "false" "1.4.0" "signed"
+test_case "tag" "v12.3.45" "12.3.45" "12.3.45" "12.3.45" "12.3.45.0" "12.3.45" "false" "12.3.45" "signed"
 
 # 2. Valid semver prerelease tags (vX.Y.Z-prerelease)
-test_case "tag" "v1.6.0-rc1" "1.6.0-rc1" "1.6.0" "1.6.0" "1.6.0.0" "1.6.0~rc1" "true"
-test_case "tag" "v1.6.0-beta.2" "1.6.0-beta.2" "1.6.0" "1.6.0" "1.6.0.0" "1.6.0~beta.2" "true"
+test_case "tag" "v1.6.0-rc1" "1.6.0-rc1" "1.6.0" "1.6.0" "1.6.0.0" "1.6.0~rc1" "true" "1.6.0-rc1" "signed"
+test_case "tag" "v1.6.0-beta.2" "1.6.0-beta.2" "1.6.0" "1.6.0" "1.6.0.0" "1.6.0~beta.2" "true" "1.6.0-beta.2" "signed"
 
 # 3. Invalid or non-conforming tags (must resolve to development)
-test_case "tag" "1.4.0" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false"
-test_case "tag" "v1.4.0foo" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false"
-test_case "tag" "v1.4" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false"
+test_case "tag" "1.4.0" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false" "unsigned-dev" "unsigned-dev"
+test_case "tag" "v1.4.0foo" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false" "unsigned-dev" "unsigned-dev"
+test_case "tag" "v1.4" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false" "unsigned-dev" "unsigned-dev"
 
 # 4. Branches / untagged builds (must resolve to development)
-test_case "branch" "main" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false"
-test_case "branch" "feat/something" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false"
-test_case "" "" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false"
+test_case "branch" "main" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false" "unsigned-dev" "unsigned-dev"
+test_case "branch" "feat/something" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false" "unsigned-dev" "unsigned-dev"
+test_case "" "" "dev" "0.0.0" "0.0.0" "0.0.0.0" "0.0.0~dev+git.9908855a5e5f" "false" "unsigned-dev" "unsigned-dev"
 
 echo "=== All 10 version-metadata test cases passed ==="


### PR DESCRIPTION
## Summary
Implements zero-cost binary signing and supply-chain verification for SendBeam release assets (V16-PR02) without recurring commercial certificate fees.

- **Minisign (Ed25519) Signing:**
  - Added official release signing public key in `minisign.pub` (`BA67BC598735C8DC`).
  - Added pure Go Minisign utility (`scripts/minisign.go`) for Ed25519 signing, verification, and key generation.
  - Releases sign `SHA256SUMS.txt` to produce `SHA256SUMS.txt.minisig`.
  - Fail-closed CI check in `.github/workflows/release.yml` when `MINISIGN_SECRET_KEY` is absent during release packaging.
- **Sigstore Cosign (Keyless OIDC):**
  - Integrated `sigstore/cosign-installer` into `.github/workflows/release.yml`.
  - Signs `SHA256SUMS.txt` via GitHub Actions OIDC identity token to produce `SHA256SUMS.txt.sigstore.json` bundle.
- **Verification Tooling & Tests:**
  - Added `scripts/verify-release.sh` to verify SHA-256 digests, Minisign signatures, and Sigstore Cosign bundles.
  - Added test suite `scripts/verify-release_test.sh` testing happy paths and tamper detection vectors (corrupted payload, tampered manifest, forged signature, mismatched public key, strict vs ignore-missing modes).
- **Version Metadata & Documentation:**
  - Non-release CI builds are labeled `unsigned-dev` in `scripts/version-metadata.sh`.
  - Updated `docs/supply-chain.md`, `docs/distribution.md`, and `docs/install.md` with zero-cost signing architecture, verification commands, key rotation procedure, and OS security caveats (macOS Gatekeeper and Windows SmartScreen).