### PR TITLE
feat(updater): signed update manifests, minisign verification, and release channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -624,6 +624,21 @@ jobs:
           subject-path: release-bundle/SendBeam-*
           sbom-path: release-bundle/sendbeam-desktop.spdx.json
 
+      - name: Generate Signed Update Channel Manifests
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+        run: |
+          mkdir -p updates
+          go run ./scripts/generate-update-manifest.go \
+            --version "${{ steps.meta.outputs.version }}" \
+            --tag "${{ inputs.tag || github.ref_name }}" \
+            --channel "auto" \
+            --sums release-bundle/SHA256SUMS.txt \
+            --dir release-bundle \
+            --pubkey minisign.pub \
+            --out updates
+          cp updates/* release-bundle/
+
       - name: Generate release notes
         run: |
           TAG_VAL="${{ inputs.tag || github.ref_name }}"
@@ -728,6 +743,17 @@ jobs:
       - name: Run Release Verification Gate (Minisign + Cosign + Checksums)
         run: |
           bash ./scripts/verify-release.sh --dir bundle --pubkey minisign.pub --strict
+
+      - name: Verify update channel manifests
+        run: |
+          test -f bundle/beta.json
+          test -f bundle/beta.json.minisig
+          go run ./scripts/minisign.go verify -m bundle/beta.json -p minisign.pub -x bundle/beta.json.minisig
+          if [ "${{ steps.meta.outputs.is_prerelease }}" != "true" ]; then
+            test -f bundle/stable.json
+            test -f bundle/stable.json.minisig
+            go run ./scripts/minisign.go verify -m bundle/stable.json -p minisign.pub -x bundle/stable.json.minisig
+          fi
 
       - name: Unpack and smoke test Linux CLI binary
         working-directory: bundle

--- a/apps/cli/internal/updater/manifest.go
+++ b/apps/cli/internal/updater/manifest.go
@@ -95,6 +95,43 @@ func CurrentPlatformArchiveName() string {
 	return TargetCLIArchiveName(runtime.GOOS, runtime.GOARCH)
 }
 
+// ChannelManifest represents the canonical, signed JSON update manifest published per release channel.
+type ChannelManifest struct {
+	SchemaVersion       int                     `json:"schema_version"`
+	Version             string                  `json:"version"`
+	Channel             string                  `json:"channel"`
+	MinSupportedVersion string                  `json:"min_supported_version,omitempty"`
+	PublishedAt         time.Time               `json:"published_at"`
+	ReleaseNotes        string                  `json:"release_notes,omitempty"`
+	Assets              map[string]ReleaseAsset `json:"assets"`
+}
+
+// FindTargetAsset finds the asset matching the expected platform from the channel manifest.
+func (cm *ChannelManifest) FindTargetAsset(targetOS, targetArch string) (*ReleaseAsset, error) {
+	if cm.Assets == nil {
+		return nil, fmt.Errorf("no assets defined in channel manifest for %s/%s", targetOS, targetArch)
+	}
+
+	platformKey := fmt.Sprintf("%s-%s", targetOS, targetArch)
+	if asset, ok := cm.Assets[platformKey]; ok {
+		return &asset, nil
+	}
+
+	archiveName := TargetCLIArchiveName(targetOS, targetArch)
+	if asset, ok := cm.Assets[archiveName]; ok {
+		return &asset, nil
+	}
+
+	// Also search values by Name
+	for _, asset := range cm.Assets {
+		if asset.Name == archiveName {
+			return &asset, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no distribution artifact found in manifest for %s/%s (expected %q)", targetOS, targetArch, archiveName)
+}
+
 // FindTargetAsset finds the asset matching the expected platform archive or binary.
 func (rm *ReleaseMetadata) FindTargetAsset(targetOS, targetArch string) (*ReleaseAsset, error) {
 	archiveName := TargetCLIArchiveName(targetOS, targetArch)

--- a/apps/cli/internal/updater/manifest_test.go
+++ b/apps/cli/internal/updater/manifest_test.go
@@ -54,3 +54,82 @@ func TestTargetNames(t *testing.T) {
 		t.Errorf("unexpected windows binary name %q", got)
 	}
 }
+
+func TestChannelManifest_FindTargetAsset(t *testing.T) {
+	manifest := ChannelManifest{
+		SchemaVersion: 1,
+		Version:       "1.6.0",
+		Channel:       "stable",
+		Assets: map[string]ReleaseAsset{
+			"linux-amd64": {
+				Name:        "sendbeam-cli-linux-amd64.tar.gz",
+				DownloadURL: "https://example.com/sendbeam-cli-linux-amd64.tar.gz",
+				SHA256:      "4a7f123456789012345678901234567890123456789012345678901234567890",
+				Size:        1000,
+			},
+			"windows-amd64": {
+				Name:        "sendbeam-cli-windows-amd64.zip",
+				DownloadURL: "https://example.com/sendbeam-cli-windows-amd64.zip",
+				SHA256:      "5b8e123456789012345678901234567890123456789012345678901234567890",
+				Size:        2000,
+			},
+		},
+	}
+
+	asset, err := manifest.FindTargetAsset("linux", "amd64")
+	if err != nil {
+		t.Fatalf("FindTargetAsset(linux, amd64) failed: %v", err)
+	}
+	if asset.Name != "sendbeam-cli-linux-amd64.tar.gz" {
+		t.Errorf("unexpected asset name: %s", asset.Name)
+	}
+
+	assetWin, err := manifest.FindTargetAsset("windows", "amd64")
+	if err != nil {
+		t.Fatalf("FindTargetAsset(windows, amd64) failed: %v", err)
+	}
+	if assetWin.Name != "sendbeam-cli-windows-amd64.zip" {
+		t.Errorf("unexpected asset name: %s", assetWin.Name)
+	}
+
+	_, err = manifest.FindTargetAsset("freebsd", "arm")
+	if err == nil {
+		t.Error("expected error for unsupported platform, got nil")
+	}
+}
+
+func TestVerifyMinisignSignature(t *testing.T) {
+	// Generate mock keypair seed (32 bytes hex)
+	testSeed := "d022346a8020c24891d1af56531c471c7160eaee16e05618202ef8fd953533ad"
+	testPub := DefaultMinisignPublicKey
+
+	payload := []byte(`{"version":"1.6.0","channel":"stable"}`)
+
+	sig, err := SignMinisign(payload, testSeed, testPub, "stable.json")
+	if err != nil {
+		t.Fatalf("SignMinisign failed: %v", err)
+	}
+
+	// 1. Valid signature
+	if err := VerifyMinisignSignature(payload, sig, testPub); err != nil {
+		t.Fatalf("VerifyMinisignSignature failed on valid signature: %v", err)
+	}
+
+	// 2. Tampered payload
+	tamperedPayload := []byte(`{"version":"1.6.0","channel":"tampered"}`)
+	if err := VerifyMinisignSignature(tamperedPayload, sig, testPub); err == nil {
+		t.Error("expected signature error on tampered payload, got nil")
+	}
+
+	// 3. Tampered signature
+	tamperedSig := strings.Replace(sig, "RWT", "AAA", 1)
+	if err := VerifyMinisignSignature(payload, tamperedSig, testPub); err == nil {
+		t.Error("expected signature error on tampered signature, got nil")
+	}
+
+	// 4. Wrong public key
+	wrongPub := "RWSfFakePublicKeyForTestingOnly1234567890123456789012345678"
+	if err := VerifyMinisignSignature(payload, sig, wrongPub); err == nil {
+		t.Error("expected signature error on wrong public key, got nil")
+	}
+}

--- a/apps/cli/internal/updater/updater.go
+++ b/apps/cli/internal/updater/updater.go
@@ -41,14 +41,16 @@ type CheckResult struct {
 
 // Updater coordinates checking, downloading, and applying updates.
 type Updater struct {
-	CurrentVersion Version
-	Channel        Channel
-	Repository     string
-	BaseURL        string // Default https://api.github.com
-	HTTPClient     *http.Client
-	TargetOS       string
-	TargetArch     string
-	ExecutablePath string
+	CurrentVersion    Version
+	Channel           Channel
+	Repository        string
+	BaseURL           string // Default DefaultUpdateBaseURL (https://akshay7273.github.io/sendbeam/updates)
+	MinisignPublicKey string // Pinned Ed25519 public key
+	UseGitHubAPI      bool   // Direct GitHub API releases fallback mode
+	HTTPClient        *http.Client
+	TargetOS          string
+	TargetArch        string
+	ExecutablePath    string
 
 	mu sync.Mutex
 }
@@ -67,6 +69,20 @@ func WithChannel(ch Channel) Option {
 func WithBaseURL(rawURL string) Option {
 	return func(u *Updater) {
 		u.BaseURL = rawURL
+	}
+}
+
+// WithGitHubAPI forces using the direct GitHub Releases API mode.
+func WithGitHubAPI(enabled bool) Option {
+	return func(u *Updater) {
+		u.UseGitHubAPI = enabled
+	}
+}
+
+// WithMinisignPublicKey overrides the public key for manifest signature verification.
+func WithMinisignPublicKey(pubKey string) Option {
+	return func(u *Updater) {
+		u.MinisignPublicKey = pubKey
 	}
 }
 
@@ -105,10 +121,12 @@ func New(currentVerStr string, repo string, opts ...Option) (*Updater, error) {
 	}
 
 	u := &Updater{
-		CurrentVersion: ver,
-		Channel:        ChannelStable,
-		Repository:     repo,
-		BaseURL:        "https://api.github.com",
+		CurrentVersion:    ver,
+		Channel:           ChannelStable,
+		Repository:        repo,
+		BaseURL:           DefaultUpdateBaseURL,
+		MinisignPublicKey: DefaultMinisignPublicKey,
+		UseGitHubAPI:      false,
 		HTTPClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -139,7 +157,53 @@ func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
 		return res, nil
 	}
 
-	// Fetch releases
+	// If BaseURL points to GitHub API releases endpoint or UseGitHubAPI is set, use GitHub API releases fetcher
+	if u.UseGitHubAPI || strings.Contains(u.BaseURL, "api.github.com") {
+		return u.checkGitHubReleases(ctx, res)
+	}
+
+	// Production channel manifest flow
+	manifest, err := u.fetchSignedManifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	targetVer, err := ParseVersion(manifest.Version)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid version %q in manifest: %v", ErrManifestMalformed, manifest.Version, err)
+	}
+
+	// Validate channel policy
+	if !targetVer.CompatibleWithChannel(u.Channel) {
+		return nil, fmt.Errorf("%w: version %s incompatible with channel %s", ErrChannelMismatch, targetVer, u.Channel)
+	}
+
+	res.LatestVersion = targetVer
+	res.PublishedAt = manifest.PublishedAt
+	res.ReleaseNotes = manifest.ReleaseNotes
+
+	// Downgrade protection: candidate version must be strictly greater than active version
+	if !targetVer.IsGreaterThan(u.CurrentVersion) {
+		res.UpdateAvailable = false
+		res.Message = fmt.Sprintf("SendBeam is up to date (version %s on channel %s).", u.CurrentVersion, u.Channel)
+		return res, nil
+	}
+
+	// Find matching target platform asset
+	asset, err := manifest.FindTargetAsset(u.TargetOS, u.TargetArch)
+	if err != nil {
+		return nil, fmt.Errorf("checking update asset: %w", err)
+	}
+
+	res.UpdateAvailable = true
+	res.TargetAsset = asset
+	res.Message = fmt.Sprintf("Update available: %s → %s (%s)", u.CurrentVersion, targetVer, u.Channel)
+
+	return res, nil
+}
+
+// checkGitHubReleases evaluates updates via legacy/direct GitHub Releases API.
+func (u *Updater) checkGitHubReleases(ctx context.Context, res *CheckResult) (*CheckResult, error) {
 	releases, err := u.fetchReleases(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetching release information: %w", err)
@@ -150,7 +214,6 @@ func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
 		return res, nil
 	}
 
-	// Select the highest eligible release matching channel policy
 	var candidate *ReleaseMetadata
 	for i := range releases {
 		rel := &releases[i]
@@ -177,7 +240,6 @@ func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
 		return res, nil
 	}
 
-	// Find matching target platform asset
 	asset, err := candidate.FindTargetAsset(u.TargetOS, u.TargetArch)
 	if err != nil {
 		return nil, fmt.Errorf("checking update asset: %w", err)
@@ -188,6 +250,77 @@ func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
 	res.Message = fmt.Sprintf("Update available: %s → %s (%s)", u.CurrentVersion, candidate.Version, u.Channel)
 
 	return res, nil
+}
+
+// fetchSignedManifest downloads <baseURL>/<channel>.json and <baseURL>/<channel>.json.minisig and verifies the signature.
+func (u *Updater) fetchSignedManifest(ctx context.Context) (*ChannelManifest, error) {
+	channelName := u.Channel.String()
+	manifestURL := fmt.Sprintf("%s/%s.json", strings.TrimSuffix(u.BaseURL, "/"), channelName)
+	sigURL := fmt.Sprintf("%s/%s.json.minisig", strings.TrimSuffix(u.BaseURL, "/"), channelName)
+
+	// Fetch manifest JSON
+	reqJSON, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating manifest request: %w", err)
+	}
+	reqJSON.Header.Set("User-Agent", "SendBeam-Updater/"+u.CurrentVersion.String())
+
+	respJSON, err := u.HTTPClient.Do(reqJSON)
+	if err != nil {
+		return nil, fmt.Errorf("fetching update manifest %s: %w", manifestURL, err)
+	}
+	defer func() {
+		_ = respJSON.Body.Close()
+	}()
+
+	if respJSON.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching update manifest failed with HTTP %d %s", respJSON.StatusCode, respJSON.Status)
+	}
+
+	manifestBytes, err := io.ReadAll(respJSON.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest payload: %w", err)
+	}
+
+	// Fetch signature
+	reqSig, err := http.NewRequestWithContext(ctx, http.MethodGet, sigURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating signature request: %w", err)
+	}
+	reqSig.Header.Set("User-Agent", "SendBeam-Updater/"+u.CurrentVersion.String())
+
+	respSig, err := u.HTTPClient.Do(reqSig)
+	if err != nil {
+		return nil, fmt.Errorf("fetching update manifest signature %s: %w", sigURL, err)
+	}
+	defer func() {
+		_ = respSig.Body.Close()
+	}()
+
+	if respSig.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: missing signature file (HTTP %d %s)", ErrInvalidSignature, respSig.StatusCode, respSig.Status)
+	}
+
+	sigBytes, err := io.ReadAll(respSig.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading signature payload: %w", err)
+	}
+
+	// Cryptographic Minisign verification
+	if err := VerifyMinisignSignature(manifestBytes, string(sigBytes), u.MinisignPublicKey); err != nil {
+		return nil, err
+	}
+
+	var manifest ChannelManifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, fmt.Errorf("%w: JSON unmarshal error: %v", ErrManifestMalformed, err)
+	}
+
+	if manifest.Version == "" {
+		return nil, fmt.Errorf("%w: missing version in manifest", ErrManifestMalformed)
+	}
+
+	return &manifest, nil
 }
 
 // Apply downloads and atomically replaces the active executable with the new version.

--- a/apps/cli/internal/updater/updater_test.go
+++ b/apps/cli/internal/updater/updater_test.go
@@ -83,6 +83,7 @@ func TestUpdater_CheckAndApply(t *testing.T) {
 		"1.3.0",
 		"Akshay7273/sendbeam",
 		WithBaseURL(srv.URL),
+		WithGitHubAPI(true),
 		WithChannel(ChannelStable),
 		WithTargetPlatform("linux", "amd64"),
 		WithExecutablePath(targetBinary),
@@ -126,6 +127,7 @@ func TestUpdater_CheckAndApply(t *testing.T) {
 		"1.4.0",
 		"Akshay7273/sendbeam",
 		WithBaseURL(srv.URL),
+		WithGitHubAPI(true),
 		WithChannel(ChannelStable),
 		WithTargetPlatform("linux", "amd64"),
 		WithExecutablePath(targetBinary),
@@ -144,6 +146,7 @@ func TestUpdater_CheckAndApply(t *testing.T) {
 		"1.4.0",
 		"Akshay7273/sendbeam",
 		WithBaseURL(srv.URL),
+		WithGitHubAPI(true),
 		WithChannel(ChannelBeta),
 		WithTargetPlatform("linux", "amd64"),
 		WithExecutablePath(targetBinary),
@@ -173,5 +176,189 @@ func TestUpdater_DevVersion(t *testing.T) {
 	}
 	if check.UpdateAvailable {
 		t.Fatal("dev version should not report automatic update available")
+	}
+}
+
+func TestUpdater_SignedChannelManifest_HappyPath(t *testing.T) {
+	tempDir := t.TempDir()
+	targetBinary := filepath.Join(tempDir, "sendbeam")
+
+	oldBinary := []byte("sendbeam-v1.5.0")
+	if err := os.WriteFile(targetBinary, oldBinary, 0755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	newBinary := []byte("sendbeam-v1.6.0-signed-update")
+	tarData := createTestTarGz(t, "sendbeam", newBinary)
+	tarHash := sha256Hex(tarData)
+
+	testSeed := "d022346a8020c24891d1af56531c471c7160eaee16e05618202ef8fd953533ad"
+	testPub := DefaultMinisignPublicKey
+
+	archiveName := "sendbeam-cli-linux-amd64.tar.gz"
+
+	var srv *httptest.Server
+	manifest := ChannelManifest{
+		SchemaVersion: 1,
+		Version:       "1.6.0",
+		Channel:       "stable",
+		PublishedAt:   time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC),
+		ReleaseNotes:  "SendBeam v1.6.0 release",
+		Assets: map[string]ReleaseAsset{
+			"linux-amd64": {
+				Name:        archiveName,
+				DownloadURL: "", // populated below
+				SHA256:      tarHash,
+				Size:        int64(len(tarData)),
+			},
+		},
+	}
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		manifest.Assets["linux-amd64"] = ReleaseAsset{
+			Name:        archiveName,
+			DownloadURL: srv.URL + "/download/" + archiveName,
+			SHA256:      tarHash,
+			Size:        int64(len(tarData)),
+		}
+		data, _ := json.Marshal(manifest)
+		sig, _ := SignMinisign(data, testSeed, testPub, "stable.json")
+
+		switch r.URL.Path {
+		case "/stable.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(data)
+		case "/stable.json.minisig":
+			_, _ = w.Write([]byte(sig))
+		case "/download/" + archiveName:
+			_, _ = w.Write(tarData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	u, err := New(
+		"1.5.0",
+		"Akshay7273/sendbeam",
+		WithBaseURL(srv.URL),
+		WithChannel(ChannelStable),
+		WithTargetPlatform("linux", "amd64"),
+		WithExecutablePath(targetBinary),
+		WithMinisignPublicKey(testPub),
+		WithHTTPClient(srv.Client()),
+	)
+	if err != nil {
+		t.Fatalf("New updater: %v", err)
+	}
+
+	check, err := u.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+
+	if !check.UpdateAvailable {
+		t.Fatalf("expected update to be available, got: %s", check.Message)
+	}
+	if check.LatestVersion.String() != "1.6.0" {
+		t.Fatalf("expected version 1.6.0, got: %s", check.LatestVersion)
+	}
+
+	if err := u.Apply(context.Background(), check); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+
+	updated, err := os.ReadFile(targetBinary)
+	if err != nil {
+		t.Fatalf("ReadFile after apply: %v", err)
+	}
+	if !bytes.Equal(updated, newBinary) {
+		t.Fatalf("target binary content mismatch: %s", string(updated))
+	}
+}
+
+func TestUpdater_SignedChannelManifest_TamperedPayload(t *testing.T) {
+	testSeed := "d022346a8020c24891d1af56531c471c7160eaee16e05618202ef8fd953533ad"
+	testPub := DefaultMinisignPublicKey
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/stable.json":
+			// Return tampered JSON payload
+			_, _ = w.Write([]byte(`{"version":"1.6.0","channel":"stable","tampered":true}`))
+		case "/stable.json.minisig":
+			// Signature of untampered JSON
+			orig := []byte(`{"version":"1.6.0","channel":"stable"}`)
+			sig, _ := SignMinisign(orig, testSeed, testPub, "stable.json")
+			_, _ = w.Write([]byte(sig))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	u, _ := New(
+		"1.5.0",
+		"Akshay7273/sendbeam",
+		WithBaseURL(srv.URL),
+		WithChannel(ChannelStable),
+		WithMinisignPublicKey(testPub),
+		WithHTTPClient(srv.Client()),
+	)
+
+	_, err := u.Check(context.Background())
+	if err == nil {
+		t.Fatal("expected signature verification error on tampered payload, got nil")
+	}
+}
+
+func TestUpdater_SignedChannelManifest_DowngradeRejection(t *testing.T) {
+	testSeed := "d022346a8020c24891d1af56531c471c7160eaee16e05618202ef8fd953533ad"
+	testPub := DefaultMinisignPublicKey
+
+	manifest := ChannelManifest{
+		SchemaVersion: 1,
+		Version:       "1.5.0", // older than current 1.6.0
+		Channel:       "stable",
+		PublishedAt:   time.Now().UTC(),
+		Assets: map[string]ReleaseAsset{
+			"linux-amd64": {
+				Name:        "sendbeam-cli-linux-amd64.tar.gz",
+				DownloadURL: "https://example.com/sendbeam.tar.gz",
+				SHA256:      "0000000000000000000000000000000000000000000000000000000000000000",
+			},
+		},
+	}
+	data, _ := json.Marshal(manifest)
+	sig, _ := SignMinisign(data, testSeed, testPub, "stable.json")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/stable.json":
+			_, _ = w.Write(data)
+		case "/stable.json.minisig":
+			_, _ = w.Write([]byte(sig))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	u, _ := New(
+		"1.6.0", // running newer version
+		"Akshay7273/sendbeam",
+		WithBaseURL(srv.URL),
+		WithChannel(ChannelStable),
+		WithTargetPlatform("linux", "amd64"),
+		WithMinisignPublicKey(testPub),
+		WithHTTPClient(srv.Client()),
+	)
+
+	check, err := u.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+	if check.UpdateAvailable {
+		t.Fatal("expected UpdateAvailable to be false for older candidate (downgrade rejection)")
 	}
 }

--- a/apps/cli/internal/updater/verify.go
+++ b/apps/cli/internal/updater/verify.go
@@ -1,0 +1,224 @@
+package updater
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultMinisignPublicKey is the pinned Ed25519 public key used to verify SendBeam update manifests.
+	DefaultMinisignPublicKey = "RWTcyDWHWbxnuo3LVM5mWoZrx0HDwSQzAZvXK1lPRcdtJxshUDxJh+rE"
+
+	// DefaultUpdateBaseURL is the official production update manifest endpoint hosted on GitHub Pages.
+	DefaultUpdateBaseURL = "https://akshay7273.github.io/sendbeam/updates"
+
+	sigAlgEd        = "Ed"
+	pubKeyLen       = 42
+	sigPart1Len     = 74
+	sigPart2Len     = 64
+	untrustedPrefix = "untrusted comment: "
+	trustedPrefix   = "trusted comment: "
+)
+
+var (
+	// ErrInvalidSignature is returned when cryptographic signature verification over an update manifest fails.
+	ErrInvalidSignature = errors.New("invalid or tampered update manifest signature")
+
+	// ErrDowngradeRejected is returned when attempting to apply a version older than or equal to the current version.
+	ErrDowngradeRejected = errors.New("downgrade rejected: target version is not newer than current installation")
+
+	// ErrManifestMalformed is returned when the update manifest is not valid JSON or lacks required fields.
+	ErrManifestMalformed = errors.New("malformed update manifest")
+)
+
+// VerifyMinisignSignature cryptographically verifies a manifest payload against a minisign signature string and public key.
+func VerifyMinisignSignature(content []byte, sigStr string, pubKeyStr string) error {
+	pubKey, expectedKeyID, err := parsePublicKey(pubKeyStr)
+	if err != nil {
+		return fmt.Errorf("%w: invalid public key: %v", ErrInvalidSignature, err)
+	}
+
+	sigLines := strings.Split(strings.TrimSpace(sigStr), "\n")
+	if len(sigLines) < 4 {
+		return fmt.Errorf("%w: signature file must contain at least 4 lines, got %d", ErrInvalidSignature, len(sigLines))
+	}
+
+	sig1Raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(sigLines[1]))
+	if err != nil || len(sig1Raw) != sigPart1Len {
+		return fmt.Errorf("%w: invalid signature format", ErrInvalidSignature)
+	}
+
+	if sig1Raw[0] != 'E' || sig1Raw[1] != 'd' {
+		return fmt.Errorf("%w: unsupported signature algorithm", ErrInvalidSignature)
+	}
+
+	sigKeyID := sig1Raw[2:10]
+	if len(expectedKeyID) == 8 && !bytes.Equal(sigKeyID, expectedKeyID) {
+		return fmt.Errorf("%w: key ID mismatch (expected %x, got %x)", ErrInvalidSignature, expectedKeyID, sigKeyID)
+	}
+
+	fileSig := sig1Raw[10:74]
+	if !ed25519.Verify(pubKey, content, fileSig) {
+		return fmt.Errorf("%w: content digest signature verification failed", ErrInvalidSignature)
+	}
+
+	if !strings.HasPrefix(sigLines[2], trustedPrefix) {
+		return fmt.Errorf("%w: missing trusted comment", ErrInvalidSignature)
+	}
+	trustedComment := strings.TrimPrefix(sigLines[2], trustedPrefix)
+
+	globalSigRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(sigLines[3]))
+	if err != nil || len(globalSigRaw) != sigPart2Len {
+		return fmt.Errorf("%w: invalid global signature format", ErrInvalidSignature)
+	}
+
+	globalData := append(append([]byte(nil), fileSig...), []byte(trustedComment)...)
+	if !ed25519.Verify(pubKey, globalData, globalSigRaw) {
+		return fmt.Errorf("%w: trusted comment signature verification failed", ErrInvalidSignature)
+	}
+
+	return nil
+}
+
+// SignMinisign generates a standard Minisign signature file content for the given payload.
+func SignMinisign(content []byte, secretKeyStr string, pubKeyStr string, filename string) (string, error) {
+	privKey, err := parsePrivateKey(secretKeyStr)
+	if err != nil {
+		return "", fmt.Errorf("parsing secret key: %w", err)
+	}
+
+	pubKey := privKey.Public().(ed25519.PublicKey)
+	var keyID []byte
+
+	if pubKeyStr != "" {
+		_, pKeyID, err := parsePublicKey(pubKeyStr)
+		if err == nil && len(pKeyID) == 8 {
+			keyID = pKeyID
+		}
+	}
+	if len(keyID) != 8 {
+		derived := deriveKeyID(pubKey)
+		keyID = derived[:]
+	}
+
+	fileSig := ed25519.Sign(privKey, content)
+
+	var sig1Raw [sigPart1Len]byte
+	sig1Raw[0] = 'E'
+	sig1Raw[1] = 'd'
+	copy(sig1Raw[2:10], keyID)
+	copy(sig1Raw[10:], fileSig)
+	sig1B64 := base64.StdEncoding.EncodeToString(sig1Raw[:])
+
+	if filename == "" {
+		filename = "manifest.json"
+	}
+	tComment := fmt.Sprintf("timestamp:%d\tfile:%s", time.Now().Unix(), filepath.Base(filename))
+
+	globalData := append(append([]byte(nil), fileSig...), []byte(tComment)...)
+	globalSig := ed25519.Sign(privKey, globalData)
+	globalSigB64 := base64.StdEncoding.EncodeToString(globalSig)
+
+	sigContent := fmt.Sprintf("%ssignature from minisign secret key\n%s\n%s%s\n%s\n",
+		untrustedPrefix, sig1B64, trustedPrefix, tComment, globalSigB64)
+
+	return sigContent, nil
+}
+
+func parsePublicKey(input string) (ed25519.PublicKey, []byte, error) {
+	s := strings.TrimSpace(input)
+	if data, err := os.ReadFile(s); err == nil {
+		s = strings.TrimSpace(string(data))
+	}
+
+	lines := strings.Split(s, "\n")
+	var b64 string
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if !strings.HasPrefix(trimmed, untrustedPrefix) && trimmed != "" {
+			b64 = trimmed
+			break
+		}
+	}
+	if b64 == "" {
+		return nil, nil, errors.New("no public key line found")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("base64 decode failed: %w", err)
+	}
+
+	if len(raw) == 32 {
+		return ed25519.PublicKey(raw), nil, nil
+	}
+	if len(raw) == pubKeyLen {
+		if raw[0] != 'E' || raw[1] != 'd' {
+			return nil, nil, errors.New("unsupported signature algorithm in pubkey")
+		}
+		keyID := raw[2:10]
+		pub := ed25519.PublicKey(raw[10:])
+		return pub, keyID, nil
+	}
+
+	return nil, nil, fmt.Errorf("unexpected public key length: %d", len(raw))
+}
+
+func parsePrivateKey(input string) (ed25519.PrivateKey, error) {
+	s := strings.TrimSpace(input)
+	if data, err := os.ReadFile(s); err == nil {
+		s = strings.TrimSpace(string(data))
+	}
+
+	lines := strings.Split(s, "\n")
+	var keyText string
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if !strings.HasPrefix(trimmed, untrustedPrefix) && trimmed != "" {
+			keyText = trimmed
+			break
+		}
+	}
+	if keyText == "" {
+		return nil, errors.New("no secret key content found")
+	}
+
+	if len(keyText) == 64 {
+		seed, err := hex.DecodeString(keyText)
+		if err == nil && len(seed) == 32 {
+			return ed25519.NewKeyFromSeed(seed), nil
+		}
+	}
+
+	if len(keyText) == 128 {
+		full, err := hex.DecodeString(keyText)
+		if err == nil && len(full) == 64 {
+			return ed25519.PrivateKey(full), nil
+		}
+	}
+
+	if raw, err := base64.StdEncoding.DecodeString(keyText); err == nil {
+		if len(raw) == 32 {
+			return ed25519.NewKeyFromSeed(raw), nil
+		}
+		if len(raw) == 64 {
+			return ed25519.PrivateKey(raw), nil
+		}
+	}
+
+	return nil, errors.New("unrecognized private key format")
+}
+
+func deriveKeyID(pub ed25519.PublicKey) [8]byte {
+	var id [8]byte
+	copy(id[:], pub[:8])
+	return id
+}

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -10,24 +10,63 @@ SendBeam provides a framework-independent Go updater engine (`apps/cli/internal/
 
 ---
 
-## 2. Distribution Channels
+## 2. Distribution Channels & Production Endpoints
 
-SendBeam defines three formal distribution channels:
+SendBeam defines three formal distribution channels hosted on GitHub Pages:
 
-| Channel                | Description                    | Allowed Release Types                                 | Downgrade / Prerelease Rule                                                        |
-| :--------------------- | :----------------------------- | :---------------------------------------------------- | :--------------------------------------------------------------------------------- |
-| **`stable`** (Default) | Official production releases.  | Stable releases only (`vX.Y.Z`).                      | **Never** checks or applies prereleases, beta builds, or RC tags.                  |
-| **`beta`**             | Early-access candidate builds. | Stable + Prerelease (`vX.Y.Z-beta.N`, `vX.Y.Z-rc.N`). | Tracks both stable and candidate builds.                                           |
-| **`dev`**              | Local / development builds.    | Untagged / `dev` versions.                            | Informs user they are on a dev build; automated updates are skipped unless forced. |
+| Channel                | Description                    | Production Endpoint Manifest                                | Allowed Release Types                                 | Downgrade / Prerelease Rule                                                        |
+| :--------------------- | :----------------------------- | :---------------------------------------------------------- | :---------------------------------------------------- | :--------------------------------------------------------------------------------- |
+| **`stable`** (Default) | Official production releases.  | `https://akshay7273.github.io/sendbeam/updates/stable.json` | Stable releases only (`vX.Y.Z`).                      | **Never** checks or applies prereleases, beta builds, or RC tags.                  |
+| **`beta`**             | Early-access candidate builds. | `https://akshay7273.github.io/sendbeam/updates/beta.json`   | Stable + Prerelease (`vX.Y.Z-beta.N`, `vX.Y.Z-rc.N`). | Tracks both stable and candidate builds.                                           |
+| **`dev`**              | Local / development builds.    | —                                                           | Untagged / `dev` versions.                            | Informs user they are on a dev build; automated updates are skipped unless forced. |
 
 ---
 
-## 3. Cryptographic Verification & Invariants
+## 3. Cryptographic Manifest Verification & Security Invariants
 
-1. **Transport Security:** Release metadata and checksum manifests are retrieved exclusively over HTTPS.
-2. **Authoritative Hash Verification:** Every downloaded artifact is streamed through a SHA-256 hasher and verified against the canonical checksum manifest (`SHA256SUMS.txt`) before touching the active binary.
-3. **Downgrade Rejection:** Candidate versions must be strictly greater than the currently running version according to SemVer 2.0.0 precedence rules. Equal or older versions are rejected.
-4. **Platform Matching:** Artifact names are matched strictly against target OS and architecture (`sendbeam-cli-<os>-<arch>.tar.gz` or `.zip`).
+Every update manifest is cryptographically authenticated prior to parsing or processing:
+
+```mermaid
+flowchart TD
+    A[Updater Client] -->|Fetch| B[stable.json & stable.json.minisig]
+    B --> C{Minisign Ed25519 Verification}
+    C -->|Invalid Signature| D[Fail Closed: ErrInvalidSignature]
+    C -->|Valid Signature| E[Parse ChannelManifest JSON]
+    E --> F{Downgrade Check: Candidate > Current?}
+    F -->|No| G[Up to Date / Reject Downgrade]
+    F -->|Yes| H[Download Target Asset & Verify SHA-256]
+```
+
+### Pinned Release Key
+
+- **Pinned Minisign Public Key:**
+  ```text
+  RWTcyDWHWbxnuo3LVM5mWoZrx0HDwSQzAZvXK1lPRcdtJxshUDxJh+rE
+  ```
+- **Manifest Pre-Verification Invariant:** The updater fetches `<channel>.json` and `<channel>.json.minisig` and verifies the cryptographic Ed25519 signature **before** trusting any URL, version string, or SHA-256 digest inside the payload. A compromised CDN, proxy, or hosting bucket cannot force clients to download tampered binaries.
+- **Authoritative SHA-256 Verification:** Downloaded binary archives are streamed through SHA-256 digest computation and validated against the verified manifest hash prior to extraction or staging.
+- **Strict Downgrade Rejection:** Candidate versions must strictly exceed the active version under SemVer 2.0.0 precedence rules. Equal or older versions are rejected.
+
+### Canonical Manifest Schema
+
+```json
+{
+  "schema_version": 1,
+  "version": "1.6.0",
+  "channel": "stable",
+  "min_supported_version": "1.0.0",
+  "published_at": "2026-08-27T12:00:00Z",
+  "release_notes": "SendBeam 1.6.0 release notes",
+  "assets": {
+    "linux-amd64": {
+      "name": "sendbeam-cli-linux-amd64.tar.gz",
+      "download_url": "https://github.com/Akshay7273/sendbeam/releases/download/v1.6.0/sendbeam-cli-linux-amd64.tar.gz",
+      "sha256": "4a7f123456789012345678901234567890123456789012345678901234567890",
+      "size": 12345678
+    }
+  }
+}
+```
 
 ---
 

--- a/scripts/generate-update-manifest.go
+++ b/scripts/generate-update-manifest.go
@@ -1,0 +1,358 @@
+package main
+
+import (
+	"bufio"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	sigPart1Len     = 74
+	sigPart2Len     = 64
+	untrustedPrefix = "untrusted comment: "
+	trustedPrefix   = "trusted comment: "
+)
+
+type ReleaseAsset struct {
+	Name        string `json:"name"`
+	Size        int64  `json:"size"`
+	DownloadURL string `json:"download_url"`
+	SHA256      string `json:"sha256"`
+}
+
+type ChannelManifest struct {
+	SchemaVersion       int                     `json:"schema_version"`
+	Version             string                  `json:"version"`
+	Channel             string                  `json:"channel"`
+	MinSupportedVersion string                  `json:"min_supported_version,omitempty"`
+	PublishedAt         time.Time               `json:"published_at"`
+	ReleaseNotes        string                  `json:"release_notes,omitempty"`
+	Assets              map[string]ReleaseAsset `json:"assets"`
+}
+
+func main() {
+	var (
+		versionFlag   = flag.String("version", "", "product version (e.g. 1.6.0 or 1.6.0-rc1)")
+		tagFlag       = flag.String("tag", "", "release tag (e.g. v1.6.0 or v1.6.0-rc1)")
+		channelFlag   = flag.String("channel", "auto", "update channel (stable, beta, or auto)")
+		repoFlag      = flag.String("repo", "Akshay7273/sendbeam", "GitHub repository owner/name")
+		sumsFlag      = flag.String("sums", "SHA256SUMS.txt", "path to SHA256SUMS.txt manifest")
+		assetDirFlag  = flag.String("dir", ".", "directory containing release assets")
+		outDirFlag    = flag.String("out", "updates", "output directory for manifest files")
+		keyFlag       = flag.String("key", "", "minisign secret key or seed (or MINISIGN_SECRET_KEY env)")
+		pubKeyFlag    = flag.String("pubkey", "minisign.pub", "minisign public key file")
+		minSupported  = flag.String("min-supported", "1.0.0", "minimum supported version")
+		notesFlag     = flag.String("notes", "", "release notes summary")
+	)
+	flag.Parse()
+
+	if *versionFlag == "" && *tagFlag == "" {
+		fmt.Fprintf(os.Stderr, "error: either --version or --tag is required\n")
+		os.Exit(1)
+	}
+
+	version := *versionFlag
+	tag := *tagFlag
+	if version == "" {
+		version = strings.TrimPrefix(tag, "v")
+	}
+	if tag == "" {
+		tag = "v" + version
+	}
+
+	// Parse checksums
+	checksums, err := parseChecksums(*sumsFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading checksums %s: %v\n", *sumsFlag, err)
+		os.Exit(1)
+	}
+
+	// Build assets map
+	assets := make(map[string]ReleaseAsset)
+	for filename, sha := range checksums {
+		// Skip non-distribution files
+		if strings.HasSuffix(filename, ".spdx.json") ||
+			strings.HasSuffix(filename, ".txt") ||
+			strings.HasSuffix(filename, ".minisig") ||
+			strings.HasSuffix(filename, ".sigstore.json") ||
+			strings.HasSuffix(filename, ".bundle") {
+			continue
+		}
+
+		downloadURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", *repoFlag, tag, filename)
+		var size int64 = 0
+		filePath := filepath.Join(*assetDirFlag, filename)
+		if fi, err := os.Stat(filePath); err == nil {
+			size = fi.Size()
+		}
+
+		asset := ReleaseAsset{
+			Name:        filename,
+			Size:        size,
+			DownloadURL: downloadURL,
+			SHA256:      sha,
+		}
+
+		// Key by canonical platform ID if CLI archive
+		platformKey := detectPlatformKey(filename)
+		if platformKey != "" {
+			assets[platformKey] = asset
+		}
+		assets[filename] = asset
+	}
+
+	if err := os.MkdirAll(*outDirFlag, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "error creating output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Determine target channels
+	var channels []string
+	switch strings.ToLower(*channelFlag) {
+	case "stable":
+		channels = []string{"stable"}
+	case "beta":
+		channels = []string{"beta"}
+	case "auto":
+		if strings.Contains(version, "-") {
+			channels = []string{"beta"}
+		} else {
+			channels = []string{"stable", "beta"}
+		}
+	default:
+		channels = []string{*channelFlag}
+	}
+
+	secKey := *keyFlag
+	if secKey == "" {
+		secKey = os.Getenv("MINISIGN_SECRET_KEY")
+	}
+
+	now := time.Now().UTC()
+
+	for _, ch := range channels {
+		manifest := ChannelManifest{
+			SchemaVersion:       1,
+			Version:             version,
+			Channel:             ch,
+			MinSupportedVersion: *minSupported,
+			PublishedAt:         now,
+			ReleaseNotes:        *notesFlag,
+			Assets:              assets,
+		}
+
+		data, err := json.MarshalIndent(manifest, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error serializing manifest for %s: %v\n", ch, err)
+			os.Exit(1)
+		}
+		data = append(data, '\n')
+
+		jsonFile := filepath.Join(*outDirFlag, ch+".json")
+		if err := os.WriteFile(jsonFile, data, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "error writing %s: %v\n", jsonFile, err)
+			os.Exit(1)
+		}
+		fmt.Printf("Generated manifest: %s (%d assets)\n", jsonFile, len(assets))
+
+		if secKey != "" {
+			sigContent, err := signPayload(data, secKey, *pubKeyFlag, ch+".json")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error signing %s: %v\n", jsonFile, err)
+				os.Exit(1)
+			}
+
+			sigFile := filepath.Join(*outDirFlag, ch+".json.minisig")
+			if err := os.WriteFile(sigFile, []byte(sigContent), 0644); err != nil {
+				fmt.Fprintf(os.Stderr, "error writing %s: %v\n", sigFile, err)
+				os.Exit(1)
+			}
+			fmt.Printf("Signed manifest: %s\n", sigFile)
+		}
+	}
+}
+
+func detectPlatformKey(filename string) string {
+	switch {
+	case strings.Contains(filename, "sendbeam-cli-linux-amd64"):
+		return "linux-amd64"
+	case strings.Contains(filename, "sendbeam-cli-linux-arm64"):
+		return "linux-arm64"
+	case strings.Contains(filename, "sendbeam-cli-darwin-amd64"):
+		return "darwin-amd64"
+	case strings.Contains(filename, "sendbeam-cli-darwin-arm64"):
+		return "darwin-arm64"
+	case strings.Contains(filename, "sendbeam-cli-windows-amd64"):
+		return "windows-amd64"
+	case strings.Contains(filename, "sendbeam-cli-windows-arm64"):
+		return "windows-arm64"
+	default:
+		return ""
+	}
+}
+
+func parseChecksums(path string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		hash := strings.ToLower(fields[0])
+		if len(hash) != 64 {
+			continue
+		}
+		name := strings.TrimPrefix(strings.Join(fields[1:], " "), "*")
+		result[strings.TrimSpace(name)] = hash
+	}
+	return result, scanner.Err()
+}
+
+func signPayload(content []byte, secretKeyStr, pubKeyPath, filename string) (string, error) {
+	privKey, err := parsePrivateKey(secretKeyStr)
+	if err != nil {
+		return "", err
+	}
+
+	pubKey := privKey.Public().(ed25519.PublicKey)
+	var keyID []byte
+
+	if pubKeyPath != "" {
+		_, pKeyID, err := parsePublicKey(pubKeyPath)
+		if err == nil && len(pKeyID) == 8 {
+			keyID = pKeyID
+		}
+	}
+	if len(keyID) != 8 {
+		derived := deriveKeyID(pubKey)
+		keyID = derived[:]
+	}
+
+	fileSig := ed25519.Sign(privKey, content)
+
+	var sig1Raw [sigPart1Len]byte
+	sig1Raw[0] = 'E'
+	sig1Raw[1] = 'd'
+	copy(sig1Raw[2:10], keyID)
+	copy(sig1Raw[10:], fileSig)
+	sig1B64 := base64.StdEncoding.EncodeToString(sig1Raw[:])
+
+	tComment := fmt.Sprintf("timestamp:%d\tfile:%s", time.Now().Unix(), filepath.Base(filename))
+
+	globalData := append(append([]byte(nil), fileSig...), []byte(tComment)...)
+	globalSig := ed25519.Sign(privKey, globalData)
+	globalSigB64 := base64.StdEncoding.EncodeToString(globalSig)
+
+	return fmt.Sprintf("%ssignature from minisign secret key\n%s\n%s%s\n%s\n",
+		untrustedPrefix, sig1B64, trustedPrefix, tComment, globalSigB64), nil
+}
+
+func parsePublicKey(input string) (ed25519.PublicKey, []byte, error) {
+	s := strings.TrimSpace(input)
+	if data, err := os.ReadFile(s); err == nil {
+		s = strings.TrimSpace(string(data))
+	}
+
+	lines := strings.Split(s, "\n")
+	var b64 string
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if !strings.HasPrefix(trimmed, untrustedPrefix) && trimmed != "" {
+			b64 = trimmed
+			break
+		}
+	}
+	if b64 == "" {
+		return nil, nil, errors.New("no public key line found")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("base64 decode failed: %w", err)
+	}
+
+	if len(raw) == 32 {
+		return ed25519.PublicKey(raw), nil, nil
+	}
+	if len(raw) == 42 {
+		if raw[0] != 'E' || raw[1] != 'd' {
+			return nil, nil, errors.New("unsupported signature algorithm")
+		}
+		keyID := raw[2:10]
+		pub := ed25519.PublicKey(raw[10:])
+		return pub, keyID, nil
+	}
+
+	return nil, nil, fmt.Errorf("unexpected public key length: %d", len(raw))
+}
+
+func parsePrivateKey(input string) (ed25519.PrivateKey, error) {
+	s := strings.TrimSpace(input)
+	if data, err := os.ReadFile(s); err == nil {
+		s = strings.TrimSpace(string(data))
+	}
+
+	lines := strings.Split(s, "\n")
+	var keyText string
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if !strings.HasPrefix(trimmed, untrustedPrefix) && trimmed != "" {
+			keyText = trimmed
+			break
+		}
+	}
+	if keyText == "" {
+		return nil, errors.New("no secret key content found")
+	}
+
+	if len(keyText) == 64 {
+		seed, err := hex.DecodeString(keyText)
+		if err == nil && len(seed) == 32 {
+			return ed25519.NewKeyFromSeed(seed), nil
+		}
+	}
+
+	if len(keyText) == 128 {
+		full, err := hex.DecodeString(keyText)
+		if err == nil && len(full) == 64 {
+			return ed25519.PrivateKey(full), nil
+		}
+	}
+
+	if raw, err := base64.StdEncoding.DecodeString(keyText); err == nil {
+		if len(raw) == 32 {
+			return ed25519.NewKeyFromSeed(raw), nil
+		}
+		if len(raw) == 64 {
+			return ed25519.PrivateKey(raw), nil
+		}
+	}
+
+	return nil, errors.New("unrecognized private key format")
+}
+
+func deriveKeyID(pub ed25519.PublicKey) [8]byte {
+	var id [8]byte
+	copy(id[:], pub[:8])
+	return id
+}

--- a/scripts/generate-update-manifest_test.sh
+++ b/scripts/generate-update-manifest_test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# SendBeam Update Manifest Generator Test Suite
+# Tests scripts/generate-update-manifest.go across channels and signing.
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GENERATOR="${SCRIPT_DIR}/generate-update-manifest.go"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+echo "=== Running Update Manifest Generator Test Suite ==="
+
+# 1. Setup test keypair
+TEST_PUBKEY="${TMPDIR}/test-minisign.pub"
+TEST_SECKEY="${TMPDIR}/test-minisign.key"
+go run "${SCRIPT_DIR}/minisign.go" keygen -p "${TEST_PUBKEY}" -s "${TEST_SECKEY}" >/dev/null
+TEST_SEED="$(grep -v '^untrusted' "${TEST_SECKEY}" | head -n 1)"
+
+# 2. Setup mock release assets and SHA256SUMS.txt
+ASSET_DIR="${TMPDIR}/assets"
+mkdir -p "${ASSET_DIR}"
+
+for target in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64; do
+  echo "dummy binary ${target}" > "${ASSET_DIR}/sendbeam-cli-${target}.tar.gz"
+done
+for target in windows-amd64 windows-arm64; do
+  echo "dummy binary ${target}" > "${ASSET_DIR}/sendbeam-cli-${target}.zip"
+done
+echo "dummy desktop deb" > "${ASSET_DIR}/sendbeam-desktop_1.6.0_amd64.deb"
+echo "dummy desktop appimage" > "${ASSET_DIR}/SendBeam-linux-amd64.AppImage"
+
+(
+  cd "${ASSET_DIR}"
+  sha256sum * > SHA256SUMS.txt
+)
+
+# Test 1: Stable version with auto channel generates both stable.json and beta.json
+echo "--- Test 1: Stable release (v1.6.0) auto channel ---"
+OUT1="${TMPDIR}/out1"
+MINISIGN_SECRET_KEY="${TEST_SEED}" go run "${GENERATOR}" \
+  --version "1.6.0" \
+  --tag "v1.6.0" \
+  --channel "auto" \
+  --sums "${ASSET_DIR}/SHA256SUMS.txt" \
+  --dir "${ASSET_DIR}" \
+  --pubkey "${TEST_PUBKEY}" \
+  --out "${OUT1}" >/dev/null
+
+test -f "${OUT1}/stable.json"
+test -f "${OUT1}/stable.json.minisig"
+test -f "${OUT1}/beta.json"
+test -f "${OUT1}/beta.json.minisig"
+
+# Verify Minisign signatures
+go run "${SCRIPT_DIR}/minisign.go" verify -m "${OUT1}/stable.json" -p "${TEST_PUBKEY}" -x "${OUT1}/stable.json.minisig" >/dev/null
+go run "${SCRIPT_DIR}/minisign.go" verify -m "${OUT1}/beta.json" -p "${TEST_PUBKEY}" -x "${OUT1}/beta.json.minisig" >/dev/null
+
+# Verify JSON contents
+python3 -c "
+import json
+d = json.load(open('${OUT1}/stable.json'))
+assert d['version'] == '1.6.0'
+assert d['channel'] == 'stable'
+assert 'linux-amd64' in d['assets']
+assert 'windows-amd64' in d['assets']
+assert d['assets']['linux-amd64']['download_url'].startswith('https://github.com/Akshay7273/sendbeam/releases/download/v1.6.0/')
+assert len(d['assets']['linux-amd64']['sha256']) == 64
+"
+echo "PASS [Test 1: Stable release generated and verified]"
+
+# Test 2: Prerelease (v1.6.0-rc1) with auto channel generates ONLY beta.json
+echo "--- Test 2: Prerelease (v1.6.0-rc1) auto channel ---"
+OUT2="${TMPDIR}/out2"
+MINISIGN_SECRET_KEY="${TEST_SEED}" go run "${GENERATOR}" \
+  --version "1.6.0-rc1" \
+  --tag "v1.6.0-rc1" \
+  --channel "auto" \
+  --sums "${ASSET_DIR}/SHA256SUMS.txt" \
+  --dir "${ASSET_DIR}" \
+  --pubkey "${TEST_PUBKEY}" \
+  --out "${OUT2}" >/dev/null
+
+test ! -f "${OUT2}/stable.json"
+test -f "${OUT2}/beta.json"
+test -f "${OUT2}/beta.json.minisig"
+
+go run "${SCRIPT_DIR}/minisign.go" verify -m "${OUT2}/beta.json" -p "${TEST_PUBKEY}" -x "${OUT2}/beta.json.minisig" >/dev/null
+
+python3 -c "
+import json
+d = json.load(open('${OUT2}/beta.json'))
+assert d['version'] == '1.6.0-rc1'
+assert d['channel'] == 'beta'
+assert 'linux-amd64' in d['assets']
+"
+echo "PASS [Test 2: Prerelease correctly scoped to beta channel only]"
+
+# Test 3: Explicit channel override
+echo "--- Test 3: Explicit channel override ---"
+OUT3="${TMPDIR}/out3"
+MINISIGN_SECRET_KEY="${TEST_SEED}" go run "${GENERATOR}" \
+  --version "1.6.0" \
+  --tag "v1.6.0" \
+  --channel "stable" \
+  --sums "${ASSET_DIR}/SHA256SUMS.txt" \
+  --dir "${ASSET_DIR}" \
+  --pubkey "${TEST_PUBKEY}" \
+  --out "${OUT3}" >/dev/null
+
+test -f "${OUT3}/stable.json"
+test ! -f "${OUT3}/beta.json"
+
+echo "PASS [Test 3: Explicit channel flag respected]"
+
+echo ""
+echo "=== ALL 3 MANIFEST GENERATOR TESTS PASSED ==="


### PR DESCRIPTION
## Summary
Implements signed update channel manifests, pinned Minisign Ed25519 verification, and release channels for SendBeam updater (V16-PR03).

- **Canonical JSON Channel Manifest Schema:**
  - Defined `ChannelManifest` struct (`schema_version`, `version`, `channel`, `min_supported_version`, `published_at`, `release_notes`, `assets`).
  - Added platform asset resolver supporting target keys (`linux-amd64`, `windows-arm64`, etc.) and archive filenames.
- **Minisign Signature Pre-Verification:**
  - Pinned SendBeam release public key (`RWTcyDWHWbxnuo3LVM5mWoZrx0HDwSQzAZvXK1lPRcdtJxshUDxJh+rE`) inside `apps/cli/internal/updater`.
  - Added cryptographic verification engine (`apps/cli/internal/updater/verify.go`) verifying `<channel>.json.minisig` over `<channel>.json` BEFORE trusting any URL, version string, or SHA-256 hash inside the manifest.
  - Fail-closed security model: returns `ErrInvalidSignature` on tampered manifest, corrupted signature, or key mismatch.
- **Channel Policy & Downgrade Prevention:**
  - Enforces strict SemVer precedence: candidate version must strictly exceed active running version; rejects downgrades.
  - Enforces channel rules: `stable` channel rejects prerelease candidate versions; `beta` channel tracks stable and candidate versions.
- **Manifest Generator & Automation:**
  - Added `scripts/generate-update-manifest.go` generating `updates/stable.json`, `updates/beta.json` and Minisign signatures.
  - Added automated test suite `scripts/generate-update-manifest_test.sh` (3/3 tests passing).
  - Integrated manifest generation and signature verification gates into `.github/workflows/release.yml`.
- **Documentation:**
  - Updated `docs/updater.md` documenting production endpoints (`https://akshay7273.github.io/sendbeam/updates/<channel>.json`), manifest schema, Minisign pre-verification invariant, and rollback transaction.