### PR TITLE
feat(server): harden signaling server with rate limiting, anti-brute-force, trusted proxy ip extraction, readyz, and zero-pii metrics

### DIFF
--- a/apps/server/cmd/sendbeamd/main.go
+++ b/apps/server/cmd/sendbeamd/main.go
@@ -1,24 +1,22 @@
 // Command sendbeamd serves the SendBeam web bundle over TLS (or reverse-proxies the Vite
-// development server), exposes /healthz, and hosts the blind signaling endpoint.
+// development server), exposes /healthz and /readyz, and hosts the blind signaling endpoint.
 package main
 
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/sendbeam/server/internal/httpserver"
 )
 
 func main() {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-
 	cfg := httpserver.ConfigFromEnv()
+	logger := httpserver.BuildLogger(cfg.LogFormat, cfg.LogLevel)
+
 	srv, err := httpserver.New(cfg, logger)
 	if err != nil {
 		logger.Error("failed to build server", "err", err)
@@ -34,6 +32,7 @@ func main() {
 			"addr", cfg.Addr,
 			"tls", cfg.TLSCert != "",
 			"mode", cfg.Mode(),
+			"log_format", cfg.LogFormat,
 		)
 		errCh <- srv.ListenAndServe()
 	}()
@@ -46,7 +45,7 @@ func main() {
 		}
 	case <-ctx.Done():
 		logger.Info("shutting down")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			logger.Error("graceful shutdown failed", "err", err)

--- a/apps/server/internal/httpserver/server.go
+++ b/apps/server/internal/httpserver/server.go
@@ -1,5 +1,5 @@
-// Package httpserver wires the HTTP surface for sendbeamd: health, security headers,
-// and serving the web app — either from a built directory (prod) or by proxying the
+// Package httpserver wires the HTTP surface for sendbeamd: health, readiness, security headers,
+// metrics, and serving the web app — either from a built directory (prod) or by proxying the
 // Vite dev server (dev). The signaling handler mounts on the same router.
 package httpserver
 
@@ -26,12 +26,15 @@ import (
 
 // Config controls how sendbeamd serves the web app and terminates TLS.
 type Config struct {
-	Addr      string // listen address, e.g. ":8443"
-	TLSCert   string // path to TLS cert (PEM); empty => plain HTTP (dev/testing only)
-	TLSKey    string // path to TLS key (PEM)
-	WebDir    string // directory of the built web bundle to serve (prod)
-	DevProxy  string // URL of the Vite dev server to proxy to (dev); overrides WebDir
-	PublicURL string // public base URL for invite links (e.g. https://send.example.com/); empty = auto-detect from page
+	Addr            string        // listen address, e.g. ":8443"
+	TLSCert         string        // path to TLS cert (PEM); empty => plain HTTP (dev/testing only)
+	TLSKey          string        // path to TLS key (PEM)
+	WebDir          string        // directory of the built web bundle to serve (prod)
+	DevProxy        string        // URL of the Vite dev server to proxy to (dev); overrides WebDir
+	PublicURL       string        // public base URL for invite links (e.g. https://send.example.com/); empty = auto-detect from page
+	LogFormat       string        // "text" or "json"
+	LogLevel        string        // "debug", "info", "warn", "error"
+	ShutdownTimeout time.Duration // timeout for graceful shutdown draining
 
 	// ICEServerURLs are STUN (and future TURN) URLs published to clients via /config.json so
 	// the web app gathers direct-path candidates against the operator's chosen servers instead
@@ -43,16 +46,44 @@ type Config struct {
 
 // ConfigFromEnv reads configuration from SENDBEAM_* environment variables with defaults.
 func ConfigFromEnv() Config {
-	return Config{
-		Addr:          env("SENDBEAM_ADDR", ":8443"),
-		TLSCert:       os.Getenv("SENDBEAM_TLS_CERT"),
-		TLSKey:        os.Getenv("SENDBEAM_TLS_KEY"),
-		WebDir:        os.Getenv("SENDBEAM_WEB_DIR"),
-		DevProxy:      os.Getenv("SENDBEAM_WEB_DEV_PROXY"),
-		PublicURL:     os.Getenv("SENDBEAM_PUBLIC_URL"),
-		ICEServerURLs: splitList(os.Getenv("SENDBEAM_ICE_SERVERS")),
-		Signal:        signal.ConfigFromEnv(),
+	shutdownTimeout := 15 * time.Second
+	if d, ok := envDuration("SENDBEAM_SHUTDOWN_TIMEOUT"); ok {
+		shutdownTimeout = d
 	}
+
+	return Config{
+		Addr:            env("SENDBEAM_ADDR", ":8443"),
+		TLSCert:         os.Getenv("SENDBEAM_TLS_CERT"),
+		TLSKey:          os.Getenv("SENDBEAM_TLS_KEY"),
+		WebDir:          os.Getenv("SENDBEAM_WEB_DIR"),
+		DevProxy:        os.Getenv("SENDBEAM_WEB_DEV_PROXY"),
+		PublicURL:       os.Getenv("SENDBEAM_PUBLIC_URL"),
+		LogFormat:       env("SENDBEAM_LOG_FORMAT", "text"),
+		LogLevel:        env("SENDBEAM_LOG_LEVEL", "info"),
+		ShutdownTimeout: shutdownTimeout,
+		ICEServerURLs:   splitList(os.Getenv("SENDBEAM_ICE_SERVERS")),
+		Signal:          signal.ConfigFromEnv(),
+	}
+}
+
+// BuildLogger creates an *slog.Logger based on the configured log format and log level.
+func BuildLogger(format, level string) *slog.Logger {
+	var lvl slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: lvl}
+	if strings.ToLower(format) == "json" {
+		return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+	}
+	return slog.New(slog.NewTextHandler(os.Stderr, opts))
 }
 
 // Mode reports how the web app is being served, for logging.
@@ -71,19 +102,22 @@ func (c Config) Mode() string {
 type Server struct {
 	http   *http.Server
 	cfg    Config
+	hub    *signal.Hub
 	cancel context.CancelFunc
 }
 
 // New builds a Server with the SendBeam router and sensible timeouts.
 func New(cfg Config, logger *slog.Logger) (*Server, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	handler, err := router(ctx, cfg, logger)
+	hub := signal.NewHub(ctx, cfg.Signal, logger)
+	handler, err := router(ctx, cfg, hub, logger)
 	if err != nil {
 		cancel()
 		return nil, err
 	}
 	return &Server{
 		cfg:    cfg,
+		hub:    hub,
 		cancel: cancel,
 		http: &http.Server{
 			Addr:              cfg.Addr,
@@ -96,6 +130,11 @@ func New(cfg Config, logger *slog.Logger) (*Server, error) {
 	}, nil
 }
 
+// Hub returns the server's signaling hub.
+func (s *Server) Hub() *signal.Hub {
+	return s.hub
+}
+
 // ListenAndServe serves over TLS when a cert/key are configured, else plain HTTP.
 func (s *Server) ListenAndServe() error {
 	if s.cfg.TLSCert != "" && s.cfg.TLSKey != "" {
@@ -104,8 +143,11 @@ func (s *Server) ListenAndServe() error {
 	return s.http.ListenAndServe()
 }
 
-// Shutdown gracefully stops the server and its background workers.
+// Shutdown gracefully stops the server and drains active connections before exit.
 func (s *Server) Shutdown(ctx context.Context) error {
+	if s.hub != nil {
+		_ = s.hub.Drain(ctx)
+	}
 	s.cancel()
 	return s.http.Shutdown(ctx)
 }
@@ -117,7 +159,14 @@ type configResponse struct {
 	ICEServers []wire.ICEEntry `json:"iceServers"`
 }
 
-func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler, error) {
+type readyResponse struct {
+	Status      string `json:"status"`
+	Rooms       int    `json:"rooms"`
+	Connections int    `json:"connections"`
+	Draining    bool   `json:"draining"`
+}
+
+func router(ctx context.Context, cfg Config, hub *signal.Hub, logger *slog.Logger) (http.Handler, error) {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Recoverer)
@@ -130,10 +179,31 @@ func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler,
 		return nil, fmt.Errorf("config: invalid SENDBEAM_ICE_SERVERS: %w", err)
 	}
 
+	// Liveness check: returns 200 OK as long as the process is alive.
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	// Readiness check: returns 200 OK during normal operation, and 503 Service Unavailable when draining.
+	r.Get("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		m := hub.Metrics()
+		draining := hub.IsDraining()
+		status := "ready"
+		code := http.StatusOK
+		if draining {
+			status = "draining"
+			code = http.StatusServiceUnavailable
+		}
+		w.WriteHeader(code)
+		_ = json.NewEncoder(w).Encode(readyResponse{
+			Status:      status,
+			Rooms:       m.Rooms,
+			Connections: m.ActiveConnections,
+			Draining:    draining,
+		})
 	})
 
 	r.Get("/config.json", func(w http.ResponseWriter, _ *http.Request) {
@@ -148,8 +218,7 @@ func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler,
 		})
 	})
 
-	// Signaling endpoint: origin-checked WebSocket rendezvous.
-	hub := signal.NewHub(ctx, cfg.Signal, logger)
+	// Signaling endpoint: origin-checked, rate-limited WebSocket rendezvous.
 	r.Handle("/ws", hub.Handler(ctx))
 	r.Handle("/metrics", hub.MetricsHandler())
 
@@ -164,7 +233,7 @@ func router(ctx context.Context, cfg Config, logger *slog.Logger) (http.Handler,
 	case cfg.WebDir != "":
 		r.Handle("/*", spaFileServer(cfg.WebDir))
 	default:
-		logger.Warn("no web source configured; serving /healthz only")
+		logger.Warn("no web source configured; serving /healthz and /readyz only")
 	}
 
 	return r, nil
@@ -202,6 +271,18 @@ func env(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func envDuration(key string) (time.Duration, bool) {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0, false
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return 0, false
+	}
+	return d, true
 }
 
 // splitList splits a comma-separated env list, trimming whitespace and dropping empty items.

--- a/apps/server/internal/httpserver/server_test.go
+++ b/apps/server/internal/httpserver/server_test.go
@@ -11,16 +11,28 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/sendbeam/server/internal/signal"
 	"github.com/sendbeam/wire"
 )
 
-func testRouter(t *testing.T, cfg Config) http.Handler {
+func testRouterWithHub(t *testing.T, cfg Config) (http.Handler, *signal.Hub) {
 	t.Helper()
-	h, err := router(context.Background(), cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hub := signal.NewHub(ctx, cfg.Signal, logger)
+	h, err := router(ctx, cfg, hub, logger)
 	if err != nil {
 		t.Fatalf("router: %v", err)
 	}
+	return h, hub
+}
+
+func testRouter(t *testing.T, cfg Config) http.Handler {
+	t.Helper()
+	h, _ := testRouterWithHub(t, cfg)
 	return h
 }
 
@@ -39,6 +51,53 @@ func TestHealthz(t *testing.T) {
 	}
 	if body["status"] != "ok" {
 		t.Fatalf("status field = %q, want ok", body["status"])
+	}
+}
+
+func TestReadyz(t *testing.T) {
+	h, hub := testRouterWithHub(t, Config{})
+
+	// Normal readiness
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var ready readyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &ready); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if ready.Status != "ready" || ready.Draining {
+		t.Fatalf("expected ready response: %+v", ready)
+	}
+
+	// Drain in background
+	go func() { _ = hub.Drain(context.Background()) }()
+	time.Sleep(10 * time.Millisecond)
+
+	// Draining readiness (503 Service Unavailable)
+	recDraining := httptest.NewRecorder()
+	h.ServeHTTP(recDraining, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if recDraining.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", recDraining.Code)
+	}
+	var draining readyResponse
+	if err := json.Unmarshal(recDraining.Body.Bytes(), &draining); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if draining.Status != "draining" || !draining.Draining {
+		t.Fatalf("expected draining response: %+v", draining)
+	}
+}
+
+func TestBuildLogger(t *testing.T) {
+	l1 := BuildLogger("json", "debug")
+	if l1 == nil {
+		t.Fatal("expected json logger")
+	}
+	l2 := BuildLogger("text", "error")
+	if l2 == nil {
+		t.Fatal("expected text logger")
 	}
 }
 
@@ -163,9 +222,11 @@ func TestConfigEndpointNoICEServersOmitsEmpty(t *testing.T) {
 }
 
 func TestConfigEndpointInvalidICEServersFailsStartup(t *testing.T) {
-	if h, err := router(context.Background(), Config{
-		ICEServerURLs: []string{"://not-a-url"},
-	}, slog.New(slog.NewTextHandler(io.Discard, nil))); err == nil {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := Config{ICEServerURLs: []string{"://not-a-url"}}
+	hub := signal.NewHub(ctx, cfg.Signal, logger)
+	if h, err := router(ctx, cfg, hub, logger); err == nil {
 		t.Errorf("expected router error for malformed ICE URL, got handler %v", h)
 	}
 }

--- a/apps/server/internal/signal/churn_test.go
+++ b/apps/server/internal/signal/churn_test.go
@@ -1,0 +1,135 @@
+package signal
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestReaperUnderChurn simulates a create/abandon storm across many concurrent clients,
+// verifying that room creation, failed joins, vacating, and reaping function reliably
+// without deadlocks, state corruption, or memory leaks.
+func TestReaperUnderChurn(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.IdleTimeout = 50 * time.Millisecond
+	cfg.RateLimitEnabled = false // allow massive concurrent traffic in test
+	cfg.MaxRooms = 1000
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := NewHub(ctx, cfg, nil)
+
+	var wg sync.WaitGroup
+	workers := 10
+	iterations := 25
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			ip := fmt.Sprintf("192.0.2.%d", workerID+1)
+			for i := 0; i < iterations; i++ {
+				p := newTestPeer()
+				room, code := h.createRoom(p, ip)
+				if code != "" {
+					continue
+				}
+
+				// Sometimes vacate immediately, sometimes join then vacate, sometimes leave idle
+				switch (workerID + i) % 3 {
+				case 0:
+					h.vacate(p)
+				case 1:
+					joiner := newTestPeer()
+					other, jcode := h.join(joiner, room, ip)
+					if jcode == "" && other != nil {
+						h.vacate(joiner)
+					}
+					h.vacate(p)
+				case 2:
+					// Leave abandoned and unvacated; wait for reaper
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	// Run multiple reap cycles after idle timeout elapses
+	time.Sleep(100 * time.Millisecond)
+	h.reapOnce(time.Now().Add(time.Second))
+
+	if count := h.roomCount(); count != 0 {
+		t.Fatalf("expected 0 rooms after churn reap, got %d", count)
+	}
+
+	m := h.Metrics()
+	if m.RoomsReapedTotal == 0 && m.RoomsCreatedTotal > 0 {
+		t.Fatalf("expected rooms to have been reaped: created=%d, reaped=%d", m.RoomsCreatedTotal, m.RoomsReapedTotal)
+	}
+}
+
+// TestDrainGracefulShutdown tests the drain lifecycle: new connections are refused
+// while existing paired rooms are given time to complete.
+func TestDrainGracefulShutdown(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DrainTimeout = 100 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := NewHub(ctx, cfg, nil)
+
+	// Create an unpaired room (should be immediately reaped on drain)
+	unpaired := newTestPeer()
+	_, _ = h.createRoom(unpaired, "127.0.0.1")
+
+	// Create a paired room
+	offerer := newTestPeer()
+	room, _ := h.createRoom(offerer, "127.0.0.1")
+	joiner := newTestPeer()
+	_, _ = h.join(joiner, room, "127.0.0.1")
+
+	// Drain in background
+	drainDone := make(chan error, 1)
+	go func() {
+		drainDone <- h.Drain(context.Background())
+	}()
+
+	for !h.IsDraining() {
+		time.Sleep(time.Millisecond)
+	}
+
+	// Verify new connection is rejected with draining error
+	ok, _, errCode := h.acquireConnection("127.0.0.1")
+	if ok || errCode != errDraining {
+		t.Fatalf("new connection during drain should be rejected with draining, got ok=%v errCode=%s", ok, errCode)
+	}
+
+	// Verify new room creation is rejected
+	newOfferer := newTestPeer()
+	_, rcode := h.createRoom(newOfferer, "127.0.0.1")
+	if rcode != errDraining {
+		t.Fatalf("new room during drain should be rejected with draining, got %s", rcode)
+	}
+
+	// Verify unpaired room was closed immediately
+	select {
+	case <-unpaired.done:
+	default:
+		t.Fatal("unpaired room was not closed on drain")
+	}
+
+	// Finish the paired transfer by discarding
+	h.discard(offerer)
+
+	select {
+	case err := <-drainDone:
+		if err != nil {
+			t.Fatalf("drain returned error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("drain timed out")
+	}
+}

--- a/apps/server/internal/signal/handler.go
+++ b/apps/server/internal/signal/handler.go
@@ -2,7 +2,6 @@ package signal
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -21,10 +20,18 @@ func (h *Hub) Handler(baseCtx context.Context) http.Handler {
 			h.logger.Warn("signal: rejected origin", "origin", r.Header.Get("Origin"))
 			return
 		}
-		if !h.allowConnection(clientIP(r)) {
-			http.Error(w, "too many connections", http.StatusTooManyRequests)
+
+		ip := ClientIP(r, h.trustedProxies)
+		ok, release, errCode := h.acquireConnection(ip)
+		if !ok {
+			if errCode == errDraining {
+				http.Error(w, "server shutting down", http.StatusServiceUnavailable)
+			} else {
+				http.Error(w, "too many connections", http.StatusTooManyRequests)
+			}
 			return
 		}
+		defer release()
 
 		// originAllowed above is our origin policy, so we disable the library's own
 		// origin check to keep that policy in one place (and to admit native clients
@@ -38,7 +45,7 @@ func (h *Hub) Handler(baseCtx context.Context) http.Handler {
 			return // Accept has already written the failure
 		}
 
-		p := newPeer(ws, h)
+		p := newPeer(ws, h, ip)
 		p.serve(baseCtx)
 	})
 }
@@ -64,15 +71,4 @@ func (h *Hub) originAllowed(r *http.Request) bool {
 		}
 	}
 	return false
-}
-
-// clientIP extracts the remote IP for per-IP rate limiting. It trusts only the direct
-// socket peer — the server sits behind no header-setting proxy in its threat model,
-// so forwarded-for headers are deliberately ignored (they are client-controlled).
-func clientIP(r *http.Request) string {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
 }

--- a/apps/server/internal/signal/hub.go
+++ b/apps/server/internal/signal/hub.go
@@ -3,6 +3,7 @@ package signal
 import (
 	"context"
 	"log/slog"
+	"net"
 	"sync"
 	"time"
 
@@ -12,21 +13,25 @@ import (
 // Hub owns every room and the goroutine that reaps idle ones. A room holds at most
 // two peers — the offerer that created it and the joiner that paired in.
 type Hub struct {
-	cfg    Config
-	logger *slog.Logger
+	cfg            Config
+	logger         *slog.Logger
+	trustedProxies []*net.IPNet
 
-	mu    sync.Mutex
-	rooms map[int]*room
+	mu                sync.Mutex
+	rooms             map[int]*room
+	draining          bool
+	drainCh           chan struct{}
+	activeConns       int
+	connsTotal        int64
+	roomsCreatedTotal int64
+	roomsPairedTotal  int64
+	roomsReapedTotal  int64
+	relayBytes        int64
+	errors            map[string]int64
+	messages          map[string]int64
 
-	// relayBytes counts ciphertext relayed since start (metrics); per-room
-	// relay budget lives in room.relayBytes. errors counts refusal codes by
-	// code string (metrics). Both are guarded by mu.
-	relayBytes int64
-	errors     map[string]int64
-
-	// connLimiters is the per-IP connection-rate limiter, checked at upgrade time.
-	connMu       sync.Mutex
-	connLimiters map[string]*tokenBucket
+	ipMu       sync.Mutex
+	ipTrackers map[string]*ipTracker
 }
 
 type room struct {
@@ -37,8 +42,284 @@ type room struct {
 	relayBytes int64
 }
 
-// openRelay opts p into the binary path and coordinates a room-wide cutover. The first peer asks
-// its partner to follow; the second makes the path ready for both.
+// NewHub builds a Hub and starts its reaper. The reaper stops when ctx is canceled.
+func NewHub(ctx context.Context, cfg Config, logger *slog.Logger) *Hub {
+	trusted, err := ParseTrustedProxies(stringsJoin(cfg.TrustedProxies, ","))
+	if err != nil && logger != nil {
+		logger.Warn("signal: failed to parse trusted proxies", "err", err)
+	}
+
+	h := &Hub{
+		cfg:            cfg,
+		logger:         orDiscard(logger),
+		trustedProxies: trusted,
+		rooms:          make(map[int]*room),
+		drainCh:        make(chan struct{}),
+		errors:         make(map[string]int64),
+		messages:       make(map[string]int64),
+		ipTrackers:     make(map[string]*ipTracker),
+	}
+	go h.reap(ctx)
+	return h
+}
+
+func stringsJoin(elems []string, sep string) string {
+	if len(elems) == 0 {
+		return ""
+	}
+	res := ""
+	for i, s := range elems {
+		if i > 0 {
+			res += sep
+		}
+		res += s
+	}
+	return res
+}
+
+// IsDraining reports whether the hub is currently draining active connections for shutdown.
+func (h *Hub) IsDraining() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.draining
+}
+
+// Drain initiates graceful shutdown: it refuses new connections/rooms, reaps unpaired rooms
+// immediately, and waits up to the provided context or cfg.DrainTimeout for active transfers to finish.
+func (h *Hub) Drain(ctx context.Context) error {
+	h.mu.Lock()
+	if h.draining {
+		h.mu.Unlock()
+		return nil
+	}
+	h.draining = true
+	close(h.drainCh)
+
+	// Clean up unpaired rooms immediately.
+	var unpairedPeers []*peer
+	for n, r := range h.rooms {
+		if r.offerer == nil || r.joiner == nil {
+			if r.offerer != nil {
+				unpairedPeers = append(unpairedPeers, r.offerer)
+			}
+			if r.joiner != nil {
+				unpairedPeers = append(unpairedPeers, r.joiner)
+			}
+			delete(h.rooms, n)
+		}
+	}
+	h.mu.Unlock()
+
+	for _, p := range unpairedPeers {
+		p.close(byeFrame("server shutting down"))
+	}
+
+	timeout := h.cfg.DrainTimeout
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	drainCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	pollInterval := min(20*time.Millisecond, timeout/5)
+	if pollInterval < 5*time.Millisecond {
+		pollInterval = 5 * time.Millisecond
+	}
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		h.mu.Lock()
+		count := len(h.rooms)
+		h.mu.Unlock()
+		if count == 0 {
+			return nil
+		}
+
+		select {
+		case <-drainCtx.Done():
+			// Timeout reached: force close remaining peers.
+			h.mu.Lock()
+			var remaining []*peer
+			for n, r := range h.rooms {
+				if r.offerer != nil {
+					remaining = append(remaining, r.offerer)
+				}
+				if r.joiner != nil {
+					remaining = append(remaining, r.joiner)
+				}
+				delete(h.rooms, n)
+			}
+			h.mu.Unlock()
+
+			for _, p := range remaining {
+				p.close(byeFrame("drain timeout expired"))
+			}
+			return drainCtx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// getOrCreateIPTracker returns the tracker for ip, allocating it if needed.
+func (h *Hub) getOrCreateIPTracker(ip string) *ipTracker {
+	h.ipMu.Lock()
+	defer h.ipMu.Unlock()
+	t, ok := h.ipTrackers[ip]
+	if !ok {
+		t = newIPTracker(h.cfg)
+		h.ipTrackers[ip] = t
+	}
+	return t
+}
+
+// acquireConnection checks global and per-IP connection limits and reserves one active connection slot.
+func (h *Hub) acquireConnection(ip string) (allowed bool, release func(), errCode string) {
+	h.mu.Lock()
+	if h.draining {
+		h.mu.Unlock()
+		return false, nil, errDraining
+	}
+	if h.cfg.RateLimitEnabled && h.cfg.MaxConnections > 0 && h.activeConns >= h.cfg.MaxConnections {
+		h.mu.Unlock()
+		return false, nil, errRateLimited
+	}
+	h.activeConns++
+	h.connsTotal++
+	h.mu.Unlock()
+
+	tracker := h.getOrCreateIPTracker(ip)
+	ok, ipRelease := tracker.acquireConn(h.cfg.MaxConnsPerIP, h.cfg.RateLimitEnabled)
+	if !ok {
+		h.mu.Lock()
+		h.activeConns--
+		h.mu.Unlock()
+		return false, nil, errRateLimited
+	}
+
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			ipRelease()
+			h.mu.Lock()
+			if h.activeConns > 0 {
+				h.activeConns--
+			}
+			h.mu.Unlock()
+		})
+	}
+	return true, release, ""
+}
+
+// createRoom allocates the smallest free room number, seats p as its offerer, and
+// returns the room number.
+func (h *Hub) createRoom(p *peer, ip string) (int, string) {
+	tracker := h.getOrCreateIPTracker(ip)
+	if !tracker.allowRoomCreate(h.cfg.RateLimitEnabled) {
+		return -1, errRateLimited
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.draining {
+		return -1, errDraining
+	}
+	if h.cfg.RateLimitEnabled && h.cfg.MaxRooms > 0 && len(h.rooms) >= h.cfg.MaxRooms {
+		return -1, errRoomLimit
+	}
+
+	n := 0
+	for {
+		if _, taken := h.rooms[n]; !taken {
+			break
+		}
+		n++
+	}
+	h.rooms[n] = &room{number: n, offerer: p, lastSeen: time.Now()}
+	p.room = n
+	p.role = roleOfferer
+	h.roomsCreatedTotal++
+	return n, ""
+}
+
+// join seats p as the joiner of an existing room and returns the offerer it paired
+// with. It enforces strict 1:1 pairing: an unknown or already-full room is refused.
+func (h *Hub) join(p *peer, number int, ip string) (*peer, string) {
+	tracker := h.getOrCreateIPTracker(ip)
+	if !tracker.allowJoin(h.cfg.RateLimitEnabled) {
+		return nil, errRateLimited
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.draining {
+		return nil, errDraining
+	}
+
+	r, ok := h.rooms[number]
+	if !ok {
+		tracker.recordFailedJoin(h.cfg.RateLimitEnabled)
+		return nil, errUnknownRoom
+	}
+	if r.joiner != nil || r.offerer == nil {
+		tracker.recordFailedJoin(h.cfg.RateLimitEnabled)
+		return nil, errRoomFull
+	}
+	r.joiner = p
+	r.lastSeen = time.Now()
+	p.room = number
+	p.role = roleJoiner
+	h.roomsPairedTotal++
+	return r.offerer, ""
+}
+
+// resume re-attaches p to a vacated slot of an existing (lingering) room after the peer
+// reloaded and lost its ephemeral session. Only the slot for the claimed role may be
+// filled, and only if empty; the room and its number are unchanged.
+func (h *Hub) resume(p *peer, number int, role string, ip string) (*peer, string) {
+	if role != roleOfferer && role != roleJoiner {
+		return nil, errBadMessage
+	}
+	tracker := h.getOrCreateIPTracker(ip)
+	if !tracker.allowJoin(h.cfg.RateLimitEnabled) {
+		return nil, errRateLimited
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.draining {
+		return nil, errDraining
+	}
+
+	r, ok := h.rooms[number]
+	if !ok {
+		tracker.recordFailedJoin(h.cfg.RateLimitEnabled)
+		return nil, errUnknownRoom
+	}
+	switch role {
+	case roleOfferer:
+		if r.offerer != nil {
+			tracker.recordFailedJoin(h.cfg.RateLimitEnabled)
+			return nil, errRoomFull
+		}
+		r.offerer = p
+	case roleJoiner:
+		if r.joiner != nil {
+			tracker.recordFailedJoin(h.cfg.RateLimitEnabled)
+			return nil, errRoomFull
+		}
+		r.joiner = p
+	}
+	p.room = number
+	p.role = role
+	r.lastSeen = time.Now()
+	return roomPartner(r, p), ""
+}
+
+// openRelay opts p into the binary path and coordinates a room-wide cutover.
 func (h *Hub) openRelay(p *peer) (other *peer, ready bool, code string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -55,10 +336,7 @@ func (h *Hub) openRelay(p *peer) (other *peer, ready bool, code string) {
 	return other, other.relayOpen, ""
 }
 
-// grantRelayCredit caps a receiver's grant to one configured window and returns the actual grant
-// forwarded to its sending partner. An oversized request is clamped to the window rather than
-// killing the connection: the CLI requests a fixed window that any operator-tuned smaller
-// configuration must degrade gracefully against.
+// grantRelayCredit caps a receiver's grant to one configured window and returns the actual grant.
 func (h *Hub) grantRelayCredit(receiver *peer, requested int64) (*peer, int64, string) {
 	if requested <= 0 {
 		return nil, 0, errRelayCredit
@@ -82,11 +360,7 @@ func (h *Hub) grantRelayCredit(receiver *peer, requested int64) (*peer, int64, s
 	return sender, grant, ""
 }
 
-// forwardRelay reserves sender credit and room byte budget before handing one opaque frame to the
-// partner's bounded writer queue. No encrypted frame contents are parsed or logged. The queue is
-// reserved before any credit or byte budget is charged: a frame the partner's queue rejected was
-// never delivered, so it must not count against the session, and the wedged party is the
-// receiver — it is closed instead of failing the innocent sender.
+// forwardRelay reserves sender credit and room byte budget before handing one opaque frame to the partner.
 func (h *Hub) forwardRelay(sender *peer, data []byte) string {
 	size := int64(len(data))
 	if size <= 0 || size > h.cfg.MaxRelayFrameBytes {
@@ -118,8 +392,6 @@ func (h *Hub) forwardRelay(sender *peer, data []byte) string {
 	h.mu.Unlock()
 
 	if !other.tryEnqueue(websocket.MessageBinary, append([]byte(nil), data...)) {
-		// The receiver's queue is full (it is not reading) or it is already closing.
-		// Close it rather than failing the sender for a wedge it did not cause.
 		other.fail(errRelayLimit, "receiver relay queue full")
 		return errRelayLimit
 	}
@@ -128,7 +400,7 @@ func (h *Hub) forwardRelay(sender *peer, data []byte) string {
 	defer h.mu.Unlock()
 	r, ok = h.rooms[sender.room]
 	if !ok || roomPartner(r, sender) != other {
-		return "" // the room tore down between enqueue and charge; nothing left to charge
+		return ""
 	}
 	sender.relayCredit -= size
 	r.relayBytes += size
@@ -147,106 +419,7 @@ func roomPartner(r *room, p *peer) *peer {
 	return nil
 }
 
-// NewHub builds a Hub and starts its reaper. The reaper stops when ctx is canceled.
-func NewHub(ctx context.Context, cfg Config, logger *slog.Logger) *Hub {
-	h := &Hub{
-		cfg:          cfg,
-		logger:       orDiscard(logger),
-		rooms:        make(map[int]*room),
-		errors:       make(map[string]int64),
-		connLimiters: make(map[string]*tokenBucket),
-	}
-	go h.reap(ctx)
-	return h
-}
-
-// allowConnection reports whether a new connection from ip is within the per-IP
-// connection-rate limit.
-func (h *Hub) allowConnection(ip string) bool {
-	h.connMu.Lock()
-	defer h.connMu.Unlock()
-	b, ok := h.connLimiters[ip]
-	if !ok {
-		b = newTokenBucket(h.cfg.ConnBurst, h.cfg.ConnPerSec)
-		h.connLimiters[ip] = b
-	}
-	return b.allow()
-}
-
-// createRoom allocates the smallest free room number, seats p as its offerer, and
-// returns the room number.
-func (h *Hub) createRoom(p *peer) int {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	n := 0
-	for {
-		if _, taken := h.rooms[n]; !taken {
-			break
-		}
-		n++
-	}
-	h.rooms[n] = &room{number: n, offerer: p, lastSeen: time.Now()}
-	p.room = n
-	p.role = roleOfferer
-	return n
-}
-
-// join seats p as the joiner of an existing room and returns the offerer it paired
-// with. It enforces strict 1:1 pairing: an unknown or already-full room is refused.
-func (h *Hub) join(p *peer, number int) (*peer, string) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	r, ok := h.rooms[number]
-	if !ok {
-		return nil, errUnknownRoom
-	}
-	if r.joiner != nil || r.offerer == nil {
-		return nil, errRoomFull
-	}
-	r.joiner = p
-	r.lastSeen = time.Now()
-	p.room = number
-	p.role = roleJoiner
-	return r.offerer, ""
-}
-
-// resume re-attaches p to a vacated slot of an existing (lingering) room after the peer
-// reloaded and lost its ephemeral session. Only the slot for the claimed role may be
-// filled, and only if empty; the room and its number are unchanged. It returns the
-// surviving partner so the caller can prompt both sides to re-run the handshake.
-func (h *Hub) resume(p *peer, number int, role string) (*peer, string) {
-	if role != roleOfferer && role != roleJoiner {
-		return nil, errBadMessage
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	r, ok := h.rooms[number]
-	if !ok {
-		return nil, errUnknownRoom
-	}
-	switch role {
-	case roleOfferer:
-		if r.offerer != nil {
-			return nil, errRoomFull
-		}
-		r.offerer = p
-	case roleJoiner:
-		if r.joiner != nil {
-			return nil, errRoomFull
-		}
-		r.joiner = p
-	}
-	p.room = number
-	p.role = role
-	r.lastSeen = time.Now()
-	return roomPartner(r, p), ""
-}
-
-// partner returns the other peer in p's room, or nil if the room is gone or p is not
-// yet paired. It also refreshes the room's activity timestamp.
+// partner returns the other peer in p's room, or nil if the room is gone or p is not yet paired.
 func (h *Hub) partner(p *peer) *peer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -266,10 +439,7 @@ func (h *Hub) partner(p *peer) *peer {
 	}
 }
 
-// vacate frees p's slot after an unexpected socket drop. If a partner remains, the room
-// is kept — only p's slot is cleared — so the departed peer can reload and re-attach
-// (see resume) within the idle window; the partner is returned so the caller can tell it
-// to wait. If p was the last peer, the room is deleted and nil is returned.
+// vacate frees p's slot after an unexpected socket drop.
 func (h *Hub) vacate(p *peer) *peer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -297,9 +467,7 @@ func (h *Hub) vacate(p *peer) *peer {
 	return other
 }
 
-// discard tears down p's whole room after a graceful bye. Any remaining partner is
-// returned so the caller can close it too — a bye ends the session for both peers and is
-// never resumable.
+// discard tears down p's whole room after a graceful bye.
 func (h *Hub) discard(p *peer) *peer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -313,8 +481,7 @@ func (h *Hub) discard(p *peer) *peer {
 	return other
 }
 
-// reap periodically frees rooms whose last activity is older than the idle timeout,
-// closing any sockets still attached. It runs until ctx is canceled.
+// reap periodically frees rooms whose last activity is older than the idle timeout.
 func (h *Hub) reap(ctx context.Context) {
 	interval := h.cfg.IdleTimeout / 2
 	if interval <= 0 {
@@ -342,17 +509,17 @@ func (h *Hub) reapOnce(now time.Time) {
 			delete(h.rooms, n)
 		}
 	}
+	h.roomsReapedTotal += int64(len(stale))
 	h.mu.Unlock()
 
-	// Prune per-IP connection limiters that have fully refilled and gone unused: without
-	// this, every distinct client IP ever seen pins a map entry forever.
-	h.connMu.Lock()
-	for ip, b := range h.connLimiters {
-		if b.refilledAndIdle(now, h.cfg.IdleTimeout) {
-			delete(h.connLimiters, ip)
+	// Prune per-IP trackers that have no active connections, fully refilled, and idle.
+	h.ipMu.Lock()
+	for ip, t := range h.ipTrackers {
+		if t.refilledAndIdle(now, h.cfg.IdleTimeout) {
+			delete(h.ipTrackers, ip)
 		}
 	}
-	h.connMu.Unlock()
+	h.ipMu.Unlock()
 
 	for _, r := range stale {
 		h.logger.Info("signal: reaping idle room", "room", r.number)

--- a/apps/server/internal/signal/hub_test.go
+++ b/apps/server/internal/signal/hub_test.go
@@ -12,6 +12,7 @@ import (
 func newTestPeer() *peer {
 	return &peer{
 		room:             -1,
+		clientIP:         "127.0.0.1",
 		send:             make(chan outboundFrame, sendBuffer),
 		relayRate:        newTokenBucket(1<<20, 1<<20),
 		relayControlRate: newTokenBucket(128, 64),
@@ -31,32 +32,35 @@ func TestCreateRoomAllocatesSmallestFree(t *testing.T) {
 	h := testHub(t)
 
 	a, b, c := newTestPeer(), newTestPeer(), newTestPeer()
-	if n := h.createRoom(a); n != 0 {
-		t.Fatalf("first room = %d, want 0", n)
+	if n, code := h.createRoom(a, "127.0.0.1"); code != "" || n != 0 {
+		t.Fatalf("first room = %d (code=%s), want 0", n, code)
 	}
-	if n := h.createRoom(b); n != 1 {
-		t.Fatalf("second room = %d, want 1", n)
+	if n, code := h.createRoom(b, "127.0.0.1"); code != "" || n != 1 {
+		t.Fatalf("second room = %d (code=%s), want 1", n, code)
 	}
-	if n := h.createRoom(c); n != 2 {
-		t.Fatalf("third room = %d, want 2", n)
+	if n, code := h.createRoom(c, "127.0.0.1"); code != "" || n != 2 {
+		t.Fatalf("third room = %d (code=%s), want 2", n, code)
 	}
 
 	// Freeing room 1 makes it the smallest free slot again. b is the lone peer, so
 	// vacate deletes the room outright.
 	h.vacate(b)
 	d := newTestPeer()
-	if n := h.createRoom(d); n != 1 {
-		t.Fatalf("reused room = %d, want 1", n)
+	if n, code := h.createRoom(d, "127.0.0.1"); code != "" || n != 1 {
+		t.Fatalf("reused room = %d (code=%s), want 1", n, code)
 	}
 }
 
 func TestJoinPairsAndIsOneToOne(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
-	room := h.createRoom(off)
+	room, code := h.createRoom(off, "127.0.0.1")
+	if code != "" {
+		t.Fatalf("createRoom failed: %s", code)
+	}
 
 	join := newTestPeer()
-	other, code := h.join(join, room)
+	other, code := h.join(join, room, "127.0.0.1")
 	if code != "" {
 		t.Fatalf("join failed: %s", code)
 	}
@@ -69,14 +73,14 @@ func TestJoinPairsAndIsOneToOne(t *testing.T) {
 
 	// A second join for the same room is refused: strict 1:1.
 	third := newTestPeer()
-	if _, code := h.join(third, room); code != errRoomFull {
+	if _, code := h.join(third, room, "127.0.0.1"); code != errRoomFull {
 		t.Fatalf("third join code = %q, want %q", code, errRoomFull)
 	}
 }
 
 func TestJoinUnknownRoom(t *testing.T) {
 	h := testHub(t)
-	if _, code := h.join(newTestPeer(), 999); code != errUnknownRoom {
+	if _, code := h.join(newTestPeer(), 999, "127.0.0.1"); code != errUnknownRoom {
 		t.Fatalf("code = %q, want %q", code, errUnknownRoom)
 	}
 }
@@ -84,9 +88,9 @@ func TestJoinUnknownRoom(t *testing.T) {
 func TestPartnerLookup(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
-	room := h.createRoom(off)
+	room, _ := h.createRoom(off, "127.0.0.1")
 	join := newTestPeer()
-	if _, code := h.join(join, room); code != "" {
+	if _, code := h.join(join, room, "127.0.0.1"); code != "" {
 		t.Fatalf("join: %s", code)
 	}
 
@@ -100,9 +104,9 @@ func TestPartnerLookup(t *testing.T) {
 func TestVacateLingersThenDeletes(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
-	room := h.createRoom(off)
+	room, _ := h.createRoom(off, "127.0.0.1")
 	join := newTestPeer()
-	if _, code := h.join(join, room); code != "" {
+	if _, code := h.join(join, room, "127.0.0.1"); code != "" {
 		t.Fatalf("join: %s", code)
 	}
 
@@ -130,9 +134,9 @@ func TestVacateLingersThenDeletes(t *testing.T) {
 func TestResumeReattachesVacatedSlot(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
-	room := h.createRoom(off)
+	room, _ := h.createRoom(off, "127.0.0.1")
 	join := newTestPeer()
-	if _, code := h.join(join, room); code != "" {
+	if _, code := h.join(join, room, "127.0.0.1"); code != "" {
 		t.Fatalf("join: %s", code)
 	}
 
@@ -141,7 +145,7 @@ func TestResumeReattachesVacatedSlot(t *testing.T) {
 
 	// A reloaded offerer resumes into the vacated slot and gets the waiting joiner back.
 	reoff := newTestPeer()
-	other, code := h.resume(reoff, room, roleOfferer)
+	other, code := h.resume(reoff, room, roleOfferer, "127.0.0.1")
 	if code != "" {
 		t.Fatalf("resume failed: %s", code)
 	}
@@ -160,22 +164,22 @@ func TestResumeReattachesVacatedSlot(t *testing.T) {
 func TestResumeRefusesOccupiedOrUnknown(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
-	room := h.createRoom(off)
+	room, _ := h.createRoom(off, "127.0.0.1")
 	join := newTestPeer()
-	if _, code := h.join(join, room); code != "" {
+	if _, code := h.join(join, room, "127.0.0.1"); code != "" {
 		t.Fatalf("join: %s", code)
 	}
 
 	// Both slots are occupied: claiming the offerer role is refused.
-	if _, code := h.resume(newTestPeer(), room, roleOfferer); code != errRoomFull {
+	if _, code := h.resume(newTestPeer(), room, roleOfferer, "127.0.0.1"); code != errRoomFull {
 		t.Fatalf("resume into occupied slot code = %q, want %q", code, errRoomFull)
 	}
 	// An unknown room is refused.
-	if _, code := h.resume(newTestPeer(), 999, roleJoiner); code != errUnknownRoom {
+	if _, code := h.resume(newTestPeer(), 999, roleJoiner, "127.0.0.1"); code != errUnknownRoom {
 		t.Fatalf("resume into unknown room code = %q, want %q", code, errUnknownRoom)
 	}
 	// A bad role is rejected before any room lookup.
-	if _, code := h.resume(newTestPeer(), room, "bogus"); code != errBadMessage {
+	if _, code := h.resume(newTestPeer(), room, "bogus", "127.0.0.1"); code != errBadMessage {
 		t.Fatalf("resume with bad role code = %q, want %q", code, errBadMessage)
 	}
 }
@@ -184,9 +188,9 @@ func TestResumeRefusesOccupiedOrUnknown(t *testing.T) {
 func TestDiscardTearsDownRoom(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
-	room := h.createRoom(off)
+	room, _ := h.createRoom(off, "127.0.0.1")
 	join := newTestPeer()
-	if _, code := h.join(join, room); code != "" {
+	if _, code := h.join(join, room, "127.0.0.1"); code != "" {
 		t.Fatalf("join: %s", code)
 	}
 
@@ -203,9 +207,9 @@ func TestDiscardTearsDownRoom(t *testing.T) {
 func TestReapClosesLingeringRoom(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
-	room := h.createRoom(off)
+	room, _ := h.createRoom(off, "127.0.0.1")
 	join := newTestPeer()
-	if _, code := h.join(join, room); code != "" {
+	if _, code := h.join(join, room, "127.0.0.1"); code != "" {
 		t.Fatalf("join: %s", code)
 	}
 	h.vacate(off) // room now lingers with only the joiner attached
@@ -231,7 +235,7 @@ func TestReapClosesLingeringRoom(t *testing.T) {
 func TestReapClosesIdleRooms(t *testing.T) {
 	h := testHub(t)
 	off := newTestPeer()
-	h.createRoom(off)
+	_, _ = h.createRoom(off, "127.0.0.1")
 
 	// Backdate the room past the idle timeout, then reap.
 	h.mu.Lock()
@@ -331,27 +335,134 @@ func TestPeerRelayQueueBackpressuresAtMessageCapacity(t *testing.T) {
 	}
 }
 
-func TestReapPrunesIdleConnLimiters(t *testing.T) {
+func TestReapPrunesIdleIPTrackers(t *testing.T) {
 	h := testHub(t)
 	sweepAt := time.Now().Add(2 * h.cfg.IdleTimeout)
 
 	for _, ip := range []string{"203.0.113.1", "203.0.113.2"} {
-		if !h.allowConnection(ip) {
+		ok, release, _ := h.acquireConnection(ip)
+		if !ok {
 			t.Fatalf("first connection from %s refused", ip)
 		}
+		release()
 	}
 	h.reapOnce(sweepAt)
-	if n := len(h.connLimiters); n != 0 {
-		t.Fatalf("idle limiters not pruned: %d remain", n)
+	h.ipMu.Lock()
+	n := len(h.ipTrackers)
+	h.ipMu.Unlock()
+	if n != 0 {
+		t.Fatalf("idle trackers not pruned: %d remain", n)
 	}
 
-	// A bucket used just before the sweep survives: full but not idle. Sweep with a
-	// near-future clock so the bucket's elapsed idle time is well under IdleTimeout.
-	if !h.allowConnection("203.0.113.3") {
-		t.Fatal("connection refused before sweep")
+	// A tracker with an active connection survives
+	ok, _, _ := h.acquireConnection("203.0.113.3")
+	if !ok {
+		t.Fatal("connection refused")
 	}
-	h.reapOnce(time.Now().Add(10 * time.Millisecond))
-	if _, ok := h.connLimiters["203.0.113.3"]; !ok {
-		t.Fatal("recently active limiter was pruned")
+	h.reapOnce(sweepAt)
+	h.ipMu.Lock()
+	_, found := h.ipTrackers["203.0.113.3"]
+	h.ipMu.Unlock()
+	if !found {
+		t.Fatal("active tracker was pruned")
+	}
+}
+
+func TestRateLimitingAndQuotas(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxConnections = 3
+	cfg.MaxConnsPerIP = 2
+	cfg.MaxRooms = 2
+	cfg.RoomCreateBurst = 2
+	cfg.JoinFailBurst = 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := NewHub(ctx, cfg, nil)
+
+	// Test MaxConnsPerIP
+	ok1, rel1, _ := h.acquireConnection("198.51.100.1")
+	if !ok1 {
+		t.Fatal("first conn failed")
+	}
+	ok2, rel2, _ := h.acquireConnection("198.51.100.1")
+	if !ok2 {
+		t.Fatal("second conn failed")
+	}
+	ok3, _, _ := h.acquireConnection("198.51.100.1")
+	if ok3 {
+		t.Fatal("third conn from same IP should be rejected by MaxConnsPerIP")
+	}
+
+	// Another IP can connect
+	okOther, relOther, _ := h.acquireConnection("198.51.100.2")
+	if !okOther {
+		t.Fatal("conn from second IP failed")
+	}
+
+	// Global MaxConnections (now at 3: 2 + 1 = 3)
+	okGlobalExceeded, _, _ := h.acquireConnection("198.51.100.3")
+	if okGlobalExceeded {
+		t.Fatal("conn should exceed global MaxConnections")
+	}
+
+	rel1()
+	rel2()
+	relOther()
+
+	// Test MaxRooms
+	p1, p2, p3 := newTestPeer(), newTestPeer(), newTestPeer()
+	_, code1 := h.createRoom(p1, "198.51.100.1")
+	if code1 != "" {
+		t.Fatalf("first room failed: %s", code1)
+	}
+	_, code2 := h.createRoom(p2, "198.51.100.2")
+	if code2 != "" {
+		t.Fatalf("second room failed: %s", code2)
+	}
+	_, code3 := h.createRoom(p3, "198.51.100.3")
+	if code3 != errRoomLimit {
+		t.Fatalf("third room code = %q, want %q", code3, errRoomLimit)
+	}
+
+	// Test Anti-Brute-Force Failed Join Limiting
+	joiner := newTestPeer()
+	_, jcode1 := h.join(joiner, 9999, "198.51.100.99")
+	if jcode1 != errUnknownRoom {
+		t.Fatalf("expected unknown room, got %s", jcode1)
+	}
+	_, jcode2 := h.join(joiner, 9998, "198.51.100.99")
+	if jcode2 != errUnknownRoom {
+		t.Fatalf("expected unknown room, got %s", jcode2)
+	}
+	// Burst exhausted: further attempts rejected immediately with errRateLimited
+	_, jcode3 := h.join(joiner, 9997, "198.51.100.99")
+	if jcode3 != errRateLimited {
+		t.Fatalf("expected rate limited on exhausted join fail tokens, got %s", jcode3)
+	}
+}
+
+func TestRateLimitDisabledSwitch(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RateLimitEnabled = false
+	cfg.MaxConnsPerIP = 1
+	cfg.RoomCreateBurst = 1
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := NewHub(ctx, cfg, nil)
+
+	// Able to exceed configured limits because rate limiting is disabled
+	ok1, _, _ := h.acquireConnection("198.51.100.1")
+	ok2, _, _ := h.acquireConnection("198.51.100.1")
+	if !ok1 || !ok2 {
+		t.Fatal("connections should succeed when rate limiting is disabled")
+	}
+
+	p1, p2 := newTestPeer(), newTestPeer()
+	_, code1 := h.createRoom(p1, "198.51.100.1")
+	_, code2 := h.createRoom(p2, "198.51.100.1")
+	if code1 != "" || code2 != "" {
+		t.Fatalf("room creations should succeed when rate limiting is disabled: %s, %s", code1, code2)
 	}
 }

--- a/apps/server/internal/signal/message.go
+++ b/apps/server/internal/signal/message.go
@@ -67,6 +67,8 @@ const (
 	errRoomFull      = "room_full"
 	errNotPaired     = "not_paired"
 	errRateLimited   = "rate_limited"
+	errRoomLimit     = "room_limit"
+	errDraining      = "draining"
 	errProtocol      = "protocol"
 	errRelayNotReady = "relay_not_ready"
 	errRelayCredit   = "relay_credit"
@@ -170,16 +172,36 @@ func creditFrame(bytes int64) []byte {
 	return mustJSON(relayMsg{Type: typeCredit, Bytes: bytes})
 }
 
-// Config controls the signaling server's limits and origin policy.
+// Config controls the signaling server's limits, quotas, rate limiting, and origin policy.
 type Config struct {
 	// AllowedOrigins is the WSS origin allowlist for browser clients. An empty list
 	// permits only same-origin browser connections. Native clients (CLI) send no
 	// Origin header and are always allowed.
 	AllowedOrigins []string
 
+	// TrustedProxies is a list of CIDRs or bare IP addresses of upstream reverse proxies
+	// (e.g. "127.0.0.1/32, 10.0.0.0/8"). When set, client IP extraction trusts
+	// CF-Connecting-IP, X-Real-IP, and X-Forwarded-For headers from these peers.
+	TrustedProxies []string
+
+	// RateLimitEnabled controls whether token-bucket rate limiting and IP quotas are enforced.
+	RateLimitEnabled bool
+
+	// MaxConnections caps the global number of concurrent active WebSocket connections.
+	MaxConnections int
+
+	// MaxConnsPerIP caps the concurrent active WebSocket connections from a single client IP.
+	MaxConnsPerIP int
+
+	// MaxRooms caps the global number of concurrent signaling rooms.
+	MaxRooms int
+
 	// IdleTimeout closes a socket that sends nothing for this long, and bounds how
 	// long an unpaired room lingers before the reaper frees it.
 	IdleTimeout time.Duration
+
+	// DrainTimeout is the maximum duration to wait for active transfers to drain during shutdown.
+	DrainTimeout time.Duration
 
 	// MaxMessageBytes caps a single inbound WebSocket message; larger frames close
 	// the connection. Handshake and caps frames are small, so this stays modest.
@@ -189,10 +211,17 @@ type Config struct {
 	MsgBurst  int
 	MsgPerSec float64
 
-	// ConnBurst / ConnPerSec are the per-IP connection-rate token bucket applied at
-	// upgrade time.
+	// ConnBurst / ConnPerSec are the per-IP connection-rate token bucket applied at upgrade time.
 	ConnBurst  int
 	ConnPerSec float64
+
+	// RoomCreateBurst / RoomCreatePerSec are the per-IP room creation rate token bucket.
+	RoomCreateBurst  int
+	RoomCreatePerSec float64
+
+	// JoinFailBurst / JoinFailPerSec are the per-IP failed join attempt rate token bucket.
+	JoinFailBurst  int
+	JoinFailPerSec float64
 
 	// Relay limits bound every layer of the opaque binary data path.
 	MaxRelayFrameBytes   int64
@@ -207,12 +236,21 @@ type Config struct {
 // enough for ordinary transfers while keeping memory, bandwidth, and lifetime bytes explicit.
 func DefaultConfig() Config {
 	return Config{
+		RateLimitEnabled:     true,
+		MaxConnections:       10000,
+		MaxConnsPerIP:        32,
+		MaxRooms:             5000,
 		IdleTimeout:          10 * time.Minute,
+		DrainTimeout:         15 * time.Second,
 		MaxMessageBytes:      64 * 1024,
 		MsgBurst:             32,
 		MsgPerSec:            16,
 		ConnBurst:            16,
 		ConnPerSec:           8,
+		RoomCreateBurst:      8,
+		RoomCreatePerSec:     2.0,
+		JoinFailBurst:        10,
+		JoinFailPerSec:       1.0,
 		MaxRelayFrameBytes:   128 * 1024,
 		RelayWindowBytes:     1 * 1024 * 1024,
 		RelayQueueBytes:      2 * 1024 * 1024,
@@ -232,11 +270,61 @@ func ConfigFromEnv() Config {
 			}
 		}
 	}
+	if v := os.Getenv("SENDBEAM_TRUSTED_PROXIES"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				cfg.TrustedProxies = append(cfg.TrustedProxies, p)
+			}
+		}
+	}
+	if b, ok := envBool("SENDBEAM_RATE_LIMIT_ENABLED"); ok {
+		cfg.RateLimitEnabled = b
+	}
+	if n, ok := envInt("SENDBEAM_MAX_CONNECTIONS"); ok {
+		cfg.MaxConnections = n
+	}
+	if n, ok := envInt("SENDBEAM_MAX_CONNS_PER_IP"); ok {
+		cfg.MaxConnsPerIP = n
+	}
+	if n, ok := envInt("SENDBEAM_MAX_ROOMS"); ok {
+		cfg.MaxRooms = n
+	}
 	if d, ok := envDuration("SENDBEAM_SIGNAL_IDLE_TIMEOUT"); ok {
 		cfg.IdleTimeout = d
 	}
+	if d, ok := envDuration("SENDBEAM_DRAIN_TIMEOUT"); ok {
+		cfg.DrainTimeout = d
+	}
 	if n, ok := envInt("SENDBEAM_SIGNAL_MAX_MESSAGE_BYTES"); ok {
 		cfg.MaxMessageBytes = int64(n)
+	}
+	if n, ok := envInt("SENDBEAM_SIGNAL_MSG_BURST"); ok {
+		cfg.MsgBurst = n
+	}
+	if f, ok := envFloat64("SENDBEAM_SIGNAL_MSG_PER_SEC"); ok {
+		cfg.MsgPerSec = f
+	}
+	if n, ok := envInt("SENDBEAM_CONN_BURST"); ok {
+		cfg.ConnBurst = n
+	} else if n, ok := envInt("SENDBEAM_SIGNAL_CONN_BURST"); ok {
+		cfg.ConnBurst = n
+	}
+	if f, ok := envFloat64("SENDBEAM_CONN_PER_SEC"); ok {
+		cfg.ConnPerSec = f
+	} else if f, ok := envFloat64("SENDBEAM_SIGNAL_CONN_PER_SEC"); ok {
+		cfg.ConnPerSec = f
+	}
+	if n, ok := envInt("SENDBEAM_ROOM_CREATE_BURST"); ok {
+		cfg.RoomCreateBurst = n
+	}
+	if f, ok := envFloat64("SENDBEAM_ROOM_CREATE_PER_SEC"); ok {
+		cfg.RoomCreatePerSec = f
+	}
+	if n, ok := envInt("SENDBEAM_JOIN_FAIL_BURST"); ok {
+		cfg.JoinFailBurst = n
+	}
+	if f, ok := envFloat64("SENDBEAM_JOIN_FAIL_PER_SEC"); ok {
+		cfg.JoinFailPerSec = f
 	}
 	if n, ok := envInt64("SENDBEAM_RELAY_MAX_FRAME_BYTES"); ok {
 		cfg.MaxRelayFrameBytes = n
@@ -257,6 +345,30 @@ func ConfigFromEnv() Config {
 		cfg.RelayMaxSessionBytes = n
 	}
 	return cfg
+}
+
+func envBool(key string) (bool, bool) {
+	v := os.Getenv(key)
+	if v == "" {
+		return false, false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, false
+	}
+	return b, true
+}
+
+func envFloat64(key string) (float64, bool) {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0, false
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || f <= 0 {
+		return 0, false
+	}
+	return f, true
 }
 
 func envDuration(key string) (time.Duration, bool) {

--- a/apps/server/internal/signal/metrics.go
+++ b/apps/server/internal/signal/metrics.go
@@ -8,51 +8,102 @@ import (
 )
 
 // Metrics is a point-in-time snapshot of server-wide counters, rendered by
-// /metrics in the Prometheus text format. Nothing here reveals content: rooms
-// count live sessions, relayBytes counts ciphertext, errors counts refusal codes.
+// /metrics in the Prometheus text format. Nothing here reveals content or PII:
+// rooms count live sessions, active connections count sockets, relayBytes counts
+// ciphertext, errors and messages count counts by opaque code/type.
 type Metrics struct {
-	Rooms      int
-	RelayBytes int64
-	Errors     map[string]int64
+	Rooms             int
+	ActiveConnections int
+	ConnectionsTotal  int64
+	RoomsCreatedTotal int64
+	RoomsPairedTotal  int64
+	RoomsReapedTotal  int64
+	RelayBytes        int64
+	Errors            map[string]int64
+	Messages          map[string]int64
 }
 
 // Metrics returns a snapshot of the hub's counters. All fields are guarded by
-// hub.mu, which also protects room state and relay byte accounting.
+// hub.mu, which also protects room state, connection tracking, and relay byte accounting.
 func (h *Hub) Metrics() Metrics {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	m := Metrics{
-		Rooms:      len(h.rooms),
-		RelayBytes: h.relayBytes,
-		Errors:     make(map[string]int64, len(h.errors)),
+		Rooms:             len(h.rooms),
+		ActiveConnections: h.activeConns,
+		ConnectionsTotal:  h.connsTotal,
+		RoomsCreatedTotal: h.roomsCreatedTotal,
+		RoomsPairedTotal:  h.roomsPairedTotal,
+		RoomsReapedTotal:  h.roomsReapedTotal,
+		RelayBytes:        h.relayBytes,
+		Errors:            make(map[string]int64, len(h.errors)),
+		Messages:          make(map[string]int64, len(h.messages)),
 	}
 	for code, n := range h.errors {
 		m.Errors[code] = n
 	}
+	for typ, n := range h.messages {
+		m.Messages[typ] = n
+	}
 	return m
 }
 
-// recordError counts one refusal or protocol error by code. It is called from
-// peer goroutines and from hub methods; hub.mu serializes it with snapshots.
+// recordError counts one refusal or protocol error by code.
 func (h *Hub) recordError(code string) {
+	if code == "" {
+		return
+	}
 	h.mu.Lock()
 	h.errors[code]++
 	h.mu.Unlock()
 }
 
-// MetricsHandler serves Prometheus text metrics for the demo dashboard.
+// recordMessage counts one parsed client message by type.
+func (h *Hub) recordMessage(typ string) {
+	if typ == "" {
+		return
+	}
+	h.mu.Lock()
+	h.messages[typ]++
+	h.mu.Unlock()
+}
+
+// MetricsHandler serves Prometheus text metrics.
 func (h *Hub) MetricsHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		m := h.Metrics()
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 		var b strings.Builder
+
 		b.WriteString("# HELP sendbeam_rooms Active signaling rooms (live sessions).\n")
 		b.WriteString("# TYPE sendbeam_rooms gauge\n")
 		fmt.Fprintf(&b, "sendbeam_rooms %d\n", m.Rooms)
+
+		b.WriteString("# HELP sendbeam_active_connections Active WebSocket connections.\n")
+		b.WriteString("# TYPE sendbeam_active_connections gauge\n")
+		fmt.Fprintf(&b, "sendbeam_active_connections %d\n", m.ActiveConnections)
+
+		b.WriteString("# HELP sendbeam_connections_total Total WebSocket connections accepted since start.\n")
+		b.WriteString("# TYPE sendbeam_connections_total counter\n")
+		fmt.Fprintf(&b, "sendbeam_connections_total %d\n", m.ConnectionsTotal)
+
+		b.WriteString("# HELP sendbeam_rooms_created_total Total rooms created since start.\n")
+		b.WriteString("# TYPE sendbeam_rooms_created_total counter\n")
+		fmt.Fprintf(&b, "sendbeam_rooms_created_total %d\n", m.RoomsCreatedTotal)
+
+		b.WriteString("# HELP sendbeam_rooms_paired_total Total rooms paired since start.\n")
+		b.WriteString("# TYPE sendbeam_rooms_paired_total counter\n")
+		fmt.Fprintf(&b, "sendbeam_rooms_paired_total %d\n", m.RoomsPairedTotal)
+
+		b.WriteString("# HELP sendbeam_rooms_reaped_total Total idle rooms reaped since start.\n")
+		b.WriteString("# TYPE sendbeam_rooms_reaped_total counter\n")
+		fmt.Fprintf(&b, "sendbeam_rooms_reaped_total %d\n", m.RoomsReapedTotal)
+
 		b.WriteString("# HELP sendbeam_relay_bytes_total Ciphertext bytes relayed since server start.\n")
 		b.WriteString("# TYPE sendbeam_relay_bytes_total counter\n")
 		fmt.Fprintf(&b, "sendbeam_relay_bytes_total %d\n", m.RelayBytes)
-		b.WriteString("# HELP sendbeam_errors_total Error frames sent, by refusal code.\n")
+
+		b.WriteString("# HELP sendbeam_errors_total Error frames and refusals sent, by refusal code.\n")
 		b.WriteString("# TYPE sendbeam_errors_total counter\n")
 		codes := make([]string, 0, len(m.Errors))
 		for code := range m.Errors {
@@ -62,6 +113,18 @@ func (h *Hub) MetricsHandler() http.Handler {
 		for _, code := range codes {
 			fmt.Fprintf(&b, "sendbeam_errors_total{code=%q} %d\n", code, m.Errors[code])
 		}
+
+		b.WriteString("# HELP sendbeam_messages_total Inbound signaling and control messages by type.\n")
+		b.WriteString("# TYPE sendbeam_messages_total counter\n")
+		types := make([]string, 0, len(m.Messages))
+		for typ := range m.Messages {
+			types = append(types, typ)
+		}
+		sort.Strings(types)
+		for _, typ := range types {
+			fmt.Fprintf(&b, "sendbeam_messages_total{type=%q} %d\n", typ, m.Messages[typ])
+		}
+
 		_, _ = w.Write([]byte(b.String()))
 	})
 }

--- a/apps/server/internal/signal/metrics_test.go
+++ b/apps/server/internal/signal/metrics_test.go
@@ -15,24 +15,39 @@ func TestMetricsSnapshot(t *testing.T) {
 	}
 
 	a, b := newTestPeer(), newTestPeer()
-	h.createRoom(a)
-	h.createRoom(b)
+	_, _ = h.createRoom(a, "127.0.0.1")
+	room2, _ := h.createRoom(b, "127.0.0.1")
+	joiner := newTestPeer()
+	_, _ = h.join(joiner, room2, "127.0.0.1")
+
 	h.recordError("bad_message")
 	h.recordError("bad_message")
 	h.recordError("room_full")
+	h.recordMessage("create")
+	h.recordMessage("join")
 
 	m := h.Metrics()
 	if m.Rooms != 2 {
 		t.Errorf("Rooms = %d, want 2", m.Rooms)
 	}
+	if m.RoomsCreatedTotal != 2 {
+		t.Errorf("RoomsCreatedTotal = %d, want 2", m.RoomsCreatedTotal)
+	}
+	if m.RoomsPairedTotal != 1 {
+		t.Errorf("RoomsPairedTotal = %d, want 1", m.RoomsPairedTotal)
+	}
 	if m.Errors["bad_message"] != 2 || m.Errors["room_full"] != 1 {
 		t.Errorf("Errors = %v, want bad_message=2 room_full=1", m.Errors)
+	}
+	if m.Messages["create"] != 1 || m.Messages["join"] != 1 {
+		t.Errorf("Messages = %v, want create=1 join=1", m.Messages)
 	}
 }
 
 func TestMetricsHandlerRendersPrometheusText(t *testing.T) {
 	h := testHub(t)
 	h.recordError("room_full")
+	h.recordMessage("pake")
 
 	rec := httptest.NewRecorder()
 	h.MetricsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
@@ -43,11 +58,30 @@ func TestMetricsHandlerRendersPrometheusText(t *testing.T) {
 	for _, want := range []string{
 		"# TYPE sendbeam_rooms gauge",
 		"sendbeam_rooms 0",
+		"# TYPE sendbeam_active_connections gauge",
+		"sendbeam_active_connections 0",
+		"# TYPE sendbeam_connections_total counter",
+		"sendbeam_connections_total 0",
+		"# TYPE sendbeam_rooms_created_total counter",
+		"sendbeam_rooms_created_total 0",
+		"# TYPE sendbeam_rooms_paired_total counter",
+		"sendbeam_rooms_paired_total 0",
+		"# TYPE sendbeam_rooms_reaped_total counter",
+		"sendbeam_rooms_reaped_total 0",
+		"# TYPE sendbeam_relay_bytes_total counter",
 		"sendbeam_relay_bytes_total 0",
 		`sendbeam_errors_total{code="room_full"} 1`,
+		`sendbeam_messages_total{type="pake"} 1`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q:\n%s", want, body)
+		}
+	}
+
+	// Verify no high cardinality or PII strings appear in metrics
+	for _, forbidden := range []string{"127.0.0.1", "ip", "client", "room_0", "token"} {
+		if strings.Contains(body, forbidden+"=") {
+			t.Errorf("metrics must not contain PII or high-cardinality labels: %s", forbidden)
 		}
 	}
 }

--- a/apps/server/internal/signal/peer.go
+++ b/apps/server/internal/signal/peer.go
@@ -30,9 +30,10 @@ type outboundFrame struct {
 // owns every write to ws; all other goroutines hand it frames through send. done is
 // closed exactly once to unwind both the reader and the writer.
 type peer struct {
-	ws     *websocket.Conn
-	hub    *Hub
-	logger *slog.Logger
+	ws       *websocket.Conn
+	hub      *Hub
+	logger   *slog.Logger
+	clientIP string
 
 	room int    // -1 until the peer creates or joins a room
 	role string // set on create/join
@@ -51,11 +52,12 @@ type peer struct {
 	graceful         bool // set when this peer sent a bye; makes teardown non-resumable
 }
 
-func newPeer(ws *websocket.Conn, h *Hub) *peer {
+func newPeer(ws *websocket.Conn, h *Hub, clientIP string) *peer {
 	return &peer{
 		ws:               ws,
 		hub:              h,
 		logger:           h.logger,
+		clientIP:         clientIP,
 		room:             -1,
 		send:             make(chan outboundFrame, 16),
 		relayRate:        newTokenBucket(int(h.cfg.RelayBurstBytes), float64(h.cfg.RelayBytesPerSec)),
@@ -69,7 +71,10 @@ func newPeer(ws *websocket.Conn, h *Hub) *peer {
 // the socket closes or a protocol error ends it, then tears the room down.
 func (p *peer) serve(ctx context.Context) {
 	p.ws.SetReadLimit(max(p.hub.cfg.MaxMessageBytes, p.hub.cfg.MaxRelayFrameBytes))
-	msgLimiter := newTokenBucket(p.hub.cfg.MsgBurst, p.hub.cfg.MsgPerSec)
+	var msgLimiter *tokenBucket
+	if p.hub.cfg.RateLimitEnabled {
+		msgLimiter = newTokenBucket(p.hub.cfg.MsgBurst, p.hub.cfg.MsgPerSec)
+	}
 
 	go p.writeLoop(ctx)
 	defer p.teardown()
@@ -112,12 +117,14 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 		p.fail(errBadMessage, "invalid message")
 		return false
 	}
+	p.hub.recordMessage(m.Type)
+
 	if m.Type == typeRelayCredit {
-		if !p.relayControlRate.allow() {
+		if p.hub.cfg.RateLimitEnabled && !p.relayControlRate.allow() {
 			p.fail(errRateLimited, "too many relay credit messages")
 			return false
 		}
-	} else if !msgLimiter.allow() {
+	} else if msgLimiter != nil && !msgLimiter.allow() {
 		p.fail(errRateLimited, "too many messages")
 		return false
 	}
@@ -128,7 +135,11 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 			p.fail(errProtocol, "already in a room")
 			return false
 		}
-		room := p.hub.createRoom(p)
+		room, code := p.hub.createRoom(p, p.clientIP)
+		if code != "" {
+			p.fail(code, "")
+			return false
+		}
 		p.logger.Info("signal: room created", "room", room)
 		p.enqueue(createdFrame(room))
 		return true
@@ -142,7 +153,7 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 			p.fail(errBadMessage, "join requires a room")
 			return false
 		}
-		other, code := p.hub.join(p, *m.Room)
+		other, code := p.hub.join(p, *m.Room, p.clientIP)
 		if code != "" {
 			p.fail(code, "")
 			return false
@@ -161,7 +172,7 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 			p.fail(errBadMessage, "resume requires a room")
 			return false
 		}
-		other, code := p.hub.resume(p, *m.Room, m.Role)
+		other, code := p.hub.resume(p, *m.Room, m.Role, p.clientIP)
 		if code != "" {
 			p.fail(code, "")
 			return false

--- a/apps/server/internal/signal/proxy.go
+++ b/apps/server/internal/signal/proxy.go
@@ -1,0 +1,122 @@
+package signal
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ParseTrustedProxies parses a comma-separated list of CIDR strings or bare IP
+// addresses into a slice of *net.IPNet. Whitespace is trimmed and empty entries are ignored.
+func ParseTrustedProxies(raw string) ([]*net.IPNet, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	var nets []*net.IPNet
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if !strings.Contains(p, "/") {
+			// Bare IP: convert to /32 (IPv4) or /128 (IPv6)
+			ip := net.ParseIP(p)
+			if ip == nil {
+				return nil, &net.ParseError{Type: "IP address", Text: p}
+			}
+			if ip.To4() != nil {
+				p += "/32"
+			} else {
+				p += "/128"
+			}
+		}
+		_, ipNet, err := net.ParseCIDR(p)
+		if err != nil {
+			return nil, err
+		}
+		nets = append(nets, ipNet)
+	}
+	return nets, nil
+}
+
+// isTrustedProxy reports whether ip is covered by any network in trustedNets.
+func isTrustedProxy(ip net.IP, trustedNets []*net.IPNet) bool {
+	if ip == nil || len(trustedNets) == 0 {
+		return false
+	}
+	for _, n := range trustedNets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ClientIP extracts the canonical client IP from an HTTP request.
+//
+// When trustedNets is empty or r.RemoteAddr is not from a trusted proxy,
+// the direct remote address is returned verbatim and headers like X-Forwarded-For
+// are deliberately ignored to prevent client spoofing.
+//
+// When r.RemoteAddr is in trustedNets, headers are parsed in priority order:
+// 1. CF-Connecting-IP (Cloudflare)
+// 2. X-Real-IP
+// 3. X-Forwarded-For (evaluating right-to-left for the first untrusted upstream hop)
+func ClientIP(r *http.Request, trustedNets []*net.IPNet) string {
+	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		remoteHost = r.RemoteAddr
+	}
+	remoteHost = strings.TrimSpace(remoteHost)
+	if len(trustedNets) == 0 {
+		return remoteHost
+	}
+
+	remoteIP := net.ParseIP(remoteHost)
+	if remoteIP == nil || !isTrustedProxy(remoteIP, trustedNets) {
+		return remoteHost
+	}
+
+	// Remote peer is a trusted proxy. Check CF-Connecting-IP first.
+	if cf := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); cf != "" {
+		if ip := net.ParseIP(cf); ip != nil {
+			return ip.String()
+		}
+	}
+
+	// Check X-Real-IP next.
+	if realIP := strings.TrimSpace(r.Header.Get("X-Real-IP")); realIP != "" {
+		if ip := net.ParseIP(realIP); ip != nil {
+			return ip.String()
+		}
+	}
+
+	// Check X-Forwarded-For (comma-separated list of client, proxy1, proxy2...).
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		hops := strings.Split(xff, ",")
+		// Walk backwards from rightmost (nearest proxy) to find the first untrusted IP.
+		for i := len(hops) - 1; i >= 0; i-- {
+			hop := strings.TrimSpace(hops[i])
+			if hop == "" {
+				continue
+			}
+			ip := net.ParseIP(hop)
+			if ip == nil {
+				continue
+			}
+			if !isTrustedProxy(ip, trustedNets) {
+				return ip.String()
+			}
+		}
+		// If all hops in XFF are trusted proxies, take the leftmost hop as the original client.
+		for _, hop := range hops {
+			hop = strings.TrimSpace(hop)
+			if ip := net.ParseIP(hop); ip != nil {
+				return ip.String()
+			}
+		}
+	}
+
+	return remoteHost
+}

--- a/apps/server/internal/signal/proxy_test.go
+++ b/apps/server/internal/signal/proxy_test.go
@@ -1,0 +1,137 @@
+package signal
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseTrustedProxies(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int
+		wantErr bool
+	}{
+		{name: "empty", input: "", wantLen: 0, wantErr: false},
+		{name: "single cidr", input: "127.0.0.1/32", wantLen: 1, wantErr: false},
+		{name: "bare ip", input: "127.0.0.1", wantLen: 1, wantErr: false},
+		{name: "ipv6 bare", input: "::1", wantLen: 1, wantErr: false},
+		{name: "multiple mixed", input: "10.0.0.0/8, 172.16.0.0/12, 192.168.1.1, ::1/128", wantLen: 4, wantErr: false},
+		{name: "invalid cidr", input: "999.999.999.999/32", wantLen: 0, wantErr: true},
+		{name: "invalid ip", input: "not-an-ip", wantLen: 0, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nets, err := ParseTrustedProxies(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseTrustedProxies(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if len(nets) != tt.wantLen {
+				t.Fatalf("ParseTrustedProxies(%q) got len %d, want %d", tt.input, len(nets), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestClientIP(t *testing.T) {
+	trusted, err := ParseTrustedProxies("127.0.0.1/32, 10.0.0.0/8, 192.168.0.0/16, ::1/128")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string]string
+		trusted    bool
+		wantIP     string
+	}{
+		{
+			name:       "direct untrusted ignores xff",
+			remoteAddr: "203.0.113.50:54321",
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.1"},
+			trusted:    true,
+			wantIP:     "203.0.113.50",
+		},
+		{
+			name:       "direct untrusted ignores cf-connecting-ip",
+			remoteAddr: "203.0.113.50:54321",
+			headers:    map[string]string{"CF-Connecting-IP": "198.51.100.1"},
+			trusted:    true,
+			wantIP:     "203.0.113.50",
+		},
+		{
+			name:       "no trusted proxies configured ignores headers",
+			remoteAddr: "127.0.0.1:54321",
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.1"},
+			trusted:    false,
+			wantIP:     "127.0.0.1",
+		},
+		{
+			name:       "trusted proxy with single xff",
+			remoteAddr: "127.0.0.1:54321",
+			headers:    map[string]string{"X-Forwarded-For": "203.0.113.77"},
+			trusted:    true,
+			wantIP:     "203.0.113.77",
+		},
+		{
+			name:       "trusted proxy with chained xff picks rightmost untrusted",
+			remoteAddr: "10.0.0.1:54321",
+			headers:    map[string]string{"X-Forwarded-For": "198.51.100.22, 203.0.113.99, 10.0.0.2"},
+			trusted:    true,
+			wantIP:     "203.0.113.99",
+		},
+		{
+			name:       "trusted proxy with cf-connecting-ip takes precedence",
+			remoteAddr: "10.0.0.1:54321",
+			headers: map[string]string{
+				"CF-Connecting-IP": "203.0.113.123",
+				"X-Forwarded-For":  "198.51.100.22",
+			},
+			trusted: true,
+			wantIP:  "203.0.113.123",
+		},
+		{
+			name:       "trusted proxy with x-real-ip fallback",
+			remoteAddr: "192.168.1.1:54321",
+			headers:    map[string]string{"X-Real-IP": "203.0.113.88"},
+			trusted:    true,
+			wantIP:     "203.0.113.88",
+		},
+		{
+			name:       "trusted proxy with all trusted hops in xff returns leftmost",
+			remoteAddr: "127.0.0.1:54321",
+			headers:    map[string]string{"X-Forwarded-For": "10.0.0.5, 10.0.0.2"},
+			trusted:    true,
+			wantIP:     "10.0.0.5",
+		},
+		{
+			name:       "trusted proxy ipv6",
+			remoteAddr: "[::1]:54321",
+			headers:    map[string]string{"X-Forwarded-For": "2001:db8::1"},
+			trusted:    true,
+			wantIP:     "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+			r.RemoteAddr = tt.remoteAddr
+			for k, v := range tt.headers {
+				r.Header.Set(k, v)
+			}
+			var nets []*net.IPNet
+			if tt.trusted {
+				nets = trusted
+			}
+			got := ClientIP(r, nets)
+			if got != tt.wantIP {
+				t.Fatalf("ClientIP() = %q, want %q", got, tt.wantIP)
+			}
+		})
+	}
+}

--- a/apps/server/internal/signal/ratelimit.go
+++ b/apps/server/internal/signal/ratelimit.go
@@ -37,7 +37,30 @@ func (b *tokenBucket) allowAt(now time.Time) bool {
 	return b.allowNAt(1, now)
 }
 
+func (b *tokenBucket) hasToken() bool {
+	return b.hasTokenAt(time.Now())
+}
+
+func (b *tokenBucket) hasTokenAt(now time.Time) bool {
+	if b == nil || b.burst <= 0 || b.rate <= 0 {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if elapsed := now.Sub(b.last).Seconds(); elapsed > 0 {
+		b.tokens = min(b.burst, b.tokens+elapsed*b.rate)
+		b.last = now
+	}
+	return b.tokens >= 1.0
+}
+
 func (b *tokenBucket) allowNAt(tokens float64, now time.Time) bool {
+	if b == nil || b.burst <= 0 || b.rate <= 0 {
+		return true // unlimited
+	}
+	if tokens <= 0 {
+		return true
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -45,7 +68,7 @@ func (b *tokenBucket) allowNAt(tokens float64, now time.Time) bool {
 		b.tokens = min(b.burst, b.tokens+elapsed*b.rate)
 		b.last = now
 	}
-	if tokens <= 0 || b.tokens < tokens {
+	if b.tokens < tokens {
 		return false
 	}
 	b.tokens -= tokens
@@ -56,6 +79,9 @@ func (b *tokenBucket) allowNAt(tokens float64, now time.Time) bool {
 // least idle. It refills before checking and refreshes last, so it is safe to call from a
 // periodic sweeper that keeps non-idle buckets alive.
 func (b *tokenBucket) refilledAndIdle(now time.Time, idle time.Duration) bool {
+	if b == nil || b.burst <= 0 || b.rate <= 0 {
+		return true
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	elapsed := now.Sub(b.last)
@@ -64,4 +90,96 @@ func (b *tokenBucket) refilledAndIdle(now time.Time, idle time.Duration) bool {
 		b.last = now
 	}
 	return b.tokens >= b.burst && elapsed >= idle
+}
+
+// ipTracker tracks active connections and multi-dimensional rate limiters for a single client IP.
+type ipTracker struct {
+	mu           sync.Mutex
+	activeConns  int
+	connLimiter  *tokenBucket
+	roomLimiter  *tokenBucket
+	joinLimiter  *tokenBucket
+	lastActivity time.Time
+}
+
+func newIPTracker(cfg Config) *ipTracker {
+	return &ipTracker{
+		connLimiter:  newTokenBucket(cfg.ConnBurst, cfg.ConnPerSec),
+		roomLimiter:  newTokenBucket(cfg.RoomCreateBurst, cfg.RoomCreatePerSec),
+		joinLimiter:  newTokenBucket(cfg.JoinFailBurst, cfg.JoinFailPerSec),
+		lastActivity: time.Now(),
+	}
+}
+
+func (t *ipTracker) acquireConn(maxPerIP int, rateLimitEnabled bool) (allowed bool, release func()) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastActivity = time.Now()
+
+	if rateLimitEnabled {
+		if maxPerIP > 0 && t.activeConns >= maxPerIP {
+			return false, nil
+		}
+		if !t.connLimiter.allow() {
+			return false, nil
+		}
+	}
+
+	t.activeConns++
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			t.mu.Lock()
+			if t.activeConns > 0 {
+				t.activeConns--
+			}
+			t.lastActivity = time.Now()
+			t.mu.Unlock()
+		})
+	}
+	return true, release
+}
+
+func (t *ipTracker) allowRoomCreate(rateLimitEnabled bool) bool {
+	if !rateLimitEnabled {
+		return true
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastActivity = time.Now()
+	return t.roomLimiter.allow()
+}
+
+func (t *ipTracker) allowJoin(rateLimitEnabled bool) bool {
+	if !rateLimitEnabled {
+		return true
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastActivity = time.Now()
+	return t.joinLimiter.hasToken()
+}
+
+func (t *ipTracker) recordFailedJoin(rateLimitEnabled bool) {
+	if !rateLimitEnabled {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastActivity = time.Now()
+	_ = t.joinLimiter.allow() // spend 1 failure token
+}
+
+func (t *ipTracker) refilledAndIdle(now time.Time, idle time.Duration) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.activeConns > 0 {
+		return false
+	}
+	if now.Sub(t.lastActivity) < idle {
+		return false
+	}
+	return t.connLimiter.refilledAndIdle(now, idle) &&
+		t.roomLimiter.refilledAndIdle(now, idle) &&
+		t.joinLimiter.refilledAndIdle(now, idle)
 }

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -2,7 +2,8 @@
 
 SendBeam ships as a single container that serves the web app, the signaling
 endpoint, and the encrypted relay from one process on one port. This guide
-covers running it yourself, including TLS, STUN/TURN, and relay limits.
+covers running it yourself, including TLS, reverse proxies, STUN/TURN, rate
+limiting, and relay quotas.
 
 ## Quickstart
 
@@ -14,15 +15,27 @@ docker run -d --name sendbeam -p 8443:8443 ghcr.io/akshay7273/sendbeam
 
 Then open <http://localhost:8443> and send your first file. Plain HTTP on
 `localhost` is a browser secure context, so WebRTC works; for anything
-reachable from another machine, put TLS in front (see [TLS](#tls)).
+reachable from another machine, put TLS in front (see [TLS & Reverse Proxies](#tls--reverse-proxies)).
 
-Health: `GET /healthz` returns `{"status":"ok"}`; the container also
-exposes a `HEALTHCHECK` against it.
+### Health & Readiness Endpoints
 
-Metrics: `GET /metrics` serves Prometheus text with active rooms
-(`sendbeam_rooms`), relayed ciphertext bytes (`sendbeam_relay_bytes_total`),
-and refusal/error codes (`sendbeam_errors_total{code=...}`). Point a scraper
-or a dashboard at it; nothing content-bearing is ever exposed.
+- **Liveness probe:** `GET /healthz` returns `{"status":"ok"}` (HTTP 200). The container image includes a `HEALTHCHECK` against this endpoint.
+- **Readiness probe:** `GET /readyz` returns `{"status":"ready","rooms":N,"connections":M,"draining":false}` (HTTP 200) during normal operation. When the server begins graceful shutdown, it transitions to `{"status":"draining",...}` (HTTP 503 Service Unavailable) so load balancers stop sending new ingress traffic while active relay transfers drain.
+
+### Prometheus Metrics
+
+- **Metrics endpoint:** `GET /metrics` serves Prometheus text metrics:
+  - `sendbeam_rooms`: Active signaling rooms (gauge)
+  - `sendbeam_active_connections`: Active WebSocket connections (gauge)
+  - `sendbeam_connections_total`: Total accepted WebSocket connections (counter)
+  - `sendbeam_rooms_created_total`: Total rooms created since start (counter)
+  - `sendbeam_rooms_paired_total`: Total rooms paired since start (counter)
+  - `sendbeam_rooms_reaped_total`: Total idle rooms reaped (counter)
+  - `sendbeam_relay_bytes_total`: Ciphertext bytes relayed (counter)
+  - `sendbeam_errors_total{code="..."}`: Error and refusal counts by code (counter)
+  - `sendbeam_messages_total{type="..."}`: Signaling and control messages by type (counter)
+
+All metrics expose aggregate counters and byte totals only — **zero IP addresses, zero room codes, zero client IDs, and zero content metadata are ever exposed**.
 
 ## What the image contains
 
@@ -36,32 +49,95 @@ so web + signaling + relay all share the published port.
 
 ## Environment variables
 
-| Variable                                 | Default       | Purpose                                                                                                                                          |
-| ---------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SENDBEAM_ADDR`                          | `:8443`       | Listen address.                                                                                                                                  |
-| `SENDBEAM_TLS_CERT` / `SENDBEAM_TLS_KEY` | unset         | PEM cert/key paths; when both are set `sendbeamd` terminates TLS itself.                                                                         |
-| `SENDBEAM_WEB_DIR`                       | unset         | Directory of the built web bundle to serve; set to `/srv/web` in the image.                                                                      |
-| `SENDBEAM_WEB_DEV_PROXY`                 | unset         | Vite dev-server URL to proxy to (development only; overrides `SENDBEAM_WEB_DIR`).                                                                |
-| `SENDBEAM_ALLOWED_ORIGINS`               | empty         | Comma-separated WSS origin allowlist. Empty allows only same-origin browser sockets; native CLI clients (no `Origin` header) are always allowed. |
-| `SENDBEAM_ICE_SERVERS`                   | unset         | Comma-separated STUN (or TURN) URLs published to the web app via `/config.json`; unset keeps the bundled Google STUN default.                    |
-| `SENDBEAM_SIGNAL_IDLE_TIMEOUT`           | `2m`          | Close a socket silent this long; also bounds how long an unpaired room lingers.                                                                  |
-| `SENDBEAM_SIGNAL_MAX_MESSAGE_BYTES`      | `65536`       | Cap on a single inbound signaling message.                                                                                                       |
-| `SENDBEAM_RELAY_MAX_FRAME_BYTES`         | `131072`      | Cap on a single relay frame.                                                                                                                     |
-| `SENDBEAM_RELAY_WINDOW_BYTES`            | `1048576`     | In-flight window per relay connection.                                                                                                           |
-| `SENDBEAM_RELAY_QUEUE_BYTES`             | `2097152`     | Bounded per-connection relay queue.                                                                                                              |
-| `SENDBEAM_RELAY_BURST_BYTES`             | `8388608`     | Token-bucket burst for relay throughput.                                                                                                         |
-| `SENDBEAM_RELAY_BYTES_PER_SEC`           | `33554432`    | Relay throughput ceiling (32 MiB/s by default).                                                                                                  |
-| `SENDBEAM_RELAY_MAX_SESSION_BYTES`       | `17179869184` | Lifetime bytes relayed per session (16 GiB).                                                                                                     |
+| Variable                                  | Default       | Purpose                                                                                                                                                                       |
+| ----------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SENDBEAM_ADDR`                           | `:8443`       | Listen address.                                                                                                                                                               |
+| `SENDBEAM_TLS_CERT` / `_TLS_KEY`          | unset         | PEM cert/key paths; when both are set `sendbeamd` terminates TLS itself.                                                                                                      |
+| `SENDBEAM_WEB_DIR`                        | unset         | Directory of the built web bundle to serve; set to `/srv/web` in the image.                                                                                                   |
+| `SENDBEAM_WEB_DEV_PROXY`                  | unset         | Vite dev-server URL to proxy to (development only; overrides `SENDBEAM_WEB_DIR`).                                                                                             |
+| `SENDBEAM_ALLOWED_ORIGINS`                | empty         | Comma-separated WSS origin allowlist. Empty allows only same-origin browser sockets; native CLI clients (no `Origin` header) are always allowed.                              |
+| `SENDBEAM_TRUSTED_PROXIES`                | empty         | Comma-separated CIDRs/IPs of trusted upstream reverse proxies (e.g. `127.0.0.1/32,10.0.0.0/8`). Enables secure `X-Forwarded-For` and `CF-Connecting-IP` client IP extraction. |
+| `SENDBEAM_RATE_LIMIT_ENABLED`             | `true`        | Master toggle for token-bucket rate limiters and concurrency quotas. Set to `false` for private unconstrained LAN operation.                                                  |
+| `SENDBEAM_MAX_CONNECTIONS`                | `10000`       | Global ceiling for concurrent active WebSocket connections.                                                                                                                   |
+| `SENDBEAM_MAX_CONNS_PER_IP`               | `32`          | Maximum concurrent active WebSocket connections per client IP.                                                                                                                |
+| `SENDBEAM_MAX_ROOMS`                      | `5000`        | Global ceiling for concurrent active signaling rooms.                                                                                                                         |
+| `SENDBEAM_CONN_BURST` / `_PER_SEC`        | `16` / `8.0`  | Token-bucket connection rate limit per client IP at WebSocket upgrade.                                                                                                        |
+| `SENDBEAM_ROOM_CREATE_BURST` / `_PER_SEC` | `8` / `2.0`   | Token-bucket room creation rate limit per client IP.                                                                                                                          |
+| `SENDBEAM_JOIN_FAIL_BURST` / `_PER_SEC`   | `10` / `1.0`  | Token-bucket anti-brute-force rate limit for failed room join attempts per client IP.                                                                                         |
+| `SENDBEAM_DRAIN_TIMEOUT`                  | `15s`         | Maximum duration to wait for active transfers to drain during graceful shutdown.                                                                                              |
+| `SENDBEAM_SHUTDOWN_TIMEOUT`               | `15s`         | Maximum total duration for HTTP server shutdown.                                                                                                                              |
+| `SENDBEAM_LOG_FORMAT`                     | `text`        | Structured log format: `text` or `json`.                                                                                                                                      |
+| `SENDBEAM_LOG_LEVEL`                      | `info`        | Structured log level: `debug`, `info`, `warn`, `error`. Zero-PII policy applies at all levels.                                                                                |
+| `SENDBEAM_ICE_SERVERS`                    | unset         | Comma-separated STUN (or TURN) URLs published to the web app via `/config.json`; unset keeps the bundled Google STUN default.                                                 |
+| `SENDBEAM_SIGNAL_IDLE_TIMEOUT`            | `10m`         | Close a socket silent this long; also bounds how long an unpaired room lingers before being reaped.                                                                           |
+| `SENDBEAM_SIGNAL_MAX_MESSAGE_BYTES`       | `65536`       | Cap on a single inbound signaling message (64 KiB).                                                                                                                           |
+| `SENDBEAM_RELAY_MAX_FRAME_BYTES`          | `131072`      | Cap on a single relay frame (128 KiB).                                                                                                                                        |
+| `SENDBEAM_RELAY_WINDOW_BYTES`             | `1048576`     | In-flight window per relay connection (1 MiB).                                                                                                                                |
+| `SENDBEAM_RELAY_QUEUE_BYTES`              | `2097152`     | Bounded per-connection relay queue (2 MiB).                                                                                                                                   |
+| `SENDBEAM_RELAY_BURST_BYTES`              | `8388608`     | Token-bucket burst for relay throughput (8 MiB).                                                                                                                              |
+| `SENDBEAM_RELAY_BYTES_PER_SEC`            | `33554432`    | Relay throughput ceiling per session (32 MiB/s by default).                                                                                                                   |
+| `SENDBEAM_RELAY_MAX_SESSION_BYTES`        | `17179869184` | Lifetime bytes relayed per session (16 GiB).                                                                                                                                  |
 
 Durations use Go's `time.ParseDuration` syntax (`30s`, `5m`); sizes use
-plain integers (bytes). Overrides apply only to the signaling/relay layer;
-the web bundle is a fixed artifact.
+plain integers (bytes).
 
-## TLS
+## TLS & Reverse Proxies
 
-Two supported arrangements:
+### Option 1: Reverse proxy (recommended)
 
-**1. Terminate at `sendbeamd`** — mount a PEM cert and key:
+Use Caddy, Nginx, Traefik, or Cloudflare to handle TLS certificate issuance and renewal, proxying plain HTTP to SendBeam:
+
+#### Caddy
+
+```caddy
+send.example.com {
+    reverse_proxy 127.0.0.1:8443 {
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+    }
+}
+```
+
+```sh
+docker run -d --name sendbeam -p 127.0.0.1:8443:8443 \
+  -e SENDBEAM_ALLOWED_ORIGINS=https://send.example.com \
+  -e SENDBEAM_TRUSTED_PROXIES=127.0.0.1/32,::1/128 \
+  ghcr.io/akshay7273/sendbeam
+```
+
+#### Nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name send.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/send.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/send.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8443;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+    }
+}
+```
+
+When behind a reverse proxy:
+
+1. Set `SENDBEAM_ALLOWED_ORIGINS` to your public HTTPS origin (e.g. `https://send.example.com`).
+2. Set `SENDBEAM_TRUSTED_PROXIES` to the proxy's IP/subnet (e.g. `127.0.0.1/32` or your private Docker network `172.16.0.0/12`) so client IP extraction safely parses `X-Forwarded-For` or `CF-Connecting-IP`.
+
+### Option 2: Terminate TLS directly at `sendbeamd`
+
+Mount your PEM certificate and private key into the container:
 
 ```sh
 docker run -d --name sendbeam \
@@ -75,25 +151,6 @@ docker run -d --name sendbeam \
 ```
 
 Minimum TLS 1.2 is enforced server-side.
-
-**2. Reverse proxy (recommended)** — let Caddy (or Traefik) handle issuance
-and renewal, and proxy plain HTTP to the container:
-
-```caddy
-example.com {
-    reverse_proxy 127.0.0.1:8443
-}
-```
-
-```sh
-docker run -d --name sendbeam -p 127.0.0.1:8443:8443 \
-  -e SENDBEAM_ALLOWED_ORIGINS=https://example.com \
-  ghcr.io/akshay7273/sendbeam
-```
-
-With a proxy, set `SENDBEAM_ALLOWED_ORIGINS` to your public origin so the
-browser's `Origin` header (rewritten to `https://example.com`) passes the
-allowlist. Any WebSocket-aware reverse proxy works.
 
 ## STUN and TURN
 
@@ -116,37 +173,31 @@ allowlist. Any WebSocket-aware reverse proxy works.
   end-to-end encrypted and framed inside WebSocket messages, and a TURN server
   observes only encrypted WebRTC datagrams. See `docs/adr/0003-path-selection.md`.
 
-For pairings behind symmetric NATs, make sure this server is reachable on
-the public port (it is the fallback path), and budget its bandwidth with
-the relay limits below.
+## Relay & Rate Limits
 
-## Relay limits
+Every layer of the public server is bounded:
 
-The relay is the only place an operator spends bandwidth and memory, so
-every layer is bounded. Defaults are in the table above; raise or lower
-them per instance:
+| Protection             | Mechanism                  | Default                    |
+| ---------------------- | -------------------------- | -------------------------- |
+| Connection rate        | Token bucket per IP        | 16 burst, 8 / sec          |
+| Connection concurrency | Active connection quota    | 32 per IP, 10,000 global   |
+| Room creation rate     | Token bucket per IP        | 8 burst, 2.0 / sec         |
+| Room capacity          | Global room ceiling        | 5,000 rooms                |
+| Room code brute force  | Failed join penalty bucket | 10 burst, 1.0 / sec refill |
+| Relay frame size       | Hard frame limit           | 128 KiB                    |
+| Relay window           | In-flight credit window    | 1 MiB                      |
+| Relay queue            | Buffer ceiling per socket  | 2 MiB                      |
+| Relay throughput       | Token bucket per session   | 32 MiB/s                   |
+| Session byte ceiling   | Lifetime relay bytes       | 16 GiB                     |
 
-| What             | Default  | Effect                                                     |
-| ---------------- | -------- | ---------------------------------------------------------- |
-| Frame size       | 128 KiB  | A single relay frame cannot exceed this.                   |
-| Window           | 1 MiB    | Unacked in-flight bytes per connection.                    |
-| Queue            | 2 MiB    | Buffered bytes per connection before backpressure.         |
-| Throughput       | 32 MiB/s | Token-bucket ceiling shared across connections.            |
-| Session lifetime | 16 GiB   | Bytes relayed per session before the session is torn down. |
+These bounds protect the instance from memory exhaustion, socket starvation, and code-guessing scans while providing full throughput for legitimate transfers.
 
-These keep a busy instance's memory in the low tens of MiB regardless of
-how many transfers run.
+## Security & Privacy Invariants
 
-## Security notes
-
-- Pairing is code-authenticated (SPAKE2-style handshake); the server never
-  sees the word code or plaintext payloads.
-- Server logs contain room numbers and metadata only — no secrets, no
-  file names, no payload digests of content.
-- `SENDBEAM_ALLOWED_ORIGINS` blocks cross-site socket abuse; keep it set
-  when the instance is public.
-- Run behind a reverse proxy that terminates TLS for production; plain
-  HTTP is for localhost demos only.
+- Pairing is authenticated via SPAKE2; the server never sees the word code or plaintext payloads.
+- Structured server logs contain room numbers, error codes, and message counts only — **zero client IPs, zero invite codes, zero filenames, and zero cryptographic keys**.
+- `SENDBEAM_ALLOWED_ORIGINS` blocks cross-site WebSocket hijacking; always set it when operating publicly.
+- Reverse proxy IP extraction ignores `X-Forwarded-For` from untrusted direct connections to prevent IP spoofing.
 
 ## Updating
 
@@ -155,5 +206,4 @@ docker pull ghcr.io/akshay7273/sendbeam
 docker restart sendbeam
 ```
 
-The container is stateless; nothing persists inside it, so restarts are
-safe at any time.
+The container is stateless; nothing persists inside it, so restarts and rollouts are safe at any time.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -106,13 +106,17 @@ human string, its security rests on the online, single-attempt nature of SPAKE2 
 cannot brute-force it offline) combined with 1:1 pairing and the short room lifetime, not
 on the code's length.
 
-### Denial of service
+### Denial of service & anti-abuse defenses
 
 Per-session relay queue, bandwidth, frame-size, and lifetime-bytes caps
 (`SENDBEAM_RELAY_*`, see `HOSTING.md`); message-size and per-connection message-rate caps;
-per-IP connection-rate limits; and a room reaper on the idle timeout. A WSS origin
-allowlist on the signaling upgrade (`SENDBEAM_ALLOWED_ORIGINS`) blocks cross-site socket
-abuse. All limits are operator-tunable and the defaults keep memory in the low tens of MiB.
+per-IP connection-rate limits and active connection quotas (`SENDBEAM_MAX_CONNS_PER_IP`);
+per-IP room creation rate limiting; failed-join penalty buckets to mitigate online room-code
+brute-force guessing; global room and connection capacity ceilings; and a periodic room reaper on
+the idle timeout. A WSS origin allowlist on the signaling upgrade (`SENDBEAM_ALLOWED_ORIGINS`)
+blocks cross-site socket abuse, and trusted reverse-proxy CIDR filtering (`SENDBEAM_TRUSTED_PROXIES`)
+prevents client IP spoofing via forged `X-Forwarded-For` headers. All limits are operator-tunable
+and defaults keep server memory strictly bounded under load.
 
 ### Malicious sender (receiver-side safety)
 
@@ -121,17 +125,21 @@ file-count cap, quota checks, and the in-flight block bound (`DEFAULT_INFLIGHT_B
 prevent resource exhaustion; the receiver confirms before writing outside OPFS; per-block
 and whole-file digests are verified before completion is reported.
 
-### Web-facing hardening
+### Web-facing hardening & zero-PII observability
 
 The HTTP surface sets a strict CSP (`default-src 'self'`, `connect-src 'self' wss: https:`,
 `script-src 'self' 'wasm-unsafe-eval'`, `object-src 'none'`, `base-uri 'none'`,
 `frame-ancestors 'none'`), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and
-`Referrer-Policy: no-referrer`. The server logs room numbers and metadata only — never the
-invite words, filenames, plaintext, or keys.
+`Referrer-Policy: no-referrer`.
+
+The server enforces a strict **Zero-PII Observability Guarantee**:
+
+- Structured server logs (`SENDBEAM_LOG_FORMAT=text|json`) record only room numbers, error codes, and message counts — never client IP addresses, invite words, filenames, payload plaintext, or cryptographic keys.
+- Prometheus metrics (`GET /metrics`) expose only aggregate gauges and monotonic counters (e.g. `sendbeam_rooms`, `sendbeam_relay_bytes_total`, `sendbeam_errors_total{code=...}`) with low-cardinality label dimensions — zero client identifiers or user data.
 
 ## What the server can and cannot see
 
-- **Cannot see:** the invite words, file bytes, filenames, digests, session keys.
+- **Cannot see:** the invite words, file bytes, filenames, digests, session keys, client IPs in metrics/logs.
 - **Can see:** the room number, socket metadata, SDP/ICE needed to route, and — on the
   relay path only — ciphertext byte counts and timing.
 


### PR DESCRIPTION
## Summary

Hardens the SendBeam signaling server and daemon (`sendbeamd`) for reliable, robust, multi-tenant public operation and self-hosting.

### Key Additions & Security Enhancements

1. **Per-IP Rate Limiting & Concurrency Quotas (`signal/ratelimit.go`):**
   - Per-IP connection rate limiting (`ConnBurst`, `ConnPerSec`) and concurrent active connection quota (`MaxConnsPerIP`).
   - Per-IP room creation rate limiting (`RoomCreateBurst`, `RoomCreatePerSec`).
   - Anti-brute-force room code guessing penalty bucket (`JoinFailBurst`, `JoinFailPerSec`).
   - Global concurrency caps on active WebSocket connections (`MaxConnections`) and rooms (`MaxRooms`).
   - Master operator toggle `SENDBEAM_RATE_LIMIT_ENABLED` (default `true`).

2. **Trusted Reverse-Proxy Header Handling (`signal/proxy.go`):**
   - Implemented `ParseTrustedProxies` and `ClientIP` supporting CIDR lists, bare IPs, IPv4/IPv6, `CF-Connecting-IP`, `X-Real-IP`, and rightmost untrusted hop traversal in `X-Forwarded-For`.
   - Untrusted direct sockets strictly ignore forwarded headers to prevent client IP spoofing.

3. **Liveness, Readiness, and Graceful Draining (`httpserver/server.go`, `signal/hub.go`):**
   - `/healthz`: Liveness probe (HTTP 200).
   - `/readyz`: Readiness probe returning HTTP 200 during normal operation and HTTP 503 `{"status":"draining",...}` during graceful shutdown.
   - Graceful shutdown (`hub.Drain`) immediately cleans unpaired rooms, refuses new sessions, and provides up to `SENDBEAM_DRAIN_TIMEOUT` (default 15s) for active transfers to finish.

4. **Zero-PII Prometheus Metrics & Structured Logging (`signal/metrics.go`, `main.go`):**
   - `/metrics` exports Prometheus gauges and counters: `sendbeam_rooms`, `sendbeam_active_connections`, `sendbeam_connections_total`, `sendbeam_rooms_created_total`, `sendbeam_rooms_paired_total`, `sendbeam_rooms_reaped_total`, `sendbeam_relay_bytes_total`, `sendbeam_errors_total`, and `sendbeam_messages_total`.
   - Structured logging (`SENDBEAM_LOG_FORMAT=text|json`, `SENDBEAM_LOG_LEVEL`) enforcing strict zero-PII recording.

5. **Documentation & Comprehensive Tests:**
   - Updated `docs/HOSTING.md` and `docs/threat-model.md`.
   - Unit tests covering token buckets, IP trackers, churn/reaper storm, proxy parsing, readiness state transitions, and metric snapshots.