### PR TITLE
fix(scripts): resolve absolute path for pubkey in verify-release

### DIFF
--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -50,6 +50,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ "${PUBKEY_FILE}" != /* ]]; then
+  PUBKEY_FILE="$(pwd)/${PUBKEY_FILE}"
+fi
+if [[ "${TARGET_DIR}" != /* ]]; then
+  TARGET_DIR="$(pwd)/${TARGET_DIR}"
+fi
+
 cd "${TARGET_DIR}"
 
 if [[ ! -f "SHA256SUMS.txt" ]]; then


### PR DESCRIPTION
## Summary
Resolves `PUBKEY_FILE` and `TARGET_DIR` to absolute paths before `cd "${TARGET_DIR}"` in `scripts/verify-release.sh`.

This ensures relative public key paths (like `--pubkey minisign.pub`) correctly resolve to the root directory rather than failing inside the release target subdirectory.