### PR TITLE
ci: smoke test update subcommand via help in verification gates

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -601,7 +601,7 @@ jobs:
           test -x unpacked-cli/sendbeam
           unpacked-cli/sendbeam version
           unpacked-cli/sendbeam --help
-          unpacked-cli/sendbeam update --check --json
+          unpacked-cli/sendbeam update --help
           unpacked-cli/sendbeam transfers list
 
       - name: Verify SPDX SBOM documents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -763,7 +763,7 @@ jobs:
           test -x unpacked-cli/sendbeam
           unpacked-cli/sendbeam version
           unpacked-cli/sendbeam --help
-          unpacked-cli/sendbeam update --check --json
+          unpacked-cli/sendbeam update --help
           unpacked-cli/sendbeam transfers list
 
       - name: Verify SPDX SBOM documents


### PR DESCRIPTION
## Summary
Replaces `unpacked-cli/sendbeam update --check --json` with `unpacked-cli/sendbeam update --help` in the CLI unpacked smoke test in `distribution.yml` and `release.yml`.

This avoids attempting to query a remote manifest over the network before the draft release has been published.