### PR TITLE
fix(rtc): synchronize recovery restart settling and align ICE timeouts

### DIFF
--- a/packages/engine/rtc/peer.go
+++ b/packages/engine/rtc/peer.go
@@ -148,7 +148,7 @@ func NewPeer(opts PeerOptions) (*Peer, error) {
 		// Observe a transient disconnect promptly and bound the failed state so recovery (or
 		// fallback) is decided within a controlled window rather than Pion's long defaults.
 		s := webrtc.SettingEngine{}
-		s.SetICETimeouts(10*time.Second, 30*time.Second, 2*time.Second)
+		s.SetICETimeouts(3*time.Second, 8*time.Second, 2*time.Second)
 		api := webrtc.NewAPI(webrtc.WithSettingEngine(s))
 		newPC = api.NewPeerConnection
 	}

--- a/packages/engine/rtc/peer_test.go
+++ b/packages/engine/rtc/peer_test.go
@@ -355,9 +355,11 @@ func TestPeerRepeatedRecoveryCyclesKeepChannelAlive(t *testing.T) {
 		}
 		// Enter and clear the recovery window (the transient disconnect it models).
 		offerer.enterRecover()
-		// Wait briefly for the offer/answer exchange to settle to stable state.
-		for j := 0; j < 50; j++ {
-			if offerer.pc.SignalingState() == webrtc.SignalingStateStable {
+		// Wait for the offer/answer exchange to settle to stable state on both peers.
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if offerer.pc.SignalingState() == webrtc.SignalingStateStable &&
+				joiner.pc.SignalingState() == webrtc.SignalingStateStable {
 				break
 			}
 			time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
## Summary
- Sets ICE timeouts to (3s, 8s, 2s) matching the 6s DefaultRecoverWindow.
- Synchronizes signaling state settling across both peers during ICE recovery restart testing.