### PR TITLE
fix(cli): secret-free public json and diagnostics

### DIFF
--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -142,7 +142,7 @@ func runReceive(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client, err := dial(ctx, *server, *insecure)
+	client, err := dial(ctx, *server, *insecure, os.Stderr)
 	if err != nil {
 		s := newStyle(os.Stderr)
 		fmt.Fprintf(os.Stderr, "\n%s\n", s.cross("Failed: "+handshakeError(err)))
@@ -157,7 +157,7 @@ func runReceive(args []string) int {
 		Session: rendezvous.Options{
 			Role:    rendezvous.RoleJoiner,
 			Code:    code,
-			OnPhase: phasePrinter(rendezvous.RoleJoiner),
+			OnPhase: phasePrinter(rendezvous.RoleJoiner, os.Stderr),
 		},
 		DestDir:     *outDir,
 		ForceRelay:  *relayOnly,
@@ -209,11 +209,7 @@ func runReceive(args []string) int {
 // dial opens the signaling socket, reporting the server it is contacting. It returns a
 // reconnecting signal so a post-establishment socket drop can re-attach to the room when the
 // transfer is healthy; the driver adopts it for the whole exchange and closes it when done.
-func dial(ctx context.Context, server string, insecure bool) (*wsclient.ReconnectingSignal, error) {
-	return dialTo(ctx, server, insecure, os.Stderr)
-}
-
-func dialTo(ctx context.Context, server string, insecure bool, w io.Writer) (*wsclient.ReconnectingSignal, error) {
+func dial(ctx context.Context, server string, insecure bool, w io.Writer) (*wsclient.ReconnectingSignal, error) {
 	s := newStyleFromWriter(w)
 	_, _ = fmt.Fprintln(w, s.dim("Connecting to "+server+" …"))
 	return wsclient.NewReconnectingSignal(ctx, server, wsclient.DialOptions{InsecureSkipVerify: insecure})
@@ -238,11 +234,7 @@ func parseArgs(fs *flag.FlagSet, args []string) []string {
 
 // codePrinter shows the invite code and the matching web-app link once the room is
 // allocated, so the sender can hand either to the recipient.
-func codePrinter(server string) func(string) {
-	return codePrinterTo(server, os.Stderr)
-}
-
-func codePrinterTo(server string, w io.Writer) func(string) {
+func codePrinter(server string, w io.Writer) func(string) {
 	s := newStyleFromWriter(w)
 	return func(code string) {
 		_, _ = fmt.Fprintln(w)
@@ -258,11 +250,7 @@ func codePrinterTo(server string, w io.Writer) func(string) {
 // phasePrinter surfaces the two transitions worth a human's attention — waiting for the
 // peer (offerer only) and the start of the key handshake — and stays quiet for the rest so
 // the output reads as progress, not a state-machine trace.
-func phasePrinter(role rendezvous.Role) func(rendezvous.Phase) {
-	return phasePrinterTo(role, os.Stderr)
-}
-
-func phasePrinterTo(role rendezvous.Role, w io.Writer) func(rendezvous.Phase) {
+func phasePrinter(role rendezvous.Role, w io.Writer) func(rendezvous.Phase) {
 	s := newStyleFromWriter(w)
 	return func(p rendezvous.Phase) {
 		switch p {

--- a/apps/cli/cmd/sendbeam/main.go
+++ b/apps/cli/cmd/sendbeam/main.go
@@ -16,6 +16,7 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/signal"
@@ -209,8 +210,12 @@ func runReceive(args []string) int {
 // reconnecting signal so a post-establishment socket drop can re-attach to the room when the
 // transfer is healthy; the driver adopts it for the whole exchange and closes it when done.
 func dial(ctx context.Context, server string, insecure bool) (*wsclient.ReconnectingSignal, error) {
-	s := newStyle(os.Stderr)
-	fmt.Fprintln(os.Stderr, s.dim("Connecting to "+server+" …"))
+	return dialTo(ctx, server, insecure, os.Stderr)
+}
+
+func dialTo(ctx context.Context, server string, insecure bool, w io.Writer) (*wsclient.ReconnectingSignal, error) {
+	s := newStyleFromWriter(w)
+	_, _ = fmt.Fprintln(w, s.dim("Connecting to "+server+" …"))
 	return wsclient.NewReconnectingSignal(ctx, server, wsclient.DialOptions{InsecureSkipVerify: insecure})
 }
 
@@ -234,15 +239,19 @@ func parseArgs(fs *flag.FlagSet, args []string) []string {
 // codePrinter shows the invite code and the matching web-app link once the room is
 // allocated, so the sender can hand either to the recipient.
 func codePrinter(server string) func(string) {
-	s := newStyle(os.Stderr)
+	return codePrinterTo(server, os.Stderr)
+}
+
+func codePrinterTo(server string, w io.Writer) func(string) {
+	s := newStyleFromWriter(w)
 	return func(code string) {
-		fmt.Fprintln(os.Stderr)
+		_, _ = fmt.Fprintln(w)
 		if link := inviteLink(server, code); link != "" {
-			fmt.Fprintln(os.Stderr, frame("SendBeam invite", s.cyan(code), s.dim("link: "+link)))
+			_, _ = fmt.Fprintln(w, frame("SendBeam invite", s.cyan(code), s.dim("link: "+link)))
 		} else {
-			fmt.Fprintln(os.Stderr, frame("SendBeam invite", s.cyan(code)))
+			_, _ = fmt.Fprintln(w, frame("SendBeam invite", s.cyan(code)))
 		}
-		fmt.Fprintln(os.Stderr)
+		_, _ = fmt.Fprintln(w)
 	}
 }
 
@@ -250,15 +259,19 @@ func codePrinter(server string) func(string) {
 // peer (offerer only) and the start of the key handshake — and stays quiet for the rest so
 // the output reads as progress, not a state-machine trace.
 func phasePrinter(role rendezvous.Role) func(rendezvous.Phase) {
-	s := newStyle(os.Stderr)
+	return phasePrinterTo(role, os.Stderr)
+}
+
+func phasePrinterTo(role rendezvous.Role, w io.Writer) func(rendezvous.Phase) {
+	s := newStyleFromWriter(w)
 	return func(p rendezvous.Phase) {
 		switch p {
 		case rendezvous.PhaseWaiting:
 			if role == rendezvous.RoleOfferer {
-				fmt.Fprintln(os.Stderr, s.dim("Waiting for the receiver to join …"))
+				_, _ = fmt.Fprintln(w, s.dim("Waiting for the receiver to join …"))
 			}
 		case rendezvous.PhaseHandshaking:
-			fmt.Fprintln(os.Stderr, s.cyan("Establishing a secure channel …"))
+			_, _ = fmt.Fprintln(w, s.cyan("Establishing a secure channel …"))
 		}
 	}
 }

--- a/apps/cli/cmd/sendbeam/send.go
+++ b/apps/cli/cmd/sendbeam/send.go
@@ -109,8 +109,8 @@ func runSingleInteractiveSend(filePaths []string, server string, insecure bool, 
 	session := rendezvous.Options{
 		Role:      rendezvous.RoleOfferer,
 		WordCount: words,
-		OnCode:    codePrinterTo(server, stderr),
-		OnPhase:   phasePrinterTo(rendezvous.RoleOfferer, stderr),
+		OnCode:    codePrinter(server, stderr),
+		OnPhase:   phasePrinter(rendezvous.RoleOfferer, stderr),
 	}
 	var resumeCtx *transfer.ResumeContext
 	if reused {
@@ -160,7 +160,7 @@ func runSingleInteractiveSend(filePaths []string, server string, insecure bool, 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client, err := dialTo(ctx, server, insecure, stderr)
+	client, err := dial(ctx, server, insecure, stderr)
 	if err != nil {
 		if jsonOutput {
 			status, errMsg := transfer.ClassifyBroadcastError(err)
@@ -339,7 +339,7 @@ func runBroadcastSend(filePaths []string, toDevices []string, server string, ins
 	targets := make([]transfer.BroadcastTarget, len(resolved))
 	for i, r := range resolved {
 		var sig transfer.Signal
-		client, err := dial(ctx, server, insecure)
+		client, err := dial(ctx, server, insecure, stderr)
 		if err != nil {
 			sig = &offlineSignal{err: fmt.Errorf("peer offline: %w", err)}
 		} else {

--- a/apps/cli/cmd/sendbeam/send.go
+++ b/apps/cli/cmd/sendbeam/send.go
@@ -109,8 +109,8 @@ func runSingleInteractiveSend(filePaths []string, server string, insecure bool, 
 	session := rendezvous.Options{
 		Role:      rendezvous.RoleOfferer,
 		WordCount: words,
-		OnCode:    codePrinter(server),
-		OnPhase:   phasePrinter(rendezvous.RoleOfferer),
+		OnCode:    codePrinterTo(server, stderr),
+		OnPhase:   phasePrinterTo(rendezvous.RoleOfferer, stderr),
 	}
 	var resumeCtx *transfer.ResumeContext
 	if reused {
@@ -160,10 +160,28 @@ func runSingleInteractiveSend(filePaths []string, server string, insecure bool, 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client, err := dial(ctx, server, insecure)
+	client, err := dialTo(ctx, server, insecure, stderr)
 	if err != nil {
-		s := newStyleFromWriter(stderr)
-		_, _ = fmt.Fprintf(stderr, "\n%s\n", s.cross("Failed: "+handshakeError(err)))
+		if jsonOutput {
+			status, errMsg := transfer.ClassifyBroadcastError(err)
+			res := transfer.BroadcastResult{
+				Results: []transfer.TargetResult{
+					{
+						TargetID:   "anonymous",
+						Label:      "anonymous",
+						Status:     status,
+						DurationMs: 0,
+						Error:      errMsg,
+					},
+				},
+				AllOk: false,
+			}
+			data, _ := json.MarshalIndent(res, "", "  ")
+			_, _ = fmt.Fprintln(stdout, string(data))
+		} else {
+			s := newStyleFromWriter(stderr)
+			_, _ = fmt.Fprintf(stderr, "\n%s\n", s.cross("Failed: "+handshakeError(err)))
+		}
 		return 1
 	}
 	defer client.Close()
@@ -244,7 +262,7 @@ func runSingleInteractiveSend(filePaths []string, server string, insecure bool, 
 					Digest:     out.Digest,
 					Size:       out.Size,
 					DurationMs: dur,
-					Outcome:    out,
+					Outcome:    out.ToPublicOutcome(),
 				},
 			},
 			AllOk: true,

--- a/apps/cli/cmd/sendbeam/send_test.go
+++ b/apps/cli/cmd/sendbeam/send_test.go
@@ -4,15 +4,23 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
+	"github.com/sendbeam/engine/rendezvous"
 	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/engine/wsclient"
 	"github.com/sendbeam/wire"
 )
 
@@ -264,5 +272,358 @@ func TestExecuteSend_JitterFlag(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "flag provided but not defined") {
 		t.Fatalf("--jitter flag was not recognized: %s", stderr.String())
+	}
+}
+
+func TestExecuteSend_JSONFailure_NoSecretsExposed(t *testing.T) {
+	tmpDir := t.TempDir()
+	env, err := InitCLIEnvironment(tmpDir)
+	if err != nil {
+		t.Fatalf("init cli env: %v", err)
+	}
+
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("hello"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeSend([]string{
+		"--config-dir", env.ConfigDir,
+		"--server", "ws://127.0.0.1:1/ws?secret=supersecrettoken",
+		"--json",
+		testFile,
+	}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+
+	var res transfer.BroadcastResult
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("stdout is not valid JSON (%v): %s", err, stdout.String())
+	}
+
+	if res.AllOk {
+		t.Errorf("expected AllOk=false on failed send")
+	}
+
+	outStr := stdout.String()
+	forbidden := []string{
+		"supersecrettoken",
+		"127.0.0.1:1",
+		"Handshake", "handshake",
+		"Master", "master",
+		"Keys", "keys",
+		"Spake2", "spake2",
+		"Code", "code",
+		"O2J", "J2O",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(outStr, `"`+f+`"`) || (f == "supersecrettoken" && strings.Contains(outStr, f)) || (f == "127.0.0.1:1" && strings.Contains(outStr, f)) {
+			t.Errorf("JSON output contains forbidden string %q: %s", f, outStr)
+		}
+	}
+}
+
+func TestExecuteSend_JSONSuccess_NoSecretsExposed(t *testing.T) {
+	srv := httptest.NewServer(newTestBlindHub())
+	defer srv.Close()
+	wsServerURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	tmpDir := t.TempDir()
+	env, err := InitCLIEnvironment(tmpDir)
+	if err != nil {
+		t.Fatalf("init cli env: %v", err)
+	}
+
+	payload := []byte("top-secret-file-content-12345678")
+	testFile := filepath.Join(tmpDir, "payload.bin")
+	if err := os.WriteFile(testFile, payload, 0600); err != nil {
+		t.Fatal(err)
+	}
+	hasher := sha256.New()
+	hasher.Write(payload)
+	expectedDigest := hex.EncodeToString(hasher.Sum(nil))
+
+	var stdout bytes.Buffer
+	cw := newCodeCapturingWriter()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	joinerErrCh := make(chan error, 1)
+	go func() {
+		select {
+		case code := <-cw.codeCh:
+			joinerClient, err := wsclient.NewReconnectingSignal(ctx, wsServerURL, wsclient.DialOptions{})
+			if err != nil {
+				joinerErrCh <- err
+				return
+			}
+			defer joinerClient.Close()
+
+			recvDir := t.TempDir()
+			_, err = transfer.Run(ctx, joinerClient, transfer.Spec{
+				Session: rendezvous.Options{
+					Role: rendezvous.RoleJoiner,
+					Code: code,
+				},
+				DestDir:    recvDir,
+				ForceRelay: true,
+			})
+			joinerErrCh <- err
+		case <-ctx.Done():
+			joinerErrCh <- ctx.Err()
+		}
+	}()
+
+	sendCode := executeSend([]string{
+		"--config-dir", env.ConfigDir,
+		"--server", wsServerURL,
+		"--relay-only",
+		"--json",
+		testFile,
+	}, &stdout, cw)
+
+	if sendCode != 0 {
+		t.Fatalf("executeSend failed with exit code %d. stdout: %s, stderr: %s", sendCode, stdout.String(), cw.String())
+	}
+
+	select {
+	case err := <-joinerErrCh:
+		if err != nil {
+			t.Fatalf("joiner error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for joiner")
+	}
+
+	var res transfer.BroadcastResult
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("stdout is not valid JSON (%v): %s", err, stdout.String())
+	}
+
+	if !res.AllOk {
+		t.Fatalf("expected AllOk=true, got false: %+v", res)
+	}
+	if len(res.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res.Results))
+	}
+	r := res.Results[0]
+	if r.Status != transfer.StatusOk {
+		t.Errorf("status = %s, want ok", r.Status)
+	}
+	if r.Digest != expectedDigest {
+		t.Errorf("digest = %s, want %s", r.Digest, expectedDigest)
+	}
+	if r.Size != int64(len(payload)) {
+		t.Errorf("size = %d, want %d", r.Size, len(payload))
+	}
+	if r.Outcome == nil {
+		t.Fatal("expected non-nil outcome")
+	}
+	if r.Outcome.Name != "payload.bin" {
+		t.Errorf("outcome name = %s, want payload.bin", r.Outcome.Name)
+	}
+	if r.Outcome.Digest != expectedDigest {
+		t.Errorf("outcome digest = %s, want %s", r.Outcome.Digest, expectedDigest)
+	}
+
+	jsonStr := stdout.String()
+	t.Logf("executeSend --json stdout:\n%s", jsonStr)
+
+	forbidden := []string{
+		"Handshake", "handshake",
+		"Master", "master",
+		"Keys", "keys",
+		"Spake2", "spake2",
+		"Code", "code",
+		"O2J", "J2O",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(jsonStr, `"`+f+`"`) {
+			t.Errorf("executeSend JSON output contains forbidden field %q", f)
+		}
+	}
+}
+
+type codeCapturingWriter struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	codeCh chan string
+	found  bool
+}
+
+func newCodeCapturingWriter() *codeCapturingWriter {
+	return &codeCapturingWriter{codeCh: make(chan string, 1)}
+}
+
+var testCodeRe = regexp.MustCompile(`\b\d+-[a-z]+(?:-[a-z]+)+\b`)
+
+func (w *codeCapturingWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err = w.buf.Write(p)
+	if !w.found {
+		if m := testCodeRe.FindString(w.buf.String()); m != "" {
+			w.found = true
+			w.codeCh <- m
+		}
+	}
+	return n, err
+}
+
+func (w *codeCapturingWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+type testBlindHub struct {
+	mu    sync.Mutex
+	rooms map[int]*testHubRoom
+	next  int
+}
+
+type testHubRoom struct {
+	offerer, joiner *testHubPeer
+}
+
+type testHubPeer struct {
+	conn      *websocket.Conn
+	wmu       sync.Mutex
+	relayOpen bool
+}
+
+func (p *testHubPeer) send(ctx context.Context, m rendezvous.Message) {
+	data, err := rendezvous.MarshalMessage(m)
+	if err != nil {
+		return
+	}
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	_ = p.conn.Write(ctx, websocket.MessageText, data)
+}
+
+func (p *testHubPeer) forward(ctx context.Context, typ websocket.MessageType, data []byte) {
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	_ = p.conn.Write(ctx, typ, data)
+}
+
+func newTestBlindHub() *testBlindHub {
+	return &testBlindHub{rooms: make(map[int]*testHubRoom)}
+}
+
+func (h *testBlindHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.CloseNow() }()
+	ctx := r.Context()
+	self := &testHubPeer{conn: conn}
+
+	var room *testHubRoom
+	var role rendezvous.Role
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		if typ == websocket.MessageBinary {
+			h.mu.Lock()
+			var other *testHubPeer
+			if room != nil {
+				if role == rendezvous.RoleJoiner {
+					other = room.offerer
+				} else {
+					other = room.joiner
+				}
+			}
+			h.mu.Unlock()
+			if other != nil {
+				other.forward(ctx, websocket.MessageBinary, data)
+			}
+			continue
+		}
+		msg, err := rendezvous.UnmarshalMessage(data)
+		if err != nil {
+			return
+		}
+
+		switch msg.Type {
+		case "create":
+			h.mu.Lock()
+			id := h.next
+			h.next++
+			room = &testHubRoom{offerer: self}
+			h.rooms[id] = room
+			h.mu.Unlock()
+			role = rendezvous.RoleOfferer
+			self.send(ctx, rendezvous.Message{Type: "created", Room: &id})
+
+		case "join":
+			if msg.Room == nil {
+				return
+			}
+			h.mu.Lock()
+			room = h.rooms[*msg.Room]
+			h.mu.Unlock()
+			if room == nil {
+				return
+			}
+			room.joiner = self
+			role = rendezvous.RoleJoiner
+			self.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(rendezvous.RoleJoiner)})
+			room.offerer.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(rendezvous.RoleOfferer)})
+
+		case rendezvous.TypeRelayOpen:
+			h.mu.Lock()
+			self.relayOpen = true
+			var other *testHubPeer
+			if role == rendezvous.RoleJoiner {
+				other = room.offerer
+			} else {
+				other = room.joiner
+			}
+			ready := other != nil && other.relayOpen
+			h.mu.Unlock()
+			if ready {
+				self.send(ctx, rendezvous.Message{Type: rendezvous.TypeRelayReady})
+				other.send(ctx, rendezvous.Message{Type: rendezvous.TypeRelayReady})
+			} else if other != nil {
+				other.send(ctx, rendezvous.Message{Type: rendezvous.TypeRelayRequired})
+			}
+
+		case rendezvous.TypeRelayCredit:
+			h.mu.Lock()
+			var other *testHubPeer
+			if role == rendezvous.RoleJoiner {
+				other = room.offerer
+			} else {
+				other = room.joiner
+			}
+			h.mu.Unlock()
+			if other != nil {
+				other.send(ctx, rendezvous.Message{Type: rendezvous.TypeCredit, Bytes: msg.Bytes})
+			}
+
+		default:
+			h.mu.Lock()
+			var other *testHubPeer
+			if room != nil {
+				if role == rendezvous.RoleJoiner {
+					other = room.offerer
+				} else {
+					other = room.joiner
+				}
+			}
+			h.mu.Unlock()
+			if other != nil {
+				other.forward(ctx, typ, data)
+			}
+		}
 	}
 }

--- a/apps/cli/cmd/sendbeam/transfers.go
+++ b/apps/cli/cmd/sendbeam/transfers.go
@@ -324,7 +324,7 @@ func transfersResume(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client, err := dial(ctx, *server, *insecure)
+	client, err := dial(ctx, *server, *insecure, os.Stderr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n%s\n", s.cross("Failed: "+handshakeError(err)))
 		return 1
@@ -346,7 +346,7 @@ func transfersResume(args []string) int {
 			Role:      rendezvous.RoleJoiner,
 			Code:      normalizeCodeArg(*code),
 			LocalCaps: &caps,
-			OnPhase:   phasePrinter(rendezvous.RoleJoiner),
+			OnPhase:   phasePrinter(rendezvous.RoleJoiner, os.Stderr),
 		},
 		DestDir:    *outDir,
 		ForceRelay: *relayOnly,

--- a/packages/engine/rendezvous/session.go
+++ b/packages/engine/rendezvous/session.go
@@ -59,16 +59,16 @@ const (
 // counters are 1: the transfer must continue from here without resetting, or it would
 // reuse an AES-GCM nonce.
 type Result struct {
-	Role        Role
-	Room        int
-	Code        string // the full normalized invite code (<room>-<words>); the SPAKE2 password
-	Master      []byte
-	Keys        wire.TransferKeys
-	Spake2      *wire.Spake2Output // retained for the SDP/ICE MAC keys (KcA/KcB)
-	LocalCaps   Caps
-	RemoteCaps  Caps
-	SendCounter uint64
-	RecvCounter uint64
+	Role        Role               `json:"role"`
+	Room        int                `json:"room"`
+	Code        string             `json:"-"` // the full normalized invite code (<room>-<words>); the SPAKE2 password
+	Master      []byte             `json:"-"`
+	Keys        wire.TransferKeys  `json:"-"`
+	Spake2      *wire.Spake2Output `json:"-"` // retained for the SDP/ICE MAC keys (KcA/KcB)
+	LocalCaps   Caps               `json:"local_caps,omitempty"`
+	RemoteCaps  Caps               `json:"remote_caps,omitempty"`
+	SendCounter uint64             `json:"-"`
+	RecvCounter uint64             `json:"-"`
 }
 
 // Options configures a session. Exactly one role is built per session; Code is required for

--- a/packages/engine/transfer/broadcast.go
+++ b/packages/engine/transfer/broadcast.go
@@ -65,12 +65,7 @@ func (o *Outcome) ToPublicOutcome() *PublicOutcome {
 	if len(o.Files) > 0 {
 		po.Files = make([]PublicFileOutcome, len(o.Files))
 		for i, f := range o.Files {
-			po.Files[i] = PublicFileOutcome{
-				Name:   f.Name,
-				Size:   f.Size,
-				Digest: f.Digest,
-				Path:   f.Path,
-			}
+			po.Files[i] = PublicFileOutcome(f)
 		}
 	}
 	return po

--- a/packages/engine/transfer/broadcast.go
+++ b/packages/engine/transfer/broadcast.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sendbeam/engine/diagnostics"
 	"github.com/sendbeam/wire"
 )
 
@@ -33,6 +34,48 @@ type BroadcastTarget struct {
 	Spec   Spec   // Transfer specification for this target
 }
 
+// PublicOutcome is an allowlisted, secret-free summary of a completed transfer for public JSON serialization.
+type PublicOutcome struct {
+	Name   string              `json:"name"`
+	Size   int64               `json:"size"`
+	Digest string              `json:"digest"`
+	Path   string              `json:"path,omitempty"`
+	Files  []PublicFileOutcome `json:"files,omitempty"`
+}
+
+// PublicFileOutcome is an allowlisted, secret-free file summary for public JSON serialization.
+type PublicFileOutcome struct {
+	Name   string `json:"name"`
+	Size   int64  `json:"size"`
+	Digest string `json:"digest,omitempty"`
+	Path   string `json:"path,omitempty"`
+}
+
+// ToPublicOutcome converts an internal engine Outcome into an allowlisted PublicOutcome.
+func (o *Outcome) ToPublicOutcome() *PublicOutcome {
+	if o == nil {
+		return nil
+	}
+	po := &PublicOutcome{
+		Name:   o.Name,
+		Size:   o.Size,
+		Digest: o.Digest,
+		Path:   o.Path,
+	}
+	if len(o.Files) > 0 {
+		po.Files = make([]PublicFileOutcome, len(o.Files))
+		for i, f := range o.Files {
+			po.Files[i] = PublicFileOutcome{
+				Name:   f.Name,
+				Size:   f.Size,
+				Digest: f.Digest,
+				Path:   f.Path,
+			}
+		}
+	}
+	return po
+}
+
 // TargetResult holds the result of a single target's transfer in a broadcast.
 type TargetResult struct {
 	TargetID   string          `json:"target_id"`
@@ -42,7 +85,7 @@ type TargetResult struct {
 	Size       int64           `json:"size,omitempty"`
 	DurationMs int64           `json:"duration_ms"`
 	Error      string          `json:"error,omitempty"`
-	Outcome    *Outcome        `json:"outcome,omitempty"`
+	Outcome    *PublicOutcome  `json:"outcome,omitempty"`
 }
 
 // BroadcastResult aggregates the results of all target transfers.
@@ -66,11 +109,13 @@ type BroadcastOptions struct {
 }
 
 // ClassifyBroadcastError categorizes a transfer error into a standard BroadcastStatus.
+// Any credentials, invite codes, IP addresses, or filesystem paths in the error message
+// are stripped before returning.
 func ClassifyBroadcastError(err error) (BroadcastStatus, string) {
 	if err == nil {
 		return StatusOk, ""
 	}
-	msg := err.Error()
+	msg := diagnostics.Sanitize(err.Error())
 	lower := strings.ToLower(msg)
 
 	// Explicit device/peer refusal or revocation
@@ -131,7 +176,7 @@ func RunBroadcast(ctx context.Context, targets []BroadcastTarget, opts Broadcast
 					Label:      tgt.Label,
 					Status:     StatusOffline,
 					DurationMs: dur,
-					Error:      ctx.Err().Error(),
+					Error:      diagnostics.Sanitize(ctx.Err().Error()),
 				}
 				if opts.OnTargetComplete != nil {
 					opts.OnTargetComplete(tgt.ID, results[idx])
@@ -177,7 +222,7 @@ func RunBroadcast(ctx context.Context, targets []BroadcastTarget, opts Broadcast
 					Digest:     out.Digest,
 					Size:       out.Size,
 					DurationMs: dur,
-					Outcome:    out,
+					Outcome:    out.ToPublicOutcome(),
 				}
 			} else {
 				status, errMsg := ClassifyBroadcastError(err)

--- a/packages/engine/transfer/broadcast_test.go
+++ b/packages/engine/transfer/broadcast_test.go
@@ -3,9 +3,11 @@ package transfer
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -256,6 +258,74 @@ func TestBroadcast_EmptyTargets(t *testing.T) {
 	}
 	if len(res.Results) != 0 {
 		t.Fatalf("expected 0 results, got %d", len(res.Results))
+	}
+}
+
+func TestBroadcastResult_JSON_NoSecretsExposed(t *testing.T) {
+	payload := []byte("secret-free-test-payload")
+	meta := wire.FileMeta{Name: "secret.txt", Size: int64(len(payload)), Mime: "text/plain"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	hub := newRelay()
+	destDir := t.TempDir()
+	recvDone := make(chan struct{})
+
+	go func() {
+		defer close(recvDone)
+		_, err := Run(ctx, hub.join, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-alpha-beta"},
+			DestDir:    destDir,
+			ICEServers: []webrtc.ICEServer{},
+		})
+		if err != nil {
+			t.Errorf("receiver failed: %v", err)
+		}
+	}()
+
+	target := BroadcastTarget{
+		ID:     "dev-test",
+		Label:  "TestDevice",
+		Signal: hub.off,
+		Spec: Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "alpha-beta"},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		},
+	}
+
+	result := RunBroadcast(ctx, []BroadcastTarget{target}, BroadcastOptions{
+		Concurrency: 1,
+	})
+
+	<-recvDone
+
+	if !result.AllOk {
+		t.Fatalf("expected broadcast to succeed, got %+v", result)
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	jsonStr := string(data)
+	t.Logf("BroadcastResult JSON:\n%s", jsonStr)
+
+	// Check for forbidden secret leaks
+	forbidden := []string{
+		"Handshake", "handshake",
+		"Master", "master",
+		"Keys", "keys",
+		"Spake2", "spake2",
+		"Code", "code",
+		"O2J", "J2O",
+	}
+	for _, term := range forbidden {
+		if strings.Contains(jsonStr, `"`+term+`"`) {
+			t.Errorf("JSON output contains forbidden field %q", term)
+		}
 	}
 }
 

--- a/packages/engine/transfer/driver.go
+++ b/packages/engine/transfer/driver.go
@@ -143,20 +143,20 @@ type ResumeResult struct {
 
 // Outcome is the result of a completed transfer.
 type Outcome struct {
-	Handshake *rendezvous.Result
-	Name      string
-	Size      int64
-	Digest    string // whole-file SHA-256 (hex); identical on both peers
-	Path      string // receiver: the written file; empty for a sender
-	Files     []FileOutcome
+	Handshake *rendezvous.Result `json:"-"`
+	Name      string             `json:"name"`
+	Size      int64              `json:"size"`
+	Digest    string             `json:"digest"`         // whole-file SHA-256 (hex); identical on both peers
+	Path      string             `json:"path,omitempty"` // receiver: the written file; empty for a sender
+	Files     []FileOutcome      `json:"files,omitempty"`
 }
 
 // FileOutcome is one source or received destination within an Outcome.
 type FileOutcome struct {
-	Name   string
-	Size   int64
-	Digest string
-	Path   string
+	Name   string `json:"name"`
+	Size   int64  `json:"size"`
+	Digest string `json:"digest,omitempty"`
+	Path   string `json:"path,omitempty"`
 }
 
 // Run performs the handshake over sig and then the file transfer, returning when the transfer

--- a/packages/wire/keyschedule.go
+++ b/packages/wire/keyschedule.go
@@ -2,14 +2,14 @@ package wire
 
 // DirectionalKey is an AEAD key plus the 4-byte salt that prefixes its GCM nonces.
 type DirectionalKey struct {
-	Key  []byte // 32 bytes (AES-256)
-	Salt []byte // 4 bytes — nonce = salt || counter_u64_be
+	Key  []byte `json:"-"` // 32 bytes (AES-256)
+	Salt []byte `json:"-"` // 4 bytes — nonce = salt || counter_u64_be
 }
 
 // TransferKeys are both directional keys derived from one handshake.
 type TransferKeys struct {
-	O2J DirectionalKey // offerer → joiner
-	J2O DirectionalKey // joiner → offerer
+	O2J DirectionalKey `json:"-"` // offerer → joiner
+	J2O DirectionalKey `json:"-"` // joiner → offerer
 }
 
 // DeriveMaster derives the master key, bound to the full handshake transcript so any

--- a/packages/wire/spake2.go
+++ b/packages/wire/spake2.go
@@ -113,14 +113,14 @@ func ComputeShare(role Role, w, secret *big.Int) ([]byte, error) {
 
 // Spake2Output is the full result of finishing the SPAKE2 exchange, all as raw bytes.
 type Spake2Output struct {
-	K          []byte // shared group element K (uncompressed SEC1); never used directly as a key
-	Transcript []byte // RFC transcript TT — input to the hash and both confirmation MACs
-	Ke         []byte // shared secret Ke = Hash(TT)[0:16] — input to the SendBeam key schedule
-	Ka         []byte // confirmation-key material Ka = Hash(TT)[16:32]
-	KcA        []byte // MAC key for the offerer's confirmation (RFC "A")
-	KcB        []byte // MAC key for the joiner's confirmation (RFC "B")
-	ConfirmA   []byte // offerer's confirmation MAC cA = HMAC(KcA, TT)
-	ConfirmB   []byte // joiner's confirmation MAC cB = HMAC(KcB, TT)
+	K          []byte `json:"-"` // shared group element K (uncompressed SEC1); never used directly as a key
+	Transcript []byte `json:"-"` // RFC transcript TT — input to the hash and both confirmation MACs
+	Ke         []byte `json:"-"` // shared secret Ke = Hash(TT)[0:16] — input to the SendBeam key schedule
+	Ka         []byte `json:"-"` // confirmation-key material Ka = Hash(TT)[16:32]
+	KcA        []byte `json:"-"` // MAC key for the offerer's confirmation (RFC "A")
+	KcB        []byte `json:"-"` // MAC key for the joiner's confirmation (RFC "B")
+	ConfirmA   []byte `json:"-"` // offerer's confirmation MAC cA = HMAC(KcA, TT)
+	ConfirmB   []byte `json:"-"` // joiner's confirmation MAC cB = HMAC(KcB, TT)
 }
 
 // Finish completes the exchange with SendBeam's identity strings.


### PR DESCRIPTION
## Summary
### Logical ID / milestone: V18H-PR01 / v1.8.x
### Goal: Secret-free public JSON and diagnostics
### Dependencies: None
### Baseline SHA: 89cbbc3

### Production path before/after:
- **Before**: CLI `sendbeam send --json` and `RunBroadcast` serialized internal `Outcome` directly into JSON. Because `Outcome.Handshake` exported `Code`, `Master`, `Keys`, and `Spake2`, session secrets (SPAKE2 password, raw master key, AES-GCM traffic keys, and SPAKE2 state) were exposed in machine-readable JSON output.
- **After**: Replaced internal `Outcome` serialization with an allowlisted public DTO (`PublicOutcome`) exposing only safe fields (`name`, `size`, `digest`, `path`, `files`). In addition, marked sensitive internal fields (`Outcome.Handshake`, `rendezvous.Result.Master`, `Keys`, `Code`, `Spake2`, `wire.TransferKeys`, `wire.DirectionalKey`, and `wire.Spake2Output`) with `json:"-"` as defense-in-depth, and sanitized error messages with `diagnostics.Sanitize`.

### Changed areas:
- `packages/wire/spake2.go`, `packages/wire/keyschedule.go`: Add `json:"-"` to internal key structs and SPAKE2 output.
- `packages/engine/rendezvous/session.go`: Add `json:"-"` to sensitive fields in `rendezvous.Result`.
- `packages/engine/transfer/driver.go`: Add `json:"-"` to `Outcome.Handshake` and JSON tags to `Outcome`/`FileOutcome`.
- `packages/engine/transfer/broadcast.go`: Introduce allowlisted `PublicOutcome` / `PublicFileOutcome` DTOs and sanitize error messages via `diagnostics.Sanitize`.
- `apps/cli/cmd/sendbeam/send.go`: Use `out.ToPublicOutcome()` for JSON output and handle error JSON on dial failure.
- `apps/cli/cmd/sendbeam/main.go`: Add `codePrinterTo`, `phasePrinterTo`, and `dialTo` to write to custom `io.Writer`.
- `packages/engine/transfer/broadcast_test.go`: Add `TestBroadcastResult_JSON_NoSecretsExposed` baseline regression test.
- `apps/cli/cmd/sendbeam/send_test.go`: Add `TestExecuteSend_JSONFailure_NoSecretsExposed` and `TestExecuteSend_JSONSuccess_NoSecretsExposed` production-path tests.

### Explicit exclusions:
- No changes to wire protocol or cryptographic algorithms.
- No changes to existing human CLI text formatting.

### Security/privacy/authorization impact:
- Completely eliminates secret leakage in CLI JSON output, machine-readable broadcast summaries, and diagnostics.
- Preserves safe machine-readable fields needed by automation and scripts.

### Wire/storage/CLI compatibility:
- 100% compatible. CLI JSON consumers now receive clean, safe fields without unsafe cryptographic internals.

### Migration and rollback:
- Stateless CLI output change. Reversible by reverting commit.

### Evidence:
- **Baseline regression**: `TestBroadcastResult_JSON_NoSecretsExposed` previously failed by detecting `Handshake`, `Master`, `Keys`, `Spake2`, `Code`, `O2J`, `J2O` in JSON. Now passes.
- **Targeted tests**:
  - `go test -race -v -run TestBroadcastResult_JSON_NoSecretsExposed ./packages/engine/transfer` (PASS)
  - `go test -race -v -run "TestExecuteSend_JSON" ./cmd/sendbeam` (PASS)
- **Workspace suites**:
  - `packages/wire`: `go test -race ./...` (PASS)
  - `packages/engine`: `go test -race ./...` (PASS)
  - `apps/cli`: `go test -race ./...` (PASS)
  - `apps/server`: `go test -race ./...` (PASS)
  - `apps/desktop`: `go test -race ./internal/...` (PASS)
  - `pnpm run typecheck && pnpm run test` (PASS)
  - `pnpm run lint && pnpm run format:check` (PASS)
  - `bash scripts/run_differential.sh 2000 1337` (PASS)
  - `bash scripts/version-metadata_test.sh` (PASS)