### PR TITLE
fix(desktop): render paths and errors as literal text

### DIFF
--- a/apps/desktop/frontend/dist/index.html
+++ b/apps/desktop/frontend/dist/index.html
@@ -511,6 +511,24 @@
       const call = (fqn, ...args) => wails.Call.ByName(fqn, ...args);
       const $ = (id) => document.getElementById(id);
 
+      // Safe literal-text DOM rendering helpers: ensure untrusted strings (paths, errors,
+      // identities, update details) never enter the HTML parser.
+      function setStatusMessage(el, cls, text, extraText) {
+        if (!el) return;
+        el.replaceChildren();
+        if (cls) {
+          const span = document.createElement("span");
+          span.className = cls;
+          span.textContent = text;
+          el.appendChild(span);
+        } else {
+          el.appendChild(document.createTextNode(text));
+        }
+        if (extraText) {
+          el.appendChild(document.createTextNode(extraText));
+        }
+      }
+
       const state = {
         mode: "send",
         selected: [],
@@ -548,7 +566,7 @@
       // SEND
       function renderSelection() {
         const list = $("send-list");
-        list.innerHTML = "";
+        list.replaceChildren();
         for (const p of state.selected) {
           const li = document.createElement("li");
           li.textContent = p.path;
@@ -642,16 +660,22 @@
       wireControls("send");
       wireControls("recv");
 
-      function chips(ev) {
-        const out = [];
-        if (ev.phase) out.push('<span class="chip">' + ev.phase.replace(/-/g, " ") + "</span>");
-        if (ev.transport) out.push('<span class="chip relay">' + ev.transport + "</span>");
-        if (ev.fingerprint) out.push('<span class="chip auth">fingerprint ' + ev.fingerprint + "</span>");
-        if (ev.paused) out.push('<span class="chip err">paused</span>');
-        if (ev.canceled) out.push('<span class="chip err">canceled</span>');
-        if (ev.failed) out.push('<span class="chip err">failed</span>');
-        if (ev.state) out.push('<span class="chip live">' + ev.state + "</span>");
-        return out.join("");
+      function renderChips(container, ev) {
+        if (!container) return;
+        container.replaceChildren();
+        const add = (cls, text) => {
+          const span = document.createElement("span");
+          span.className = cls;
+          span.textContent = text;
+          container.appendChild(span);
+        };
+        if (ev.phase) add("chip", String(ev.phase).replace(/-/g, " "));
+        if (ev.transport) add("chip relay", String(ev.transport));
+        if (ev.fingerprint) add("chip auth", "fingerprint " + ev.fingerprint);
+        if (ev.paused) add("chip err", "paused");
+        if (ev.canceled) add("chip err", "canceled");
+        if (ev.failed) add("chip err", "failed");
+        if (ev.state) add("chip live", String(ev.state));
       }
 
       function renderTransfer(ev, prefix) {
@@ -659,7 +683,7 @@
         const id = state[p].id;
         if (ev.id !== id) return;
 
-        $(p + "-chips").innerHTML = chips(ev);
+        renderChips($(p + "-chips"), ev);
         $(p + "-bar").style.width = Math.max(0, Math.min(100, ev.percent || 0)) + "%";
         $(p + "-percent").textContent = (ev.percent || 0) + "% · " + humanBytes(ev.doneBytes || 0) + " / " + humanBytes(ev.totalBytes || 0);
 
@@ -681,15 +705,19 @@
 
         const status = p === "recv" ? $("recv-status-line") : $("send-status");
         if (ev.kind === "done") {
-          status.innerHTML = '<span class="ok">✓ Verified transfer complete.</span>' +
-            (ev.outPath ? " Saved to " + ev.outPath + "." : "");
+          setStatusMessage(
+            status,
+            "ok",
+            "✓ Verified transfer complete.",
+            ev.outPath ? " Saved to " + ev.outPath + "." : null
+          );
           $(p + "-pause").disabled = $(p + "-resume").disabled = $(p + "-cancel").disabled = true;
           if (p === "recv" && (ev.outPath || ev.outDir)) {
             state.recv.outPath = ev.outPath || ev.outDir;
             $("recv-reveal").classList.remove("hidden");
           }
         } else if (ev.kind === "error") {
-          status.innerHTML = '<span class="err">✗ ' + (ev.error || "transfer failed") + "</span>";
+          setStatusMessage(status, "err", "✗ " + (ev.error || "transfer failed"));
         } else if (ev.kind === "connect") {
           status.textContent = "Secure channel established — transferring…";
         } else if (ev.phase === "waiting") {
@@ -706,7 +734,11 @@
           $("invite-card").classList.remove("hidden");
           $("invite-code").textContent = ev.code;
           $("invite-link").textContent = ev.link || "";
-          $("invite-qr").src = ev.qr || "";
+          if (ev.qr && typeof ev.qr === "string" && (ev.qr.startsWith("data:image/") || ev.qr.startsWith("http://") || ev.qr.startsWith("https://"))) {
+            $("invite-qr").src = ev.qr;
+          } else {
+            $("invite-qr").src = "";
+          }
           $("invite-status").textContent = "Share the code or link — the receiver can also scan the QR.";
         }
       });
@@ -732,7 +764,7 @@
         try {
           const items = await call(SV.Transfer + ".ListInterrupted", "");
           const tbody = $("durable-tbody");
-          tbody.innerHTML = "";
+          tbody.replaceChildren();
           if (!items || items.length === 0) {
             $("durable-empty").classList.remove("hidden");
             $("durable-empty").textContent = "No interrupted transfers found.";
@@ -743,17 +775,51 @@
           $("durable-table").classList.remove("hidden");
           for (const item of items) {
             const tr = document.createElement("tr");
-            tr.innerHTML = `
-              <td><span class="chip">${item.role}</span></td>
-              <td class="mono">${item.transferId.slice(0, 8)}…</td>
-              <td>${item.files}</td>
-              <td>${humanBytes(item.committedBytes)} / ${humanBytes(item.totalBytes)}</td>
-              <td>${item.status}</td>
-              <td>
-                <button class="ghost" data-action="inspect" data-id="${item.transferId}">Inspect</button>
-                <button class="ghost danger" data-action="discard" data-id="${item.transferId}">Discard</button>
-              </td>
-            `;
+
+            const tdRole = document.createElement("td");
+            const chipRole = document.createElement("span");
+            chipRole.className = "chip";
+            chipRole.textContent = item.role || "";
+            tdRole.appendChild(chipRole);
+            tr.appendChild(tdRole);
+
+            const tdId = document.createElement("td");
+            tdId.className = "mono";
+            const tid = String(item.transferId || "");
+            tdId.textContent = tid.length > 8 ? tid.slice(0, 8) + "…" : tid;
+            tr.appendChild(tdId);
+
+            const tdFiles = document.createElement("td");
+            tdFiles.textContent = String(item.files ?? "");
+            tr.appendChild(tdFiles);
+
+            const tdProgress = document.createElement("td");
+            tdProgress.textContent =
+              humanBytes(item.committedBytes || 0) + " / " + humanBytes(item.totalBytes || 0);
+            tr.appendChild(tdProgress);
+
+            const tdStatus = document.createElement("td");
+            tdStatus.textContent = String(item.status || "");
+            tr.appendChild(tdStatus);
+
+            const tdActions = document.createElement("td");
+            const btnInspect = document.createElement("button");
+            btnInspect.className = "ghost";
+            btnInspect.dataset.action = "inspect";
+            btnInspect.dataset.id = String(item.transferId || "");
+            btnInspect.textContent = "Inspect";
+
+            const btnDiscard = document.createElement("button");
+            btnDiscard.className = "ghost danger";
+            btnDiscard.dataset.action = "discard";
+            btnDiscard.dataset.id = String(item.transferId || "");
+            btnDiscard.textContent = "Discard";
+
+            tdActions.appendChild(btnInspect);
+            tdActions.appendChild(document.createTextNode(" "));
+            tdActions.appendChild(btnDiscard);
+            tr.appendChild(tdActions);
+
             tbody.appendChild(tr);
           }
         } catch (err) {
@@ -825,9 +891,9 @@
         };
         try {
           await call(SV.Transfer + ".SaveConfig", cfg);
-          $("settings-status").innerHTML = '<span class="ok">✓ Settings saved successfully.</span>';
+          setStatusMessage($("settings-status"), "ok", "✓ Settings saved successfully.");
         } catch (err) {
-          $("settings-status").innerHTML = '<span class="err">✗ ' + err + '</span>';
+          setStatusMessage($("settings-status"), "err", "✗ " + err);
         }
       });
 
@@ -859,9 +925,9 @@
         }
 
         if (st.state === "available") {
-          statusLabel.innerHTML = '<span class="ok">✓ Version ' + st.latestVersion + ' available</span>';
+          setStatusMessage(statusLabel, "ok", "✓ Version " + (st.latestVersion || "") + " available");
           if (!updateDismissed) {
-            bannerText.textContent = "SendBeam Desktop " + st.latestVersion + " is available!";
+            bannerText.textContent = "SendBeam Desktop " + (st.latestVersion || "") + " is available!";
             banner.classList.remove("hidden");
           }
           if (st.releaseNotes) {
@@ -877,14 +943,18 @@
           installBtn.disabled = true;
           installBtn.textContent = "Downloading…";
         } else if (st.state === "ready_to_restart") {
-          statusLabel.innerHTML = '<span class="ok">✓ Update installed! Restart to apply.</span>';
+          setStatusMessage(statusLabel, "ok", "✓ Update installed! Restart to apply.");
           bannerText.textContent = "Update ready! Restart SendBeam to apply.";
           $("update-banner-apply").textContent = "Restart now";
           banner.classList.remove("hidden");
           installBtn.disabled = true;
           installBtn.textContent = "Restart required";
         } else if (st.state === "managed_by_pkg_manager") {
-          statusLabel.innerHTML = '<span style="color:var(--text-muted);">' + (st.message || "Managed by package manager.") + '</span>';
+          statusLabel.replaceChildren();
+          const mutedSpan = document.createElement("span");
+          mutedSpan.style.color = "var(--text-muted)";
+          mutedSpan.textContent = st.message || "Managed by package manager.";
+          statusLabel.appendChild(mutedSpan);
           banner.classList.add("hidden");
           details.classList.add("hidden");
         } else if (st.state === "up_to_date") {
@@ -892,7 +962,7 @@
           banner.classList.add("hidden");
           details.classList.add("hidden");
         } else if (st.state === "error") {
-          statusLabel.innerHTML = '<span class="err">✗ ' + (st.error || "Update check failed") + '</span>';
+          setStatusMessage(statusLabel, "err", "✗ " + (st.error || "Update check failed"));
           details.classList.add("hidden");
         }
       }
@@ -907,7 +977,7 @@
           const st = await call(SV.Update + ".CheckUpdate", ch);
           renderUpdateStatus(st);
         } catch (e) {
-          $("update-status-label").innerHTML = '<span class="err">✗ ' + e + '</span>';
+          setStatusMessage($("update-status-label"), "err", "✗ " + e);
         }
       });
 
@@ -927,7 +997,7 @@
           const st = await call(SV.Update + ".ApplyUpdate");
           renderUpdateStatus(st);
         } catch (e) {
-          $("update-status-label").innerHTML = '<span class="err">✗ ' + e + '</span>';
+          setStatusMessage($("update-status-label"), "err", "✗ " + e);
         }
       }
 

--- a/apps/desktop/internal/engine/render_safety_test.go
+++ b/apps/desktop/internal/engine/render_safety_test.go
@@ -1,0 +1,82 @@
+package engine_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestDesktopFrontend_LiteralTextRendering verifies that the embedded desktop
+// HTML shell never uses innerHTML, outerHTML, document.write, or other unsafe
+// DOM sinks, ensuring untrusted remote data (paths, errors, identities) is rendered
+// strictly as literal text.
+func TestDesktopFrontend_LiteralTextRendering(t *testing.T) {
+	path := filepath.Join("..", "..", "frontend", "dist", "index.html")
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read desktop index.html at %s: %v", path, err)
+	}
+	content := string(contentBytes)
+	if len(content) == 0 {
+		t.Fatal("desktop index.html is empty")
+	}
+
+	prohibitedSinks := []struct {
+		pattern string
+		reason  string
+	}{
+		{"innerHTML", "must not use innerHTML; use textContent, createTextNode, or replaceChildren"},
+		{"outerHTML", "must not use outerHTML"},
+		{"document.write", "must not use document.write"},
+		{"insertAdjacentHTML", "must not use insertAdjacentHTML"},
+		{"javascript:", "must not contain javascript: pseudo-protocol"},
+		{"vbscript:", "must not contain vbscript: pseudo-protocol"},
+	}
+
+	for _, tc := range prohibitedSinks {
+		if strings.Contains(content, tc.pattern) {
+			t.Errorf("desktop index.html contains forbidden pattern %q: %s", tc.pattern, tc.reason)
+		}
+	}
+
+	requiredConstructs := []struct {
+		pattern string
+		desc    string
+	}{
+		{"setStatusMessage", "safe literal-text status helper"},
+		{"renderChips", "safe literal-text chips helper"},
+		{"replaceChildren", "safe DOM child clearing"},
+		{"textContent", "literal text assignment"},
+	}
+
+	for _, req := range requiredConstructs {
+		if !strings.Contains(content, req.pattern) {
+			t.Errorf("desktop index.html missing required safe rendering construct %q (%s)", req.pattern, req.desc)
+		}
+	}
+}
+
+// TestDesktopFrontend_NoInlineEventHandlers ensures HTML tags do not declare
+// inline on* handlers (which could be targeted or set bad precedent).
+func TestDesktopFrontend_NoInlineEventHandlers(t *testing.T) {
+	path := filepath.Join("..", "..", "frontend", "dist", "index.html")
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read desktop index.html: %v", err)
+	}
+	content := string(contentBytes)
+
+	// Split HTML before <script> tag to check markup only
+	scriptIdx := strings.Index(content, "<script>")
+	if scriptIdx == -1 {
+		t.Fatal("no <script> tag found in desktop index.html")
+	}
+	markup := content[:scriptIdx]
+
+	inlineHandlerRe := regexp.MustCompile(`(?i)\s+on[a-z]+\s*=`)
+	if matches := inlineHandlerRe.FindAllString(markup, -1); len(matches) > 0 {
+		t.Errorf("found inline event handlers in markup: %v", matches)
+	}
+}

--- a/apps/web/src/desktop-render.test.ts
+++ b/apps/web/src/desktop-render.test.ts
@@ -1,0 +1,249 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+// @ts-expect-error jsdom lacks bundled type definitions
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+
+const htmlPath = resolve(__dirname, '../../desktop/frontend/dist/index.html');
+const htmlContent = readFileSync(htmlPath, 'utf8');
+
+function setupDesktopDOM(options?: {
+  onCall?: (name: string, ...args: unknown[]) => Promise<unknown>;
+}) {
+  const events: Record<string, ((ev: unknown) => void)[]> = {};
+  const dom = new JSDOM(htmlContent, {
+    url: 'http://localhost',
+    runScripts: 'dangerously',
+    beforeParse(win: Record<string, unknown>) {
+      // Mock Wails v3 runtime
+      win.wails = {
+        Events: {
+          On: (name: string, cb: (ev: unknown) => void) => {
+            if (!events[name]) events[name] = [];
+            events[name].push(cb);
+          },
+        },
+        Call: {
+          ByName: (name: string, ...args: unknown[]) => {
+            if (options?.onCall) {
+              return options.onCall(name, ...args);
+            }
+            return Promise.resolve({});
+          },
+        },
+      };
+    },
+  });
+
+  const emit = (name: string, payload: unknown) => {
+    const list = events[name] || [];
+    for (const cb of list) {
+      cb(payload);
+    }
+  };
+
+  return { dom, window: dom.window, document: dom.window.document, emit };
+}
+
+describe('Desktop frontend literal-text rendering', () => {
+  it('contains zero usage of innerHTML in source', () => {
+    expect(htmlContent).not.toContain('innerHTML');
+    expect(htmlContent).not.toContain('outerHTML');
+    expect(htmlContent).not.toContain('document.write');
+    expect(htmlContent).not.toContain('insertAdjacentHTML');
+  });
+
+  it('renders transfer error as literal text without injecting HTML elements', () => {
+    const { document, emit } = setupDesktopDOM();
+
+    // Adopt transfer ID via drop
+    emit('sendbeam:transfer', {
+      kind: 'drop',
+      id: 'tx-err-1',
+      files: ['/tmp/file.txt'],
+    });
+
+    // Send error event containing malicious HTML tags and event handlers
+    const payload = '<img src="x" onerror="window.__xss1=1"><b id="xss-err-tag">error</b>';
+    emit('sendbeam:transfer', {
+      kind: 'error',
+      id: 'tx-err-1',
+      error: payload,
+    });
+
+    const sendStatus = document.getElementById('send-status');
+    expect(sendStatus).not.toBeNull();
+    // Element must NOT have parsed child elements
+    expect(sendStatus?.querySelector('img')).toBeNull();
+    expect(document.querySelector('img[src="x"]')).toBeNull();
+    expect(document.querySelector('#xss-err-tag')).toBeNull();
+    // Text must be literal
+    expect(sendStatus?.textContent).toContain(payload);
+  });
+
+  it('renders done transfer outPath as literal text without injecting HTML elements', () => {
+    const { document, emit } = setupDesktopDOM();
+
+    emit('sendbeam:transfer', {
+      kind: 'drop',
+      id: 'tx-done-1',
+      files: ['/tmp/file.txt'],
+    });
+
+    const maliciousPath =
+      '/home/user/<svg onload="window.__xss2=1"><div id="xss-path-tag">dir</div>';
+    emit('sendbeam:transfer', {
+      kind: 'done',
+      id: 'tx-done-1',
+      outPath: maliciousPath,
+    });
+
+    const sendStatus = document.getElementById('send-status');
+    expect(sendStatus).not.toBeNull();
+    expect(document.querySelector('svg')).toBeNull();
+    expect(document.querySelector('#xss-path-tag')).toBeNull();
+    expect(sendStatus?.textContent).toContain(maliciousPath);
+  });
+
+  it('renders transfer chips as literal text without injecting HTML elements', () => {
+    const { document, emit } = setupDesktopDOM();
+
+    emit('sendbeam:transfer', {
+      kind: 'drop',
+      id: 'tx-chip-1',
+      files: ['/tmp/file.txt'],
+    });
+
+    emit('sendbeam:transfer', {
+      kind: 'progress',
+      id: 'tx-chip-1',
+      phase: '<b id="xss_chip_tag">connecting</b>',
+      transport: '<i id="xss_transport_tag">relay</i>',
+      fingerprint: '<span id="xss_fp_tag">fp123</span>',
+      state: '<u id="xss_state_tag">transferring</u>',
+    });
+
+    expect(document.querySelector('#xss_chip_tag')).toBeNull();
+    expect(document.querySelector('#xss_transport_tag')).toBeNull();
+    expect(document.querySelector('#xss_fp_tag')).toBeNull();
+    expect(document.querySelector('#xss_state_tag')).toBeNull();
+
+    const chips = document.getElementById('send-chips');
+    expect(chips?.textContent).toContain('<b id="xss_chip_tag">connecting</b>');
+    expect(chips?.textContent).toContain('<i id="xss_transport_tag">relay</i>');
+  });
+
+  it('renders interrupted transfers list as literal text without injecting HTML elements', async () => {
+    const maliciousId = '<script id="xss-script">alert(1)</script>';
+    const maliciousRole = '<b id="xss-role">joiner</b>';
+    const maliciousStatus = '<img id="xss-status-img" src="x" onerror="1">';
+
+    const { document } = setupDesktopDOM({
+      onCall: (name) => {
+        if (name.includes('ListInterrupted')) {
+          return Promise.resolve([
+            {
+              role: maliciousRole,
+              transferId: maliciousId,
+              files: 2,
+              committedBytes: 1024,
+              totalBytes: 2048,
+              status: maliciousStatus,
+            },
+          ]);
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    // Switch to interrupted tab
+    const tab = document.getElementById('tab-interrupted') as HTMLButtonElement;
+    tab.click();
+
+    // Allow promise microtasks to run
+    await new Promise((r) => setTimeout(r, 50));
+
+    const tbody = document.getElementById('durable-tbody');
+    expect(tbody).not.toBeNull();
+    expect(document.querySelector('#xss-script')).toBeNull();
+    expect(document.querySelector('#xss-role')).toBeNull();
+    expect(document.querySelector('#xss-status-img')).toBeNull();
+
+    // Verify dataset.id preserves exact literal transfer ID safely
+    const inspectBtn = tbody?.querySelector('button[data-action="inspect"]') as HTMLButtonElement;
+    expect(inspectBtn).not.toBeNull();
+    expect(inspectBtn.dataset.id).toBe(maliciousId);
+  });
+
+  it('renders settings status and errors as literal text', async () => {
+    const { document } = setupDesktopDOM({
+      onCall: (name) => {
+        if (name.includes('SaveConfig')) {
+          return Promise.reject(new Error('<b id="xss-settings-err">Save failed</b>'));
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    const saveBtn = document.getElementById('save-settings') as HTMLButtonElement;
+    saveBtn.click();
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(document.querySelector('#xss-settings-err')).toBeNull();
+    const settingsStatus = document.getElementById('settings-status');
+    expect(settingsStatus?.textContent).toContain('<b id="xss-settings-err">Save failed</b>');
+  });
+
+  it('renders update notifications as literal text', () => {
+    const { document, emit } = setupDesktopDOM();
+
+    emit('sendbeam:update', {
+      state: 'available',
+      latestVersion: '2.0.0<img src="x" onerror="1">',
+      releaseNotes: 'Security fixes <script id="xss-notes">alert(1)</script>',
+    });
+
+    const statusLabel = document.getElementById('update-status-label');
+    expect(statusLabel?.querySelector('img')).toBeNull();
+    expect(document.querySelector('img[src="x"]')).toBeNull();
+    expect(document.querySelector('script#xss-notes')).toBeNull();
+    expect(statusLabel?.textContent).toContain('2.0.0<img src="x" onerror="1">');
+
+    const bannerText = document.getElementById('update-banner-text');
+    expect(bannerText?.querySelector('img')).toBeNull();
+    expect(bannerText?.textContent).toContain('2.0.0<img src="x" onerror="1">');
+  });
+
+  it('rejects unsafe protocol schemes on invite QR image', () => {
+    const { document, emit } = setupDesktopDOM();
+
+    emit('sendbeam:transfer', {
+      kind: 'drop',
+      id: 'tx-qr-1',
+      files: ['/tmp/file.txt'],
+    });
+
+    // Attempt javascript: scheme in qr
+    emit('sendbeam:transfer', {
+      kind: 'invite',
+      id: 'tx-qr-1',
+      code: '7-alpha-bravo',
+      qr: 'javascript:alert(1)',
+    });
+
+    const qrImg = document.getElementById('invite-qr') as HTMLImageElement;
+    expect(qrImg.src).not.toContain('javascript');
+
+    // Valid data URI should be accepted
+    const validDataUrl =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    emit('sendbeam:transfer', {
+      kind: 'invite',
+      id: 'tx-qr-1',
+      code: '7-alpha-bravo',
+      qr: validDataUrl,
+    });
+    expect(qrImg.src).toBe(validDataUrl);
+  });
+});


### PR DESCRIPTION
## Summary

### Logical ID / milestone: V18H-PR02 / v1.8.x

### Goal: Literal-text desktop rendering

### Dependencies: None

### Baseline SHA: e6d144d

### Production path before/after:
- Before: The embedded desktop shell (`frontend/dist/index.html`) used `innerHTML` and template literal interpolation to render transfer paths (`ev.outPath`), error messages (`ev.error`, catch errors), status chips (`ev.phase`, `ev.transport`), update notes/versions, and interrupted transfer table rows. Malicious or HTML-looking remote strings could be parsed into DOM nodes in the privileged Wails v3 WebView.
- After: Completely eliminated all `innerHTML` usage in the desktop frontend shell. All untrusted remote strings, filenames, error messages, and status updates are inserted strictly through safe DOM APIs (`textContent`, `createTextNode`, `replaceChildren()`), ensuring they render inertly as literal text. Additionally guarded `invite-qr` image source against non-image schemes.

### Changed areas:
- `apps/desktop/frontend/dist/index.html`: Replaced all 14 `innerHTML` assignments with safe DOM construction (`setStatusMessage`, `renderChips`, `replaceChildren`, `textContent`). Added URI scheme validation for the QR image.
- `apps/desktop/internal/engine/render_safety_test.go`: Added Go unit tests validating that the desktop frontend HTML contains zero prohibited sinks (`innerHTML`, `outerHTML`, `document.write`, `insertAdjacentHTML`, `javascript:`) and no inline event handlers.
- `apps/web/src/desktop-render.test.ts`: Added JSDOM test suite verifying that simulated Wails events carrying HTML payloads (`<img>`, `<svg>`, `<script>`, event handlers) are rendered as literal text without creating unexpected DOM elements.

### Explicit exclusions:
- No changes to Wails Go service APIs or IPC protocol.
- No changes to UI styling or visual layout.

### Security/privacy/authorization impact:
- Eliminates HTML injection / XSS risks in the privileged desktop renderer.
- Remote peer errors, malicious manifest paths, and update payloads cannot inject DOM elements or trigger script execution.

### Wire/storage/CLI compatibility:
- Fully compatible. Internal desktop renderer hardening only.

### Migration and rollback:
- Pure UI hardening change. Reversible by reverting commit.

### Evidence:
- Baseline regression: JSDOM harness confirmed `<img src=x onerror=...>` in errors/paths was previously parsed into DOM elements. Now safely rendered as inert text (`querySelector('img')` returns null).
- Targeted tests:
  - `go test -race -v -run TestDesktopFrontend ./internal/...` (PASS)
  - `pnpm --filter @sendbeam/web test run src/desktop-render.test.ts` (PASS, 8/8)
- Workspace suites:
  - `apps/desktop`: `go test -race ./internal/...` (PASS)
  - `golangci-lint`: 0 issues across `./internal/...`
  - `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, `pnpm run test`, `pnpm run build` (PASS)
  - `bash scripts/version-metadata_test.sh` (PASS)