### PR TITLE
fix(pwa): allowlist shell caching and preserve unrelated caches

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,13 +1,18 @@
 /**
- * SendBeam Minimal PWA Service Worker (V16-PR05)
+ * SendBeam PWA Service Worker (V18H-PR03)
  *
- * Implements an offline-installable app shell while strictly enforcing:
+ * Implements an allowlisted offline app shell while strictly enforcing:
  * - TRANSFERS STAY ONLINE-ONLY: Never cache WebSocket (/ws), WebRTC signaling,
  *   /config.json, Range requests, or transfer data streams.
- * - Stale-while-revalidate for local static assets (/assets/*, /icons/*).
- * - Fast app shell loading and automatic client claiming.
+ * - Shell-only caching: Only cache verified, owned static shell assets
+ *   (/assets/*, /icons/*, precached shell files). Never cache arbitrary endpoints,
+ *   invite URLs, or query parameters.
+ * - Cache isolation: Only prune SendBeam's own older cache versions (sendbeam-shell-*)
+ *   during activation. Never delete unrelated caches on the origin.
+ * - Active-transfer coordination: Defer disruptive updates while file transfers are active.
  */
 
+const CACHE_PREFIX = 'sendbeam-shell-';
 const CACHE_NAME = 'sendbeam-shell-v1';
 
 const PRECACHE_ASSETS = [
@@ -23,12 +28,107 @@ const PRECACHE_ASSETS = [
   '/icons/apple-touch-icon.png',
 ];
 
+const ALLOWED_EXACT_SHELL_PATHS = new Set([
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/favicon.svg',
+]);
+
+const ALLOWED_SHELL_PREFIXES = ['/assets/', '/icons/'];
+
+/**
+ * Validates whether a URL represents an owned static shell asset eligible for caching.
+ * Enforces a strict allowlist — arbitrary paths, invite links, and query parameters
+ * are never cached.
+ */
+function isAllowedShellAsset(url) {
+  // Only same-origin requests can be shell assets
+  if (url.origin !== self.location.origin) {
+    return false;
+  }
+
+  // Never cache requests with query strings (invite codes, room tokens, params)
+  if (url.search) {
+    return false;
+  }
+
+  // Never cache the service worker itself
+  if (url.pathname === '/sw.js') {
+    return false;
+  }
+
+  // Match exact root shell assets
+  if (ALLOWED_EXACT_SHELL_PATHS.has(url.pathname)) {
+    return true;
+  }
+
+  // Match allowlisted static asset directory prefixes (Vite immutable builds, icons)
+  for (const prefix of ALLOWED_SHELL_PREFIXES) {
+    if (url.pathname.startsWith(prefix)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Active transfer tracking and client coordination
+let activeTransfers = 0;
+let waitingToActivate = false;
+
+self.addEventListener('message', (event) => {
+  if (!event.data || typeof event.data !== 'object') {
+    return;
+  }
+
+  switch (event.data.type) {
+    case 'TRANSFER_START':
+      activeTransfers++;
+      break;
+
+    case 'TRANSFER_END':
+      activeTransfers = Math.max(0, activeTransfers - 1);
+      if (activeTransfers === 0 && waitingToActivate) {
+        waitingToActivate = false;
+        self.skipWaiting();
+      }
+      break;
+
+    case 'SKIP_WAITING':
+      if (activeTransfers === 0 || event.data.force) {
+        waitingToActivate = false;
+        self.skipWaiting();
+      } else {
+        waitingToActivate = true;
+      }
+      break;
+
+    case 'GET_STATUS':
+      if (event.ports && event.ports[0]) {
+        event.ports[0].postMessage({
+          activeTransfers,
+          cacheName: CACHE_NAME,
+          waitingToActivate,
+        });
+      }
+      break;
+  }
+});
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches
       .open(CACHE_NAME)
       .then((cache) => cache.addAll(PRECACHE_ASSETS))
-      .then(() => self.skipWaiting()),
+      .then(async () => {
+        // If an active transfer is currently running, defer skipWaiting to prevent disruption
+        if (activeTransfers === 0) {
+          await self.skipWaiting();
+        } else {
+          waitingToActivate = true;
+        }
+      }),
   );
 });
 
@@ -37,7 +137,11 @@ self.addEventListener('activate', (event) => {
     caches
       .keys()
       .then((keys) =>
-        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))),
+        Promise.all(
+          keys
+            .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
       )
       .then(() => self.clients.claim()),
   );
@@ -51,7 +155,7 @@ self.addEventListener('fetch', (event) => {
 
   const url = new URL(req.url);
 
-  // 1. Strict online-only bypass: WebSocket signaling, dynamic configs, health endpoints
+  // 1. Strict online-only bypass: WebSocket signaling, dynamic configs, health/metrics, Range requests
   if (
     url.pathname === '/ws' ||
     url.pathname.startsWith('/ws/') ||
@@ -65,7 +169,7 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // 2. Navigation requests: Network-first with fallback to cached app shell
+  // 2. Navigation requests: Network-first with fallback to clean cached app shell
   if (req.mode === 'navigate') {
     event.respondWith(
       fetch(req).catch(async () => {
@@ -77,8 +181,9 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // 3. Same-origin static assets: Stale-While-Revalidate
-  if (url.origin === self.location.origin) {
+  // 3. Allowlisted shell assets: Stale-While-Revalidate
+  // Strictly applies ONLY to verified owned static shell assets (no query strings, no dynamic paths)
+  if (isAllowedShellAsset(url)) {
     event.respondWith(
       caches.open(CACHE_NAME).then(async (cache) => {
         const cached = await cache.match(req);
@@ -94,5 +199,9 @@ self.addEventListener('fetch', (event) => {
         return cached || fetchPromise;
       }),
     );
+    return;
   }
+
+  // 4. Any other request is deliberately NOT intercepted by the service worker,
+  // falling through to standard browser network handling without polluting the cache.
 });

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -35,6 +35,7 @@
   import DevicesModal from './lib/trust/DevicesModal.svelte';
   import IncomingTransferModal from './lib/trust/IncomingTransferModal.svelte';
   import type { TrustedDeviceUI, IncomingTransferRequest } from './lib/trust/types.js';
+  import { notifyTransferStart, notifyTransferEnd } from './lib/pwa/register.js';
 
   loadConfig();
   import {
@@ -528,6 +529,10 @@
   /** Bind a running transfer's live progress and terminal outcome to the UI. */
   function beginTransfer(ctrl: TransferController) {
     transfer = ctrl;
+    notifyTransferStart();
+    ctrl.done.finally(() => {
+      notifyTransferEnd();
+    });
     sentBytes = 0;
     totalBytes = ctrl.total() ?? 0;
     reusedBytes = 0;

--- a/apps/web/src/lib/pwa/register.ts
+++ b/apps/web/src/lib/pwa/register.ts
@@ -28,3 +28,22 @@ export function registerServiceWorker(): void {
       });
   });
 }
+
+/**
+ * Notify the Service Worker that an active file transfer has started.
+ * Prevents disruptive service worker updates from evicting active transfer state.
+ */
+export function notifyTransferStart(): void {
+  if (typeof navigator !== 'undefined' && navigator.serviceWorker?.controller) {
+    navigator.serviceWorker.controller.postMessage({ type: 'TRANSFER_START' });
+  }
+}
+
+/**
+ * Notify the Service Worker that an active file transfer has settled.
+ */
+export function notifyTransferEnd(): void {
+  if (typeof navigator !== 'undefined' && navigator.serviceWorker?.controller) {
+    navigator.serviceWorker.controller.postMessage({ type: 'TRANSFER_END' });
+  }
+}

--- a/apps/web/src/sw.test.ts
+++ b/apps/web/src/sw.test.ts
@@ -1,0 +1,350 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+
+const swPath = resolve(__dirname, '../public/sw.js');
+const swCode = readFileSync(swPath, 'utf8');
+
+class MockCache {
+  readonly store = new Map<string, Response>();
+  constructor(readonly name: string) {}
+
+  async match(req: RequestInfo | URL): Promise<Response | undefined> {
+    const key = typeof req === 'string' ? req : 'url' in req ? req.url : req.toString();
+    return this.store.get(key);
+  }
+
+  async put(req: RequestInfo | URL, res: Response): Promise<void> {
+    const key = typeof req === 'string' ? req : 'url' in req ? req.url : req.toString();
+    this.store.set(key, res);
+  }
+
+  async addAll(urls: string[]): Promise<void> {
+    for (const u of urls) {
+      this.store.set(u, new Response('ok', { status: 200 }));
+    }
+  }
+
+  async delete(req: RequestInfo | URL): Promise<boolean> {
+    const key = typeof req === 'string' ? req : 'url' in req ? req.url : req.toString();
+    return this.store.delete(key);
+  }
+}
+
+class MockCacheStorage {
+  readonly caches = new Map<string, MockCache>();
+
+  async open(name: string): Promise<MockCache> {
+    if (!this.caches.has(name)) {
+      this.caches.set(name, new MockCache(name));
+    }
+    return this.caches.get(name)!;
+  }
+
+  async keys(): Promise<string[]> {
+    return Array.from(this.caches.keys());
+  }
+
+  async delete(name: string): Promise<boolean> {
+    return this.caches.delete(name);
+  }
+
+  async match(req: RequestInfo | URL): Promise<Response | undefined> {
+    for (const cache of this.caches.values()) {
+      const res = await cache.match(req);
+      if (res) return res;
+    }
+    return undefined;
+  }
+}
+
+interface MockExtendableEvent {
+  waitUntil: (p: Promise<unknown>) => void;
+}
+
+interface MockFetchEvent {
+  request: Request;
+  respondWith: (r: Response | Promise<Response>) => void;
+}
+
+interface MockMessageEvent {
+  data: unknown;
+  ports?: readonly { postMessage: (msg: unknown) => void }[];
+}
+
+interface SWMockEnvironment {
+  dispatchInstall: (ev: MockExtendableEvent) => void;
+  dispatchActivate: (ev: MockExtendableEvent) => void;
+  dispatchFetch: (ev: MockFetchEvent) => void;
+  dispatchMessage: (ev: MockMessageEvent) => void;
+  mockCaches: MockCacheStorage;
+  skipWaiting: ReturnType<typeof vi.fn>;
+  claim: ReturnType<typeof vi.fn>;
+  sandbox: Record<string, unknown>;
+}
+
+function setupSWEnvironment(initialCaches: string[] = []): SWMockEnvironment {
+  const listeners: Record<string, ((ev: unknown) => void)[]> = {};
+  const mockCaches = new MockCacheStorage();
+  for (const c of initialCaches) {
+    mockCaches.caches.set(c, new MockCache(c));
+  }
+
+  const skipWaiting = vi.fn().mockResolvedValue(undefined);
+  const claim = vi.fn().mockResolvedValue(undefined);
+
+  const selfObj = {
+    addEventListener: (type: string, cb: (ev: unknown) => void) => {
+      if (!listeners[type]) listeners[type] = [];
+      listeners[type].push(cb);
+    },
+    location: { origin: 'https://sendbeam.test' },
+    clients: { claim },
+    skipWaiting,
+  };
+
+  const sandbox: Record<string, unknown> = {
+    self: selfObj,
+    caches: mockCaches,
+    fetch: vi.fn().mockImplementation(async () => {
+      return new Response('network-ok', { status: 200 });
+    }),
+    URL,
+    Response,
+    Request,
+    Set,
+    Map,
+    Promise,
+    Math,
+  };
+
+  vm.createContext(sandbox);
+  vm.runInContext(swCode, sandbox);
+
+  return {
+    dispatchInstall: (ev: MockExtendableEvent) => listeners['install']?.[0]?.(ev),
+    dispatchActivate: (ev: MockExtendableEvent) => listeners['activate']?.[0]?.(ev),
+    dispatchFetch: (ev: MockFetchEvent) => listeners['fetch']?.[0]?.(ev),
+    dispatchMessage: (ev: MockMessageEvent) => listeners['message']?.[0]?.(ev),
+    mockCaches,
+    skipWaiting,
+    claim,
+    sandbox,
+  };
+}
+
+describe('PWA Service Worker allowlisted caching and isolation', () => {
+  it('precaches only owned shell assets on install', async () => {
+    const { dispatchInstall, mockCaches, skipWaiting } = setupSWEnvironment();
+
+    let installWait: Promise<unknown> | undefined;
+    dispatchInstall({
+      waitUntil: (p: Promise<unknown>) => {
+        installWait = p;
+      },
+    });
+
+    await installWait;
+    expect(mockCaches.caches.has('sendbeam-shell-v1')).toBe(true);
+
+    const shellCache = mockCaches.caches.get('sendbeam-shell-v1')!;
+    expect(await shellCache.match('/')).toBeDefined();
+    expect(await shellCache.match('/index.html')).toBeDefined();
+    expect(await shellCache.match('/manifest.webmanifest')).toBeDefined();
+    expect(await shellCache.match('/favicon.svg')).toBeDefined();
+    expect(await shellCache.match('/icons/icon-192.png')).toBeDefined();
+
+    expect(skipWaiting).toHaveBeenCalled();
+  });
+
+  it('preserves unrelated caches on activation while pruning older sendbeam-shell versions', async () => {
+    const { dispatchActivate, mockCaches, claim } = setupSWEnvironment([
+      'unrelated-app-cache',
+      'user-download-cache',
+      'sendbeam-shell-v0',
+      'sendbeam-shell-v1',
+    ]);
+
+    let activateWait: Promise<unknown> | undefined;
+    dispatchActivate({
+      waitUntil: (p: Promise<unknown>) => {
+        activateWait = p;
+      },
+    });
+
+    await activateWait;
+
+    const remainingKeys = await mockCaches.keys();
+    // Unrelated caches must NOT be deleted
+    expect(remainingKeys).toContain('unrelated-app-cache');
+    expect(remainingKeys).toContain('user-download-cache');
+    // Current shell cache must be retained
+    expect(remainingKeys).toContain('sendbeam-shell-v1');
+    // Older SendBeam shell cache must be pruned
+    expect(remainingKeys).not.toContain('sendbeam-shell-v0');
+
+    expect(claim).toHaveBeenCalled();
+  });
+
+  it('caches allowlisted shell assets in Stale-While-Revalidate mode', async () => {
+    const { dispatchFetch, mockCaches } = setupSWEnvironment();
+
+    const allowedUrls = [
+      'https://sendbeam.test/assets/index-abc12345.js',
+      'https://sendbeam.test/assets/index-def67890.css',
+      'https://sendbeam.test/icons/icon-192.png',
+      'https://sendbeam.test/favicon.svg',
+      'https://sendbeam.test/manifest.webmanifest',
+      'https://sendbeam.test/index.html',
+    ];
+
+    for (const url of allowedUrls) {
+      let respondPromise: Promise<Response> | undefined;
+      const req = new Request(url, { method: 'GET' });
+      dispatchFetch({
+        request: req,
+        respondWith: (p: Response | Promise<Response>) => {
+          respondPromise = Promise.resolve(p);
+        },
+      });
+
+      expect(respondPromise).toBeDefined();
+      const response = await respondPromise!;
+      expect(response.status).toBe(200);
+
+      // Wait a microtask tick for the background cache.put promise to resolve
+      await new Promise((r) => setTimeout(r, 10));
+
+      const shellCache = await mockCaches.open('sendbeam-shell-v1');
+      const cached = await shellCache.match(req);
+      expect(cached).toBeDefined();
+    }
+  });
+
+  it('strictly bypasses dynamic endpoints, query parameters, signaling, and sw.js from cache', async () => {
+    const { dispatchFetch, mockCaches } = setupSWEnvironment();
+
+    const nonAllowlisted = [
+      // Dynamic room / invite requests with query parameters
+      'https://sendbeam.test/?code=7-alpha-bravo',
+      'https://sendbeam.test/index.html?code=888-mobile',
+      'https://sendbeam.test/room/123-abc',
+      'https://sendbeam.test/api/transfer/status',
+      'https://sendbeam.test/arbitrary/data/file.bin',
+      // Signaling and operational endpoints
+      'https://sendbeam.test/ws',
+      'https://sendbeam.test/ws/peer-123',
+      'https://sendbeam.test/config.json',
+      'https://sendbeam.test/healthz',
+      'https://sendbeam.test/metrics',
+      // Service worker itself
+      'https://sendbeam.test/sw.js',
+    ];
+
+    for (const url of nonAllowlisted) {
+      const req = new Request(url, { method: 'GET' });
+      dispatchFetch({
+        request: req,
+        respondWith: () => {},
+      });
+
+      // Navigation requests to ?code=... respond with fallback to clean app shell,
+      // but must NOT cache the ?code=... request itself in CacheStorage
+      const shellCache = await mockCaches.open('sendbeam-shell-v1');
+      const cached = await shellCache.match(req);
+      expect(cached).toBeUndefined();
+    }
+  });
+
+  it('strictly bypasses Range requests and cross-origin requests', async () => {
+    const { dispatchFetch, mockCaches } = setupSWEnvironment();
+
+    // Range request on same-origin asset
+    let rangeResponded = false;
+    const rangeReq = new Request('https://sendbeam.test/assets/large.dat', {
+      headers: { range: 'bytes=0-1024' },
+    });
+    dispatchFetch({
+      request: rangeReq,
+      respondWith: () => {
+        rangeResponded = true;
+      },
+    });
+    expect(rangeResponded).toBe(false);
+
+    // Cross-origin request
+    let foreignResponded = false;
+    const foreignReq = new Request('https://external-cdn.com/assets/lib.js');
+    dispatchFetch({
+      request: foreignReq,
+      respondWith: () => {
+        foreignResponded = true;
+      },
+    });
+    expect(foreignResponded).toBe(false);
+
+    const shellCache = await mockCaches.open('sendbeam-shell-v1');
+    expect(await shellCache.match(rangeReq)).toBeUndefined();
+    expect(await shellCache.match(foreignReq)).toBeUndefined();
+  });
+
+  it('coordinates updates during active transfers and defers skipWaiting until settled', async () => {
+    const { dispatchInstall, dispatchMessage, skipWaiting } = setupSWEnvironment();
+
+    // Client signals active transfer started
+    dispatchMessage({
+      data: { type: 'TRANSFER_START' },
+    });
+
+    // Verify status query reports active transfer
+    let statusMsg:
+      { activeTransfers: number; cacheName: string; waitingToActivate: boolean } | undefined;
+    dispatchMessage({
+      data: { type: 'GET_STATUS' },
+      ports: [
+        {
+          postMessage: (msg: unknown) => {
+            statusMsg = msg as {
+              activeTransfers: number;
+              cacheName: string;
+              waitingToActivate: boolean;
+            };
+          },
+        },
+      ],
+    });
+    expect(statusMsg).toEqual({
+      activeTransfers: 1,
+      cacheName: 'sendbeam-shell-v1',
+      waitingToActivate: false,
+    });
+
+    // Install event occurs while transfer is running
+    skipWaiting.mockClear();
+    let installWait: Promise<unknown> | undefined;
+    dispatchInstall({
+      waitUntil: (p: Promise<unknown>) => {
+        installWait = p;
+      },
+    });
+    await installWait;
+
+    // skipWaiting must NOT be called while activeTransfers > 0
+    expect(skipWaiting).not.toHaveBeenCalled();
+
+    // An unforced SKIP_WAITING from client is also deferred
+    dispatchMessage({
+      data: { type: 'SKIP_WAITING', force: false },
+    });
+    expect(skipWaiting).not.toHaveBeenCalled();
+
+    // Active transfer settles
+    dispatchMessage({
+      data: { type: 'TRANSFER_END' },
+    });
+
+    // Now skipWaiting must have been invoked to complete activation cleanly
+    expect(skipWaiting).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

### Logical ID / milestone: V18H-PR03 / v1.8.x

### Goal: Allowlisted PWA caching & cache isolation

### Dependencies: None

### Baseline SHA: de52250

### Production path before/after:

- **Before**:
  1. Service worker activation purged every cache key where `key !== CACHE_NAME`, indiscriminately deleting unrelated caches and app data on the same origin/port.
  2. The fetch handler intercepted and cached any same-origin GET request into `sendbeam-shell-v1`, potentially persisting sensitive query tokens (e.g. `/?code=secret`), dynamic room endpoints, and transient API responses in browser CacheStorage.
  3. Service worker update activation (`skipWaiting`) was not coordinated with active file transfers, risking abrupt teardown or state resets during in-flight transfers.
- **After**:
  1. Service worker activation restricts pruning strictly to older SendBeam caches matching `sendbeam-shell-*`. All unrelated origin caches and download stores are preserved.
  2. The fetch handler implements an explicit, strict static shell allowlist (`isAllowedShellAsset`). Only verified static assets (`/`, `/index.html`, `/manifest.webmanifest`, `/favicon.svg`, `/assets/*`, `/icons/*`) without query strings are cached in SWR mode. Arbitrary URLs, invite codes, query tokens (`?code=...`), dynamic endpoints, Range requests, and `/sw.js` are never cached.
  3. Client-coordinated transfer lifecycle: client informs service worker of active transfers (`TRANSFER_START` / `TRANSFER_END`). Disruptive service worker update activation (`skipWaiting`) is deferred until active transfers settle cleanly.

### Changed areas:

- `apps/web/public/sw.js`: Added `CACHE_PREFIX`, scoped cache deletion on activate to `CACHE_PREFIX`, implemented `isAllowedShellAsset(url)`, added active transfer coordination message handlers, and deferred `skipWaiting` during active transfers.
- `apps/web/src/lib/pwa/register.ts`: Added `notifyTransferStart()` and `notifyTransferEnd()` helpers for client-to-SW messaging.
- `apps/web/src/App.svelte`: Hooked `notifyTransferStart()` on `beginTransfer()` and `notifyTransferEnd()` on `ctrl.done.finally()`.
- `apps/web/src/sw.test.ts`: Added Node VM Vitest unit tests verifying precaching, cache isolation, stale-while-revalidate allowlisting, bypass of dynamic/query/signaling/range endpoints, and active-transfer update deferral.

### Explicit exclusions:

- No changes to transfer protocol, WebRTC engine, or wire packets.
- No changes to desktop Wails application shell or CLI tool.

### Security/privacy/authorization impact:

- Prevents local cache poisoning and credential/token exposure in CacheStorage (e.g. transfer passphrases or room codes in query parameters).
- Prevents cross-app cache clobbering when SendBeam is hosted on shared origin domains or multi-tenant subpaths.
- Protects in-flight data transfers from abrupt lifecycle interruptions caused by background service worker updates.

### Wire/storage/CLI compatibility:

- Fully compatible. Browser PWA service worker and client shell hardening only.

### Migration and rollback:

- Standard service worker rollout. Reverting commit updates the service worker script version and restores default behavior.

### Evidence:

- **Targeted tests**:
  - `pnpm --filter @sendbeam/web test run src/sw.test.ts`: 6/6 tests passing (precaching, cache isolation, SWR allowlisting, dynamic/query/signaling/range bypass, and active transfer coordination).
- **Workspace suites**:
  - `pnpm run format:check`: PASS (0 differences)
  - `pnpm run lint`: PASS (0 errors, 0 warnings across all packages)
  - `pnpm run typecheck`: PASS (0 TypeScript errors)
  - `pnpm run test`: PASS (27 test files, 237 tests passed)
  - `pnpm run build`: PASS (protocol + web build succeeded)
  - `(cd apps/desktop && go test -race ./internal/...)`: PASS
  - `(cd apps/cli && go test -race ./...)`: PASS
  - `bash scripts/version-metadata_test.sh`: PASS (all 10 test cases)