### PR TITLE
docs(security): establish honest capability matrix and safety patch release gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ SendBeam is fully optimized for mobile devices and installable as a PWA on Andro
 
 SendBeam v1.5 introduces cryptographic device identity, mutual pairing, and instant transfer automation across your personal device fleet — with zero cloud accounts or centralized directories:
 
-- **Pair Once, Connect Forever:** Pair two devices over an authenticated SPAKE2 ceremony (`sendbeam pair` in CLI, or via Web/Desktop UI). Once paired, devices establish mutual forward-secret sessions (`sendbeam/2`) without typing room codes.
+- **Pair Once, Connect Forever:** Pair two devices over an authenticated SPAKE2 ceremony (`sendbeam pair` in CLI, or via Web/Desktop UI). Once paired, devices establish mutual authenticated sessions (`sendbeam/2`) without typing room codes.
 - **Targeted & Multi-Device Broadcast Sending (v1.7):** Send files directly to one or multiple paired devices concurrently with independent failure isolation:
   ```bash
   sendbeam send report.pdf @macbook
@@ -252,6 +252,7 @@ commitments, see [SECURITY.md](SECURITY.md).
 - [Supply Chain Integrity](docs/supply-chain.md) — build provenance attestations, SPDX 2.3 SBOMs, checksum manifests
 - [Updater Architecture](docs/updater.md) — self-update channels, cryptographic verification, and rollback safety
 - [Distribution](docs/distribution.md) — multi-platform packaging, artifacts, and build metadata
+- [Release Gate v1.8.1 (Safety Patch)](docs/RELEASE-v1.8.1.md) — v1.8.1 safety patch criteria, honest capability matrix, and verification checklist
 - [Release Gate v1.8](docs/RELEASE-v1.8.md) — v1.8 milestone criteria, verification evidence, and release checklist
 - [Release Gate v1.7](docs/RELEASE-v1.7.md) — v1.7 milestone criteria, verification evidence, and release checklist
 - [Release Gate v1.6](docs/RELEASE-v1.6.md) — v1.6 milestone criteria, verification evidence, and release checklist

--- a/docs/RELEASE-v1.8.1.md
+++ b/docs/RELEASE-v1.8.1.md
@@ -1,0 +1,72 @@
+# SendBeam v1.8.1 — Safety Patch Release Gate
+
+The v1.8.1 milestone (**Safety Patch & Honest Capability Matrix**) gates release on the critical security remediations, capability boundary honesty corrections, and verification checks below, each verified against merged `main`.
+
+---
+
+## 1. Safety Patch Deliverables
+
+| Logical ID    | Deliverable                                 |             Status              | Evidence                                                                                                                                                                                                                                                                                                                                        |
+| :------------ | :------------------------------------------ | :-----------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **V18H-PR01** | **Secret-Free Public JSON and Diagnostics** | **MERGED** (PR #176, `e6d144d`) | Public DTO (`transfer.PublicOutcome`) exposes only safe transfer metadata (`name`, `size`, `digest`, `path`, `files`). Sensitive cryptographic state marked `json:"-"` across wire and engine. Redacted diagnostics prevent credential leaks in terminal and log outputs.                                                                       |
+| **V18H-PR02** | **Literal-Text Desktop Rendering**          | **MERGED** (PR #177, `de52250`) | Eliminated all 14 `innerHTML` assignments in desktop Wails shell (`apps/desktop/frontend/dist/index.html`). Remote filenames, error strings, and status updates render inertly as literal DOM text nodes (`textContent`, `replaceChildren`, `createTextNode`).                                                                                  |
+| **V18H-PR03** | **Allowlisted PWA Caching & Isolation**     | **MERGED** (PR #178, `1597f46`) | Scoped Service Worker cache pruning on activation strictly to SendBeam shell caches (`sendbeam-shell-*`), preserving all unrelated origin caches. Intercepts and caches only verified static shell assets; bypasses query parameters (`?code=...`), dynamic endpoints, Range requests, and `/sw.js`. Defers updates while transfers are active. |
+| **V18H-PR04** | **Honest Capability Matrix & Patch Gate**   |           **CURRENT**           | Corrected forward-secrecy and network-anonymity claims across documentation and code comments. Documented exact runtime boundaries for WebKit CI emulation, OPFS memory pressure, traffic padding negotiation, and 32-bit archive limits. Verified safety fixes and ordinary transfer stability.                                                |
+
+---
+
+## 2. Honest Capability Matrix & Trust Boundaries
+
+Following systematic security review, the following capabilities and boundaries are explicitly defined:
+
+### 2.1 Cryptographic Session Key Derivation (`sendbeam/2`)
+
+- **Implemented Behavior:** Pairwise session keys (`k_i2r`, `k_r2i`) are derived via `HMAC-SHA256(k_pair, Ephem_A || Ephem_B || Nonce_A || Nonce_B)` and `HKDF-SHA256`.
+- **Guarantees:** Mutual peer authentication, transcript binding, replay protection, and clock skew bounding (±5 min).
+- **Boundary & Limitation:** Because ephemeral values are authenticated via `k_pair` without an ephemeral Diffie-Hellman (ECDH) exchange, compromise of `k_pair` permits retroactive decryption of past session recordings. It does **not** provide forward secrecy.
+- **Roadmap:** A reviewed, versioned authenticated ephemeral Diffie-Hellman key exchange (X25519) providing true forward secrecy is scheduled for v1.9 (V19-PR01 / V19-PR02).
+
+### 2.2 Network Presence & Rendezvous Handles
+
+- **Implemented Behavior:** 15-minute epoch-rotated blind handles (`HMAC(k_pair, "sendbeam/2 rendezvous-handle:" || epoch)`).
+- **Guarantees:** Third parties and the signaling server cannot index or harvest a global directory of registered devices from handle strings alone.
+- **Boundary & Limitation:** Opaque handles do **not** provide transport-layer network anonymity. The signaling server and upstream network observers observe client TCP/WebSocket connections, public IP addresses, and message timing.
+
+### 2.3 Wire Traffic Padding Policy
+
+- **Implemented Behavior:** Frame payloads are quantized into power-of-two buckets ($256..65535$) when negotiated.
+- **Guarantees:** Obfuscates exact file sizes and chunk boundaries when both peers support and advertise `padding`.
+- **Boundary & Limitation:** In v1.8, wire padding is negotiated opportunistically. `--private` advertises padding, but if the remote peer lacks the capability, transfers proceed unpadded. Strict host-level policy (refusing transfers when private mode is requested against an unpadded peer) is scheduled for v1.9 (V19-PR11).
+
+### 2.4 Browser Platform & Storage Ceilings
+
+- **WebKit / iOS Testing:** CI tests execute Playwright on Linux using the WebKit engine with mobile viewport emulation. This demonstrates browser engine compliance, but is not physical iOS hardware testing.
+- **OPFS Memory Bounds:** Transfers stream blocks to disk to prevent JS heap accumulation. While bounded for tested workloads, peak memory on physical mobile devices remains subject to OS jetsam constraints.
+- **ZIP Archive Sinks:** In-browser archive generation uses standard 32-bit ZIP formats capped at 4 GiB. Streaming ZIP64 with arbitrary file counts and 64-bit sizes is scheduled for v2.0 (V20-PR05).
+
+---
+
+## 3. Ordinary Transfer & Safety Verification
+
+All ordinary transfer paths and safety remediations have been verified:
+
+1. **Ordinary SPAKE2 Transfers (`sendbeam/1`):**
+   - Direct WebRTC DataChannel transfers: Verified.
+   - Encrypted WebSocket relay fallback: Verified.
+   - SHA-256 end-to-end whole-file digest verification: Verified.
+2. **Safety Remediations:**
+   - CLI JSON outputs contain zero secrets or key material: Verified (`diagnostics.test.ts`, CLI tests).
+   - Desktop frontend contains zero `innerHTML` or script injection sinks: Verified (`render_safety_test.go`, JSDOM suite).
+   - PWA Service Worker caches only static shell files, preserves unrelated caches, and defers activation during transfers: Verified (`sw.test.ts`, Playwright e2e).
+   - Wire padding negotiation helper (`NegotiatePadding` / `isPaddingNegotiated`): Verified in Go and TypeScript suites.
+
+---
+
+## 4. Release Checklist
+
+- [x] V18H-PR01 merged to main (`e6d144d`)
+- [x] V18H-PR02 merged to main (`de52250`)
+- [x] V18H-PR03 merged to main (`1597f46`)
+- [x] V18H-PR04 honest capability matrix and patch gate implemented
+- [x] Documentation synchronized across `README.md`, `protocol.md`, `trust-model.md`, `compat-matrix.md`, `threat-model.md`
+- [x] Workspace verification passes 100% green: `format:check`, `lint`, `typecheck`, `test`, `build`, Go test `-race`, version metadata

--- a/docs/RELEASE-v1.8.md
+++ b/docs/RELEASE-v1.8.md
@@ -108,3 +108,16 @@ The standard SendBeam distribution artifact set is produced and cryptographicall
 - [x] V18-PR04 — Attack matrix expansion: 12 → 20+ vectors merged (`3eaf8a4`)
 - [x] V18-PR05 — Security posture: disclosure policy, scorecard, pinned actions merged (`73f5f42`)
 - [x] V18-PR06 — Release gate: RELEASE-v1.8.md + docs sweep + version metadata
+
+---
+
+## 6. Post-v1.8.0 Safety Patch Addendum (v1.8.1)
+
+Following the v1.8.0 release, critical security hardening and capability honesty corrections were implemented across the v1.8.x safety patch line (V18H-PR01 through V18H-PR04):
+
+- **V18H-PR01 (PR #176, `e6d144d`):** Secret-free public JSON and diagnostics. Internal handshake secrets, master keys, and traffic credentials stripped from CLI JSON output and error logs.
+- **V18H-PR02 (PR #177, `de52250`):** Literal-text desktop rendering. Replaced all `innerHTML` assignments in desktop Wails shell with safe DOM text node APIs to prevent HTML injection.
+- **V18H-PR03 (PR #178, `1597f46`):** Allowlisted PWA caching. Scoped SW cache pruning to `sendbeam-shell-*`, restricted cache interception strictly to owned static shell assets, and coordinated background updates with active transfers.
+- **V18H-PR04:** Honest capability matrix and patch release gate. Documented cryptographic and architectural trust boundaries (forward secrecy limitation of v1.5 key schedule, network IP metadata visibility on signaling server, and traffic padding negotiation requirements).
+
+See [`docs/RELEASE-v1.8.1.md`](RELEASE-v1.8.1.md) for full patch verification evidence, release criteria, and security clarifications.

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -98,10 +98,11 @@ SendBeam is fully installable as a Progressive Web App (PWA) on mobile (Android 
 - **Strict Online-Only Transfer Semantics:** The service worker precaches the app shell and local assets while strictly never caching WebSockets (`/ws`), WebRTC signaling, or live transfer data.
 - **Mobile Responsive UX:** Prominent QR code pairing on small viewports, auto-populated code joining via `?code=` query parameters, touch-optimized minimum 44px tap targets, and native `navigator.share` integration.
 - **Screen Wake Lock & Visibility Lifecycle:** Keeps screen awake during active mobile transfers where supported. On iOS Safari (where Wake Lock is not exposed), tab backgrounding or screen locks suspend WebKit execution; SendBeam's visibility-change handler transitions the transfer to a deterministic paused state with a prominent Resume action, preventing indefinite socket stalls.
-- **Memory-Bounded OPFS Streaming:** Because neither mobile Safari nor Android Chrome exposes `showSaveFilePicker`, SendBeam streams blocks directly to the Origin Private File System (OPFS) without accumulating chunks in JS heap memory, preventing mobile browser jetsam OOM crashes.
+- **Memory-Bounded OPFS Streaming:** Because neither mobile Safari nor Android Chrome exposes `showSaveFilePicker`, SendBeam streams blocks directly to the Origin Private File System (OPFS) without accumulating chunks in JS heap memory, preventing mobile browser jetsam OOM crashes. Note: A small mobile round-trip with a conditional OPFS assertion in CI demonstrates the streaming path, but is not an unbounded peak-memory proof across all physical devices under system memory pressure.
+- **ZIP Archive Limits:** The ZIP fallback utilizes 32-bit archive fields (ZIP32) and is capped at 4 GiB. Streaming ZIP64 with arbitrary file count/size boundaries is scheduled for v2.0 (V20-PR05).
 - **Private Browsing Safeguards:** In Safari Private Browsing mode where OPFS or IndexedDB is restricted, SendBeam probes storage capabilities before transfer and fails closed with actionable diagnostic guidance rather than silently failing mid-transfer.
 - **WebKit DataChannel Backpressure Guard:** Protects against WebKit SCTP buffer stalls with dual event-listener registration and adaptive safety drain timers when `bufferedamountlow` events are coalesced or dropped.
-- **CI Test Coverage:** Tested in CI via Playwright mobile device profiles: `mobile-chrome` (Pixel 7) and `mobile-webkit` (iPhone 14 / WebKit engine).
+- **CI Test Coverage vs Physical Hardware:** Tested in CI via Playwright mobile device emulation profiles: `mobile-chrome` (Pixel 7 emulation) and `mobile-webkit` (iPhone 14 emulation on Linux WebKit engine). WebKit emulation demonstrates browser engine correctness, but is not physical iOS device hardware testing.
 
 ## Cross-Client Interoperability Matrix (Browser ↔ CLI ↔ Desktop)
 
@@ -187,6 +188,10 @@ SendBeam v1.5 adds mutual cryptographic pairing, persistent trust management, re
 
 All 9 cross-client pairs (Browser ↔ CLI ↔ Desktop) interoperate seamlessly across both ephemeral one-time (`sendbeam/1`) and persistent trusted (`sendbeam/2`) sessions.
 
+> [!NOTE]
+> **Cryptographic Properties & Limits (`sendbeam/2`):**
+> `sendbeam/2` trusted sessions establish mutual peer authentication, replay protection, and domain-separated directional keys derived from the pairwise credential `k_pair` and ephemeral nonces. Because derivation mixes ephemeral public parameters via HMAC with `k_pair` rather than computing an ephemeral Diffie-Hellman exchange, `sendbeam/2` in v1.5–v1.8 does **not** provide forward secrecy against compromise of `k_pair`. A redesigned, reviewed authenticated ephemeral Diffie-Hellman key exchange is scheduled for v1.9 (V19-PR01 / V19-PR02).
+
 ## Distribution, Packaging & Self-Update Matrix (v1.6)
 
 SendBeam publishes cryptographically signed binaries, installers, and update channel manifests for all major desktop and server operating systems:
@@ -224,6 +229,10 @@ SendBeam v1.7 introduces traffic padding, opportunistic mesh revocation sync, an
 | **Revocation Sync (`sendbeam/2`)** |           Opportunistic Sync            |       Ignored by v1.6        | Signed revocation records are piggybacked over trusted sessions. Ignored by peers without the feature.  |
 | **Broadcast Send (`@dev1 @dev2`)** |           Concurrent Fan-Out            |     Independent Session      | Each target establishes an independent `sendbeam/2` session. Single peer failure does not abort others. |
 | **Package Manager Distribution**   |      Homebrew, Scoop, WinGet, AUR       |    GitHub Releases Direct    | Manifests verify against signed `SHA256SUMS.txt` at zero hosting cost.                                  |
+
+> [!NOTE]
+> **Negotiated Padding vs Host Enforcement Policy:**
+> Wire traffic padding is negotiated via `caps.features` and engaged only when both peers support and announce `padding`. When a sender enables `--private`, it requests padding but does not reject unpadded peers in v1.8. Strict host-level policy (refusing transfers when private mode is requested against an unpadded peer or when frames are unpadded) is scheduled for v1.9 (V19-PR11).
 
 ## Interpretation
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -372,7 +372,10 @@ SendBeam v1.5 introduces `sendbeam/2` for persistent trusted devices. For comple
 2. **Trusted Session Authentication (`sendbeam/2`)**:
    - `trusted_auth_init`: Initiator sends `initiator_device_id`, timestamp, 32-byte nonce, ephemeral X25519 public key, and HMAC tag over the domain challenge.
    - `trusted_auth_response`: Responder validates device trust, timestamp freshness (±5 min), verifies tag, generates responder ephemeral key, and returns HMAC response tag.
-   - `trusted_auth_confirm`: Initiator verifies responder tag, derives forward-secret `SessionMaster`, `k_i2r`, `k_r2i`, and returns mutual confirmation tag.
+   - `trusted_auth_confirm`: Initiator verifies responder tag, derives pairwise authenticated `SessionMaster`, `k_i2r`, `k_r2i`, and returns mutual confirmation tag.
+
+> [!NOTE]
+> **Cryptographic Note (v1.8.x clarification):** In `sendbeam/2`, session keys are derived from the pairwise credential `k_pair` and ephemeral nonces via HMAC-SHA256 and HKDF-SHA256. This construction guarantees mutual peer authentication, replay protection, and transcript binding. However, because ephemeral public values are mixed via HMAC with `k_pair` rather than through an ephemeral Diffie-Hellman (ECDH) exchange, compromise of `k_pair` allows decryption of captured past traffic (i.e. it does not provide forward secrecy). A reviewed authenticated ephemeral Diffie-Hellman key exchange is scheduled for v1.9 (V19-PR01 / V19-PR02).
 
 3. **Privacy-Preserving Presence & LAN Discovery**:
    - **Remote Presence**: 15-minute epoch-rotated blind handles (`HMAC(k_pair, "sendbeam/2 rendezvous-handle:" || epoch)`).
@@ -401,7 +404,7 @@ Inside the AEAD envelope, the plaintext is formatted as:
 
 - **Header AAD Invariant:** The 16-byte frame header remains verbatim as AEAD Associated Data; its `len` field matches the total padded ciphertext length ($S + 16$ bytes AEAD tag).
 - **Integrity Validation:** Upon decryption, the receiver validates that `ActualPayloadLength <= BucketSize - 2` and verifies all padding bytes are strictly `0x00`. Any malformed length or non-zero padding byte fails closed (`ErrInvalidFramePadding`).
-- **Interop Fallback:** If either peer lacks the `padding` capability, transfers automatically proceed unpadded without protocol failure.
+- **Interop Fallback:** If either peer lacks the `padding` capability, transfers automatically proceed unpadded without protocol failure. In v1.8, `--private` requests padding on the wire, but does not refuse unpadded peers unless enforced by future policy. A strict client-side require-padding policy (rejecting transfers if padding is unnegotiated or stripped) is scheduled for v1.9 (V19-PR11).
 
 ---
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -212,3 +212,26 @@ and server are security-reviewed and the JS/Go dependencies audited.
 | **18** | **Relay Frame Corruption / Reorder**          | Relay server flips ciphertext bits, delays/reorders sequenced frames, or truncates payload.         | AES-GCM AEAD envelope integrity fails on corruption; monotonic counter window rejects reordered frames.               | `wire/attack_matrix_test.go`                                  | `protocol/src/attack-matrix.test.ts` (Vector 18)               |
 | **19** | **Durable Journal Tampering**                 | Corrupt transfer journal JSON, truncate write, alter manifest fingerprint, or falsify blocks.       | `DecodeJournal` validates JSON, schema version, checksum, fingerprint match, and committed block bounds.              | `wire/attack_matrix_test.go`                                  | `protocol/src/attack-matrix.test.ts` (Vector 19)               |
 | **20** | **Pairing Confirmation Misuse**               | Replay SPAKE2+ confirmation tag across sessions, substitute peer ID, or forge tag.                  | HMAC-SHA256 over `DomainPairingConfirm` and peer device ID; verified before any trust store write.                    | `wire/attack_matrix_test.go`                                  | `protocol/src/attack-matrix.test.ts` (Vector 20)               |
+
+---
+
+## Dated Security Clarifications & Trust Boundaries (v1.8.x Addendum)
+
+The following dated clarifications document exact security and privacy boundaries in the v1.8 release line:
+
+1. **Trusted Session Key Schedule (`sendbeam/2`)**:
+   - In v1.5–v1.8, session traffic keys are derived using `k_pair` (the pairwise shared secret established during pairing) and ephemeral nonces via HMAC-SHA256 and HKDF-SHA256.
+   - **Boundary:** This construction establishes mutual peer authentication, freshness, and replay resistance. However, because ephemeral parameters are authenticated under `k_pair` without an ephemeral Diffie-Hellman exchange, compromise of `k_pair` permits retroactive decryption of past session recordings (it does **not** provide forward secrecy).
+   - **Roadmap:** A reviewed, versioned authenticated ephemeral Diffie-Hellman key exchange (X25519) providing true forward secrecy is scheduled for v1.9 (V19-PR01 / V19-PR02).
+
+2. **Network Metadata & Presence Privacy**:
+   - 15-minute epoch-rotated rendezvous handles prevent passive third parties and the signaling server from indexing or enumerating a global device directory from handle strings alone.
+   - **Boundary:** Opaque handles do **not** provide transport anonymity. The signaling server and upstream network observers observe TCP/WebSocket connection metadata, source IP addresses, and message timing.
+
+3. **Wire Traffic Padding Policy**:
+   - In v1.8, wire traffic padding is an opportunistic negotiated capability (`caps.features`). `--private` advertises padding support to the remote peer, but does not abort transfers if the remote peer lacks padding support.
+   - **Boundary:** Attack Vector 14 demonstrates the policy invariant via test helpers; full production-path policy enforcement (failing closed when `--private` is requested against an unpadded peer) is scheduled for v1.9 (V19-PR11).
+
+4. **Storage & Archive Boundaries**:
+   - In-browser ZIP archive fallback utilizes standard 32-bit archive structures (ZIP32) with a strict 4 GiB size ceiling. Streaming ZIP64 is scheduled for v2.0 (V20-PR05).
+   - Origin Private File System (OPFS) streaming operates under browser-enforced memory pressure limits; testing in CI via Linux WebKit emulation demonstrates browser engine correctness, but does not substitute for physical iOS hardware profiling.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -178,13 +178,18 @@ sequenceDiagram
     Note over B: 3. Generate Ephem_B, Nonce_B<br/>Sign Challenge_B with Ed25519<br/>Compute MAC_B using k_pair
     B->>A: TrustedAuthResponse (Status, RespID, Ephem_B, Nonce_B, Caps_B, Sig_B, MAC_B)
     Note over A: 4. Verify Sig_B & MAC_B
-    Note over A,B: 5. Derive Forward-Secret Session Keys (k_i2r, k_r2i)
+    Note over A,B: 5. Derive Pairwise Authenticated Session Keys (k_i2r, k_r2i)
     A->>B: TrustedAuthConfirm (Status: ready, AuthTag: HMAC(Master, InitID))
     B->>A: TrustedAuthConfirm (Status: ready, AuthTag: HMAC(Master, RespID))
     Note over A,B: 6. Secure Transfer Epoch Established
 ```
 
-### 7.1 Forward-Secret Key Schedule
+### 7.1 Pairwise Authenticated Key Schedule (sendbeam/2)
+
+> [!WARNING]
+> **Forward Secrecy Limitation (v1.8.x Security Note):**
+> In the v1.5 key schedule below, `IKM` is derived via `HMAC-SHA256(k_pair, Ephem_A || Ephem_B || Nonce_A || Nonce_B)`. While this binds ephemeral nonces and mutual public parameters to authenticate both participants and prevent replay, it relies on symmetric authentication under `k_pair` without an ephemeral Diffie-Hellman (ECDH) exchange.
+> Consequently, compromise of the long-term pairwise secret `k_pair` enables retroactive decryption of recorded past session traffic (it does **not** provide forward secrecy). A reviewed authenticated ephemeral Diffie-Hellman key exchange (X25519) providing true forward secrecy is scheduled for v1.9 (V19-PR01 / V19-PR02).
 
 ```
 IKM = HMAC-SHA256(k_pair, Ephem_A || Ephem_B || Nonce_A || Nonce_B)
@@ -219,7 +224,7 @@ To discover peers over the signaling server without creating a global directory 
   handle = HMAC-SHA256(k_pair, "sendbeam/2 rendezvous-handle:" || epochIndex)
   ```
 - **Clock Drift Tolerance:** Clients compute candidate handles for `[epochIndex-1, epochIndex, epochIndex+1]` to tolerate clock skew.
-- **Server Privacy:** The signaling server matches connections solely on exact handle equality. The server cannot determine which devices share a handle or link different epoch handles together.
+- **Server Privacy & Limits:** The signaling server matches connections solely on exact handle equality. The server cannot determine which devices share a handle or link different epoch handles together from the handle alone. However, opaque handles do **not** provide network-level anonymity: the signaling server and network observers still observe client IP addresses, TCP/WebSocket connection metadata, and message timing.
 
 ### 8.2 Blinded LAN Discovery Beacons
 

--- a/packages/engine/trust/trusted_session.go
+++ b/packages/engine/trust/trusted_session.go
@@ -151,7 +151,7 @@ func (c *TrustedSessionCoordinator) InitiateTrustedSession(ctx context.Context, 
 	// Opportunistically process mesh revocation records piggybacked on response
 	c.processIncomingRevocations(ctx, respMsg.Revocations, cfg.PeerDeviceID)
 
-	// 3. Derive forward-secret session keys
+	// 3. Derive pairwise authenticated session keys
 	ephemInit, _ := hex.DecodeString(initMsg.EphemeralPub)
 	nonceInit, _ := hex.DecodeString(initMsg.Nonce)
 
@@ -283,7 +283,7 @@ func (c *TrustedSessionCoordinator) AcceptTrustedSession(ctx context.Context, tr
 		return nil, fmt.Errorf("send trusted auth response: %w", err)
 	}
 
-	// 3. Derive forward-secret session keys
+	// 3. Derive pairwise authenticated session keys
 	ephemResp, _ := hex.DecodeString(respMsg.EphemeralPub)
 	nonceResp, _ := hex.DecodeString(respMsg.Nonce)
 

--- a/packages/protocol/src/attack-matrix.test.ts
+++ b/packages/protocol/src/attack-matrix.test.ts
@@ -58,6 +58,7 @@ import {
   signRevocation,
   verifyRevocation,
   signDeviceMessage,
+  isPaddingNegotiated,
   FEATURE_PADDING,
   FRAME_FLAG_PADDED,
   FRAME_VERSION,
@@ -438,19 +439,20 @@ describe('SendBeam v1.8 Attack-Matrix & Adversarial Security Campaign', () => {
 
   // Vector 14: Bucket-downgrade coercion & private session requirement
   it('Vector 14: Rejects bucket downgrade coercion and unpadded frames in private sessions', async () => {
+    const localCaps = ['transfer.v1', FEATURE_PADDING];
     const privatePeerCaps = ['transfer.v1', FEATURE_PADDING];
     const publicPeerCaps = ['transfer.v1'];
 
-    const hasPadding = (caps: string[]) => caps.includes(FEATURE_PADDING);
-    expect(hasPadding(privatePeerCaps)).toBe(true);
-    expect(hasPadding(publicPeerCaps)).toBe(false);
+    expect(isPaddingNegotiated(localCaps, privatePeerCaps)).toBe(true);
+    expect(isPaddingNegotiated(localCaps, publicPeerCaps)).toBe(false);
 
     // Attacker strips FEATURE_PADDING from offered capabilities
     const strippedCaps = privatePeerCaps.filter((c) => c !== FEATURE_PADDING);
+    expect(isPaddingNegotiated(localCaps, strippedCaps)).toBe(false);
 
-    // Session enforcing private mode fails closed if FEATURE_PADDING was stripped
+    // Session enforcing private mode fails closed if FEATURE_PADDING was not negotiated
     const enforcePrivateSession = (peerCaps: string[]) => {
-      if (!hasPadding(peerCaps)) {
+      if (!isPaddingNegotiated(localCaps, peerCaps)) {
         throw new Error(
           `downgrade rejected: peer does not negotiate ${FEATURE_PADDING} capability`,
         );

--- a/packages/protocol/src/capability.test.ts
+++ b/packages/protocol/src/capability.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   isDirectFileSystemSupported,
+  isPaddingNegotiated,
   isPersistentTrustSupported,
   isStorageQuotaSupported,
   isWakeLockSupported,
@@ -117,5 +118,12 @@ describe('capability detection', () => {
         configurable: true,
       });
     }
+  });
+
+  it('correctly reports mutual padding capability negotiation', () => {
+    expect(isPaddingNegotiated(['transfer.v1', 'padding'], ['transfer.v1', 'padding'])).toBe(true);
+    expect(isPaddingNegotiated(['transfer.v1'], ['transfer.v1', 'padding'])).toBe(false);
+    expect(isPaddingNegotiated(['transfer.v1', 'padding'], ['transfer.v1'])).toBe(false);
+    expect(isPaddingNegotiated([], [])).toBe(false);
   });
 });

--- a/packages/protocol/src/capability.ts
+++ b/packages/protocol/src/capability.ts
@@ -1,3 +1,5 @@
+import { FEATURE_PADDING } from './constants.js';
+
 export interface StorageCapabilities {
   persistentTrust: boolean;
   opfs: boolean;
@@ -159,4 +161,16 @@ export async function probeStorageCapabilities(customIdb?: unknown): Promise<Sto
     directFileSystem,
     canStreamToDisk,
   };
+}
+
+/**
+ * Reports whether wire traffic padding is negotiated between local and remote advertised features.
+ * In v1.8, wire padding is negotiated opportunistically. Both peers must advertise 'padding'
+ * for padded frame buckets to be transmitted.
+ */
+export function isPaddingNegotiated(
+  localFeatures: readonly string[],
+  remoteFeatures: readonly string[],
+): boolean {
+  return localFeatures.includes(FEATURE_PADDING) && remoteFeatures.includes(FEATURE_PADDING);
 }

--- a/packages/protocol/src/trusted-auth.test.ts
+++ b/packages/protocol/src/trusted-auth.test.ts
@@ -115,7 +115,7 @@ describe('Trusted session cross-language vector validation (sendbeam/2)', () => 
       expect(bytesToHex(verifiedResp.ephemeralPub)).toBe(vec.resp_ephem_pub_hex);
       expect(bytesToHex(verifiedResp.nonce)).toBe(vec.resp_nonce_hex);
 
-      // Derive forward-secret session keys on both sides
+      // Derive pairwise authenticated session keys on both sides
       const keysAlice = await deriveTrustedSessionKeys(
         kPair,
         initEphem,

--- a/packages/protocol/src/trusted-auth.ts
+++ b/packages/protocol/src/trusted-auth.ts
@@ -1,5 +1,5 @@
 /**
- * Trusted-session authentication messages, forward-secret session key derivation,
+ * Trusted-session authentication messages, pairwise authenticated session key derivation,
  * and mutual challenge verification for paired SendBeam devices (V15-PR03).
  *
  * Matches Go `packages/wire/trusted_auth.go` byte-for-byte.
@@ -187,7 +187,8 @@ export async function verifyTrustedMACTag(
 }
 
 /**
- * Derive forward-secret directional session keys from ephemeral material and k_pair.
+ * Derive pairwise authenticated directional session keys from ephemeral material and k_pair.
+ * Note: Provides mutual authentication and replay resistance, but not forward secrecy against k_pair compromise.
  */
 export async function deriveTrustedSessionKeys(
   kPair: Uint8Array,

--- a/packages/wire/frame.go
+++ b/packages/wire/frame.go
@@ -32,6 +32,12 @@ const (
 	MaxPadBucketSize = 65535
 )
 
+// NegotiatePadding reports whether both peers advertised the padding capability.
+// Wire traffic padding is negotiated; if either peer lacks the capability, padding is not engaged.
+func NegotiatePadding(localFeatures, remoteFeatures []string) bool {
+	return containsFeature(localFeatures, PaddingCapability) && containsFeature(remoteFeatures, PaddingCapability)
+}
+
 // FrameHeader is the 16-byte frame header. Its encoded bytes are the
 // AES-GCM additional authenticated data, so the codec must be exact and stable.
 //

--- a/packages/wire/padding_test.go
+++ b/packages/wire/padding_test.go
@@ -137,3 +137,19 @@ func TestSealPaddedAndOpen(t *testing.T) {
 		t.Errorf("got plaintext %q, want %q", opened.Plaintext, payload)
 	}
 }
+
+func TestNegotiatePadding(t *testing.T) {
+	if !NegotiatePadding([]string{"transfer.v1", PaddingCapability}, []string{"transfer.v1", PaddingCapability}) {
+		t.Error("expected NegotiatePadding to return true when both peers advertise padding")
+	}
+	if NegotiatePadding([]string{"transfer.v1"}, []string{"transfer.v1", PaddingCapability}) {
+		t.Error("expected NegotiatePadding to return false when local peer lacks padding")
+	}
+	if NegotiatePadding([]string{"transfer.v1", PaddingCapability}, []string{"transfer.v1"}) {
+		t.Error("expected NegotiatePadding to return false when remote peer lacks padding")
+	}
+	if NegotiatePadding(nil, nil) {
+		t.Error("expected NegotiatePadding to return false for nil capability lists")
+	}
+}
+

--- a/packages/wire/trusted_auth.go
+++ b/packages/wire/trusted_auth.go
@@ -98,7 +98,7 @@ type TrustedAuthConfirm struct {
 	AuthTag string `json:"auth_tag,omitempty"`
 }
 
-// TrustedSessionKeys contains forward-secret directional session keys and negotiated features.
+// TrustedSessionKeys contains directional session keys and negotiated features for sendbeam/2.
 type TrustedSessionKeys struct {
 	SessionMaster           []byte
 	InitiatorToResponderKey []byte
@@ -180,7 +180,9 @@ func VerifyTrustedMACTag(kPair []byte, domain string, challenge []byte, tagHex s
 	return subtle.ConstantTimeCompare(tagBytes, expectedBytes) == 1
 }
 
-// DeriveTrustedSessionKeys derives forward-secret directional traffic keys from ephemeral material and k_pair.
+// DeriveTrustedSessionKeys derives pairwise authenticated directional traffic keys from ephemeral material and k_pair.
+// Note: This derivation provides mutual authentication and replay resistance, but does not provide forward secrecy
+// against compromise of k_pair. An ephemeral Diffie-Hellman authenticated key exchange is scheduled for v1.9.
 func DeriveTrustedSessionKeys(kPair, ephemPubInit, ephemPubResp, nonceInit, nonceResp []byte, initID, respID string, capsInit, capsResp []string) (*TrustedSessionKeys, error) {
 	if len(kPair) == 0 {
 		return nil, errors.New("k_pair required")


### PR DESCRIPTION
## Summary

### Logical ID / milestone: V18H-PR04 / v1.8.x

### Goal: Honest capability matrix and patch release gate

### Dependencies:
- PR #176 (`e6d144d`)
- PR #177 (`de52250`)
- PR #178 (`1597f46`)

### Baseline SHA: 1597f46

### Production path before/after:

- **Before**:
  1. Documentation and code comments described `sendbeam/2` session keys as "forward-secret". However, because `SessionMaster` derives from `k_pair` and ephemeral nonces via HMAC without an ephemeral Diffie-Hellman (ECDH) exchange, compromise of `k_pair` permits retroactive decryption of past session transcripts.
  2. Descriptions of 15-minute epoch-rotated rendezvous handles could be conflated with network transport anonymity, whereas the signaling server and network observers still observe client IP addresses, TCP/WebSocket metadata, and connection timing.
  3. Traffic padding (`padding`) was documented as an enforced privacy feature, while on the wire it is negotiated opportunistically; in v1.8, peers lacking the capability fall back to unpadded transfers rather than aborting.
  4. CI mobile WebKit Playwright runs on Linux were not explicitly distinguished from physical iOS device testing, and OPFS memory streaming under memory pressure lacked explicit scope qualification.
- **After**:
  1. Systematically corrected forward-secrecy claims across `README.md`, `docs/protocol.md`, `docs/trust-model.md`, `docs/compat-matrix.md`, `docs/threat-model.md`, and code comments in `packages/wire`, `packages/engine`, and `packages/protocol`. Clarified that `sendbeam/2` derives pairwise authenticated session keys with replay resistance and transcript binding; true forward secrecy via reviewed ephemeral Diffie-Hellman (X25519) is scheduled for v1.9 (V19-PR01 / V19-PR02).
  2. Clarified that rendezvous handles provide blind lookup preventing directory harvesting, but do not provide transport-layer IP anonymity from the signaling server.
  3. Formally added `NegotiatePadding` (Go) and `isPaddingNegotiated` (TypeScript) capability negotiation helpers. Clarified that strict host-level policy (refusing unpadded peers when `--private` is requested) is scheduled for v1.9 (V19-PR11).
  4. Clarified that WebKit in CI is emulated via Playwright on Linux; noted that 32-bit ZIP archives are capped at 4 GiB (streaming ZIP64 scheduled for v2.0).
  5. Established the v1.8.1 Safety Patch Release Gate (`docs/RELEASE-v1.8.1.md`) validating that PR01 (secret-free JSON), PR02 (literal-text desktop rendering), PR03 (allowlisted PWA caching), and PR04 pass all verification gates alongside ordinary transfers.

### Changed areas:

- `packages/wire/frame.go` & `padding_test.go`: Added `NegotiatePadding(localFeatures, remoteFeatures []string) bool` and unit tests.
- `packages/wire/trusted_auth.go`: Corrected doc comments to pairwise authenticated session keys.
- `packages/engine/trust/trusted_session.go`: Corrected comments.
- `packages/protocol/src/capability.ts` & `capability.test.ts`: Exported and tested `isPaddingNegotiated()`.
- `packages/protocol/src/attack-matrix.test.ts`: Used `isPaddingNegotiated()` in Vector 14 test.
- `packages/protocol/src/trusted-auth.ts` & `trusted-auth.test.ts`: Corrected comments.
- `README.md`: Corrected pairing description and added link to Release Gate v1.8.1.
- `docs/protocol.md`, `docs/trust-model.md`, `docs/compat-matrix.md`, `docs/threat-model.md`, `docs/RELEASE-v1.8.md`: Updated trust boundaries, dated security callouts, and capability clarifications.
- `docs/RELEASE-v1.8.1.md`: New comprehensive safety patch release gate document.

### Explicit exclusions:

- No breaking wire format changes or alterations to existing wire protocols.
- No changes to existing cryptographic primitives before v1.9 reviewed ADR.

### Security/privacy/authorization impact:

- Aligns all security and privacy claims with actual implementation reality.
- Explicitly gates incomplete controls (require-padding policy, forward-secret ECDH) to their respective planned milestones (v1.9).
- Ensures no false sense of forward secrecy or IP anonymity is conveyed to users or auditors.

### Wire/storage/CLI compatibility:

- Fully compatible. Non-breaking documentation, capability helper, and release gate changes.

### Evidence:

- **Targeted tests**:
  - `(cd packages/wire && go test -race -run TestNegotiatePadding .)`: PASS
  - `pnpm --filter @sendbeam/protocol test run src/capability.test.ts`: PASS (7/7)
  - `pnpm --filter @sendbeam/protocol test run src/attack-matrix.test.ts`: PASS (20/20 vectors)
- **Ordinary transfers**:
  - `packages/wire`: `go test -race ./...` (PASS)
  - `packages/engine`: `go test -race ./...` (PASS)
  - `apps/server`: `go test -race ./...` (PASS)
  - `apps/cli`: `go test -race ./...` (PASS)
  - `apps/desktop`: `go test -race ./internal/...` (PASS)
- **Differential parity**:
  - `bash scripts/run_differential.sh 2000 1337`: PASS across all codecs
- **Workspace suites**:
  - `pnpm run format:check`: PASS
  - `pnpm run lint`: PASS (0 errors, 0 warnings across all packages)
  - `pnpm run typecheck`: PASS
  - `pnpm run test`: PASS
  - `pnpm run build`: PASS
  - `bash scripts/version-metadata_test.sh`: PASS