### PR TITLE
feat(protocol): implement sendbeam/3 forward-secret authenticated key exchange

### DIFF
--- a/packages/engine/trust/trusted_session.go
+++ b/packages/engine/trust/trusted_session.go
@@ -4,9 +4,11 @@ package trust
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/sendbeam/wire"
@@ -57,17 +59,19 @@ type TrustedSessionResult struct {
 
 // TrustedSessionCoordinator manages mutual challenge-response authentication between paired devices.
 type TrustedSessionCoordinator struct {
-	idMgr    *IdentityManager
-	store    Store
-	resolver SecretResolver
+	idMgr       *IdentityManager
+	store       Store
+	resolver    SecretResolver
+	replayCache *wire.NonceReplayCache
 }
 
 // NewTrustedSessionCoordinator creates a new TrustedSessionCoordinator.
 func NewTrustedSessionCoordinator(idMgr *IdentityManager, store Store, resolver SecretResolver) *TrustedSessionCoordinator {
 	return &TrustedSessionCoordinator{
-		idMgr:    idMgr,
-		store:    store,
-		resolver: resolver,
+		idMgr:       idMgr,
+		store:       store,
+		resolver:    resolver,
+		replayCache: wire.NewNonceReplayCache(10 * time.Minute),
 	}
 }
 
@@ -103,8 +107,22 @@ func (c *TrustedSessionCoordinator) InitiateTrustedSession(ctx context.Context, 
 		return nil, fmt.Errorf("get local identity: %w", err)
 	}
 
-	// 1. Create and send TrustedAuthInit with mesh revocation records
+	// 1. Generate ephemeral keypair and nonce
+	privA, pubA, err := wire.GenerateX25519KeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("generate ephemeral key: %w", err)
+	}
+
+	nonceA := make([]byte, wire.TrustedAuthNonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonceA); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
 	now := time.Now().UTC()
+	if err := c.replayCache.CheckAndRecord(id.DeviceID, hex.EncodeToString(nonceA), now); err != nil {
+		return nil, err
+	}
+
 	storedRevs, _ := c.store.ListRevocations(ctx)
 	revList := make([]wire.RevocationRecord, 0, len(storedRevs))
 	for _, r := range storedRevs {
@@ -113,7 +131,7 @@ func (c *TrustedSessionCoordinator) InitiateTrustedSession(ctx context.Context, 
 		}
 	}
 
-	initMsg, err := wire.NewTrustedAuthInitWithRevocations(id, cfg.PeerDeviceID, record.PairCredentialRef, kPair, cfg.Capabilities, nil, nil, now, revList)
+	initMsg, err := wire.NewTrustedAuthInitV3(id, cfg.PeerDeviceID, record.PairCredentialRef, kPair, cfg.Capabilities, pubA, nonceA, now, revList)
 	if err != nil {
 		return nil, fmt.Errorf("create trusted auth init: %w", err)
 	}
@@ -143,25 +161,32 @@ func (c *TrustedSessionCoordinator) InitiateTrustedSession(ctx context.Context, 
 		return nil, errors.New("expected trusted auth response message")
 	}
 
-	ephemResp, nonceResp, err := wire.VerifyTrustedAuthResponse(respMsg, initMsg, kPair, peerPub, id.DeviceID)
+	ephemResp, nonceResp, err := wire.VerifyTrustedAuthResponseV3(respMsg, initMsg, kPair, peerPub, id.DeviceID)
 	if err != nil {
 		return nil, fmt.Errorf("verify trusted auth response: %w", err)
+	}
+
+	if err := c.replayCache.CheckAndRecord(cfg.PeerDeviceID, hex.EncodeToString(nonceResp), now); err != nil {
+		return nil, err
 	}
 
 	// Opportunistically process mesh revocation records piggybacked on response
 	c.processIncomingRevocations(ctx, respMsg.Revocations, cfg.PeerDeviceID)
 
-	// 3. Derive pairwise authenticated session keys
-	ephemInit, _ := hex.DecodeString(initMsg.EphemeralPub)
-	nonceInit, _ := hex.DecodeString(initMsg.Nonce)
+	// 3. Diffie-Hellman and session key derivation
+	ssECDH, err := wire.ComputeX25519SharedSecret(privA, ephemResp)
+	if err != nil {
+		return nil, fmt.Errorf("compute shared secret: %w", err)
+	}
+	defer wire.ZeroizeBytes(ssECDH)
 
-	keys, err := wire.DeriveTrustedSessionKeys(kPair, ephemInit, ephemResp, nonceInit, nonceResp, id.DeviceID, cfg.PeerDeviceID, cfg.Capabilities, respMsg.Capabilities)
+	keys, err := wire.DeriveTrustedSessionKeysV3(kPair, ssECDH, pubA, ephemResp, nonceA, nonceResp, id.DeviceID, cfg.PeerDeviceID, cfg.Capabilities, respMsg.Capabilities)
 	if err != nil {
 		return nil, fmt.Errorf("derive trusted session keys: %w", err)
 	}
 
 	// 4. Send our confirmation and verify peer's confirmation
-	confInit := wire.NewTrustedAuthConfirm(keys.SessionMaster, wire.DomainTrustedConfirmInit, id.DeviceID, true)
+	confInit := wire.NewTrustedAuthConfirmV3(keys.SessionMaster, wire.DomainTrustedConfirmInit3, id.DeviceID, true)
 	confData, err := wire.EncodeTrustedAuthMessage(confInit)
 	if err != nil {
 		return nil, fmt.Errorf("encode confirm: %w", err)
@@ -186,7 +211,7 @@ func (c *TrustedSessionCoordinator) InitiateTrustedSession(ctx context.Context, 
 		return nil, errors.New("expected trusted auth confirm message")
 	}
 
-	if err := wire.VerifyTrustedAuthConfirm(peerConf, keys.SessionMaster, wire.DomainTrustedConfirmResp, cfg.PeerDeviceID); err != nil {
+	if err := wire.VerifyTrustedAuthConfirmV3(peerConf, keys.SessionMaster, wire.DomainTrustedConfirmResp3, cfg.PeerDeviceID); err != nil {
 		return nil, fmt.Errorf("verify peer confirm: %w", err)
 	}
 
@@ -251,16 +276,38 @@ func (c *TrustedSessionCoordinator) AcceptTrustedSession(ctx context.Context, tr
 	}
 
 	now := time.Now().UTC()
-	ephemInit, nonceInit, err := wire.VerifyTrustedAuthInit(initMsg, kPair, peerPub, id.DeviceID, now)
+	ephemInit, nonceInit, err := wire.VerifyTrustedAuthInitV3(initMsg, kPair, peerPub, id.DeviceID, now)
 	if err != nil {
 		_ = c.sendRejection(ctx, transport, "rejected")
 		return nil, fmt.Errorf("verify trusted auth init: %w", err)
 	}
 
+	if err := c.replayCache.CheckAndRecord(initMsg.InitiatorDeviceID, hex.EncodeToString(nonceInit), now); err != nil {
+		_ = c.sendRejection(ctx, transport, "rejected")
+		return nil, err
+	}
+
 	// Opportunistically process mesh revocation records piggybacked on init
 	c.processIncomingRevocations(ctx, initMsg.Revocations, initMsg.InitiatorDeviceID)
 
-	// 2. Create and send TrustedAuthResponse with mesh revocation records
+	// 2. Generate responder ephemeral keypair and nonce
+	privB, pubB, err := wire.GenerateX25519KeyPair()
+	if err != nil {
+		_ = c.sendRejection(ctx, transport, "rejected")
+		return nil, fmt.Errorf("generate ephemeral key: %w", err)
+	}
+
+	nonceB := make([]byte, wire.TrustedAuthNonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonceB); err != nil {
+		_ = c.sendRejection(ctx, transport, "rejected")
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	if err := c.replayCache.CheckAndRecord(id.DeviceID, hex.EncodeToString(nonceB), now); err != nil {
+		_ = c.sendRejection(ctx, transport, "rejected")
+		return nil, err
+	}
+
 	storedRevs, _ := c.store.ListRevocations(ctx)
 	revList := make([]wire.RevocationRecord, 0, len(storedRevs))
 	for _, r := range storedRevs {
@@ -269,7 +316,7 @@ func (c *TrustedSessionCoordinator) AcceptTrustedSession(ctx context.Context, tr
 		}
 	}
 
-	respMsg, err := wire.NewTrustedAuthResponseWithRevocations(id, initMsg, kPair, capabilities, nil, nil, revList)
+	respMsg, err := wire.NewTrustedAuthResponseV3(id, initMsg, kPair, capabilities, pubB, nonceB, revList)
 	if err != nil {
 		return nil, fmt.Errorf("create trusted auth response: %w", err)
 	}
@@ -283,11 +330,14 @@ func (c *TrustedSessionCoordinator) AcceptTrustedSession(ctx context.Context, tr
 		return nil, fmt.Errorf("send trusted auth response: %w", err)
 	}
 
-	// 3. Derive pairwise authenticated session keys
-	ephemResp, _ := hex.DecodeString(respMsg.EphemeralPub)
-	nonceResp, _ := hex.DecodeString(respMsg.Nonce)
+	// 3. Diffie-Hellman and session key derivation
+	ssECDH, err := wire.ComputeX25519SharedSecret(privB, ephemInit)
+	if err != nil {
+		return nil, fmt.Errorf("compute shared secret: %w", err)
+	}
+	defer wire.ZeroizeBytes(ssECDH)
 
-	keys, err := wire.DeriveTrustedSessionKeys(kPair, ephemInit, ephemResp, nonceInit, nonceResp, initMsg.InitiatorDeviceID, id.DeviceID, initMsg.Capabilities, capabilities)
+	keys, err := wire.DeriveTrustedSessionKeysV3(kPair, ssECDH, ephemInit, pubB, nonceInit, nonceB, initMsg.InitiatorDeviceID, id.DeviceID, initMsg.Capabilities, capabilities)
 	if err != nil {
 		return nil, fmt.Errorf("derive trusted session keys: %w", err)
 	}
@@ -308,11 +358,11 @@ func (c *TrustedSessionCoordinator) AcceptTrustedSession(ctx context.Context, tr
 		return nil, errors.New("expected trusted auth confirm message")
 	}
 
-	if err := wire.VerifyTrustedAuthConfirm(peerConf, keys.SessionMaster, wire.DomainTrustedConfirmInit, initMsg.InitiatorDeviceID); err != nil {
+	if err := wire.VerifyTrustedAuthConfirmV3(peerConf, keys.SessionMaster, wire.DomainTrustedConfirmInit3, initMsg.InitiatorDeviceID); err != nil {
 		return nil, fmt.Errorf("verify peer confirm: %w", err)
 	}
 
-	confResp := wire.NewTrustedAuthConfirm(keys.SessionMaster, wire.DomainTrustedConfirmResp, id.DeviceID, true)
+	confResp := wire.NewTrustedAuthConfirmV3(keys.SessionMaster, wire.DomainTrustedConfirmResp3, id.DeviceID, true)
 	confData, err := wire.EncodeTrustedAuthMessage(confResp)
 	if err != nil {
 		return nil, fmt.Errorf("encode confirm: %w", err)
@@ -336,7 +386,7 @@ func (c *TrustedSessionCoordinator) sendRejection(ctx context.Context, transport
 	id, _ := c.idMgr.GetOrCreateIdentity()
 	resp := &wire.TrustedAuthResponse{
 		Type:              wire.MsgTrustedAuthResponse,
-		ProtocolVersion:   wire.TrustedAuthProtocolVersion,
+		ProtocolVersion:   wire.TrustedAuthProtocolVersionV3,
 		Status:            status,
 		ResponderDeviceID: id.DeviceID,
 	}

--- a/packages/protocol/src/trusted-auth-v3.test.ts
+++ b/packages/protocol/src/trusted-auth-v3.test.ts
@@ -1,0 +1,405 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { bytesToHex, hexToBytes } from './bytes.js';
+import { createDeviceIdentityFromSeed } from './identity.js';
+import {
+  computeX25519SharedSecret,
+  createTrustedAuthConfirmV3,
+  createTrustedAuthInitV3,
+  createTrustedAuthResponseV3,
+  deriveTrustedSessionKeysV3,
+  DOMAIN_TRUSTED_CONFIRM_INIT_3,
+  DOMAIN_TRUSTED_CONFIRM_RESP_3,
+  generateX25519KeyPair,
+  NonceReplayCache,
+  TRUSTED_AUTH_PROTOCOL_VERSION_V3,
+  verifyTrustedAuthConfirmV3,
+  verifyTrustedAuthInitV3,
+  verifyTrustedAuthResponseV3,
+  zeroizeBytes,
+} from './trusted-auth.js';
+
+interface TrustedV3Vector {
+  name: string;
+  protocol_version: string;
+  k_pair_hex: string;
+  pair_cred_ref: string;
+  init_seed_hex: string;
+  init_device_id: string;
+  init_pub_key_hex: string;
+  init_ephem_priv_hex: string;
+  init_ephem_pub_hex: string;
+  init_nonce_hex: string;
+  init_caps: string[];
+  init_timestamp: string;
+  init_sig_hex: string;
+  init_auth_tag_hex: string;
+  resp_seed_hex: string;
+  resp_device_id: string;
+  resp_pub_key_hex: string;
+  resp_ephem_priv_hex: string;
+  resp_ephem_pub_hex: string;
+  resp_nonce_hex: string;
+  resp_caps: string[];
+  resp_sig_hex: string;
+  resp_auth_tag_hex: string;
+  ecdh_shared_secret_hex: string;
+  session_master_hex: string;
+  i2r_key_hex: string;
+  r2i_key_hex: string;
+  init_confirm_tag: string;
+  resp_confirm_tag: string;
+}
+
+describe('Trusted session V3 cross-language vector validation (sendbeam/3)', () => {
+  const vectorPath = resolve(__dirname, '../../wire/testdata/trusted-session-v3-vectors.json');
+  const vectorContent = readFileSync(vectorPath, 'utf-8');
+  const vectors: TrustedV3Vector[] = JSON.parse(vectorContent);
+
+  it('matches Go generated sendbeam/3 vectors byte-for-byte', async () => {
+    for (const vec of vectors) {
+      expect(vec.protocol_version).toBe(TRUSTED_AUTH_PROTOCOL_VERSION_V3);
+
+      const kPair = hexToBytes(vec.k_pair_hex);
+      const initSeed = hexToBytes(vec.init_seed_hex);
+      const respSeed = hexToBytes(vec.resp_seed_hex);
+
+      const idInit = await createDeviceIdentityFromSeed(initSeed);
+      const idResp = await createDeviceIdentityFromSeed(respSeed);
+
+      expect(idInit.deviceId).toBe(vec.init_device_id);
+      expect(bytesToHex(idInit.publicKey)).toBe(vec.init_pub_key_hex);
+      expect(idResp.deviceId).toBe(vec.resp_device_id);
+      expect(bytesToHex(idResp.publicKey)).toBe(vec.resp_pub_key_hex);
+
+      const initEphemPriv = hexToBytes(vec.init_ephem_priv_hex);
+      const initEphemPub = hexToBytes(vec.init_ephem_pub_hex);
+      const initNonce = hexToBytes(vec.init_nonce_hex);
+
+      const respEphemPriv = hexToBytes(vec.resp_ephem_priv_hex);
+      const respEphemPub = hexToBytes(vec.resp_ephem_pub_hex);
+      const respNonce = hexToBytes(vec.resp_nonce_hex);
+
+      // 1. Create TrustedAuthInitV3 and verify byte match
+      const initMsg = await createTrustedAuthInitV3(
+        idInit,
+        idResp.deviceId,
+        vec.pair_cred_ref,
+        kPair,
+        vec.init_caps,
+        initEphemPub,
+        initNonce,
+        vec.init_timestamp,
+      );
+
+      expect(initMsg.protocol_version).toBe(TRUSTED_AUTH_PROTOCOL_VERSION_V3);
+      expect(initMsg.signature).toBe(vec.init_sig_hex);
+      expect(initMsg.auth_tag).toBe(vec.init_auth_tag_hex);
+
+      // 2. Verify TrustedAuthInitV3 on responder
+      const verInit = await verifyTrustedAuthInitV3(
+        initMsg,
+        kPair,
+        idInit.publicKey,
+        idResp.deviceId,
+        vec.init_timestamp,
+      );
+      expect(bytesToHex(verInit.ephemeralPub)).toBe(vec.init_ephem_pub_hex);
+      expect(bytesToHex(verInit.nonce)).toBe(vec.init_nonce_hex);
+
+      // 3. Create TrustedAuthResponseV3 and verify byte match
+      const respMsg = await createTrustedAuthResponseV3(
+        idResp,
+        initMsg,
+        kPair,
+        vec.resp_caps,
+        respEphemPub,
+        respNonce,
+      );
+
+      expect(respMsg.protocol_version).toBe(TRUSTED_AUTH_PROTOCOL_VERSION_V3);
+      expect(respMsg.signature).toBe(vec.resp_sig_hex);
+      expect(respMsg.auth_tag).toBe(vec.resp_auth_tag_hex);
+
+      // 4. Verify TrustedAuthResponseV3 on initiator
+      const verResp = await verifyTrustedAuthResponseV3(
+        respMsg,
+        initMsg,
+        kPair,
+        idResp.publicKey,
+        idInit.deviceId,
+      );
+      expect(bytesToHex(verResp.ephemeralPub)).toBe(vec.resp_ephem_pub_hex);
+      expect(bytesToHex(verResp.nonce)).toBe(vec.resp_nonce_hex);
+
+      // 5. Diffie-Hellman shared secret
+      const ssA = computeX25519SharedSecret(initEphemPriv, verResp.ephemeralPub);
+      const ssB = computeX25519SharedSecret(respEphemPriv, verInit.ephemeralPub);
+      expect(bytesToHex(ssA)).toBe(vec.ecdh_shared_secret_hex);
+      expect(bytesToHex(ssB)).toBe(vec.ecdh_shared_secret_hex);
+
+      // 6. Derive session keys
+      const keysA = await deriveTrustedSessionKeysV3(
+        kPair,
+        ssA,
+        initEphemPub,
+        verResp.ephemeralPub,
+        initNonce,
+        verResp.nonce,
+        idInit.deviceId,
+        idResp.deviceId,
+        vec.init_caps,
+        respMsg.capabilities || [],
+      );
+
+      const keysB = await deriveTrustedSessionKeysV3(
+        kPair,
+        ssB,
+        verInit.ephemeralPub,
+        respEphemPub,
+        verInit.nonce,
+        respNonce,
+        initMsg.initiator_device_id,
+        idResp.deviceId,
+        initMsg.capabilities,
+        vec.resp_caps,
+      );
+
+      expect(bytesToHex(keysA.sessionMaster)).toBe(vec.session_master_hex);
+      expect(bytesToHex(keysB.sessionMaster)).toBe(vec.session_master_hex);
+      expect(bytesToHex(keysA.initiatorToResponderKey)).toBe(vec.i2r_key_hex);
+      expect(bytesToHex(keysA.responderToInitiatorKey)).toBe(vec.r2i_key_hex);
+
+      // 7. Confirmation handshake
+      const confA = await createTrustedAuthConfirmV3(
+        keysA.sessionMaster,
+        DOMAIN_TRUSTED_CONFIRM_INIT_3,
+        idInit.deviceId,
+        true,
+      );
+      expect(confA.auth_tag).toBe(vec.init_confirm_tag);
+      await expect(
+        verifyTrustedAuthConfirmV3(
+          confA,
+          keysB.sessionMaster,
+          DOMAIN_TRUSTED_CONFIRM_INIT_3,
+          idInit.deviceId,
+        ),
+      ).resolves.toBeUndefined();
+
+      const confB = await createTrustedAuthConfirmV3(
+        keysB.sessionMaster,
+        DOMAIN_TRUSTED_CONFIRM_RESP_3,
+        idResp.deviceId,
+        true,
+      );
+      expect(confB.auth_tag).toBe(vec.resp_confirm_tag);
+      await expect(
+        verifyTrustedAuthConfirmV3(
+          confB,
+          keysA.sessionMaster,
+          DOMAIN_TRUSTED_CONFIRM_RESP_3,
+          idResp.deviceId,
+        ),
+      ).resolves.toBeUndefined();
+
+      // Zeroize test
+      zeroizeBytes(ssA);
+      zeroizeBytes(ssB);
+      expect(ssA.every((b) => b === 0)).toBe(true);
+      expect(ssB.every((b) => b === 0)).toBe(true);
+    }
+  });
+});
+
+describe('sendbeam/3 Downgrade rejection & security properties', () => {
+  it('rejects sendbeam/2 or sendbeam/1 in verifyTrustedAuthInitV3', async () => {
+    const seed = hexToBytes('1111111111111111111111111111111111111111111111111111111111111111');
+    const id = await createDeviceIdentityFromSeed(seed);
+    const kp = generateX25519KeyPair();
+    const kPair = new Uint8Array(32);
+    const now = '2026-09-01T12:00:00Z';
+
+    const initMsg = await createTrustedAuthInitV3(
+      id,
+      'sb-dev-responder',
+      'cred-1',
+      kPair,
+      ['transfer.v2'],
+      kp.publicKey,
+      new Uint8Array(32),
+      now,
+    );
+
+    // Tamper protocol version to sendbeam/2
+    const initV2 = { ...initMsg, protocol_version: 'sendbeam/2' };
+    await expect(
+      verifyTrustedAuthInitV3(initV2, kPair, id.publicKey, 'sb-dev-responder', now),
+    ).rejects.toThrow('trusted-session protocol downgrade forbidden');
+
+    // Tamper protocol version to sendbeam/1
+    const initV1 = { ...initMsg, protocol_version: 'sendbeam/1' };
+    await expect(
+      verifyTrustedAuthInitV3(initV1, kPair, id.publicKey, 'sb-dev-responder', now),
+    ).rejects.toThrow('trusted-session protocol downgrade forbidden');
+  });
+
+  it('rejects sendbeam/2 or sendbeam/1 in verifyTrustedAuthResponseV3', async () => {
+    const seed = hexToBytes('2222222222222222222222222222222222222222222222222222222222222222');
+    const id = await createDeviceIdentityFromSeed(seed);
+    const kp = generateX25519KeyPair();
+    const kPair = new Uint8Array(32);
+    const now = '2026-09-01T12:00:00Z';
+
+    const initMsg = await createTrustedAuthInitV3(
+      id,
+      'sb-dev-resp',
+      'cred-1',
+      kPair,
+      ['transfer.v2'],
+      kp.publicKey,
+      new Uint8Array(32),
+      now,
+    );
+
+    const respV2 = {
+      type: 'trusted_auth_response' as const,
+      protocol_version: 'sendbeam/2',
+      status: 'accepted' as const,
+      responder_device_id: 'sb-dev-resp',
+    };
+
+    await expect(
+      verifyTrustedAuthResponseV3(respV2, initMsg, kPair, new Uint8Array(32), id.deviceId),
+    ).rejects.toThrow('trusted-session protocol downgrade forbidden');
+  });
+
+  it('detects weak and low-order X25519 ephemeral keys', () => {
+    const kp = generateX25519KeyPair();
+
+    // Invalid length
+    expect(() => computeX25519SharedSecret(kp.secretKey, new Uint8Array(31))).toThrow(
+      'ephemeral public key is weak or invalid',
+    );
+    expect(() => computeX25519SharedSecret(kp.secretKey, new Uint8Array(33))).toThrow(
+      'ephemeral public key is weak or invalid',
+    );
+
+    // All-zero point
+    expect(() => computeX25519SharedSecret(kp.secretKey, new Uint8Array(32))).toThrow(
+      'ephemeral public key is weak or invalid',
+    );
+
+    // Point 1 (order 1)
+    const pt1 = new Uint8Array(32);
+    pt1[0] = 1;
+    expect(() => computeX25519SharedSecret(kp.secretKey, pt1)).toThrow(
+      'ephemeral public key is weak or invalid',
+    );
+  });
+
+  it('detects session handshakes replayed within sliding-window cache', () => {
+    const cache = new NonceReplayCache(5 * 60 * 1000);
+    const devId = 'sb-dev-alice';
+    const nonce = 'aabbccdd00112233445566778899aabbccdd00112233445566778899aabbccdd';
+    const now = 1700000000000;
+
+    // First time succeeds
+    expect(() => cache.checkAndRecord(devId, nonce, now)).not.toThrow();
+
+    // Replay within TTL throws
+    expect(() => cache.checkAndRecord(devId, nonce, now + 10000)).toThrow(
+      'trusted-session replay detected',
+    );
+
+    // Different device succeeds
+    expect(() => cache.checkAndRecord('sb-dev-bob', nonce, now)).not.toThrow();
+
+    // Different nonce succeeds
+    expect(() =>
+      cache.checkAndRecord(
+        devId,
+        '112233445566778899aabbccdd00112233445566778899aabbccdd0011223344',
+        now,
+      ),
+    ).not.toThrow();
+
+    // After TTL expiry succeeds
+    expect(() => cache.checkAndRecord(devId, nonce, now + 6 * 60 * 1000)).not.toThrow();
+  });
+
+  it('rejects adversarial tampering of timestamp, peer ID, signatures, and capabilities', async () => {
+    const seedA = hexToBytes('3333333333333333333333333333333333333333333333333333333333333333');
+    const seedB = hexToBytes('4444444444444444444444444444444444444444444444444444444444444444');
+    const idA = await createDeviceIdentityFromSeed(seedA);
+    const idB = await createDeviceIdentityFromSeed(seedB);
+    const kpA = generateX25519KeyPair();
+    const kpB = generateX25519KeyPair();
+    const kPair = new Uint8Array(32);
+    kPair.fill(0x77);
+
+    const now = new Date('2026-09-01T12:00:00Z');
+    const initMsg = await createTrustedAuthInitV3(
+      idA,
+      idB.deviceId,
+      'cred-1',
+      kPair,
+      ['transfer.v2', 'mesh_sync'],
+      kpA.publicKey,
+      new Uint8Array(32),
+      now,
+    );
+
+    // Clock skew > 5 minutes
+    const expired = new Date(now.getTime() - 10 * 60 * 1000);
+    await expect(
+      verifyTrustedAuthInitV3(initMsg, kPair, idA.publicKey, idB.deviceId, expired),
+    ).rejects.toThrow('trusted-session timestamp outside acceptable skew window');
+
+    // Peer ID mismatch
+    await expect(
+      verifyTrustedAuthInitV3(initMsg, kPair, idA.publicKey, 'sb-dev-wrong', now),
+    ).rejects.toThrow('trusted-session peer device ID mismatch');
+
+    // Tampered signature
+    const forgedSig = { ...initMsg, signature: bytesToHex(new Uint8Array(64)) };
+    await expect(
+      verifyTrustedAuthInitV3(forgedSig, kPair, idA.publicKey, idB.deviceId, now),
+    ).rejects.toThrow('trusted-session signature verification failed');
+
+    // Tampered MAC tag
+    const forgedMAC = { ...initMsg, auth_tag: bytesToHex(new Uint8Array(32)) };
+    await expect(
+      verifyTrustedAuthInitV3(forgedMAC, kPair, idA.publicKey, idB.deviceId, now),
+    ).rejects.toThrow('trusted-session MAC tag verification failed');
+
+    // Tampered capabilities in init
+    const tamperedCapsInit = { ...initMsg, capabilities: ['transfer.v2', 'injected_capability'] };
+    await expect(
+      verifyTrustedAuthInitV3(tamperedCapsInit, kPair, idA.publicKey, idB.deviceId, now),
+    ).rejects.toThrow('trusted-session signature verification failed');
+
+    // Tampered ephemeral public key
+    const anotherKp = generateX25519KeyPair();
+    const tamperedEphemInit = { ...initMsg, ephemeral_pub: bytesToHex(anotherKp.publicKey) };
+    await expect(
+      verifyTrustedAuthInitV3(tamperedEphemInit, kPair, idA.publicKey, idB.deviceId, now),
+    ).rejects.toThrow('trusted-session signature verification failed');
+
+    // Responder creates response, adversary tampers response capabilities
+    const respMsg = await createTrustedAuthResponseV3(
+      idB,
+      initMsg,
+      kPair,
+      ['transfer.v2', 'mesh_sync'],
+      kpB.publicKey,
+      new Uint8Array(32),
+    );
+
+    const tamperedRespCaps = { ...respMsg, capabilities: ['transfer.v2'] };
+    await expect(
+      verifyTrustedAuthResponseV3(tamperedRespCaps, initMsg, kPair, idB.publicKey, idA.deviceId),
+    ).rejects.toThrow('trusted-session signature verification failed');
+  });
+});

--- a/packages/protocol/src/trusted-auth.ts
+++ b/packages/protocol/src/trusted-auth.ts
@@ -5,6 +5,7 @@
  * Matches Go `packages/wire/trusted_auth.go` byte-for-byte.
  */
 
+import { x25519 } from '@noble/curves/ed25519.js';
 import { bytesToHex, concatBytes, hexToBytes, utf8 } from './bytes.js';
 import {
   deriveDeviceId,
@@ -21,6 +22,7 @@ export const MSG_TRUSTED_AUTH_RESPONSE = 'trusted_auth_response';
 export const MSG_TRUSTED_AUTH_CONFIRM = 'trusted_auth_confirm';
 
 export const TRUSTED_AUTH_PROTOCOL_VERSION = 'sendbeam/2';
+export const TRUSTED_AUTH_PROTOCOL_VERSION_V3 = 'sendbeam/3';
 
 export const DOMAIN_TRUSTED_INIT = 'sendbeam/2 trusted-init:';
 export const DOMAIN_TRUSTED_INIT_MAC = 'sendbeam/2 trusted-init-mac:';
@@ -32,13 +34,26 @@ export const DOMAIN_TRUSTED_RESP_TO_INIT_KEY = 'sendbeam/2 responder-to-initiato
 export const DOMAIN_TRUSTED_CONFIRM_INIT = 'sendbeam/2 confirm-init:';
 export const DOMAIN_TRUSTED_CONFIRM_RESP = 'sendbeam/2 confirm-resp:';
 
+// sendbeam/3 domain constants (ADR 0010)
+export const DOMAIN_TRUSTED_INIT_3 = 'sendbeam/3 trusted-init:';
+export const DOMAIN_TRUSTED_INIT_MAC_3 = 'sendbeam/3 trusted-init-mac:';
+export const DOMAIN_TRUSTED_RESP_3 = 'sendbeam/3 trusted-resp:';
+export const DOMAIN_TRUSTED_RESP_MAC_3 = 'sendbeam/3 trusted-resp-mac:';
+export const DOMAIN_TRUSTED_MASTER_3 = 'sendbeam/3 session-master:';
+export const DOMAIN_TRUSTED_INIT_TO_RESP_3 = 'sendbeam/3 initiator-to-responder key';
+export const DOMAIN_TRUSTED_RESP_TO_INIT_3 = 'sendbeam/3 responder-to-initiator key';
+export const DOMAIN_TRUSTED_CONFIRM_INIT_3 = 'sendbeam/3 confirm-init:';
+export const DOMAIN_TRUSTED_CONFIRM_RESP_3 = 'sendbeam/3 confirm-resp:';
+export const DOMAIN_TRUSTED_TRANSCRIPT_3 = 'sendbeam/3 transcript:';
+
 export const TRUSTED_AUTH_NONCE_SIZE = 32;
 export const TRUSTED_AUTH_EPHEMERAL_SIZE = 32;
+export const X25519_KEY_SIZE = 32;
 export const MAX_TRUSTED_TIMESTAMP_SKEW_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface TrustedAuthInit {
   readonly type: typeof MSG_TRUSTED_AUTH_INIT;
-  readonly protocol_version: typeof TRUSTED_AUTH_PROTOCOL_VERSION;
+  readonly protocol_version: string;
   readonly initiator_device_id: string;
   readonly responder_device_id: string;
   readonly pair_credential_ref: string;
@@ -53,7 +68,7 @@ export interface TrustedAuthInit {
 
 export interface TrustedAuthResponse {
   readonly type: typeof MSG_TRUSTED_AUTH_RESPONSE;
-  readonly protocol_version: typeof TRUSTED_AUTH_PROTOCOL_VERSION;
+  readonly protocol_version: string;
   readonly status: 'accepted' | 'rejected' | 'revoked';
   readonly responder_device_id: string;
   readonly ephemeral_pub?: string;
@@ -161,6 +176,137 @@ export async function buildTrustedRespChallenge(
 }
 
 /**
+ * Build the binary payload signed by the initiator in sendbeam/3 (ADR 0010).
+ */
+export function buildTrustedInitChallengeV3(
+  kPairHash: Uint8Array,
+  ephemPub: Uint8Array,
+  nonce: Uint8Array,
+  initId: string,
+  respId: string,
+  capsHash: Uint8Array,
+  timestamp: string,
+): Uint8Array {
+  return concatBytes(
+    utf8(DOMAIN_TRUSTED_INIT_3),
+    kPairHash,
+    ephemPub,
+    nonce,
+    utf8(initId),
+    utf8(respId),
+    capsHash,
+    utf8(timestamp),
+  );
+}
+
+/**
+ * Build the binary payload signed by the responder in sendbeam/3 (ADR 0010).
+ */
+export function buildTrustedRespChallengeV3(
+  kPairHash: Uint8Array,
+  ephemPubInit: Uint8Array,
+  ephemPubResp: Uint8Array,
+  nonceInit: Uint8Array,
+  nonceResp: Uint8Array,
+  initId: string,
+  respId: string,
+  capsHash: Uint8Array,
+): Uint8Array {
+  return concatBytes(
+    utf8(DOMAIN_TRUSTED_RESP_3),
+    kPairHash,
+    ephemPubInit,
+    ephemPubResp,
+    nonceInit,
+    nonceResp,
+    utf8(initId),
+    utf8(respId),
+    capsHash,
+  );
+}
+
+/**
+ * Build the canonical transcript bound into the sendbeam/3 session master key (ADR 0010).
+ */
+export function buildTrustedTranscriptV3(
+  kPairHash: Uint8Array,
+  ephemPubInit: Uint8Array,
+  ephemPubResp: Uint8Array,
+  nonceInit: Uint8Array,
+  nonceResp: Uint8Array,
+  initId: string,
+  respId: string,
+  capsHash: Uint8Array,
+): Uint8Array {
+  return concatBytes(
+    utf8(DOMAIN_TRUSTED_TRANSCRIPT_3),
+    kPairHash,
+    ephemPubInit,
+    ephemPubResp,
+    nonceInit,
+    nonceResp,
+    utf8(initId),
+    utf8(respId),
+    capsHash,
+  );
+}
+
+export interface X25519KeyPair {
+  readonly secretKey: Uint8Array;
+  readonly publicKey: Uint8Array;
+}
+
+/**
+ * Generate a fresh ephemeral X25519 keypair.
+ */
+export function generateX25519KeyPair(): X25519KeyPair {
+  const kp = x25519.keygen();
+  return {
+    secretKey: kp.secretKey,
+    publicKey: kp.publicKey,
+  };
+}
+
+/**
+ * Compute the Diffie-Hellman shared secret between private scalar and peer public key.
+ * Validates 32-byte key size and rejects low-order / all-zero points.
+ */
+export function computeX25519SharedSecret(
+  secretKey: Uint8Array,
+  peerPubKey: Uint8Array,
+): Uint8Array {
+  if (secretKey.length !== X25519_KEY_SIZE || peerPubKey.length !== X25519_KEY_SIZE) {
+    throw new Error('ephemeral public key is weak or invalid');
+  }
+  try {
+    const ss = x25519.getSharedSecret(secretKey, peerPubKey);
+    let allZero = true;
+    for (let i = 0; i < ss.length; i++) {
+      if (ss[i] !== 0) {
+        allZero = false;
+        break;
+      }
+    }
+    if (allZero) {
+      throw new Error('ephemeral public key is weak or invalid');
+    }
+    return ss;
+  } catch (err) {
+    if (err instanceof Error && err.message === 'ephemeral public key is weak or invalid') {
+      throw err;
+    }
+    throw new Error('ephemeral public key is weak or invalid');
+  }
+}
+
+/**
+ * Overwrite a byte slice with zeros in memory.
+ */
+export function zeroizeBytes(b: Uint8Array): void {
+  b.fill(0);
+}
+
+/**
  * Compute the HMAC-SHA256 authentication tag over a challenge using k_pair.
  */
 export async function computeTrustedMACTag(
@@ -249,6 +395,86 @@ export async function deriveTrustedSessionKeys(
     sessionMaster,
     new Uint8Array(0),
     utf8(DOMAIN_TRUSTED_RESP_TO_INIT_KEY),
+    32,
+  );
+
+  return {
+    sessionMaster,
+    initiatorToResponderKey: kI2R,
+    responderToInitiatorKey: kR2I,
+    negotiatedCapabilities: negotiated,
+  };
+}
+
+/**
+ * Derive directional traffic keys using forward-secret ephemeral Diffie-Hellman and k_pair (ADR 0010).
+ */
+export async function deriveTrustedSessionKeysV3(
+  kPair: Uint8Array,
+  ssECDH: Uint8Array,
+  ephemPubInit: Uint8Array,
+  ephemPubResp: Uint8Array,
+  nonceInit: Uint8Array,
+  nonceResp: Uint8Array,
+  initId: string,
+  respId: string,
+  capsInit: readonly string[],
+  capsResp: readonly string[],
+): Promise<TrustedSessionKeys> {
+  if (kPair.length === 0) {
+    throw new Error('k_pair required');
+  }
+  if (ssECDH.length !== X25519_KEY_SIZE) {
+    throw new Error('ephemeral public key is weak or invalid');
+  }
+  let allZero = true;
+  for (let i = 0; i < ssECDH.length; i++) {
+    if (ssECDH[i] !== 0) {
+      allZero = false;
+      break;
+    }
+  }
+  if (allZero) {
+    throw new Error('ephemeral public key is weak or invalid');
+  }
+  if (ephemPubInit.length !== X25519_KEY_SIZE || ephemPubResp.length !== X25519_KEY_SIZE) {
+    throw new Error('invalid ephemeral public key size');
+  }
+  if (
+    nonceInit.length !== TRUSTED_AUTH_NONCE_SIZE ||
+    nonceResp.length !== TRUSTED_AUTH_NONCE_SIZE
+  ) {
+    throw new Error('invalid nonce size');
+  }
+
+  const negotiated = intersectCapabilities(capsInit, capsResp);
+  const capsHash = await hashCapabilities(negotiated);
+  const kPairHash = await sha256(kPair);
+
+  const transcript = buildTrustedTranscriptV3(
+    kPairHash,
+    ephemPubInit,
+    ephemPubResp,
+    nonceInit,
+    nonceResp,
+    initId,
+    respId,
+    capsHash,
+  );
+  const infoMaster = concatBytes(utf8(DOMAIN_TRUSTED_MASTER_3), transcript);
+
+  const sessionMaster = await hkdfSha256(ssECDH, kPair, infoMaster, 32);
+
+  const kI2R = await hkdfSha256(
+    sessionMaster,
+    new Uint8Array(0),
+    utf8(DOMAIN_TRUSTED_INIT_TO_RESP_3),
+    32,
+  );
+  const kR2I = await hkdfSha256(
+    sessionMaster,
+    new Uint8Array(0),
+    utf8(DOMAIN_TRUSTED_RESP_TO_INIT_3),
     32,
   );
 
@@ -613,5 +839,377 @@ export async function verifyTrustedAuthConfirm(
     !(await verifyTrustedConfirmTag(sessionMaster, domain, peerDeviceId, confirm.auth_tag))
   ) {
     throw new Error('trusted-session MAC tag verification failed');
+  }
+}
+
+/**
+ * Create a signed and MAC-authenticated TrustedAuthInit message under sendbeam/3.
+ */
+export async function createTrustedAuthInitV3(
+  id: DeviceIdentity,
+  respDeviceId: string,
+  credRef: string,
+  kPair: Uint8Array,
+  caps: string[],
+  ephemPub: Uint8Array,
+  nonce?: Uint8Array,
+  now?: Date | string,
+  revocations?: RevocationRecord[],
+): Promise<TrustedAuthInit> {
+  if (kPair.length === 0) {
+    throw new Error('k_pair required');
+  }
+  if (ephemPub.length !== X25519_KEY_SIZE) {
+    throw new Error('invalid ephemeral public key size');
+  }
+  const n =
+    nonce && nonce.length === TRUSTED_AUTH_NONCE_SIZE
+      ? nonce
+      : randomBytes(TRUSTED_AUTH_NONCE_SIZE);
+  const tsStr =
+    typeof now === 'string' ? now : (now || new Date()).toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+  const capsHash = await hashCapabilities(caps);
+  const kPairHash = await sha256(kPair);
+
+  const challenge = buildTrustedInitChallengeV3(
+    kPairHash,
+    ephemPub,
+    n,
+    id.deviceId,
+    respDeviceId,
+    capsHash,
+    tsStr,
+  );
+  const sig = signDeviceMessage(id, challenge);
+  const tag = await computeTrustedMACTag(kPair, DOMAIN_TRUSTED_INIT_MAC_3, challenge);
+
+  return {
+    type: MSG_TRUSTED_AUTH_INIT,
+    protocol_version: TRUSTED_AUTH_PROTOCOL_VERSION_V3,
+    initiator_device_id: id.deviceId,
+    responder_device_id: respDeviceId,
+    pair_credential_ref: credRef,
+    ephemeral_pub: bytesToHex(ephemPub),
+    nonce: bytesToHex(n),
+    capabilities: caps,
+    timestamp: tsStr,
+    signature: bytesToHex(sig),
+    auth_tag: tag,
+    ...(revocations && revocations.length > 0 ? { revocations } : {}),
+  };
+}
+
+/**
+ * Validate format, protocol version, clock skew, Ed25519 signature, and HMAC tag for sendbeam/3.
+ */
+export async function verifyTrustedAuthInitV3(
+  init: TrustedAuthInit,
+  kPair: Uint8Array,
+  initPubKey: Uint8Array,
+  localDeviceId: string,
+  now?: Date | string,
+): Promise<{ ephemeralPub: Uint8Array; nonce: Uint8Array }> {
+  if (!init || init.type !== MSG_TRUSTED_AUTH_INIT) {
+    throw new Error('invalid trusted-session message');
+  }
+  if (init.protocol_version !== TRUSTED_AUTH_PROTOCOL_VERSION_V3) {
+    if (
+      init.protocol_version === TRUSTED_AUTH_PROTOCOL_VERSION ||
+      init.protocol_version === 'sendbeam/1'
+    ) {
+      throw new Error('trusted-session protocol downgrade forbidden');
+    }
+    throw new Error('invalid trusted-session message');
+  }
+  if (init.responder_device_id !== localDeviceId) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+  if (!validateDeviceId(init.initiator_device_id)) {
+    throw new Error('invalid device id format');
+  }
+
+  const expectedInitId = await deriveDeviceId(initPubKey);
+  if (expectedInitId !== init.initiator_device_id) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+
+  const ts = new Date(init.timestamp).getTime();
+  if (Number.isNaN(ts)) {
+    throw new Error('invalid trusted-session message');
+  }
+  const currentTime = (typeof now === 'string' ? new Date(now) : now || new Date()).getTime();
+  const skew = Math.abs(currentTime - ts);
+  if (skew > MAX_TRUSTED_TIMESTAMP_SKEW_MS) {
+    throw new Error('trusted-session timestamp outside acceptable skew window');
+  }
+
+  const ephemPub = hexToBytes(init.ephemeral_pub);
+  if (ephemPub.length !== X25519_KEY_SIZE) {
+    throw new Error('ephemeral public key is weak or invalid');
+  }
+
+  const nonce = hexToBytes(init.nonce);
+  if (nonce.length !== TRUSTED_AUTH_NONCE_SIZE) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const sigBytes = hexToBytes(init.signature);
+  if (sigBytes.length !== 64) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  const capsHash = await hashCapabilities(init.capabilities);
+  const kPairHash = await sha256(kPair);
+  const challenge = buildTrustedInitChallengeV3(
+    kPairHash,
+    ephemPub,
+    nonce,
+    init.initiator_device_id,
+    init.responder_device_id,
+    capsHash,
+    init.timestamp,
+  );
+
+  const sigValid = verifyDeviceSignature(initPubKey, challenge, sigBytes);
+  if (!sigValid) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  const macValid = await verifyTrustedMACTag(
+    kPair,
+    DOMAIN_TRUSTED_INIT_MAC_3,
+    challenge,
+    init.auth_tag,
+  );
+  if (!macValid) {
+    throw new Error('trusted-session MAC tag verification failed');
+  }
+
+  return { ephemeralPub: ephemPub, nonce };
+}
+
+/**
+ * Create a signed and MAC-authenticated TrustedAuthResponse under sendbeam/3.
+ */
+export async function createTrustedAuthResponseV3(
+  id: DeviceIdentity,
+  init: TrustedAuthInit,
+  kPair: Uint8Array,
+  caps: string[],
+  ephemPub: Uint8Array,
+  nonce?: Uint8Array,
+  revocations?: RevocationRecord[],
+): Promise<TrustedAuthResponse> {
+  if (kPair.length === 0) {
+    throw new Error('k_pair required');
+  }
+  if (ephemPub.length !== X25519_KEY_SIZE) {
+    throw new Error('invalid ephemeral public key size');
+  }
+  const n =
+    nonce && nonce.length === TRUSTED_AUTH_NONCE_SIZE
+      ? nonce
+      : randomBytes(TRUSTED_AUTH_NONCE_SIZE);
+
+  const ephemInit = hexToBytes(init.ephemeral_pub);
+  if (ephemInit.length !== X25519_KEY_SIZE) {
+    throw new Error('ephemeral public key is weak or invalid');
+  }
+  const nonceInit = hexToBytes(init.nonce);
+  if (nonceInit.length !== TRUSTED_AUTH_NONCE_SIZE) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const negotiated = intersectCapabilities(init.capabilities, caps);
+  const capsHash = await hashCapabilities(negotiated);
+  const kPairHash = await sha256(kPair);
+
+  const challenge = buildTrustedRespChallengeV3(
+    kPairHash,
+    ephemInit,
+    ephemPub,
+    nonceInit,
+    n,
+    init.initiator_device_id,
+    id.deviceId,
+    capsHash,
+  );
+  const sig = signDeviceMessage(id, challenge);
+  const tag = await computeTrustedMACTag(kPair, DOMAIN_TRUSTED_RESP_MAC_3, challenge);
+
+  return {
+    type: MSG_TRUSTED_AUTH_RESPONSE,
+    protocol_version: TRUSTED_AUTH_PROTOCOL_VERSION_V3,
+    status: 'accepted',
+    responder_device_id: id.deviceId,
+    ephemeral_pub: bytesToHex(ephemPub),
+    nonce: bytesToHex(n),
+    capabilities: caps,
+    signature: bytesToHex(sig),
+    auth_tag: tag,
+    ...(revocations && revocations.length > 0 ? { revocations } : {}),
+  };
+}
+
+/**
+ * Validate format, protocol version, Ed25519 signature, and HMAC tag for sendbeam/3.
+ */
+export async function verifyTrustedAuthResponseV3(
+  resp: TrustedAuthResponse,
+  init: TrustedAuthInit,
+  kPair: Uint8Array,
+  respPubKey: Uint8Array,
+  localDeviceId: string,
+): Promise<{ ephemeralPub: Uint8Array; nonce: Uint8Array }> {
+  if (!resp || resp.type !== MSG_TRUSTED_AUTH_RESPONSE) {
+    throw new Error('invalid trusted-session message');
+  }
+  if (resp.protocol_version !== TRUSTED_AUTH_PROTOCOL_VERSION_V3) {
+    if (
+      resp.protocol_version === TRUSTED_AUTH_PROTOCOL_VERSION ||
+      resp.protocol_version === 'sendbeam/1'
+    ) {
+      throw new Error('trusted-session protocol downgrade forbidden');
+    }
+    throw new Error('invalid trusted-session message');
+  }
+  if (localDeviceId && init.initiator_device_id !== localDeviceId) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+  if (resp.status !== 'accepted') {
+    if (resp.status === 'revoked') {
+      throw new Error('trusted peer device is revoked');
+    }
+    throw new Error('trusted session was rejected by peer');
+  }
+  if (resp.responder_device_id !== init.responder_device_id) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+
+  const expectedRespId = await deriveDeviceId(respPubKey);
+  if (expectedRespId !== resp.responder_device_id) {
+    throw new Error('trusted-session peer device ID mismatch');
+  }
+
+  const ephemInit = hexToBytes(init.ephemeral_pub);
+  if (ephemInit.length !== X25519_KEY_SIZE) {
+    throw new Error('ephemeral public key is weak or invalid');
+  }
+  const nonceInit = hexToBytes(init.nonce);
+  if (nonceInit.length !== TRUSTED_AUTH_NONCE_SIZE) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  if (!resp.ephemeral_pub || !resp.nonce || !resp.signature || !resp.auth_tag) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const ephemResp = hexToBytes(resp.ephemeral_pub);
+  if (ephemResp.length !== X25519_KEY_SIZE) {
+    throw new Error('ephemeral public key is weak or invalid');
+  }
+
+  const nonceResp = hexToBytes(resp.nonce);
+  if (nonceResp.length !== TRUSTED_AUTH_NONCE_SIZE) {
+    throw new Error('invalid trusted-session message');
+  }
+
+  const sigBytes = hexToBytes(resp.signature);
+  if (sigBytes.length !== 64) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  const negotiated = intersectCapabilities(init.capabilities, resp.capabilities || []);
+  const capsHash = await hashCapabilities(negotiated);
+  const kPairHash = await sha256(kPair);
+  const challenge = buildTrustedRespChallengeV3(
+    kPairHash,
+    ephemInit,
+    ephemResp,
+    nonceInit,
+    nonceResp,
+    init.initiator_device_id,
+    resp.responder_device_id,
+    capsHash,
+  );
+
+  const sigValid = verifyDeviceSignature(respPubKey, challenge, sigBytes);
+  if (!sigValid) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  const macValid = await verifyTrustedMACTag(
+    kPair,
+    DOMAIN_TRUSTED_RESP_MAC_3,
+    challenge,
+    resp.auth_tag,
+  );
+  if (!macValid) {
+    throw new Error('trusted-session MAC tag verification failed');
+  }
+
+  return { ephemeralPub: ephemResp, nonce: nonceResp };
+}
+
+/**
+ * Create a TrustedAuthConfirm message for sendbeam/3.
+ */
+export function createTrustedAuthConfirmV3(
+  sessionMaster: Uint8Array,
+  domain: string,
+  localDeviceId: string,
+  ready: boolean,
+): Promise<TrustedAuthConfirm> {
+  return createTrustedAuthConfirm(sessionMaster, domain, localDeviceId, ready);
+}
+
+/**
+ * Verify a TrustedAuthConfirm message for sendbeam/3.
+ */
+export function verifyTrustedAuthConfirmV3(
+  confirm: TrustedAuthConfirm,
+  sessionMaster: Uint8Array,
+  domain: string,
+  peerDeviceId: string,
+): Promise<void> {
+  return verifyTrustedAuthConfirm(confirm, sessionMaster, domain, peerDeviceId);
+}
+
+/**
+ * Tracks recently seen (deviceId, nonce) tuples to detect replays within the timestamp skew window (ADR 0010).
+ */
+export class NonceReplayCache {
+  private seen = new Map<string, number>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs: number = 10 * 60 * 1000) {
+    this.ttlMs = ttlMs > 0 ? ttlMs : 10 * 60 * 1000;
+  }
+
+  checkAndRecord(deviceId: string, nonceHex: string, now?: Date | number | string): void {
+    const currentTime =
+      typeof now === 'number'
+        ? now
+        : typeof now === 'string'
+          ? new Date(now).getTime()
+          : now instanceof Date
+            ? now.getTime()
+            : Date.now();
+    const cutoff = currentTime - this.ttlMs;
+
+    for (const [k, exp] of this.seen.entries()) {
+      if (exp < cutoff) {
+        this.seen.delete(k);
+      }
+    }
+
+    const key = `${deviceId}:${nonceHex}`;
+    const exp = this.seen.get(key);
+    if (exp !== undefined && exp >= cutoff) {
+      throw new Error('trusted-session replay detected');
+    }
+
+    this.seen.set(key, currentTime);
   }
 }

--- a/packages/wire/testdata/trusted-session-v3-vectors.json
+++ b/packages/wire/testdata/trusted-session-v3-vectors.json
@@ -1,0 +1,81 @@
+[
+  {
+    "name": "trusted_v3_session_standard",
+    "protocol_version": "sendbeam/3",
+    "k_pair_hex": "b578beac8f38df62b3f7f744ad47e6a6a6f17a7db6427e3949f981da8eb29b7d",
+    "pair_cred_ref": "cred-f5a9067216d304bf2a67fc5446d5a6e7e97dfb9152f937c8c6b6d1a872cc10a5",
+    "init_seed_hex": "34c86db8b3903e5dcf9582abb21e0340602f233b2e12b6e4de11afd585174a3a",
+    "init_device_id": "sb-dev-0ae44c43cf475df86e9a4341e75b02944142c1d4484892d244d7d2d7c4a7f216",
+    "init_pub_key_hex": "0d9745c372d04607f3a765eb7f2e0ab7ea9b7ece9fd0acfca79a57803a4f83ea",
+    "init_ephem_priv_hex": "1111111111111111111111111111111111111111111111111111111111111111",
+    "init_ephem_pub_hex": "7b4e909bbe7ffe44c465a220037d608ee35897d31ef972f07f74892cb0f73f13",
+    "init_nonce_hex": "b9d81bca729d78625201c17a8b9909aca3880515d53176b967207713d1d0d725",
+    "init_caps": [
+      "transfer.v1",
+      "transfer.v2",
+      "auto_accept"
+    ],
+    "init_timestamp": "2026-08-21T12:00:00Z",
+    "init_sig_hex": "bcbd1a215199c52ba6c5b3610414146551eb2bda2291f0e3335696017209c3c4426b504d483a1eae8fa8d48e5060dc9bbfeb63efaa94c4a3bf04f0d88370510f",
+    "init_auth_tag_hex": "8545b0e836e7eee8c5935b64af4044217360e94a7c88e98d5db63bafc35011d1",
+    "resp_seed_hex": "4fb61397bb78ad872f082a4dda02286fc585e612b731664e9b9398d85a3e85df",
+    "resp_device_id": "sb-dev-2a01b9da1e116eec290a92f9edbdb799c73c3abed9e99cd083c24bff6e3645c7",
+    "resp_pub_key_hex": "e61d3ac8f53bade331c2c5b8103b8791de6bb02d47bf4382875f4ad9ddcf5592",
+    "resp_ephem_priv_hex": "2222222222222222222222222222222222222222222222222222222222222222",
+    "resp_ephem_pub_hex": "0faa684ed28867b97f4a6a2dee5df8ce974e76b7018e3f22a1c4cf2678570f20",
+    "resp_nonce_hex": "296b24ab56c4781c3569f10ad9ea4c773fb1b98652096e58cc236207dfef0ea4",
+    "resp_caps": [
+      "transfer.v1",
+      "transfer.v2",
+      "lan_direct"
+    ],
+    "resp_sig_hex": "d84cdfda35ddbd95d25c2fbaacf7b7f5cb32b54d00e1e0c3410802f5ccb149a4bf3ebf2fae780a1baada889f439e98fc34164b922cf1786aebddb1c6071b110d",
+    "resp_auth_tag_hex": "91f833100bf36e0599cad7b0dba2d035bdc857093a558941727a8701c0ccdd0a",
+    "ecdh_shared_secret_hex": "9e004098efc091d4ec2663b4e9f5cfd4d7064571690b4bea97ab146ab9f35056",
+    "session_master_hex": "bff9b4b62d3c0db45040b5e4e4eab616ba1cf0740ab8e12b5b6838fd889ea02f",
+    "i2r_key_hex": "34a0dce0e5cf00699298c14eb6e24e804ea7f780635f67ad8766fb8c316959ae",
+    "r2i_key_hex": "307dbe2782517c215bf194632e549123a259f16fd9d8eb7d95542a6c219fcad0",
+    "init_confirm_tag": "a9809caa7e84d626390fe1ce9b3c6a671c8c8fe5d7d39eade09eef7c7c8f69af",
+    "resp_confirm_tag": "fc79961d8e8abcd9db3ef24d92855bceff48ef951e0ec0191cd5caf16fb58db8"
+  },
+  {
+    "name": "trusted_v3_session_mesh_handoff",
+    "protocol_version": "sendbeam/3",
+    "k_pair_hex": "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00",
+    "pair_cred_ref": "cred-00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+    "init_seed_hex": "5555555555555555555555555555555555555555555555555555555555555555",
+    "init_device_id": "sb-dev-b4c1ece898ece24e24e601232f95c6a18971689a0dd669e6d78218537c21c389",
+    "init_pub_key_hex": "c6822637c7d310ec57627be00ba259d253749f4aaf644470cffbe53a35f73242",
+    "init_ephem_priv_hex": "6666666666666666666666666666666666666666666666666666666666666666",
+    "init_ephem_pub_hex": "219e4d800da968d2a5fcb009c784f4746c7138edb9ee4844b739e830b05cf424",
+    "init_nonce_hex": "7777777777777777777777777777777777777777777777777777777777777777",
+    "init_caps": [
+      "transfer.v2",
+      "mesh_sync",
+      "revocation_v1"
+    ],
+    "init_timestamp": "2026-09-01T15:30:00Z",
+    "init_sig_hex": "f2b8842f1c77289be28ee08acd359ee64bbd95baf68de8d465de13c89250495db0801d5d5b78419cbed3ca2c2d957d7b5a8fe512ee3c38985278d11558b82d01",
+    "init_auth_tag_hex": "4575ad3850ef3a16864e07fa050a117844ea109759627a770fe08d2b20b14f39",
+    "resp_seed_hex": "8888888888888888888888888888888888888888888888888888888888888888",
+    "resp_device_id": "sb-dev-a2392944d82466b712478b25d95a5633111bc767c03121aada27dbd348406801",
+    "resp_pub_key_hex": "b2491d9502ae28630a2bacb2e0c74510ffcdd328c334ff3e1393e75b2d31e7dc",
+    "resp_ephem_priv_hex": "9999999999999999999999999999999999999999999999999999999999999999",
+    "resp_ephem_pub_hex": "ba193836cff1f4e866c139715d306408d26a76f76d638a39afc1001084d25411",
+    "resp_nonce_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resp_caps": [
+      "transfer.v2",
+      "mesh_sync",
+      "revocation_v1",
+      "turbo_mode"
+    ],
+    "resp_sig_hex": "f7e1f64fc480e057c5cca229e074fba0a2753e380e8205cb81619f07fb6f7baf86ea207d8cbf0bca89d6e4283a095eb373e88e949f3ced92f302e6729e88fa07",
+    "resp_auth_tag_hex": "c33dce547c3f51aa5dfacef7f8b9ec82dad727fb7537f07de205ac8f0a68f29a",
+    "ecdh_shared_secret_hex": "043480ee5bbe3d50ce34ce3ffc7e47a009dbed17422a8f0b982f320ef44cfc77",
+    "session_master_hex": "48f7cda2d937e956d093e98061bc2fab1128c1af7858b42888ebacc2bbd35e69",
+    "i2r_key_hex": "d2a7443744656d376dc36922d5924864d45ab1ca692bf09babb56963df93641a",
+    "r2i_key_hex": "2c381fe648c6cab9de40023c545dc23f3773f7686b1553bc7549f1bf8a7faa52",
+    "init_confirm_tag": "7bdc0df2c81aff63bf00b3060f4165256504f005cc98df7cd140add26d49677a",
+    "resp_confirm_tag": "6bb2512f6d8fd5366bc9e59e5f67155a1421b3f5569826acd7ed3b8d9d8416d7"
+  }
+]

--- a/packages/wire/trusted_auth.go
+++ b/packages/wire/trusted_auth.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"crypto/ecdh"
 	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/rand"
@@ -12,16 +13,18 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
-// Trusted-session message types, protocol version, and domain separation constants (V15-PR03).
+// Trusted-session message types, protocol versions, and domain separation constants (V15-PR03, V19-PR01).
 const (
 	MsgTrustedAuthInit     = "trusted_auth_init"
 	MsgTrustedAuthResponse = "trusted_auth_response"
 	MsgTrustedAuthConfirm  = "trusted_auth_confirm"
 
-	TrustedAuthProtocolVersion = "sendbeam/2"
+	TrustedAuthProtocolVersion   = "sendbeam/2"
+	TrustedAuthProtocolVersionV3 = "sendbeam/3"
 
 	DomainTrustedInit          = "sendbeam/2 trusted-init:"
 	DomainTrustedInitMAC       = "sendbeam/2 trusted-init-mac:"
@@ -33,8 +36,21 @@ const (
 	DomainTrustedConfirmInit   = "sendbeam/2 confirm-init:"
 	DomainTrustedConfirmResp   = "sendbeam/2 confirm-resp:"
 
+	// sendbeam/3 domain constants (ADR 0010)
+	DomainTrustedInit3        = "sendbeam/3 trusted-init:"
+	DomainTrustedInitMAC3     = "sendbeam/3 trusted-init-mac:"
+	DomainTrustedResp3        = "sendbeam/3 trusted-resp:"
+	DomainTrustedRespMAC3     = "sendbeam/3 trusted-resp-mac:"
+	DomainTrustedMaster3      = "sendbeam/3 session-master:"
+	DomainTrustedInitToResp3  = "sendbeam/3 initiator-to-responder key"
+	DomainTrustedRespToInit3  = "sendbeam/3 responder-to-initiator key"
+	DomainTrustedConfirmInit3 = "sendbeam/3 confirm-init:"
+	DomainTrustedConfirmResp3 = "sendbeam/3 confirm-resp:"
+	DomainTrustedTranscript3  = "sendbeam/3 transcript:"
+
 	TrustedAuthNonceSize     = 32
 	TrustedAuthEphemeralSize = 32
+	X25519KeySize            = 32
 	MaxTrustedTimestampSkew  = 5 * time.Minute
 )
 
@@ -59,6 +75,18 @@ var (
 
 	// ErrTrustedRejected indicates that the peer explicitly rejected the trusted session.
 	ErrTrustedRejected = errors.New("trusted session was rejected by peer")
+
+	// ErrProtocolDowngradeForbidden indicates an attempt to downgrade trusted-session protocol (ADR 0010).
+	ErrProtocolDowngradeForbidden = Errorf(CodeCompat, "trusted-session protocol downgrade forbidden")
+
+	// ErrWeakEphemeralKey indicates that the ephemeral public key is weak, low-order, or invalid (ADR 0010).
+	ErrWeakEphemeralKey = Errorf(CodeAuth, "ephemeral public key is weak or invalid")
+
+	// ErrSessionReplayDetected indicates that a replayed session handshake was detected (ADR 0010).
+	ErrSessionReplayDetected = Errorf(CodeProtocol, "trusted-session replay detected")
+
+	// ErrRevocationUnauthorized indicates that the revoker lacks authority to revoke the device (ADR 0010).
+	ErrRevocationUnauthorized = Errorf(CodeAuth, "revocation record is unauthorized")
 )
 
 // TrustedAuthInit is sent by the initiating device to authenticate a trusted connection.
@@ -161,6 +189,85 @@ func BuildTrustedRespChallenge(kPairHash, ephemPubInit, ephemPubResp, nonceInit,
 	return buf
 }
 
+// BuildTrustedInitChallengeV3 constructs the binary payload signed by the initiator in sendbeam/3 (ADR 0010).
+func BuildTrustedInitChallengeV3(kPairHash, ephemPub, nonce []byte, initID, respID string, capsHash []byte, timestamp string) []byte {
+	buf := make([]byte, 0, len(DomainTrustedInit3)+len(kPairHash)+len(ephemPub)+len(nonce)+len(initID)+len(respID)+len(capsHash)+len(timestamp))
+	buf = append(buf, DomainTrustedInit3...)
+	buf = append(buf, kPairHash...)
+	buf = append(buf, ephemPub...)
+	buf = append(buf, nonce...)
+	buf = append(buf, initID...)
+	buf = append(buf, respID...)
+	buf = append(buf, capsHash...)
+	buf = append(buf, timestamp...)
+	return buf
+}
+
+// BuildTrustedRespChallengeV3 constructs the binary payload signed by the responder in sendbeam/3 (ADR 0010).
+func BuildTrustedRespChallengeV3(kPairHash, ephemPubInit, ephemPubResp, nonceInit, nonceResp []byte, initID, respID string, capsHash []byte) []byte {
+	buf := make([]byte, 0, len(DomainTrustedResp3)+len(kPairHash)+len(ephemPubInit)+len(ephemPubResp)+len(nonceInit)+len(nonceResp)+len(initID)+len(respID)+len(capsHash))
+	buf = append(buf, DomainTrustedResp3...)
+	buf = append(buf, kPairHash...)
+	buf = append(buf, ephemPubInit...)
+	buf = append(buf, ephemPubResp...)
+	buf = append(buf, nonceInit...)
+	buf = append(buf, nonceResp...)
+	buf = append(buf, initID...)
+	buf = append(buf, respID...)
+	buf = append(buf, capsHash...)
+	return buf
+}
+
+// BuildTrustedTranscriptV3 constructs the canonical transcript bound into the sendbeam/3 session master key (ADR 0010).
+func BuildTrustedTranscriptV3(kPairHash, ephemPubInit, ephemPubResp, nonceInit, nonceResp []byte, initID, respID string, capsHash []byte) []byte {
+	buf := make([]byte, 0, len(DomainTrustedTranscript3)+len(kPairHash)+len(ephemPubInit)+len(ephemPubResp)+len(nonceInit)+len(nonceResp)+len(initID)+len(respID)+len(capsHash))
+	buf = append(buf, DomainTrustedTranscript3...)
+	buf = append(buf, kPairHash...)
+	buf = append(buf, ephemPubInit...)
+	buf = append(buf, ephemPubResp...)
+	buf = append(buf, nonceInit...)
+	buf = append(buf, nonceResp...)
+	buf = append(buf, initID...)
+	buf = append(buf, respID...)
+	buf = append(buf, capsHash...)
+	return buf
+}
+
+// GenerateX25519KeyPair generates a fresh ephemeral X25519 keypair and returns (privateKey, 32-byte publicKey, error).
+func GenerateX25519KeyPair() (*ecdh.PrivateKey, []byte, error) {
+	curve := ecdh.X25519()
+	priv, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate x25519 key: %w", err)
+	}
+	return priv, priv.PublicKey().Bytes(), nil
+}
+
+// ComputeX25519SharedSecret computes the Diffie-Hellman shared secret between private scalar and peer public key.
+// It verifies that peer public key and output are valid non-zero Curve25519 points (rejects weak points fail-closed).
+func ComputeX25519SharedSecret(priv *ecdh.PrivateKey, peerPubBytes []byte) ([]byte, error) {
+	if priv == nil {
+		return nil, errors.New("x25519 private key required")
+	}
+	if len(peerPubBytes) != X25519KeySize {
+		return nil, ErrWeakEphemeralKey
+	}
+	curve := ecdh.X25519()
+	peerPub, err := curve.NewPublicKey(peerPubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrWeakEphemeralKey, err)
+	}
+	ss, err := priv.ECDH(peerPub)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrWeakEphemeralKey, err)
+	}
+	allZeros := make([]byte, X25519KeySize)
+	if subtle.ConstantTimeCompare(ss, allZeros) == 1 {
+		return nil, ErrWeakEphemeralKey
+	}
+	return ss, nil
+}
+
 // ComputeTrustedMACTag computes the HMAC-SHA256 authentication tag over a challenge using k_pair.
 func ComputeTrustedMACTag(kPair []byte, domain string, challenge []byte) string {
 	mac := hmac.New(sha256.New, kPair)
@@ -227,6 +334,55 @@ func DeriveTrustedSessionKeys(kPair, ephemPubInit, ephemPubResp, nonceInit, nonc
 	}
 
 	kR2I, err := hkdfSHA256(sessionMaster, nil, []byte(DomainTrustedRespToInitKey), 32)
+	if err != nil {
+		return nil, fmt.Errorf("derive r2i key: %w", err)
+	}
+
+	return &TrustedSessionKeys{
+		SessionMaster:           sessionMaster,
+		InitiatorToResponderKey: kI2R,
+		ResponderToInitiatorKey: kR2I,
+		NegotiatedCapabilities:  negotiated,
+	}, nil
+}
+
+// DeriveTrustedSessionKeysV3 derives directional traffic keys using forward-secret ephemeral Diffie-Hellman and k_pair (ADR 0010).
+func DeriveTrustedSessionKeysV3(kPair, ssECDH, ephemPubInit, ephemPubResp, nonceInit, nonceResp []byte, initID, respID string, capsInit, capsResp []string) (*TrustedSessionKeys, error) {
+	if len(kPair) == 0 {
+		return nil, errors.New("k_pair required")
+	}
+	if len(ssECDH) != X25519KeySize {
+		return nil, ErrWeakEphemeralKey
+	}
+	allZeros := make([]byte, X25519KeySize)
+	if subtle.ConstantTimeCompare(ssECDH, allZeros) == 1 {
+		return nil, ErrWeakEphemeralKey
+	}
+	if len(ephemPubInit) != X25519KeySize || len(ephemPubResp) != X25519KeySize {
+		return nil, errors.New("invalid ephemeral public key size")
+	}
+	if len(nonceInit) != TrustedAuthNonceSize || len(nonceResp) != TrustedAuthNonceSize {
+		return nil, errors.New("invalid nonce size")
+	}
+
+	negotiated := IntersectCapabilities(capsInit, capsResp)
+	capsHash := HashCapabilities(negotiated)
+	kPairHash := sha256.Sum256(kPair)
+
+	transcript := BuildTrustedTranscriptV3(kPairHash[:], ephemPubInit, ephemPubResp, nonceInit, nonceResp, initID, respID, capsHash)
+	infoMaster := append([]byte(DomainTrustedMaster3), transcript...)
+
+	sessionMaster, err := hkdfSHA256(ssECDH, kPair, infoMaster, 32)
+	if err != nil {
+		return nil, fmt.Errorf("derive session master: %w", err)
+	}
+
+	kI2R, err := hkdfSHA256(sessionMaster, nil, []byte(DomainTrustedInitToResp3), 32)
+	if err != nil {
+		return nil, fmt.Errorf("derive i2r key: %w", err)
+	}
+
+	kR2I, err := hkdfSHA256(sessionMaster, nil, []byte(DomainTrustedRespToInit3), 32)
 	if err != nil {
 		return nil, fmt.Errorf("derive r2i key: %w", err)
 	}
@@ -510,6 +666,289 @@ func VerifyTrustedAuthConfirm(confirm *TrustedAuthConfirm, sessionMaster []byte,
 	if !VerifyTrustedConfirmTag(sessionMaster, domain, peerDeviceID, confirm.AuthTag) {
 		return ErrTrustedMACTagFailed
 	}
+	return nil
+}
+
+// ZeroizeBytes safely clears a byte slice in memory.
+func ZeroizeBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// NewTrustedAuthInitV3 creates a signed and MAC-authenticated TrustedAuthInit message under sendbeam/3.
+func NewTrustedAuthInitV3(id *DeviceIdentity, respDeviceID, credRef string, kPair []byte, caps []string, ephemPub, nonce []byte, now time.Time, revocations []RevocationRecord) (*TrustedAuthInit, error) {
+	if id == nil {
+		return nil, ErrInvalidIdentity
+	}
+	if len(kPair) == 0 {
+		return nil, errors.New("k_pair required")
+	}
+	if len(ephemPub) != X25519KeySize {
+		return nil, errors.New("invalid ephemeral public key size")
+	}
+	if len(nonce) != TrustedAuthNonceSize {
+		return nil, errors.New("invalid nonce size")
+	}
+
+	tsStr := now.UTC().Format(time.RFC3339)
+	capsHash := HashCapabilities(caps)
+	kPairHash := sha256.Sum256(kPair)
+
+	challenge := BuildTrustedInitChallengeV3(kPairHash[:], ephemPub, nonce, id.DeviceID, respDeviceID, capsHash, tsStr)
+	sig, err := id.Sign(challenge)
+	if err != nil {
+		return nil, fmt.Errorf("sign trusted init: %w", err)
+	}
+
+	tag := ComputeTrustedMACTag(kPair, DomainTrustedInitMAC3, challenge)
+
+	return &TrustedAuthInit{
+		Type:              MsgTrustedAuthInit,
+		ProtocolVersion:   TrustedAuthProtocolVersionV3,
+		InitiatorDeviceID: id.DeviceID,
+		ResponderDeviceID: respDeviceID,
+		PairCredentialRef: credRef,
+		EphemeralPub:      hex.EncodeToString(ephemPub),
+		Nonce:             hex.EncodeToString(nonce),
+		Capabilities:      caps,
+		Timestamp:         tsStr,
+		Signature:         hex.EncodeToString(sig),
+		AuthTag:           tag,
+		Revocations:       revocations,
+	}, nil
+}
+
+// VerifyTrustedAuthInitV3 validates format, protocol version, clock skew, Ed25519 signature, and HMAC tag for sendbeam/3.
+func VerifyTrustedAuthInitV3(init *TrustedAuthInit, kPair []byte, initPubKey ed25519.PublicKey, localDeviceID string, now time.Time) ([]byte, []byte, error) {
+	if init == nil || init.Type != MsgTrustedAuthInit {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+	if init.ProtocolVersion != TrustedAuthProtocolVersionV3 {
+		if init.ProtocolVersion == TrustedAuthProtocolVersion || init.ProtocolVersion == "sendbeam/1" {
+			return nil, nil, ErrProtocolDowngradeForbidden
+		}
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+	if init.ResponderDeviceID != localDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+	if !ValidateDeviceID(init.InitiatorDeviceID) {
+		return nil, nil, ErrInvalidDeviceID
+	}
+
+	expectedInitID := DeriveDeviceID(initPubKey)
+	if expectedInitID != init.InitiatorDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+
+	ts, err := time.Parse(time.RFC3339, init.Timestamp)
+	if err != nil {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+	skew := now.Sub(ts)
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > MaxTrustedTimestampSkew {
+		return nil, nil, ErrTrustedTimestampSkew
+	}
+
+	ephemPub, err := hex.DecodeString(init.EphemeralPub)
+	if err != nil || len(ephemPub) != X25519KeySize {
+		return nil, nil, ErrWeakEphemeralKey
+	}
+
+	nonce, err := hex.DecodeString(init.Nonce)
+	if err != nil || len(nonce) != TrustedAuthNonceSize {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+
+	sigBytes, err := hex.DecodeString(init.Signature)
+	if err != nil || len(sigBytes) != ed25519.SignatureSize {
+		return nil, nil, ErrTrustedSignatureFailed
+	}
+
+	capsHash := HashCapabilities(init.Capabilities)
+	kPairHash := sha256.Sum256(kPair)
+	challenge := BuildTrustedInitChallengeV3(kPairHash[:], ephemPub, nonce, init.InitiatorDeviceID, init.ResponderDeviceID, capsHash, init.Timestamp)
+
+	if !VerifyDeviceSignature(initPubKey, challenge, sigBytes) {
+		return nil, nil, ErrTrustedSignatureFailed
+	}
+
+	if !VerifyTrustedMACTag(kPair, DomainTrustedInitMAC3, challenge, init.AuthTag) {
+		return nil, nil, ErrTrustedMACTagFailed
+	}
+
+	return ephemPub, nonce, nil
+}
+
+// NewTrustedAuthResponseV3 creates a signed and MAC-authenticated TrustedAuthResponse under sendbeam/3.
+func NewTrustedAuthResponseV3(id *DeviceIdentity, init *TrustedAuthInit, kPair []byte, caps []string, ephemPub, nonce []byte, revocations []RevocationRecord) (*TrustedAuthResponse, error) {
+	if id == nil {
+		return nil, ErrInvalidIdentity
+	}
+	if len(kPair) == 0 {
+		return nil, errors.New("k_pair required")
+	}
+	if len(ephemPub) != X25519KeySize {
+		return nil, errors.New("invalid ephemeral public key size")
+	}
+	if len(nonce) != TrustedAuthNonceSize {
+		return nil, errors.New("invalid nonce size")
+	}
+
+	ephemInit, err := hex.DecodeString(init.EphemeralPub)
+	if err != nil || len(ephemInit) != X25519KeySize {
+		return nil, ErrWeakEphemeralKey
+	}
+	nonceInit, err := hex.DecodeString(init.Nonce)
+	if err != nil || len(nonceInit) != TrustedAuthNonceSize {
+		return nil, ErrInvalidTrustedMessage
+	}
+
+	negotiated := IntersectCapabilities(init.Capabilities, caps)
+	capsHash := HashCapabilities(negotiated)
+	kPairHash := sha256.Sum256(kPair)
+
+	challenge := BuildTrustedRespChallengeV3(kPairHash[:], ephemInit, ephemPub, nonceInit, nonce, init.InitiatorDeviceID, id.DeviceID, capsHash)
+	sig, err := id.Sign(challenge)
+	if err != nil {
+		return nil, fmt.Errorf("sign trusted response: %w", err)
+	}
+
+	tag := ComputeTrustedMACTag(kPair, DomainTrustedRespMAC3, challenge)
+
+	return &TrustedAuthResponse{
+		Type:              MsgTrustedAuthResponse,
+		ProtocolVersion:   TrustedAuthProtocolVersionV3,
+		Status:            "accepted",
+		ResponderDeviceID: id.DeviceID,
+		EphemeralPub:      hex.EncodeToString(ephemPub),
+		Nonce:             hex.EncodeToString(nonce),
+		Capabilities:      caps,
+		Signature:         hex.EncodeToString(sig),
+		AuthTag:           tag,
+		Revocations:       revocations,
+	}, nil
+}
+
+// VerifyTrustedAuthResponseV3 validates format, protocol version, Ed25519 signature, and HMAC tag for sendbeam/3.
+func VerifyTrustedAuthResponseV3(resp *TrustedAuthResponse, init *TrustedAuthInit, kPair []byte, respPubKey ed25519.PublicKey, localDeviceID string) ([]byte, []byte, error) {
+	if resp == nil || resp.Type != MsgTrustedAuthResponse {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+	if resp.ProtocolVersion != TrustedAuthProtocolVersionV3 {
+		if resp.ProtocolVersion == TrustedAuthProtocolVersion || resp.ProtocolVersion == "sendbeam/1" {
+			return nil, nil, ErrProtocolDowngradeForbidden
+		}
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+	if localDeviceID != "" && init.InitiatorDeviceID != localDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+	if resp.Status != "accepted" {
+		if resp.Status == "revoked" {
+			return nil, nil, ErrTrustedPeerRevoked
+		}
+		return nil, nil, ErrTrustedRejected
+	}
+	if resp.ResponderDeviceID != init.ResponderDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+
+	expectedRespID := DeriveDeviceID(respPubKey)
+	if expectedRespID != resp.ResponderDeviceID {
+		return nil, nil, ErrTrustedPeerMismatch
+	}
+
+	ephemInit, err := hex.DecodeString(init.EphemeralPub)
+	if err != nil || len(ephemInit) != X25519KeySize {
+		return nil, nil, ErrWeakEphemeralKey
+	}
+	nonceInit, err := hex.DecodeString(init.Nonce)
+	if err != nil || len(nonceInit) != TrustedAuthNonceSize {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+
+	ephemResp, err := hex.DecodeString(resp.EphemeralPub)
+	if err != nil || len(ephemResp) != X25519KeySize {
+		return nil, nil, ErrWeakEphemeralKey
+	}
+
+	nonceResp, err := hex.DecodeString(resp.Nonce)
+	if err != nil || len(nonceResp) != TrustedAuthNonceSize {
+		return nil, nil, ErrInvalidTrustedMessage
+	}
+
+	sigBytes, err := hex.DecodeString(resp.Signature)
+	if err != nil || len(sigBytes) != ed25519.SignatureSize {
+		return nil, nil, ErrTrustedSignatureFailed
+	}
+
+	negotiated := IntersectCapabilities(init.Capabilities, resp.Capabilities)
+	capsHash := HashCapabilities(negotiated)
+	kPairHash := sha256.Sum256(kPair)
+	challenge := BuildTrustedRespChallengeV3(kPairHash[:], ephemInit, ephemResp, nonceInit, nonceResp, init.InitiatorDeviceID, resp.ResponderDeviceID, capsHash)
+
+	if !VerifyDeviceSignature(respPubKey, challenge, sigBytes) {
+		return nil, nil, ErrTrustedSignatureFailed
+	}
+
+	if !VerifyTrustedMACTag(kPair, DomainTrustedRespMAC3, challenge, resp.AuthTag) {
+		return nil, nil, ErrTrustedMACTagFailed
+	}
+
+	return ephemResp, nonceResp, nil
+}
+
+// NewTrustedAuthConfirmV3 creates a TrustedAuthConfirm message for sendbeam/3.
+func NewTrustedAuthConfirmV3(sessionMaster []byte, domain, localDeviceID string, ready bool) *TrustedAuthConfirm {
+	return NewTrustedAuthConfirm(sessionMaster, domain, localDeviceID, ready)
+}
+
+// VerifyTrustedAuthConfirmV3 verifies a peer's confirmation tag for sendbeam/3.
+func VerifyTrustedAuthConfirmV3(confirm *TrustedAuthConfirm, sessionMaster []byte, domain, peerDeviceID string) error {
+	return VerifyTrustedAuthConfirm(confirm, sessionMaster, domain, peerDeviceID)
+}
+
+// NonceReplayCache tracks recently seen (deviceID, nonce) tuples to detect replays within the timestamp skew window.
+type NonceReplayCache struct {
+	mu   sync.Mutex
+	seen map[string]time.Time
+	ttl  time.Duration
+}
+
+// NewNonceReplayCache creates a new replay cache with the given TTL (defaults to 10 minutes).
+func NewNonceReplayCache(ttl time.Duration) *NonceReplayCache {
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	return &NonceReplayCache{
+		seen: make(map[string]time.Time),
+		ttl:  ttl,
+	}
+}
+
+// CheckAndRecord returns ErrSessionReplayDetected if the key was already seen within TTL, otherwise records it.
+func (c *NonceReplayCache) CheckAndRecord(deviceID, nonceHex string, now time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cutoff := now.Add(-c.ttl)
+	for k, exp := range c.seen {
+		if exp.Before(cutoff) {
+			delete(c.seen, k)
+		}
+	}
+
+	key := deviceID + ":" + nonceHex
+	if exp, exists := c.seen[key]; exists && exp.After(cutoff) {
+		return ErrSessionReplayDetected
+	}
+
+	c.seen[key] = now
 	return nil
 }
 

--- a/packages/wire/trusted_auth_test.go
+++ b/packages/wire/trusted_auth_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"crypto/ecdh"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
@@ -262,3 +263,357 @@ func TestTrustedAuthCodec(t *testing.T) {
 		t.Errorf("initiator device id mismatch")
 	}
 }
+
+type TrustedSessionV3TestVector struct {
+	Name                string   `json:"name"`
+	ProtocolVersion     string   `json:"protocol_version"`
+	KPairHex            string   `json:"k_pair_hex"`
+	PairCredRef         string   `json:"pair_cred_ref"`
+	InitSeedHex         string   `json:"init_seed_hex"`
+	InitDeviceID        string   `json:"init_device_id"`
+	InitPubKeyHex       string   `json:"init_pub_key_hex"`
+	InitEphemPrivHex    string   `json:"init_ephem_priv_hex"`
+	InitEphemPubHex     string   `json:"init_ephem_pub_hex"`
+	InitNonceHex        string   `json:"init_nonce_hex"`
+	InitCaps            []string `json:"init_caps"`
+	InitTimestamp       string   `json:"init_timestamp"`
+	InitSigHex          string   `json:"init_sig_hex"`
+	InitAuthTagHex      string   `json:"init_auth_tag_hex"`
+	RespSeedHex         string   `json:"resp_seed_hex"`
+	RespDeviceID        string   `json:"resp_device_id"`
+	RespPubKeyHex       string   `json:"resp_pub_key_hex"`
+	RespEphemPrivHex    string   `json:"resp_ephem_priv_hex"`
+	RespEphemPubHex     string   `json:"resp_ephem_pub_hex"`
+	RespNonceHex        string   `json:"resp_nonce_hex"`
+	RespCaps            []string `json:"resp_caps"`
+	RespSigHex          string   `json:"resp_sig_hex"`
+	RespAuthTagHex      string   `json:"resp_auth_tag_hex"`
+	ECDHSharedSecretHex string   `json:"ecdh_shared_secret_hex"`
+	SessionMasterHex    string   `json:"session_master_hex"`
+	I2RKeyHex           string   `json:"i2r_key_hex"`
+	R2IKeyHex           string   `json:"r2i_key_hex"`
+	InitConfirmTag      string   `json:"init_confirm_tag"`
+	RespConfirmTag      string   `json:"resp_confirm_tag"`
+}
+
+func TestTrustedAuthV3_Vectors(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "trusted-session-v3-vectors.json"))
+	if err != nil {
+		t.Fatalf("read test vector file: %v", err)
+	}
+
+	var vectors []TrustedSessionV3TestVector
+	if err := json.Unmarshal(data, &vectors); err != nil {
+		t.Fatalf("unmarshal vectors: %v", err)
+	}
+
+	curve := ecdh.X25519()
+
+	for _, vec := range vectors {
+		t.Run(vec.Name, func(t *testing.T) {
+			kPair, _ := hex.DecodeString(vec.KPairHex)
+			initSeed, _ := hex.DecodeString(vec.InitSeedHex)
+			respSeed, _ := hex.DecodeString(vec.RespSeedHex)
+			initPriv := ed25519.NewKeyFromSeed(initSeed)
+			respPriv := ed25519.NewKeyFromSeed(respSeed)
+			initPub := initPriv.Public().(ed25519.PublicKey)
+			respPub := respPriv.Public().(ed25519.PublicKey)
+
+			initID, _ := NewDeviceIdentity(initPub, initPriv)
+			respID, _ := NewDeviceIdentity(respPub, respPriv)
+
+			initEphemPrivBytes, _ := hex.DecodeString(vec.InitEphemPrivHex)
+			initEphemPriv, err := curve.NewPrivateKey(initEphemPrivBytes)
+			if err != nil {
+				t.Fatalf("init ephem priv: %v", err)
+			}
+			initEphemPub := initEphemPriv.PublicKey().Bytes()
+			if hex.EncodeToString(initEphemPub) != vec.InitEphemPubHex {
+				t.Errorf("init ephem pub mismatch: got %s, want %s", hex.EncodeToString(initEphemPub), vec.InitEphemPubHex)
+			}
+
+			respEphemPrivBytes, _ := hex.DecodeString(vec.RespEphemPrivHex)
+			respEphemPriv, err := curve.NewPrivateKey(respEphemPrivBytes)
+			if err != nil {
+				t.Fatalf("resp ephem priv: %v", err)
+			}
+			respEphemPub := respEphemPriv.PublicKey().Bytes()
+			if hex.EncodeToString(respEphemPub) != vec.RespEphemPubHex {
+				t.Errorf("resp ephem pub mismatch: got %s, want %s", hex.EncodeToString(respEphemPub), vec.RespEphemPubHex)
+			}
+
+			initNonce, _ := hex.DecodeString(vec.InitNonceHex)
+			respNonce, _ := hex.DecodeString(vec.RespNonceHex)
+			ts, _ := time.Parse(time.RFC3339, vec.InitTimestamp)
+
+			// 1. Create and verify Init
+			initMsg, err := NewTrustedAuthInitV3(initID, respID.DeviceID, vec.PairCredRef, kPair, vec.InitCaps, initEphemPub, initNonce, ts, nil)
+			if err != nil {
+				t.Fatalf("NewTrustedAuthInitV3: %v", err)
+			}
+			if initMsg.Signature != vec.InitSigHex {
+				t.Errorf("Init signature mismatch: got %s, want %s", initMsg.Signature, vec.InitSigHex)
+			}
+			if initMsg.AuthTag != vec.InitAuthTagHex {
+				t.Errorf("Init auth tag mismatch: got %s, want %s", initMsg.AuthTag, vec.InitAuthTagHex)
+			}
+
+			verEphemInit, verNonceInit, err := VerifyTrustedAuthInitV3(initMsg, kPair, initPub, respID.DeviceID, ts)
+			if err != nil {
+				t.Fatalf("VerifyTrustedAuthInitV3: %v", err)
+			}
+			if hex.EncodeToString(verEphemInit) != vec.InitEphemPubHex {
+				t.Errorf("verified ephem init mismatch")
+			}
+			if hex.EncodeToString(verNonceInit) != vec.InitNonceHex {
+				t.Errorf("verified nonce init mismatch")
+			}
+
+			// 2. Create and verify Response
+			respMsg, err := NewTrustedAuthResponseV3(respID, initMsg, kPair, vec.RespCaps, respEphemPub, respNonce, nil)
+			if err != nil {
+				t.Fatalf("NewTrustedAuthResponseV3: %v", err)
+			}
+			if respMsg.Signature != vec.RespSigHex {
+				t.Errorf("Resp signature mismatch: got %s, want %s", respMsg.Signature, vec.RespSigHex)
+			}
+			if respMsg.AuthTag != vec.RespAuthTagHex {
+				t.Errorf("Resp auth tag mismatch: got %s, want %s", respMsg.AuthTag, vec.RespAuthTagHex)
+			}
+
+			verEphemResp, verNonceResp, err := VerifyTrustedAuthResponseV3(respMsg, initMsg, kPair, respPub, initID.DeviceID)
+			if err != nil {
+				t.Fatalf("VerifyTrustedAuthResponseV3: %v", err)
+			}
+			if hex.EncodeToString(verEphemResp) != vec.RespEphemPubHex {
+				t.Errorf("verified ephem resp mismatch")
+			}
+			if hex.EncodeToString(verNonceResp) != vec.RespNonceHex {
+				t.Errorf("verified nonce resp mismatch")
+			}
+
+			// 3. ECDH shared secret
+			ssA, err := ComputeX25519SharedSecret(initEphemPriv, verEphemResp)
+			if err != nil {
+				t.Fatalf("ComputeX25519SharedSecret A: %v", err)
+			}
+			ssB, err := ComputeX25519SharedSecret(respEphemPriv, verEphemInit)
+			if err != nil {
+				t.Fatalf("ComputeX25519SharedSecret B: %v", err)
+			}
+			if hex.EncodeToString(ssA) != vec.ECDHSharedSecretHex {
+				t.Errorf("ssA mismatch: got %s, want %s", hex.EncodeToString(ssA), vec.ECDHSharedSecretHex)
+			}
+			if hex.EncodeToString(ssB) != vec.ECDHSharedSecretHex {
+				t.Errorf("ssB mismatch: got %s, want %s", hex.EncodeToString(ssB), vec.ECDHSharedSecretHex)
+			}
+
+			// 4. Derive keys
+			keysA, err := DeriveTrustedSessionKeysV3(kPair, ssA, initEphemPub, verEphemResp, initNonce, verNonceResp, initID.DeviceID, respID.DeviceID, vec.InitCaps, respMsg.Capabilities)
+			if err != nil {
+				t.Fatalf("DeriveTrustedSessionKeysV3 A: %v", err)
+			}
+			keysB, err := DeriveTrustedSessionKeysV3(kPair, ssB, verEphemInit, respEphemPub, verNonceInit, respNonce, initMsg.InitiatorDeviceID, respID.DeviceID, initMsg.Capabilities, vec.RespCaps)
+			if err != nil {
+				t.Fatalf("DeriveTrustedSessionKeysV3 B: %v", err)
+			}
+
+			if hex.EncodeToString(keysA.SessionMaster) != vec.SessionMasterHex {
+				t.Errorf("SessionMaster mismatch: got %s, want %s", hex.EncodeToString(keysA.SessionMaster), vec.SessionMasterHex)
+			}
+			if hex.EncodeToString(keysB.SessionMaster) != vec.SessionMasterHex {
+				t.Errorf("SessionMaster B mismatch")
+			}
+			if hex.EncodeToString(keysA.InitiatorToResponderKey) != vec.I2RKeyHex {
+				t.Errorf("I2R mismatch: got %s, want %s", hex.EncodeToString(keysA.InitiatorToResponderKey), vec.I2RKeyHex)
+			}
+			if hex.EncodeToString(keysA.ResponderToInitiatorKey) != vec.R2IKeyHex {
+				t.Errorf("R2I mismatch: got %s, want %s", hex.EncodeToString(keysA.ResponderToInitiatorKey), vec.R2IKeyHex)
+			}
+
+			// 5. Confirm tags
+			confA := NewTrustedAuthConfirmV3(keysA.SessionMaster, DomainTrustedConfirmInit3, initID.DeviceID, true)
+			if confA.AuthTag != vec.InitConfirmTag {
+				t.Errorf("confA tag mismatch: got %s, want %s", confA.AuthTag, vec.InitConfirmTag)
+			}
+			if err := VerifyTrustedAuthConfirmV3(confA, keysB.SessionMaster, DomainTrustedConfirmInit3, initID.DeviceID); err != nil {
+				t.Errorf("Verify confirm A failed: %v", err)
+			}
+
+			confB := NewTrustedAuthConfirmV3(keysB.SessionMaster, DomainTrustedConfirmResp3, respID.DeviceID, true)
+			if confB.AuthTag != vec.RespConfirmTag {
+				t.Errorf("confB tag mismatch: got %s, want %s", confB.AuthTag, vec.RespConfirmTag)
+			}
+			if err := VerifyTrustedAuthConfirmV3(confB, keysA.SessionMaster, DomainTrustedConfirmResp3, respID.DeviceID); err != nil {
+				t.Errorf("Verify confirm B failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestTrustedAuthV3_DowngradeRejection(t *testing.T) {
+	seedA := sha256.Sum256([]byte("seed-device-alice-downgrade"))
+	seedB := sha256.Sum256([]byte("seed-device-bob-downgrade"))
+	kPair := sha256.Sum256([]byte("k-pair-downgrade"))
+	privA := ed25519.NewKeyFromSeed(seedA[:])
+	privB := ed25519.NewKeyFromSeed(seedB[:])
+	idA, _ := NewDeviceIdentity(privA.Public().(ed25519.PublicKey), privA)
+	idB, _ := NewDeviceIdentity(privB.Public().(ed25519.PublicKey), privB)
+
+	now := time.Now().UTC()
+
+	// 1. Initiator sends sendbeam/2 to sendbeam/3 verifier -> ErrProtocolDowngradeForbidden
+	initV2, _ := NewTrustedAuthInit(idA, idB.DeviceID, "cred-ref", kPair[:], []string{"transfer.v1"}, nil, nil, now)
+	if _, _, err := VerifyTrustedAuthInitV3(initV2, kPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrProtocolDowngradeForbidden) {
+		t.Errorf("expected ErrProtocolDowngradeForbidden on v2 init, got %v", err)
+	}
+
+	// 1b. Initiator sends sendbeam/1 -> ErrProtocolDowngradeForbidden
+	initV1 := *initV2
+	initV1.ProtocolVersion = "sendbeam/1"
+	if _, _, err := VerifyTrustedAuthInitV3(&initV1, kPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrProtocolDowngradeForbidden) {
+		t.Errorf("expected ErrProtocolDowngradeForbidden on v1 init, got %v", err)
+	}
+
+	// 2. Responder sends sendbeam/2 response to sendbeam/3 initiator -> ErrProtocolDowngradeForbidden
+	_, pubEphemA, _ := GenerateX25519KeyPair()
+	initV3, _ := NewTrustedAuthInitV3(idA, idB.DeviceID, "cred-ref", kPair[:], []string{"transfer.v1"}, pubEphemA, make([]byte, 32), now, nil)
+
+	respV2 := &TrustedAuthResponse{
+		Type:              MsgTrustedAuthResponse,
+		ProtocolVersion:   "sendbeam/2",
+		Status:            "accepted",
+		ResponderDeviceID: idB.DeviceID,
+	}
+	if _, _, err := VerifyTrustedAuthResponseV3(respV2, initV3, kPair[:], idB.PublicKey, idA.DeviceID); !errors.Is(err, ErrProtocolDowngradeForbidden) {
+		t.Errorf("expected ErrProtocolDowngradeForbidden on v2 response, got %v", err)
+	}
+}
+
+func TestTrustedAuthV3_WeakEphemeralKeys(t *testing.T) {
+	priv, _, _ := GenerateX25519KeyPair()
+
+	// 1. Invalid key size
+	if _, err := ComputeX25519SharedSecret(priv, make([]byte, 31)); !errors.Is(err, ErrWeakEphemeralKey) {
+		t.Errorf("expected ErrWeakEphemeralKey on 31 bytes, got %v", err)
+	}
+	if _, err := ComputeX25519SharedSecret(priv, make([]byte, 33)); !errors.Is(err, ErrWeakEphemeralKey) {
+		t.Errorf("expected ErrWeakEphemeralKey on 33 bytes, got %v", err)
+	}
+
+	// 2. Low-order points (all zero or known weak points)
+	allZeros := make([]byte, 32)
+	if _, err := ComputeX25519SharedSecret(priv, allZeros); !errors.Is(err, ErrWeakEphemeralKey) {
+		t.Errorf("expected ErrWeakEphemeralKey on all zeros, got %v", err)
+	}
+
+	// Point 1 (order 1)
+	point1 := make([]byte, 32)
+	point1[0] = 1
+	if _, err := ComputeX25519SharedSecret(priv, point1); !errors.Is(err, ErrWeakEphemeralKey) {
+		t.Errorf("expected ErrWeakEphemeralKey on point 1, got %v", err)
+	}
+}
+
+func TestTrustedAuthV3_ReplayProtection(t *testing.T) {
+	cache := NewNonceReplayCache(5 * time.Minute)
+	now := time.Now().UTC()
+	devID := "sb-dev-alice123"
+	nonceHex := "aabbccdd00112233445566778899aabbccdd00112233445566778899aabbccdd"
+
+	// First time: succeeds
+	if err := cache.CheckAndRecord(devID, nonceHex, now); err != nil {
+		t.Fatalf("first check failed: %v", err)
+	}
+
+	// Immediate replay: ErrSessionReplayDetected
+	if err := cache.CheckAndRecord(devID, nonceHex, now.Add(10*time.Second)); !errors.Is(err, ErrSessionReplayDetected) {
+		t.Errorf("expected ErrSessionReplayDetected, got %v", err)
+	}
+
+	// Different device with same nonce: succeeds
+	if err := cache.CheckAndRecord("sb-dev-bob456", nonceHex, now); err != nil {
+		t.Errorf("different device check failed: %v", err)
+	}
+
+	// Same device with different nonce: succeeds
+	diffNonce := "112233445566778899aabbccdd00112233445566778899aabbccdd0011223344"
+	if err := cache.CheckAndRecord(devID, diffNonce, now); err != nil {
+		t.Errorf("different nonce check failed: %v", err)
+	}
+
+	// After TTL expires (6 minutes later): succeeds
+	if err := cache.CheckAndRecord(devID, nonceHex, now.Add(6*time.Minute)); err != nil {
+		t.Errorf("check after TTL failed: %v", err)
+	}
+}
+
+func TestTrustedAuthV3_AdversarialTampering(t *testing.T) {
+	seedA := sha256.Sum256([]byte("seed-device-alice-v3-adv"))
+	seedB := sha256.Sum256([]byte("seed-device-bob-v3-adv"))
+	kPair := sha256.Sum256([]byte("k-pair-v3-adv-shared"))
+	privA := ed25519.NewKeyFromSeed(seedA[:])
+	privB := ed25519.NewKeyFromSeed(seedB[:])
+	idA, _ := NewDeviceIdentity(privA.Public().(ed25519.PublicKey), privA)
+	idB, _ := NewDeviceIdentity(privB.Public().(ed25519.PublicKey), privB)
+
+	now := time.Now().UTC()
+	_, ephemPubA, _ := GenerateX25519KeyPair()
+	nonceA := make([]byte, 32)
+	nonceA[0] = 42
+
+	initMsg, _ := NewTrustedAuthInitV3(idA, idB.DeviceID, "cred-ref", kPair[:], []string{"transfer.v2", "mesh_sync"}, ephemPubA, nonceA, now, nil)
+
+	// 1. Clock skew > 5 minutes
+	expiredTime := now.Add(-10 * time.Minute)
+	if _, _, err := VerifyTrustedAuthInitV3(initMsg, kPair[:], idA.PublicKey, idB.DeviceID, expiredTime); !errors.Is(err, ErrTrustedTimestampSkew) {
+		t.Errorf("expected ErrTrustedTimestampSkew, got %v", err)
+	}
+
+	// 2. Peer mismatch
+	if _, _, err := VerifyTrustedAuthInitV3(initMsg, kPair[:], idA.PublicKey, "sb-dev-wrong", now); !errors.Is(err, ErrTrustedPeerMismatch) {
+		t.Errorf("expected ErrTrustedPeerMismatch on wrong responder, got %v", err)
+	}
+
+	// 3. Forged signature
+	tamperedSig := *initMsg
+	tamperedSig.Signature = hex.EncodeToString(make([]byte, 64))
+	if _, _, err := VerifyTrustedAuthInitV3(&tamperedSig, kPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrTrustedSignatureFailed) {
+		t.Errorf("expected ErrTrustedSignatureFailed, got %v", err)
+	}
+
+	// 4. Tampered AuthTag
+	tamperedMAC := *initMsg
+	tamperedMAC.AuthTag = hex.EncodeToString(make([]byte, 32))
+	if _, _, err := VerifyTrustedAuthInitV3(&tamperedMAC, kPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrTrustedMACTagFailed) {
+		t.Errorf("expected ErrTrustedMACTagFailed, got %v", err)
+	}
+
+	// 5. Capability tampering in init
+	tamperedCaps := *initMsg
+	tamperedCaps.Capabilities = []string{"transfer.v2", "malicious_cap"}
+	if _, _, err := VerifyTrustedAuthInitV3(&tamperedCaps, kPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrTrustedSignatureFailed) {
+		t.Errorf("expected ErrTrustedSignatureFailed on tampered capabilities, got %v", err)
+	}
+
+	// 6. Ephemeral pub tampering in init
+	tamperedEphem := *initMsg
+	_, anotherPub, _ := GenerateX25519KeyPair()
+	tamperedEphem.EphemeralPub = hex.EncodeToString(anotherPub)
+	if _, _, err := VerifyTrustedAuthInitV3(&tamperedEphem, kPair[:], idA.PublicKey, idB.DeviceID, now); !errors.Is(err, ErrTrustedSignatureFailed) {
+		t.Errorf("expected ErrTrustedSignatureFailed on tampered ephemeral pub, got %v", err)
+	}
+
+	// 7. Responder creates response, adversary tampers response capabilities
+	_, ephemPubB, _ := GenerateX25519KeyPair()
+	nonceB := make([]byte, 32)
+	nonceB[0] = 99
+	respMsg, _ := NewTrustedAuthResponseV3(idB, initMsg, kPair[:], []string{"transfer.v2", "mesh_sync"}, ephemPubB, nonceB, nil)
+
+	tamperedRespCaps := *respMsg
+	tamperedRespCaps.Capabilities = []string{"transfer.v2"}
+	if _, _, err := VerifyTrustedAuthResponseV3(&tamperedRespCaps, initMsg, kPair[:], idB.PublicKey, idA.DeviceID); !errors.Is(err, ErrTrustedSignatureFailed) {
+		t.Errorf("expected ErrTrustedSignatureFailed on tampered response capabilities, got %v", err)
+	}
+}
+


### PR DESCRIPTION
### Summary

- **Logical ID / milestone:** V19-PR02 (v1.9 Trusted Handoffs)
- **Goal:** Implement the approved `sendbeam/3` forward-secret authenticated key exchange in Go and TypeScript together, backed by canonical test vectors, mutual confirmation, downgrade prevention, and replay defenses (ADR 0010).
- **Dependencies:** PR #180 (merged at `3893766`)
- **Baseline SHA:** `3893766`

### Production Path Before / After
- **Before:** Trusted device session authentication established directional keys from static $k_{pair}$ HMAC derivation (`sendbeam/2`), without forward secrecy against long-term secret compromise.
- **After:**
  - Forward-secret hybrid key agreement using ephemeral X25519 Diffie-Hellman combined with $k_{pair}$ via standard HKDF-SHA256 Extract-and-Expand.
  - Ephemeral curve point validation rejects weak and all-zero points.
  - Full transcript binding commits initiator and responder ephemeral keys, nonces, device IDs, and negotiated capabilities.
  - Mutual confirmation via HMAC-SHA256 tags over derived `SessionMaster`.
  - Nonce replay cache with TTL window prevents replay attacks.
  - Strict protocol downgrade rejection fail-closed against `sendbeam/2` and `sendbeam/1`.

### Changed Areas
- `packages/wire/trusted_auth.go`: Protocol constants, X25519 helpers, challenge/transcript builders, HKDF derivation, message verifiers/constructors, and `NonceReplayCache`.
- `packages/wire/testdata/trusted-session-v3-vectors.json`: Canonical test vectors for cross-language validation.
- `packages/wire/trusted_auth_test.go`: Vector validation suite and adversarial test cases (downgrade, weak points, replay, tampering).
- `packages/protocol/src/trusted-auth.ts`: TypeScript implementation with identical constants, helpers, constructors, and verifiers.
- `packages/protocol/src/trusted-auth-v3.test.ts`: TypeScript test vector and security property suite.
- `packages/engine/trust/trusted_session.go`: Upgraded `TrustedSessionCoordinator` to `sendbeam/3` with ephemeral key generation, replay cache checking, and memory zeroization.

### Explicit Exclusions
- Does not modify one-time transfer flow (`sendbeam/1` SPAKE2-EE).
- Does not change trust store persistence schemas or credential formats.