### PR TITLE
feat(trust): unified pairing identity persistence and protected credential adapters

### DIFF
--- a/apps/cli/cmd/sendbeam/trust_config.go
+++ b/apps/cli/cmd/sendbeam/trust_config.go
@@ -2,14 +2,11 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/sendbeam/engine/trust"
 	"github.com/sendbeam/wire"
@@ -22,78 +19,12 @@ const (
 	secretsFileName     = "secrets.json"
 )
 
-// FileSecretResolver manages persistent storage of 32-byte k_pair secrets with 0600 permissions.
-type FileSecretResolver struct {
-	path string
-	mu   sync.RWMutex
-	data map[string]string // deviceID -> hex(k_pair)
-}
+// FileSecretResolver is an alias to trust.FileSecretStore for headless CLI environments.
+type FileSecretResolver = trust.FileSecretStore
 
-// NewFileSecretResolver initializes the secret resolver from disk.
+// NewFileSecretResolver initializes the secret store from disk.
 func NewFileSecretResolver(path string) (*FileSecretResolver, error) {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return nil, fmt.Errorf("create secrets dir: %w", err)
-	}
-
-	r := &FileSecretResolver{
-		path: path,
-		data: make(map[string]string),
-	}
-
-	content, err := os.ReadFile(path)
-	if err == nil && len(content) > 0 {
-		_ = json.Unmarshal(content, &r.data)
-	}
-	return r, nil
-}
-
-// SetSecret stores a raw 32-byte secret for a device and flushes atomically to disk.
-func (r *FileSecretResolver) SetSecret(deviceID string, secret []byte) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.data[deviceID] = hex.EncodeToString(secret)
-	data, err := json.MarshalIndent(r.data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp := fmt.Sprintf("%s.tmp.%d", r.path, os.Getpid())
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, r.path)
-}
-
-// DeleteSecret removes a device secret from storage.
-func (r *FileSecretResolver) DeleteSecret(deviceID string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	delete(r.data, deviceID)
-	data, err := json.MarshalIndent(r.data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp := fmt.Sprintf("%s.tmp.%d", r.path, os.Getpid())
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, r.path)
-}
-
-// ResolvePairSecret implements trust.SecretResolver.
-func (r *FileSecretResolver) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	hexStr, ok := r.data[deviceID]
-	if !ok || len(hexStr) == 0 {
-		return nil, errors.New("pair secret not found")
-	}
-	return hex.DecodeString(hexStr)
+	return trust.NewFileSecretStore(path)
 }
 
 // CLIEnvironment provides shared access to local device identity, trust store, and secret store.

--- a/apps/cli/cmd/sendbeam/unpair.go
+++ b/apps/cli/cmd/sendbeam/unpair.go
@@ -76,7 +76,10 @@ func executeUnpair(args []string, stdin io.Reader, stdout, stderr io.Writer) int
 			_, _ = fmt.Fprintf(stderr, "error deleting device from trust store: %v\n", err)
 			return 1
 		}
-		_ = env.Secrets.DeleteSecret(dev.DeviceID)
+		if err := env.Secrets.DeleteSecret(dev.DeviceID); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error deleting device secret: %v\n", err)
+			return 1
+		}
 	} else {
 		if err := env.TrustStore.RevokeDevice(ctx, dev.DeviceID); err != nil {
 			_, _ = fmt.Fprintf(stderr, "error revoking device in trust store: %v\n", err)

--- a/apps/desktop/internal/config/secret_store.go
+++ b/apps/desktop/internal/config/secret_store.go
@@ -2,421 +2,56 @@
 package config
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/hex"
-	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"sync"
+	"github.com/sendbeam/engine/trust"
 )
+
+// SecretStore aliases trust.SecretStore for desktop credential storage.
+type SecretStore = trust.SecretStore
 
 var (
 	// ErrSecretStoreUnavailable is returned when attempting to persist secrets on a
 	// system where OS-protected credential storage is unavailable. Silent downgrade
 	// to plaintext persistence is strictly refused.
-	ErrSecretStoreUnavailable = errors.New("os protected secret storage is unavailable; saving raw secrets in plaintext is refused")
+	ErrSecretStoreUnavailable = trust.ErrSecretStoreUnavailable
 	// ErrSecretNotFound is returned when the requested secret key does not exist.
-	ErrSecretNotFound = errors.New("secret not found")
+	ErrSecretNotFound = trust.ErrSecretNotFound
 )
 
-// SecretStore is the interface for OS-protected persistent secret storage.
-// Implementations MUST NOT store raw secrets in plaintext JSON, localStorage,
-// or diagnostic logs.
-type SecretStore interface {
-	Get(key string) ([]byte, error)
-	Set(key string, secret []byte) error
-	Delete(key string) error
-	IsAvailable() bool
-	BackendName() string
-}
+// UnavailableSecretStore aliases trust.UnavailableSecretStore.
+type UnavailableSecretStore = trust.UnavailableSecretStore
 
-// UnavailableSecretStore is used when no reliable OS-protected secret store is
-// available. It fails closed and explicitly informs the caller rather than
-// silently storing secrets insecurely.
-type UnavailableSecretStore struct {
-	reason string
-}
+// MemorySecretStore aliases trust.MemorySecretStore.
+type MemorySecretStore = trust.MemorySecretStore
 
-// NewUnavailableSecretStore creates an UnavailableSecretStore.
-func NewUnavailableSecretStore(reason string) *UnavailableSecretStore {
-	if reason == "" {
-		reason = "no protected credential facility detected"
-	}
-	return &UnavailableSecretStore{reason: reason}
-}
+// DarwinKeychainSecretStore aliases trust.DarwinKeychainSecretStore.
+type DarwinKeychainSecretStore = trust.DarwinKeychainSecretStore
 
-// Get always returns an error indicating secret storage is unavailable.
-func (u *UnavailableSecretStore) Get(_ string) ([]byte, error) {
-	return nil, fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
-}
+// LinuxSecretServiceStore aliases trust.LinuxSecretServiceStore.
+type LinuxSecretServiceStore = trust.LinuxSecretServiceStore
 
-// Set always returns an error indicating secret storage is unavailable.
-func (u *UnavailableSecretStore) Set(_ string, _ []byte) error {
-	return fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
-}
+// WindowsDPAPIStore aliases trust.WindowsDPAPIStore.
+type WindowsDPAPIStore = trust.WindowsDPAPIStore
 
-// Delete is an idempotent no-op on unavailable stores.
-func (u *UnavailableSecretStore) Delete(_ string) error {
-	return nil
-}
+// NewUnavailableSecretStore aliases trust.NewUnavailableSecretStore.
+var NewUnavailableSecretStore = trust.NewUnavailableSecretStore
 
-// IsAvailable reports false for unavailable stores.
-func (u *UnavailableSecretStore) IsAvailable() bool {
-	return false
-}
+// NewMemorySecretStore aliases trust.NewMemorySecretStore.
+var NewMemorySecretStore = trust.NewMemorySecretStore
 
-// BackendName returns a descriptive unavailable status.
-func (u *UnavailableSecretStore) BackendName() string {
-	return "unavailable (" + u.reason + ")"
-}
+// NewDarwinKeychainSecretStore aliases trust.NewDarwinKeychainSecretStore.
+var NewDarwinKeychainSecretStore = trust.NewDarwinKeychainSecretStore
 
-// MemorySecretStore is an in-memory thread-safe secret store for tests or ephemeral runs.
-type MemorySecretStore struct {
-	mu      sync.RWMutex
-	secrets map[string][]byte
-}
+// NewLinuxSecretServiceStore aliases trust.NewLinuxSecretServiceStore.
+var NewLinuxSecretServiceStore = trust.NewLinuxSecretServiceStore
 
-// NewMemorySecretStore creates a new MemorySecretStore.
-func NewMemorySecretStore() *MemorySecretStore {
-	return &MemorySecretStore{secrets: make(map[string][]byte)}
-}
+// NewWindowsDPAPIStore aliases trust.NewWindowsDPAPIStore.
+var NewWindowsDPAPIStore = trust.NewWindowsDPAPIStore
 
-// Get retrieves a stored secret by key.
-func (m *MemorySecretStore) Get(key string) ([]byte, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	val, ok := m.secrets[key]
-	if !ok {
-		return nil, ErrSecretNotFound
-	}
-	cpy := make([]byte, len(val))
-	copy(cpy, val)
-	return cpy, nil
-}
+// DefaultSecretStore aliases trust.DefaultSecretStore.
+var DefaultSecretStore = trust.DefaultSecretStore
 
-// Set stores a secret by key.
-func (m *MemorySecretStore) Set(key string, secret []byte) error {
-	if key == "" {
-		return errors.New("secret key cannot be empty")
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	cpy := make([]byte, len(secret))
-	copy(cpy, secret)
-	m.secrets[key] = cpy
-	return nil
-}
+// EncodeDPAPICiphertextBlob aliases trust.EncodeDPAPICiphertextBlob.
+var EncodeDPAPICiphertextBlob = trust.EncodeDPAPICiphertextBlob
 
-// Delete removes a stored secret by key.
-func (m *MemorySecretStore) Delete(key string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.secrets, key)
-	return nil
-}
-
-// IsAvailable reports true for in-memory stores.
-func (m *MemorySecretStore) IsAvailable() bool {
-	return true
-}
-
-// BackendName returns "memory".
-func (m *MemorySecretStore) BackendName() string {
-	return "memory"
-}
-
-// DarwinKeychainSecretStore uses the macOS Security CLI (/usr/bin/security)
-// to manage secrets in the macOS Keychain.
-type DarwinKeychainSecretStore struct {
-	serviceName string
-}
-
-// NewDarwinKeychainSecretStore creates a Darwin keychain secret store.
-func NewDarwinKeychainSecretStore(serviceName string) *DarwinKeychainSecretStore {
-	if serviceName == "" {
-		serviceName = "SendBeam"
-	}
-	return &DarwinKeychainSecretStore{serviceName: serviceName}
-}
-
-// Get retrieves a generic password from the macOS Keychain.
-func (d *DarwinKeychainSecretStore) Get(key string) ([]byte, error) {
-	if !d.IsAvailable() {
-		return nil, ErrSecretStoreUnavailable
-	}
-	cmd := exec.Command("/usr/bin/security", "find-generic-password", "-s", d.serviceName, "-a", key, "-w")
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, ErrSecretNotFound
-	}
-	trimmed := strings.TrimRight(string(out), "\r\n")
-	return []byte(trimmed), nil
-}
-
-// Set saves or updates a generic password in the macOS Keychain.
-func (d *DarwinKeychainSecretStore) Set(key string, secret []byte) error {
-	if !d.IsAvailable() {
-		return ErrSecretStoreUnavailable
-	}
-	if key == "" {
-		return errors.New("secret key cannot be empty")
-	}
-	cmd := exec.Command("/usr/bin/security", "add-generic-password", "-U", "-s", d.serviceName, "-a", key, "-w", string(secret))
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("keychain set error: %s (%w)", strings.TrimSpace(string(out)), err)
-	}
-	return nil
-}
-
-// Delete removes a generic password from the macOS Keychain.
-func (d *DarwinKeychainSecretStore) Delete(key string) error {
-	if !d.IsAvailable() {
-		return nil
-	}
-	cmd := exec.Command("/usr/bin/security", "delete-generic-password", "-s", d.serviceName, "-a", key)
-	_ = cmd.Run()
-	return nil
-}
-
-// IsAvailable reports true on Darwin when security CLI is in PATH.
-func (d *DarwinKeychainSecretStore) IsAvailable() bool {
-	if runtime.GOOS != "darwin" {
-		return false
-	}
-	_, err := exec.LookPath("security")
-	return err == nil
-}
-
-// BackendName returns "macos-keychain".
-func (d *DarwinKeychainSecretStore) BackendName() string {
-	return "macos-keychain"
-}
-
-// LinuxSecretServiceStore manages credentials via the FreeDesktop Secret Service
-// standard using the `secret-tool` CLI utility.
-type LinuxSecretServiceStore struct {
-	serviceName string
-}
-
-// NewLinuxSecretServiceStore creates a Linux Secret Service store.
-func NewLinuxSecretServiceStore(serviceName string) *LinuxSecretServiceStore {
-	if serviceName == "" {
-		serviceName = "SendBeam"
-	}
-	return &LinuxSecretServiceStore{serviceName: serviceName}
-}
-
-// Get retrieves a secret from Secret Service.
-func (l *LinuxSecretServiceStore) Get(key string) ([]byte, error) {
-	if !l.IsAvailable() {
-		return nil, ErrSecretStoreUnavailable
-	}
-	cmd := exec.Command("secret-tool", "lookup", "service", l.serviceName, "key", key)
-	out, err := cmd.Output()
-	if err != nil || len(out) == 0 {
-		return nil, ErrSecretNotFound
-	}
-	return out, nil
-}
-
-// Set saves a secret into Secret Service.
-func (l *LinuxSecretServiceStore) Set(key string, secret []byte) error {
-	if !l.IsAvailable() {
-		return ErrSecretStoreUnavailable
-	}
-	if key == "" {
-		return errors.New("secret key cannot be empty")
-	}
-	cmd := exec.Command("secret-tool", "store", "--label="+l.serviceName, "service", l.serviceName, "key", key)
-	cmd.Stdin = bytes.NewReader(secret)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("secret-tool set error: %s (%w)", strings.TrimSpace(string(out)), err)
-	}
-	return nil
-}
-
-// Delete clears a secret from Secret Service.
-func (l *LinuxSecretServiceStore) Delete(key string) error {
-	if !l.IsAvailable() {
-		return nil
-	}
-	cmd := exec.Command("secret-tool", "clear", "service", l.serviceName, "key", key)
-	_ = cmd.Run()
-	return nil
-}
-
-// IsAvailable reports true if running on Linux and secret-tool is in PATH.
-func (l *LinuxSecretServiceStore) IsAvailable() bool {
-	if runtime.GOOS != "linux" {
-		return false
-	}
-	_, err := exec.LookPath("secret-tool")
-	return err == nil
-}
-
-// BackendName returns "linux-secret-service".
-func (l *LinuxSecretServiceStore) BackendName() string {
-	return "linux-secret-service"
-}
-
-// WindowsDPAPIStore uses Windows Data Protection API (DPAPI) to encrypt secrets
-// at rest scoped to the current user.
-type WindowsDPAPIStore struct {
-	storageDir string
-}
-
-// NewWindowsDPAPIStore creates a Windows DPAPI store. If storageDir is empty,
-// it uses %APPDATA%\sendbeam\secrets.
-func NewWindowsDPAPIStore(storageDir string) *WindowsDPAPIStore {
-	if storageDir == "" {
-		if configDir, err := os.UserConfigDir(); err == nil {
-			storageDir = filepath.Join(configDir, AppDirName, "secrets")
-		} else {
-			storageDir = filepath.Join(os.TempDir(), "sendbeam_secrets")
-		}
-	}
-	return &WindowsDPAPIStore{storageDir: storageDir}
-}
-
-func (w *WindowsDPAPIStore) keyPath(key string) string {
-	h := sha256.Sum256([]byte(key))
-	return filepath.Join(w.storageDir, hex.EncodeToString(h[:])+".dpapi")
-}
-
-// EncodeDPAPICiphertextBlob formats DPAPI protected ciphertext into a Base64 string for disk storage.
-func EncodeDPAPICiphertextBlob(rawCiphertext []byte) string {
-	return base64.StdEncoding.EncodeToString(rawCiphertext)
-}
-
-// DecodeDPAPICiphertextBlob parses a Base64 string from disk into raw DPAPI ciphertext bytes.
-func DecodeDPAPICiphertextBlob(b64Ciphertext string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(strings.TrimSpace(b64Ciphertext))
-}
-
-// Get reads and decrypts a DPAPI-protected secret.
-func (w *WindowsDPAPIStore) Get(key string) ([]byte, error) {
-	if !w.IsAvailable() {
-		return nil, ErrSecretStoreUnavailable
-	}
-	p := w.keyPath(key)
-	encData, err := os.ReadFile(p)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, ErrSecretNotFound
-		}
-		return nil, fmt.Errorf("read dpapi file: %w", err)
-	}
-
-	// Validate ciphertext format
-	if _, err := DecodeDPAPICiphertextBlob(string(encData)); err != nil {
-		return nil, fmt.Errorf("corrupt dpapi ciphertext file: %w", err)
-	}
-
-	// Unprotect via PowerShell ProtectedData reading Base64 ciphertext from stdin
-	// and outputting Base64 decrypted plaintext to stdout (no secrets in command line args).
-	script := `$in = [Console]::In.ReadToEnd().Trim(); if ([string]::IsNullOrEmpty($in)) { exit 1 }; $enc = [Convert]::FromBase64String($in); $raw = [System.Security.Cryptography.ProtectedData]::Unprotect($enc, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser); [Console]::Out.Write([Convert]::ToBase64String($raw))`
-	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
-	cmd.Stdin = strings.NewReader(strings.TrimSpace(string(encData)))
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("dpapi unprotect error: %w", err)
-	}
-	dec64 := strings.TrimSpace(string(out))
-	return base64.StdEncoding.DecodeString(dec64)
-}
-
-// Set encrypts and writes a DPAPI-protected secret.
-func (w *WindowsDPAPIStore) Set(key string, secret []byte) error {
-	if !w.IsAvailable() {
-		return ErrSecretStoreUnavailable
-	}
-	if key == "" {
-		return errors.New("secret key cannot be empty")
-	}
-	if err := os.MkdirAll(w.storageDir, 0o700); err != nil {
-		return fmt.Errorf("create secrets dir: %w", err)
-	}
-
-	// Protect via PowerShell ProtectedData reading Base64 plaintext from stdin
-	// and outputting Base64 ciphertext to stdout (no secrets in command line args).
-	script := `$in = [Console]::In.ReadToEnd().Trim(); if ([string]::IsNullOrEmpty($in)) { exit 1 }; $raw = [Convert]::FromBase64String($in); $enc = [System.Security.Cryptography.ProtectedData]::Protect($raw, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser); [Console]::Out.Write([Convert]::ToBase64String($enc))`
-	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
-	cmd.Stdin = strings.NewReader(base64.StdEncoding.EncodeToString(secret))
-	out, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("dpapi protect error: %w", err)
-	}
-
-	b64Ciphertext := strings.TrimSpace(string(out))
-	if _, err := DecodeDPAPICiphertextBlob(b64Ciphertext); err != nil {
-		return fmt.Errorf("invalid dpapi output ciphertext: %w", err)
-	}
-
-	p := w.keyPath(key)
-	tmp := p + ".tmp"
-	if err := os.WriteFile(tmp, []byte(b64Ciphertext), 0o600); err != nil {
-		return fmt.Errorf("write dpapi file: %w", err)
-	}
-	if err := os.Rename(tmp, p); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("rename dpapi file: %w", err)
-	}
-	return nil
-}
-
-// Delete removes a DPAPI-protected secret.
-func (w *WindowsDPAPIStore) Delete(key string) error {
-	if !w.IsAvailable() {
-		return nil
-	}
-	_ = os.Remove(w.keyPath(key))
-	return nil
-}
-
-// IsAvailable reports true when running on Windows and PowerShell is in PATH.
-func (w *WindowsDPAPIStore) IsAvailable() bool {
-	if runtime.GOOS != "windows" {
-		return false
-	}
-	_, err := exec.LookPath("powershell")
-	return err == nil
-}
-
-// BackendName returns "windows-dpapi".
-func (w *WindowsDPAPIStore) BackendName() string {
-	return "windows-dpapi"
-}
-
-// DefaultSecretStore resolves the appropriate OS-protected secret store
-// for the current platform. If none is available, it returns an UnavailableSecretStore
-// to fail closed rather than falling back to plaintext storage.
-func DefaultSecretStore() SecretStore {
-	switch runtime.GOOS {
-	case "darwin":
-		store := NewDarwinKeychainSecretStore("SendBeam")
-		if store.IsAvailable() {
-			return store
-		}
-		return NewUnavailableSecretStore("macOS Keychain unavailable")
-	case "windows":
-		store := NewWindowsDPAPIStore("")
-		if store.IsAvailable() {
-			return store
-		}
-		return NewUnavailableSecretStore("Windows DPAPI unavailable")
-	case "linux":
-		store := NewLinuxSecretServiceStore("SendBeam")
-		if store.IsAvailable() {
-			return store
-		}
-		return NewUnavailableSecretStore("Secret Service / secret-tool not available in Linux desktop session")
-	default:
-		return NewUnavailableSecretStore("native OS credential helper not configured for " + runtime.GOOS)
-	}
-}
+// DecodeDPAPICiphertextBlob aliases trust.DecodeDPAPICiphertextBlob.
+var DecodeDPAPICiphertextBlob = trust.DecodeDPAPICiphertextBlob

--- a/apps/desktop/internal/engine/device_service.go
+++ b/apps/desktop/internal/engine/device_service.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -45,84 +44,13 @@ type discoveredPeerInfo struct {
 	lastSeen time.Time
 }
 
-// desktopSecretResolver manages encrypted/file-backed persistent pair secrets with 0600 permissions.
-type desktopSecretResolver struct {
-	path string
-	mu   sync.RWMutex
-	data map[string]string // deviceID -> hex(k_pair)
-}
-
-func newDesktopSecretResolver(path string) (*desktopSecretResolver, error) {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return nil, fmt.Errorf("create secrets dir: %w", err)
-	}
-
-	r := &desktopSecretResolver{
-		path: path,
-		data: make(map[string]string),
-	}
-
-	content, err := os.ReadFile(path)
-	if err == nil && len(content) > 0 {
-		_ = json.Unmarshal(content, &r.data)
-	}
-	return r, nil
-}
-
-func (r *desktopSecretResolver) setSecret(deviceID string, secret []byte) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.data[deviceID] = hex.EncodeToString(secret)
-	data, err := json.MarshalIndent(r.data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp := fmt.Sprintf("%s.tmp.%d", r.path, os.Getpid())
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, r.path)
-}
-
-func (r *desktopSecretResolver) deleteSecret(deviceID string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	delete(r.data, deviceID)
-	data, err := json.MarshalIndent(r.data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp := fmt.Sprintf("%s.tmp.%d", r.path, os.Getpid())
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, r.path)
-}
-
-// ResolvePairSecret implements trust.SecretResolver for desktop sessions.
-func (r *desktopSecretResolver) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	hexStr, ok := r.data[deviceID]
-	if !ok || len(hexStr) == 0 {
-		return nil, errors.New("pair secret not found")
-	}
-	return hex.DecodeString(hexStr)
-}
-
 // DeviceService manages trusted device operations and background presence for the desktop UI.
 type DeviceService struct {
 	mu           sync.RWMutex
 	emit         func(name string, data any)
 	idMgr        *trust.IdentityManager
 	store        trust.Store
-	secrets      *desktopSecretResolver
+	secrets      trust.CredentialStore
 	coordinator  *trust.PairingCoordinator
 	lanDiscovery *discovery.LanDiscoveryService
 	activePeers  map[string]discoveredPeerInfo // deviceID -> info
@@ -130,8 +58,14 @@ type DeviceService struct {
 	cancel       context.CancelFunc
 }
 
-// NewDeviceService initializes the desktop device service.
+// NewDeviceService initializes the desktop device service with the default OS-protected credential store.
 func NewDeviceService(emit func(name string, data any), customConfigDir string) (*DeviceService, error) {
+	return NewDeviceServiceWithCredentials(emit, customConfigDir, nil)
+}
+
+// NewDeviceServiceWithCredentials initializes the desktop device service with a custom CredentialStore.
+// If customSecrets is nil, it uses trust.NewProtectedCredentialStore(config.DefaultSecretStore()).
+func NewDeviceServiceWithCredentials(emit func(name string, data any), customConfigDir string, customSecrets trust.CredentialStore) (*DeviceService, error) {
 	dir := customConfigDir
 	if dir == "" {
 		userConfig, err := os.UserConfigDir()
@@ -157,13 +91,21 @@ func NewDeviceService(emit func(name string, data any), customConfigDir string) 
 		return nil, fmt.Errorf("init trust store: %w", err)
 	}
 
-	secretsPath := filepath.Join(dir, "secrets.json")
-	secrets, err := newDesktopSecretResolver(secretsPath)
-	if err != nil {
-		return nil, fmt.Errorf("init secret store: %w", err)
+	secrets := customSecrets
+	if secrets == nil {
+		secStore := config.DefaultSecretStore()
+		secrets = trust.NewProtectedCredentialStore(secStore)
 	}
 
-	coordinator := trust.NewPairingCoordinator(idMgr, trustStore)
+	// Migrate legacy plaintext secrets.json if present
+	legacySecretsPath := filepath.Join(dir, "secrets.json")
+	if _, err := os.Stat(legacySecretsPath); err == nil {
+		if err := trust.MigrateLegacyFileSecrets(legacySecretsPath, secrets); err != nil {
+			return nil, fmt.Errorf("migrate legacy secrets: %w", err)
+		}
+	}
+
+	coordinator := trust.NewPairingCoordinatorWithCredentials(idMgr, trustStore, secrets)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -309,7 +251,9 @@ func (s *DeviceService) UnpairDevice(deviceID string, purge bool) error {
 		if err := s.store.UnpairDevice(ctx, deviceID); err != nil {
 			return err
 		}
-		_ = s.secrets.deleteSecret(deviceID)
+		if err := s.secrets.DeletePairSecret(ctx, deviceID); err != nil && !errors.Is(err, trust.ErrSecretStoreUnavailable) {
+			return fmt.Errorf("delete pair secret: %w", err)
+		}
 	} else {
 		if err := s.store.RevokeDevice(ctx, deviceID); err != nil {
 			return err
@@ -374,10 +318,6 @@ func (s *DeviceService) PairDevice(serverURL, inviteCode, customLabel string, au
 	pairResult, err := s.coordinator.AcceptPairing(ctx, transport, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("pairing ceremony failed: %w", err)
-	}
-
-	if err := s.secrets.setSecret(pairResult.PeerRecord.DeviceID, pairResult.KPair); err != nil {
-		return nil, fmt.Errorf("persist secret: %w", err)
 	}
 
 	s.notifyDevicesChanged()

--- a/apps/desktop/internal/engine/device_service_test.go
+++ b/apps/desktop/internal/engine/device_service_test.go
@@ -5,10 +5,12 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/sendbeam/engine/trust"
 	"github.com/sendbeam/wire"
 )
 
@@ -124,3 +126,50 @@ func TestDeviceService_LifecycleAndPolicy(t *testing.T) {
 		t.Errorf("expected emitted event %q, got %q", DeviceEventName, emittedEvent)
 	}
 }
+
+func TestDeviceService_LegacyMigrationAndCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write legacy secrets.json
+	devID := "dev-legacy-123"
+	secret := make([]byte, 32)
+	for i := range secret {
+		secret[i] = byte(i + 1)
+	}
+	legacyJSON := `{"dev-legacy-123":"` + hex.EncodeToString(secret) + `"}`
+	legacyPath := filepath.Join(tmpDir, "secrets.json")
+	if err := os.WriteFile(legacyPath, []byte(legacyJSON), 0600); err != nil {
+		t.Fatalf("write legacy secrets: %v", err)
+	}
+
+	memStore := trust.NewMemoryCredentialStore()
+	svc, err := NewDeviceServiceWithCredentials(nil, tmpDir, memStore)
+	if err != nil {
+		t.Fatalf("NewDeviceServiceWithCredentials failed: %v", err)
+	}
+	defer svc.Close()
+
+	// Verify legacy secrets was migrated into memStore
+	ctx := context.Background()
+	migrated, err := memStore.ResolvePairSecret(ctx, devID, "")
+	if err != nil {
+		t.Fatalf("expected secret to be migrated: %v", err)
+	}
+	if hex.EncodeToString(migrated) != hex.EncodeToString(secret) {
+		t.Fatalf("migrated secret mismatch")
+	}
+
+	// Verify original legacy file is removed or renamed
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("expected legacy secrets.json to no longer exist, err: %v", err)
+	}
+
+	// Unpair with purge should remove from memStore
+	if err := svc.UnpairDevice(devID, true); err != nil {
+		t.Fatalf("UnpairDevice purge failed: %v", err)
+	}
+	if _, err := memStore.ResolvePairSecret(ctx, devID, ""); err == nil {
+		t.Errorf("expected secret to be deleted from credential store after purge")
+	}
+}
+

--- a/docs/state-storage.md
+++ b/docs/state-storage.md
@@ -40,21 +40,50 @@ This document provides a comprehensive mapping of where SendBeam stores persiste
 - **Directory:** `<DataDir>/senders` (or `~/.sendbeam/senders`)
 - **Purpose:** Stores local path key mappings to transfer IDs and resume secret envelopes so that re-sending the same files can resume an interrupted session without retransmitting already-committed blocks.
 
-### E. Native Credentials & Keychains
+### E. Native Credentials & Keychains (v1.9 Trusted Handoffs)
 
-- **macOS:** Stored in login keychain with service name `com.sendbeam.desktop`.
-- **Windows:** Encrypted with current user SID using Windows DPAPI.
-- **Linux:** Stored in default Secret Service keyring (`org.freedesktop.Secret.Generic`).
+SendBeam manages persistent device cryptographic identities and pairwise credentials (`k_pair`) with strict platform security boundaries:
+
+- **Device Identity (`identity.key`):**
+  - Stored at `<ConfigDir>/identity.key` with strict `0600` file permissions (`0700` directory).
+  - Contains the Ed25519 private key seed.
+  - **Fail-closed invariant:** If `identity.key` is zero-length, unparseable, or corrupted, SendBeam strictly refuses to overwrite or regenerate the identity. The error is raised immediately to prevent silent identity loss and unauthorized rotation.
+
+- **Trust Store (`trust.json`):**
+  - Stored at `<ConfigDir>/trust.json` (version 2 schema).
+  - Maintains paired peer device records, public keys, display labels, capabilities, trust relationships (`contact`, `cluster_member`, `cluster_owner`), cluster IDs, and auto-accept transfer policies.
+  - Migrated atomically and non-destructively from version 1 schema on startup.
+
+- **OS-Protected Credential Stores (Desktop):**
+  - **macOS:** Stored in macOS Keychain via `/usr/bin/security` under service `SendBeam` with account `sendbeam:pair:<deviceID>`.
+  - **Windows:** Encrypted at rest scoped to the logged-in user via Windows DPAPI (`ProtectedData.Protect` with `CurrentUser` scope) in `<ConfigDir>/secrets/<hash>.dpapi`.
+  - **Linux Desktop:** Stored in the freedesktop Secret Service keyring via `secret-tool` under service `SendBeam` with attribute `key=sendbeam:pair:<deviceID>`.
+  - **No Plaintext Fallback:** The desktop runtime strictly refuses silent downgrade to plaintext files if the OS protected credential store is unavailable; operations fail closed with `ErrSecretStoreUnavailable`.
+  - **Crash-Safe Legacy Migration:** On startup, if a legacy plaintext `secrets.json` file is detected, `MigrateLegacyFileSecrets` imports each secret into the protected store, verifies read-back integrity, zeroizes the plaintext file on disk, and renames it to `secrets.json.migrated`.
+
+- **Headless / CLI Credential Storage (`FileSecretStore`):**
+  - Headless environments without an active GUI session or OS secret service store credentials in `<ConfigDir>/secrets.json` with strict `0600` permissions.
+  - **Explicit Limits:** Storage is restricted solely by POSIX file permissions to the executing user account. It does not provide hardware security module (HSM), TPM, or OS keychain protection. Users requiring hardware protection must run within an OS desktop session.
 
 ---
 
 ## 3. Web Client Storage Architecture
 
-| Web Storage Primitive                 | Purpose                                                                                   | Lifetime                                                                                      |
-| :------------------------------------ | :---------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
-| **IndexedDB** (`sendbeam_journals`)   | Tracks transfer progress checkpoints, transfer lease IDs, and resume credentials.         | Persistent across page reloads and browser restarts until transfer completes or is discarded. |
-| **Origin Private File System (OPFS)** | Streams and stores incoming partial file chunks (`*.part`) with block-granular integrity. | Retained during interrupted transfers; finalized atomically to user download when complete.   |
-| **SessionStorage / LocalStorage**     | Ephemeral UI states and theme preferences.                                                | Standard browser storage lifetime.                                                            |
+| Web Storage Primitive                 | Purpose                                                                                   | Lifetime                                                                                        |
+| :------------------------------------ | :---------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
+| **IndexedDB** (`sendbeam_identity`)   | Stores local browser Ed25519 identity seed and public key.                                | Persistent until cleared. Corrupt seeds fail closed and strictly refuse overwrite/regeneration. |
+| **IndexedDB** (`sendbeam_trust`)      | Stores paired peer device records, labels, trust relationships, and auto-accept policy.   | Persistent across sessions. Validated on load.                                                  |
+| **IndexedDB** (`sendbeam_secrets`)    | Stores paired device pairwise secrets (`k_pair`).                                         | Persistent across sessions. Corrupt secrets fail closed and refuse parse.                       |
+| **IndexedDB** (`sendbeam_journals`)   | Tracks transfer progress checkpoints, transfer lease IDs, and resume credentials.         | Persistent across page reloads and browser restarts until transfer completes or is discarded.   |
+| **Origin Private File System (OPFS)** | Streams and stores incoming partial file chunks (`*.part`) with block-granular integrity. | Retained during interrupted transfers; finalized atomically to user download when complete.     |
+| **SessionStorage / LocalStorage**     | Ephemeral UI states and theme preferences.                                                | Standard browser storage lifetime.                                                              |
+
+### Explicit Browser Security Boundaries & Limits
+
+- **Origin Boundary:** All browser keys, trust records, and pair secrets are restricted to the origin (`omnitrix.space` or `localhost`).
+- **No Hardware Security Module / TPM:** In-browser cryptographic keys are maintained within browser IndexedDB storage and protected by browser sandbox boundaries, not OS Keychains or TPMs.
+- **Private Browsing / Incognito:** Identities and pairings established in Private/Incognito windows are ephemeral and cleared on window close.
+- **Fail-Closed on Corrupt Data:** If a stored identity seed in IndexedDB is malformed or invalid hex, the browser runtime strictly throws a descriptive error and refuses to generate a new key over the corrupt entry.
 
 ---
 

--- a/packages/engine/trust/credential_store.go
+++ b/packages/engine/trust/credential_store.go
@@ -1,0 +1,382 @@
+// Package trust manages local device cryptographic identity, paired device trust records, and protected credentials.
+package trust
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var (
+	// ErrCorruptSecretStore indicates corrupt or unparseable secret storage on disk.
+	ErrCorruptSecretStore = errors.New("corrupt secret store; refusing to overwrite or parse")
+	// ErrInvalidPairSecret indicates an invalid pair secret length or parameter.
+	ErrInvalidPairSecret = errors.New("invalid pair secret")
+)
+
+// CredentialStore defines persistent storage, resolution, and deletion of pairwise secrets (k_pair).
+type CredentialStore interface {
+	SecretResolver
+	SetPairSecret(ctx context.Context, deviceID, pairCredRef string, secret []byte) error
+	DeletePairSecret(ctx context.Context, deviceID string) error
+	BackendName() string
+	IsProtected() bool
+}
+
+// ProtectedCredentialStore wraps an OS-protected SecretStore to persist pair credentials.
+// Invariant: it strictly refuses silent downgrade to plaintext storage.
+type ProtectedCredentialStore struct {
+	secretStore SecretStore
+}
+
+// NewProtectedCredentialStore creates a ProtectedCredentialStore wrapping an OS-protected SecretStore.
+func NewProtectedCredentialStore(secretStore SecretStore) *ProtectedCredentialStore {
+	if secretStore == nil {
+		secretStore = DefaultSecretStore()
+	}
+	return &ProtectedCredentialStore{secretStore: secretStore}
+}
+
+func (p *ProtectedCredentialStore) pairKey(deviceID string) string {
+	return "sendbeam:pair:" + strings.TrimSpace(deviceID)
+}
+
+// ResolvePairSecret implements SecretResolver and CredentialStore.
+func (p *ProtectedCredentialStore) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
+	if !p.secretStore.IsAvailable() {
+		return nil, ErrSecretStoreUnavailable
+	}
+	key := p.pairKey(deviceID)
+	secret, err := p.secretStore.Get(key)
+	if err != nil {
+		if errors.Is(err, ErrSecretNotFound) {
+			return nil, ErrSecretNotFound
+		}
+		return nil, err
+	}
+	return secret, nil
+}
+
+// SetPairSecret stores a 32-byte pairwise secret into the OS-protected store.
+func (p *ProtectedCredentialStore) SetPairSecret(_ context.Context, deviceID, _ string, secret []byte) error {
+	if !p.secretStore.IsAvailable() {
+		return ErrSecretStoreUnavailable
+	}
+	if strings.TrimSpace(deviceID) == "" {
+		return fmt.Errorf("%w: device ID cannot be empty", ErrInvalidPairSecret)
+	}
+	if len(secret) != 32 {
+		return fmt.Errorf("%w: pair secret must be exactly 32 bytes, got %d", ErrInvalidPairSecret, len(secret))
+	}
+	key := p.pairKey(deviceID)
+	return p.secretStore.Set(key, secret)
+}
+
+// DeletePairSecret removes a pairwise secret from the OS-protected store.
+func (p *ProtectedCredentialStore) DeletePairSecret(_ context.Context, deviceID string) error {
+	if !p.secretStore.IsAvailable() {
+		return ErrSecretStoreUnavailable
+	}
+	key := p.pairKey(deviceID)
+	return p.secretStore.Delete(key)
+}
+
+// BackendName returns the name of the underlying OS protected backend.
+func (p *ProtectedCredentialStore) BackendName() string {
+	return p.secretStore.BackendName()
+}
+
+// IsProtected reports whether the underlying store is an active OS-protected backend.
+func (p *ProtectedCredentialStore) IsProtected() bool {
+	return p.secretStore.BackendName() != "memory" && p.secretStore.IsAvailable()
+}
+
+// FileSecretStore manages persistent storage of pair secrets on disk with 0600 permissions
+// for environments where OS credential facilities are unavailable (e.g. headless CLI).
+//
+// HEADLESS LIMITATION: FileSecretStore is restricted by POSIX file permissions to the local
+// user account; it does not provide hardware enclave or OS-keychain backed encryption at rest.
+type FileSecretStore struct {
+	path string
+	mu   sync.RWMutex
+	data map[string]string // deviceID -> hex(k_pair)
+}
+
+// NewFileSecretStore initializes a FileSecretStore from disk.
+func NewFileSecretStore(path string) (*FileSecretStore, error) {
+	cleanPath := filepath.Clean(path)
+	dir := filepath.Dir(cleanPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create secrets directory: %w", err)
+	}
+
+	store := &FileSecretStore{
+		path: cleanPath,
+		data: make(map[string]string),
+	}
+
+	content, err := os.ReadFile(cleanPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return store, nil
+		}
+		return nil, fmt.Errorf("read secrets file: %w", err)
+	}
+
+	if len(content) == 0 {
+		return nil, fmt.Errorf("%w: secrets file exists but is empty (0 bytes)", ErrCorruptSecretStore)
+	}
+
+	if err := json.Unmarshal(content, &store.data); err != nil {
+		return nil, fmt.Errorf("%w: parse secrets file JSON: %v", ErrCorruptSecretStore, err)
+	}
+
+	for k, hexStr := range store.data {
+		raw, decErr := hex.DecodeString(hexStr)
+		if decErr != nil || len(raw) != 32 {
+			return nil, fmt.Errorf("%w: invalid hex secret entry for device %q", ErrCorruptSecretStore, k)
+		}
+	}
+
+	return store, nil
+}
+
+// SetPairSecret persists a pairwise secret to disk atomically with 0600 permissions.
+func (f *FileSecretStore) SetPairSecret(_ context.Context, deviceID, _ string, secret []byte) error {
+	return f.SetSecret(deviceID, secret)
+}
+
+// SetSecret persists a pairwise secret by device ID.
+func (f *FileSecretStore) SetSecret(deviceID string, secret []byte) error {
+	if strings.TrimSpace(deviceID) == "" {
+		return fmt.Errorf("%w: device ID cannot be empty", ErrInvalidPairSecret)
+	}
+	if len(secret) != 32 {
+		return fmt.Errorf("%w: pair secret must be exactly 32 bytes, got %d", ErrInvalidPairSecret, len(secret))
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.data[deviceID] = hex.EncodeToString(secret)
+	return f.saveLocked()
+}
+
+// ResolvePairSecret resolves a stored pairwise secret by device ID.
+func (f *FileSecretStore) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	hexStr, ok := f.data[deviceID]
+	if !ok || len(hexStr) == 0 {
+		return nil, ErrSecretNotFound
+	}
+	raw, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decode pair secret: %v", ErrCorruptSecretStore, err)
+	}
+	return raw, nil
+}
+
+// DeletePairSecret removes a pairwise secret from storage and writes back atomically.
+func (f *FileSecretStore) DeletePairSecret(_ context.Context, deviceID string) error {
+	return f.DeleteSecret(deviceID)
+}
+
+// DeleteSecret removes a device secret from storage.
+func (f *FileSecretStore) DeleteSecret(deviceID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if _, ok := f.data[deviceID]; !ok {
+		return nil
+	}
+	delete(f.data, deviceID)
+	return f.saveLocked()
+}
+
+func (f *FileSecretStore) saveLocked() error {
+	data, err := json.MarshalIndent(f.data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal secrets: %w", err)
+	}
+
+	dir := filepath.Dir(f.path)
+	tmpFile, err := os.CreateTemp(dir, "secrets-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp secrets file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := tmpFile.Chmod(0600); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("chmod temp secrets file: %w", err)
+	}
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write temp secrets file: %w", err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("sync temp secrets file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close temp secrets file: %w", err)
+	}
+
+	// Verify temporary file before rename
+	verifyContent, err := os.ReadFile(tmpName)
+	if err != nil {
+		return fmt.Errorf("verify temp secrets file: %w", err)
+	}
+	var verifyMap map[string]string
+	if err := json.Unmarshal(verifyContent, &verifyMap); err != nil {
+		return fmt.Errorf("verify unmarshal temp secrets: %w", err)
+	}
+
+	if err := os.Rename(tmpName, f.path); err != nil {
+		return fmt.Errorf("atomic rename secrets file: %w", err)
+	}
+
+	return nil
+}
+
+// BackendName returns "file (headless)".
+func (f *FileSecretStore) BackendName() string {
+	return "file (headless)"
+}
+
+// IsProtected reports false for file-backed storage (headless mode).
+func (f *FileSecretStore) IsProtected() bool {
+	return false
+}
+
+// MemoryCredentialStore provides an in-memory CredentialStore for testing and transient sessions.
+type MemoryCredentialStore struct {
+	mu      sync.RWMutex
+	secrets map[string][]byte
+}
+
+// NewMemoryCredentialStore creates a new MemoryCredentialStore.
+func NewMemoryCredentialStore() *MemoryCredentialStore {
+	return &MemoryCredentialStore{
+		secrets: make(map[string][]byte),
+	}
+}
+
+// ResolvePairSecret resolves a secret from memory.
+func (m *MemoryCredentialStore) ResolvePairSecret(_ context.Context, deviceID, _ string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	val, ok := m.secrets[deviceID]
+	if !ok {
+		return nil, ErrSecretNotFound
+	}
+	cpy := make([]byte, len(val))
+	copy(cpy, val)
+	return cpy, nil
+}
+
+// SetPairSecret stores a 32-byte pairwise secret into memory.
+func (m *MemoryCredentialStore) SetPairSecret(_ context.Context, deviceID, _ string, secret []byte) error {
+	if strings.TrimSpace(deviceID) == "" {
+		return fmt.Errorf("%w: device ID cannot be empty", ErrInvalidPairSecret)
+	}
+	if len(secret) != 32 {
+		return fmt.Errorf("%w: pair secret must be exactly 32 bytes, got %d", ErrInvalidPairSecret, len(secret))
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cpy := make([]byte, len(secret))
+	copy(cpy, secret)
+	m.secrets[deviceID] = cpy
+	return nil
+}
+
+// DeletePairSecret removes a pairwise secret from memory.
+func (m *MemoryCredentialStore) DeletePairSecret(_ context.Context, deviceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.secrets, deviceID)
+	return nil
+}
+
+// BackendName returns "memory".
+func (m *MemoryCredentialStore) BackendName() string {
+	return "memory"
+}
+
+// IsProtected reports false for in-memory stores.
+func (m *MemoryCredentialStore) IsProtected() bool {
+	return false
+}
+
+// MigrateLegacyFileSecrets migrates secrets from a legacy plaintext secrets.json file
+// into a CredentialStore using a crash-safe write-verify-switch workflow.
+func MigrateLegacyFileSecrets(secretsPath string, target CredentialStore) error {
+	if secretsPath == "" || target == nil {
+		return nil
+	}
+
+	content, err := os.ReadFile(secretsPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read legacy secrets file: %w", err)
+	}
+
+	if len(content) == 0 {
+		_ = os.Remove(secretsPath)
+		return nil
+	}
+
+	var legacy map[string]string
+	if err := json.Unmarshal(content, &legacy); err != nil {
+		return fmt.Errorf("%w: legacy secrets JSON: %v", ErrCorruptSecretStore, err)
+	}
+
+	ctx := context.Background()
+
+	// Write each secret to the target store
+	for devID, hexSecret := range legacy {
+		raw, decErr := hex.DecodeString(hexSecret)
+		if decErr != nil || len(raw) != 32 {
+			return fmt.Errorf("%w: invalid hex secret for %q in legacy file", ErrCorruptSecretStore, devID)
+		}
+
+		if err := target.SetPairSecret(ctx, devID, "", raw); err != nil {
+			return fmt.Errorf("migrate secret for %q: %w", devID, err)
+		}
+
+		// Verify written secret
+		verified, err := target.ResolvePairSecret(ctx, devID, "")
+		if err != nil || !bytes.Equal(verified, raw) {
+			return fmt.Errorf("verify migrated secret for %q failed: %w", devID, err)
+		}
+	}
+
+	// Zeroize original file on disk before removing/renaming
+	zeros := make([]byte, len(content))
+	_ = os.WriteFile(secretsPath, zeros, 0600)
+
+	// Rename to .migrated or remove
+	migratedPath := secretsPath + ".migrated"
+	if err := os.Rename(secretsPath, migratedPath); err != nil {
+		_ = os.Remove(secretsPath)
+	}
+
+	return nil
+}

--- a/packages/engine/trust/credential_store_test.go
+++ b/packages/engine/trust/credential_store_test.go
@@ -1,0 +1,306 @@
+package trust
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+func TestProtectedCredentialStore_WithMemorySecretStore(t *testing.T) {
+	ctx := context.Background()
+	memSec := NewMemorySecretStore()
+	credStore := NewProtectedCredentialStore(memSec)
+
+	if credStore.BackendName() != "memory" {
+		t.Errorf("BackendName = %q, want 'memory'", credStore.BackendName())
+	}
+	if credStore.IsProtected() {
+		t.Errorf("IsProtected = true for memory store, want false")
+	}
+
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+	devID := "sb-dev-1111222233334444555566667777888811112222333344445555666677778888"
+
+	// 1. Initial resolve returns not found
+	_, err := credStore.ResolvePairSecret(ctx, devID, "ref-1")
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("ResolvePairSecret before set = %v, want ErrSecretNotFound", err)
+	}
+
+	// 2. SetPairSecret
+	if err := credStore.SetPairSecret(ctx, devID, "ref-1", secret); err != nil {
+		t.Fatalf("SetPairSecret: %v", err)
+	}
+
+	// 3. ResolvePairSecret
+	got, err := credStore.ResolvePairSecret(ctx, devID, "ref-1")
+	if err != nil {
+		t.Fatalf("ResolvePairSecret: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Fatalf("ResolvePairSecret got %x, want %x", got, secret)
+	}
+
+	// 4. Invalid secret size must fail
+	badSecret := []byte("too-short")
+	if err := credStore.SetPairSecret(ctx, devID, "ref-1", badSecret); err == nil {
+		t.Fatalf("expected error for short secret, got nil")
+	}
+
+	// 5. Empty device ID must fail
+	if err := credStore.SetPairSecret(ctx, "", "ref-1", secret); err == nil {
+		t.Fatalf("expected error for empty device ID, got nil")
+	}
+
+	// 6. DeletePairSecret
+	if err := credStore.DeletePairSecret(ctx, devID); err != nil {
+		t.Fatalf("DeletePairSecret: %v", err)
+	}
+	_, err = credStore.ResolvePairSecret(ctx, devID, "ref-1")
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("ResolvePairSecret after delete = %v, want ErrSecretNotFound", err)
+	}
+}
+
+func TestProtectedCredentialStore_UnavailableFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	unavail := NewUnavailableSecretStore("test simulated headless no-keychain")
+	credStore := NewProtectedCredentialStore(unavail)
+
+	secret := make([]byte, 32)
+	devID := "sb-dev-1111222233334444555566667777888811112222333344445555666677778888"
+
+	err := credStore.SetPairSecret(ctx, devID, "ref-1", secret)
+	if !errors.Is(err, ErrSecretStoreUnavailable) {
+		t.Fatalf("SetPairSecret on unavailable = %v, want ErrSecretStoreUnavailable", err)
+	}
+
+	_, err = credStore.ResolvePairSecret(ctx, devID, "ref-1")
+	if !errors.Is(err, ErrSecretStoreUnavailable) {
+		t.Fatalf("ResolvePairSecret on unavailable = %v, want ErrSecretStoreUnavailable", err)
+	}
+
+	err = credStore.DeletePairSecret(ctx, devID)
+	if !errors.Is(err, ErrSecretStoreUnavailable) {
+		t.Fatalf("DeletePairSecret on unavailable = %v, want ErrSecretStoreUnavailable", err)
+	}
+}
+
+func TestFileSecretStore_LifecycleAndCorruptHandling(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "secrets.json")
+
+	store, err := NewFileSecretStore(filePath)
+	if err != nil {
+		t.Fatalf("NewFileSecretStore: %v", err)
+	}
+
+	if store.IsProtected() {
+		t.Errorf("FileSecretStore IsProtected must be false (explicit headless limit)")
+	}
+	if store.BackendName() != "file (headless)" {
+		t.Errorf("BackendName = %q, want 'file (headless)'", store.BackendName())
+	}
+
+	secretAlice := make([]byte, 32)
+	secretAlice[0] = 0xaa
+	devAlice := "sb-dev-alice111122223333444455556666777788881111222233334444555566667777"
+
+	if err := store.SetPairSecret(ctx, devAlice, "ref-alice", secretAlice); err != nil {
+		t.Fatalf("SetPairSecret: %v", err)
+	}
+
+	// Verify file mode 0600
+	fi, err := os.Stat(filePath)
+	if err != nil || fi.Mode().Perm() != 0600 {
+		t.Fatalf("file permissions = %o, want 0600 (err=%v)", fi.Mode().Perm(), err)
+	}
+
+	// Reopen from disk
+	reloaded, err := NewFileSecretStore(filePath)
+	if err != nil {
+		t.Fatalf("reopen NewFileSecretStore: %v", err)
+	}
+	got, err := reloaded.ResolvePairSecret(ctx, devAlice, "")
+	if err != nil || !bytes.Equal(got, secretAlice) {
+		t.Fatalf("reloaded secret mismatch: got %x, want %x (err=%v)", got, secretAlice, err)
+	}
+
+	// Delete
+	if err := reloaded.DeletePairSecret(ctx, devAlice); err != nil {
+		t.Fatalf("DeletePairSecret: %v", err)
+	}
+	_, err = reloaded.ResolvePairSecret(ctx, devAlice, "")
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("expected ErrSecretNotFound after delete, got %v", err)
+	}
+
+	// Corrupt file handling: 0 bytes
+	emptyFile := filepath.Join(tmpDir, "empty_secrets.json")
+	_ = os.WriteFile(emptyFile, []byte{}, 0600)
+	_, err = NewFileSecretStore(emptyFile)
+	if !errors.Is(err, ErrCorruptSecretStore) {
+		t.Fatalf("expected ErrCorruptSecretStore on 0-byte file, got %v", err)
+	}
+
+	// Corrupt file handling: invalid JSON
+	badJSONFile := filepath.Join(tmpDir, "bad_json_secrets.json")
+	_ = os.WriteFile(badJSONFile, []byte("{ corrupt json ..."), 0600)
+	_, err = NewFileSecretStore(badJSONFile)
+	if !errors.Is(err, ErrCorruptSecretStore) {
+		t.Fatalf("expected ErrCorruptSecretStore on bad JSON, got %v", err)
+	}
+
+	// Corrupt file handling: invalid secret length
+	badSecretFile := filepath.Join(tmpDir, "bad_secret_secrets.json")
+	badData := map[string]string{devAlice: "aabbcc"} // 3 bytes instead of 32
+	rawBad, _ := json.Marshal(badData)
+	_ = os.WriteFile(badSecretFile, rawBad, 0600)
+	_, err = NewFileSecretStore(badSecretFile)
+	if !errors.Is(err, ErrCorruptSecretStore) {
+		t.Fatalf("expected ErrCorruptSecretStore on short secret, got %v", err)
+	}
+}
+
+func TestMigrateLegacyFileSecrets(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	legacyFile := filepath.Join(tmpDir, "legacy_secrets.json")
+
+	secret1 := make([]byte, 32)
+	secret1[0] = 0x11
+	secret2 := make([]byte, 32)
+	secret2[0] = 0x22
+
+	dev1 := "sb-dev-1111111111111111111111111111111111111111111111111111111111111111"
+	dev2 := "sb-dev-2222222222222222222222222222222222222222222222222222222222222222"
+
+	legacyData := map[string]string{
+		dev1: hex.EncodeToString(secret1),
+		dev2: hex.EncodeToString(secret2),
+	}
+	rawJSON, _ := json.MarshalIndent(legacyData, "", "  ")
+	if err := os.WriteFile(legacyFile, rawJSON, 0600); err != nil {
+		t.Fatalf("write legacy file: %v", err)
+	}
+
+	memSec := NewMemorySecretStore()
+	target := NewProtectedCredentialStore(memSec)
+
+	// Execute migration
+	if err := MigrateLegacyFileSecrets(legacyFile, target); err != nil {
+		t.Fatalf("MigrateLegacyFileSecrets failed: %v", err)
+	}
+
+	// Verify secrets in target
+	got1, err := target.ResolvePairSecret(ctx, dev1, "")
+	if err != nil || !bytes.Equal(got1, secret1) {
+		t.Fatalf("target dev1 mismatch: got %x, want %x", got1, secret1)
+	}
+	got2, err := target.ResolvePairSecret(ctx, dev2, "")
+	if err != nil || !bytes.Equal(got2, secret2) {
+		t.Fatalf("target dev2 mismatch: got %x, want %x", got2, secret2)
+	}
+
+	// Verify legacy plaintext file was removed or replaced
+	if _, err := os.Stat(legacyFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected legacy plaintext file to be removed")
+	}
+
+	// Verify .migrated file exists and was zeroized
+	migratedFile := legacyFile + ".migrated"
+	migratedContent, err := os.ReadFile(migratedFile)
+	if err == nil {
+		for _, b := range migratedContent {
+			if b != 0 {
+				t.Fatalf("migrated file contains non-zero bytes; zeroization failed")
+			}
+		}
+	}
+}
+
+func TestFileTrustStore_V1MigrationAndCorruptHandling(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	trustPath := filepath.Join(tmpDir, "trust.json")
+
+	id, _ := wire.GenerateDeviceIdentity()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// 1. Create a synthetic v1 trust database (missing relationship & cluster_id, version: 1)
+	v1Payload := map[string]any{
+		"version":    1,
+		"updated_at": now.Format(time.RFC3339),
+		"devices": []map[string]any{
+			{
+				"device_id":           id.DeviceID,
+				"public_key":          id.PublicKeyHex(),
+				"local_label":         "Old Laptop",
+				"pair_credential_ref": "cred-old",
+				"capabilities":        []string{wire.CapTransferV1},
+				"first_seen_at":       now.Format(time.RFC3339),
+				"last_seen_at":        now.Format(time.RFC3339),
+				"revoked":             false,
+				"policy": map[string]any{
+					"auto_accept": false,
+				},
+			},
+		},
+	}
+	v1Bytes, _ := json.MarshalIndent(v1Payload, "", "  ")
+	if err := os.WriteFile(trustPath, v1Bytes, 0600); err != nil {
+		t.Fatalf("write v1 trust file: %v", err)
+	}
+
+	// 2. Load with NewFileTrustStore
+	store, err := NewFileTrustStore(trustPath)
+	if err != nil {
+		t.Fatalf("NewFileTrustStore on v1 file: %v", err)
+	}
+
+	// 3. Verify record was migrated with RelationshipContact
+	dev, err := store.GetDevice(ctx, id.DeviceID)
+	if err != nil {
+		t.Fatalf("GetDevice: %v", err)
+	}
+	if dev.Relationship != wire.RelationshipContact {
+		t.Errorf("Relationship = %q, want %q", dev.Relationship, wire.RelationshipContact)
+	}
+
+	// 4. Verify file on disk now has version 2
+	data, _ := os.ReadFile(trustPath)
+	var verifyPayload struct {
+		Version int `json:"version"`
+	}
+	_ = json.Unmarshal(data, &verifyPayload)
+	if verifyPayload.Version != 2 {
+		t.Errorf("migrated file version = %d, want 2", verifyPayload.Version)
+	}
+
+	// 5. Corrupt file handling: 0 bytes
+	emptyTrustPath := filepath.Join(tmpDir, "empty_trust.json")
+	_ = os.WriteFile(emptyTrustPath, []byte{}, 0600)
+	_, err = NewFileTrustStore(emptyTrustPath)
+	if !errors.Is(err, ErrCorruptTrustStore) {
+		t.Fatalf("expected ErrCorruptTrustStore for 0-byte file, got %v", err)
+	}
+
+	// 6. Corrupt file handling: invalid JSON
+	badTrustPath := filepath.Join(tmpDir, "bad_trust.json")
+	_ = os.WriteFile(badTrustPath, []byte("{ bad json ..."), 0600)
+	_, err = NewFileTrustStore(badTrustPath)
+	if !errors.Is(err, ErrCorruptTrustStore) {
+		t.Fatalf("expected ErrCorruptTrustStore for bad JSON, got %v", err)
+	}
+}

--- a/packages/engine/trust/identity_manager.go
+++ b/packages/engine/trust/identity_manager.go
@@ -17,6 +17,10 @@ import (
 var (
 	// ErrIdentityNotFound is returned when identity key does not exist.
 	ErrIdentityNotFound = errors.New("device identity not found")
+
+	// ErrCorruptIdentityFile is returned when identity key file exists but is corrupted.
+	// Invariant: identities must NEVER be silently regenerated or overwritten after corrupt reads.
+	ErrCorruptIdentityFile = errors.New("corrupt device identity key file; refusing to overwrite or regenerate")
 )
 
 // IdentityManager manages local device cryptographic identity and seed persistence.
@@ -68,7 +72,7 @@ func (m *IdentityManager) GetOrCreateIdentity() (*wire.DeviceIdentity, error) {
 		return nil, fmt.Errorf("load device identity: %w", err)
 	}
 
-	// Generate fresh identity
+	// Generate fresh identity only if no file exists
 	id, err = wire.GenerateDeviceIdentityFromReader(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("generate fresh device identity: %w", err)
@@ -110,10 +114,13 @@ func (m *IdentityManager) CurrentIdentity() *wire.DeviceIdentity {
 func (m *IdentityManager) loadLocked() (*wire.DeviceIdentity, error) {
 	data, err := os.ReadFile(m.keyFilePath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrIdentityNotFound
+		}
 		return nil, err
 	}
 	if len(data) == 0 {
-		return nil, ErrIdentityNotFound
+		return nil, fmt.Errorf("%w: key file exists but is empty (0 bytes)", ErrCorruptIdentityFile)
 	}
 
 	// Seed is stored as raw 32 bytes or 64-character hex
@@ -125,7 +132,7 @@ func (m *IdentityManager) loadLocked() (*wire.DeviceIdentity, error) {
 		if err == nil && len(decoded) == ed25519.SeedSize {
 			seed = decoded
 		} else {
-			return nil, errors.New("corrupt device identity key file")
+			return nil, fmt.Errorf("%w: invalid seed data format or length (%d bytes)", ErrCorruptIdentityFile, len(data))
 		}
 	}
 

--- a/packages/engine/trust/identity_manager_test.go
+++ b/packages/engine/trust/identity_manager_test.go
@@ -80,3 +80,48 @@ func TestIdentityManagerGenerationAndPersistence(t *testing.T) {
 		t.Errorf("persisted key after rotation mismatch")
 	}
 }
+
+func TestIdentityManagerCorruptFileRefusesRegeneration(t *testing.T) {
+	// 1. Empty file (0 bytes) must fail closed and NOT regenerate
+	tmpDir := t.TempDir()
+	emptyKeyPath := filepath.Join(tmpDir, "empty_identity.key")
+	if err := os.WriteFile(emptyKeyPath, []byte{}, 0600); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+
+	mgrEmpty, err := NewIdentityManager(emptyKeyPath)
+	if err != nil {
+		t.Fatalf("NewIdentityManager: %v", err)
+	}
+	_, err = mgrEmpty.GetOrCreateIdentity()
+	if err == nil {
+		t.Fatalf("GetOrCreateIdentity on empty file succeeded, want ErrCorruptIdentityFile")
+	}
+	// Verify file was NOT overwritten with a fresh identity
+	fi, _ := os.Stat(emptyKeyPath)
+	if fi.Size() != 0 {
+		t.Errorf("expected empty file to remain untouched (0 bytes), got size %d", fi.Size())
+	}
+
+	// 2. Corrupt data must fail closed and NOT regenerate
+	corruptKeyPath := filepath.Join(tmpDir, "corrupt_identity.key")
+	corruptData := []byte("this-is-not-a-valid-ed25519-seed-and-must-fail-closed")
+	if err := os.WriteFile(corruptKeyPath, corruptData, 0600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+
+	mgrCorrupt, err := NewIdentityManager(corruptKeyPath)
+	if err != nil {
+		t.Fatalf("NewIdentityManager: %v", err)
+	}
+	_, err = mgrCorrupt.GetOrCreateIdentity()
+	if err == nil {
+		t.Fatalf("GetOrCreateIdentity on corrupt file succeeded, want ErrCorruptIdentityFile")
+	}
+
+	// Verify file was NOT overwritten
+	content, _ := os.ReadFile(corruptKeyPath)
+	if !bytes.Equal(content, corruptData) {
+		t.Errorf("corrupt file was modified or overwritten")
+	}
+}

--- a/packages/engine/trust/pairing_coordinator.go
+++ b/packages/engine/trust/pairing_coordinator.go
@@ -46,8 +46,9 @@ type PairingResult struct {
 
 // PairingCoordinator drives the multi-step pairing ceremony on both initiator and responder sides.
 type PairingCoordinator struct {
-	idMgr *IdentityManager
-	store Store
+	idMgr     *IdentityManager
+	store     Store
+	credStore CredentialStore
 }
 
 // NewPairingCoordinator creates a new PairingCoordinator.
@@ -55,6 +56,15 @@ func NewPairingCoordinator(idMgr *IdentityManager, store Store) *PairingCoordina
 	return &PairingCoordinator{
 		idMgr: idMgr,
 		store: store,
+	}
+}
+
+// NewPairingCoordinatorWithCredentials creates a PairingCoordinator that atomically manages both device trust and credentials.
+func NewPairingCoordinatorWithCredentials(idMgr *IdentityManager, store Store, credStore CredentialStore) *PairingCoordinator {
+	return &PairingCoordinator{
+		idMgr:     idMgr,
+		store:     store,
+		credStore: credStore,
 	}
 }
 
@@ -164,6 +174,7 @@ func (p *PairingCoordinator) InitiatePairing(ctx context.Context, transport Pair
 		PublicKey:         hex.EncodeToString(peerPub),
 		LocalLabel:        resp.DeviceName,
 		PairCredentialRef: credRef,
+		Relationship:      wire.RelationshipContact,
 		Capabilities:      resp.Capabilities,
 		FirstSeenAt:       now,
 		LastSeenAt:        now,
@@ -172,7 +183,16 @@ func (p *PairingCoordinator) InitiatePairing(ctx context.Context, transport Pair
 		Policy:            policy,
 	}
 
+	if p.credStore != nil {
+		if err := p.credStore.SetPairSecret(ctx, record.DeviceID, credRef, kPair); err != nil {
+			return nil, fmt.Errorf("persist pair credential: %w", err)
+		}
+	}
+
 	if err := p.store.AddOrUpdateDevice(ctx, record); err != nil {
+		if p.credStore != nil {
+			_ = p.credStore.DeletePairSecret(ctx, record.DeviceID)
+		}
 		return nil, fmt.Errorf("save trusted device: %w", err)
 	}
 
@@ -289,6 +309,7 @@ func (p *PairingCoordinator) AcceptPairing(ctx context.Context, transport Pairin
 		PublicKey:         hex.EncodeToString(peerPub),
 		LocalLabel:        req.DeviceName,
 		PairCredentialRef: credRef,
+		Relationship:      wire.RelationshipContact,
 		Capabilities:      req.Capabilities,
 		FirstSeenAt:       now,
 		LastSeenAt:        now,
@@ -297,7 +318,16 @@ func (p *PairingCoordinator) AcceptPairing(ctx context.Context, transport Pairin
 		Policy:            policy,
 	}
 
+	if p.credStore != nil {
+		if err := p.credStore.SetPairSecret(ctx, record.DeviceID, credRef, kPair); err != nil {
+			return nil, fmt.Errorf("persist pair credential: %w", err)
+		}
+	}
+
 	if err := p.store.AddOrUpdateDevice(ctx, record); err != nil {
+		if p.credStore != nil {
+			_ = p.credStore.DeletePairSecret(ctx, record.DeviceID)
+		}
 		return nil, fmt.Errorf("save trusted device: %w", err)
 	}
 

--- a/packages/engine/trust/secret_store.go
+++ b/packages/engine/trust/secret_store.go
@@ -1,0 +1,427 @@
+// Package trust manages local device cryptographic identity, paired device trust records, and protected credentials.
+package trust
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+const (
+	// DefaultAppDirName is the standard SendBeam application subdirectory in user config.
+	DefaultAppDirName = "sendbeam"
+)
+
+var (
+	// ErrSecretStoreUnavailable is returned when attempting to persist secrets on a
+	// system where OS-protected credential storage is unavailable. Silent downgrade
+	// to plaintext persistence is strictly refused.
+	ErrSecretStoreUnavailable = errors.New("os protected secret storage is unavailable; saving raw secrets in plaintext is refused")
+	// ErrSecretNotFound is returned when the requested secret key does not exist.
+	ErrSecretNotFound = errors.New("secret not found")
+)
+
+// SecretStore is the interface for OS-protected persistent secret storage.
+// Implementations MUST NOT store raw secrets in plaintext JSON, localStorage,
+// or diagnostic logs.
+type SecretStore interface {
+	Get(key string) ([]byte, error)
+	Set(key string, secret []byte) error
+	Delete(key string) error
+	IsAvailable() bool
+	BackendName() string
+}
+
+// UnavailableSecretStore is used when no reliable OS-protected secret store is
+// available. It fails closed and explicitly informs the caller rather than
+// silently storing secrets insecurely.
+type UnavailableSecretStore struct {
+	reason string
+}
+
+// NewUnavailableSecretStore creates an UnavailableSecretStore.
+func NewUnavailableSecretStore(reason string) *UnavailableSecretStore {
+	if reason == "" {
+		reason = "no protected credential facility detected"
+	}
+	return &UnavailableSecretStore{reason: reason}
+}
+
+// Get always returns an error indicating secret storage is unavailable.
+func (u *UnavailableSecretStore) Get(_ string) ([]byte, error) {
+	return nil, fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
+}
+
+// Set always returns an error indicating secret storage is unavailable.
+func (u *UnavailableSecretStore) Set(_ string, _ []byte) error {
+	return fmt.Errorf("%w: %s", ErrSecretStoreUnavailable, u.reason)
+}
+
+// Delete is an idempotent no-op on unavailable stores.
+func (u *UnavailableSecretStore) Delete(_ string) error {
+	return nil
+}
+
+// IsAvailable reports false for unavailable stores.
+func (u *UnavailableSecretStore) IsAvailable() bool {
+	return false
+}
+
+// BackendName returns a descriptive unavailable status.
+func (u *UnavailableSecretStore) BackendName() string {
+	return "unavailable (" + u.reason + ")"
+}
+
+// MemorySecretStore is an in-memory thread-safe secret store for tests or ephemeral runs.
+type MemorySecretStore struct {
+	mu      sync.RWMutex
+	secrets map[string][]byte
+}
+
+// NewMemorySecretStore creates a new MemorySecretStore.
+func NewMemorySecretStore() *MemorySecretStore {
+	return &MemorySecretStore{secrets: make(map[string][]byte)}
+}
+
+// Get retrieves a stored secret by key.
+func (m *MemorySecretStore) Get(key string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	val, ok := m.secrets[key]
+	if !ok {
+		return nil, ErrSecretNotFound
+	}
+	cpy := make([]byte, len(val))
+	copy(cpy, val)
+	return cpy, nil
+}
+
+// Set stores a secret by key.
+func (m *MemorySecretStore) Set(key string, secret []byte) error {
+	if key == "" {
+		return errors.New("secret key cannot be empty")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cpy := make([]byte, len(secret))
+	copy(cpy, secret)
+	m.secrets[key] = cpy
+	return nil
+}
+
+// Delete removes a stored secret by key.
+func (m *MemorySecretStore) Delete(key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.secrets, key)
+	return nil
+}
+
+// IsAvailable reports true for in-memory stores.
+func (m *MemorySecretStore) IsAvailable() bool {
+	return true
+}
+
+// BackendName returns "memory".
+func (m *MemorySecretStore) BackendName() string {
+	return "memory"
+}
+
+// DarwinKeychainSecretStore uses the macOS Security CLI (/usr/bin/security)
+// to manage secrets in the macOS Keychain.
+type DarwinKeychainSecretStore struct {
+	serviceName string
+}
+
+// NewDarwinKeychainSecretStore creates a Darwin keychain secret store.
+func NewDarwinKeychainSecretStore(serviceName string) *DarwinKeychainSecretStore {
+	if serviceName == "" {
+		serviceName = "SendBeam"
+	}
+	return &DarwinKeychainSecretStore{serviceName: serviceName}
+}
+
+// Get retrieves a generic password from the macOS Keychain.
+func (d *DarwinKeychainSecretStore) Get(key string) ([]byte, error) {
+	if !d.IsAvailable() {
+		return nil, ErrSecretStoreUnavailable
+	}
+	cmd := exec.Command("/usr/bin/security", "find-generic-password", "-s", d.serviceName, "-a", key, "-w")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, ErrSecretNotFound
+	}
+	trimmed := strings.TrimRight(string(out), "\r\n")
+	return []byte(trimmed), nil
+}
+
+// Set saves or updates a generic password in the macOS Keychain.
+func (d *DarwinKeychainSecretStore) Set(key string, secret []byte) error {
+	if !d.IsAvailable() {
+		return ErrSecretStoreUnavailable
+	}
+	if key == "" {
+		return errors.New("secret key cannot be empty")
+	}
+	cmd := exec.Command("/usr/bin/security", "add-generic-password", "-U", "-s", d.serviceName, "-a", key, "-w", string(secret))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("keychain set error: %s (%w)", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// Delete removes a generic password from the macOS Keychain.
+func (d *DarwinKeychainSecretStore) Delete(key string) error {
+	if !d.IsAvailable() {
+		return nil
+	}
+	cmd := exec.Command("/usr/bin/security", "delete-generic-password", "-s", d.serviceName, "-a", key)
+	_ = cmd.Run()
+	return nil
+}
+
+// IsAvailable reports true on Darwin when security CLI is in PATH.
+func (d *DarwinKeychainSecretStore) IsAvailable() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	_, err := exec.LookPath("security")
+	return err == nil
+}
+
+// BackendName returns "macos-keychain".
+func (d *DarwinKeychainSecretStore) BackendName() string {
+	return "macos-keychain"
+}
+
+// LinuxSecretServiceStore manages credentials via the FreeDesktop Secret Service
+// standard using the `secret-tool` CLI utility.
+type LinuxSecretServiceStore struct {
+	serviceName string
+}
+
+// NewLinuxSecretServiceStore creates a Linux Secret Service store.
+func NewLinuxSecretServiceStore(serviceName string) *LinuxSecretServiceStore {
+	if serviceName == "" {
+		serviceName = "SendBeam"
+	}
+	return &LinuxSecretServiceStore{serviceName: serviceName}
+}
+
+// Get retrieves a secret from Secret Service.
+func (l *LinuxSecretServiceStore) Get(key string) ([]byte, error) {
+	if !l.IsAvailable() {
+		return nil, ErrSecretStoreUnavailable
+	}
+	cmd := exec.Command("secret-tool", "lookup", "service", l.serviceName, "key", key)
+	out, err := cmd.Output()
+	if err != nil || len(out) == 0 {
+		return nil, ErrSecretNotFound
+	}
+	return out, nil
+}
+
+// Set saves a secret into Secret Service.
+func (l *LinuxSecretServiceStore) Set(key string, secret []byte) error {
+	if !l.IsAvailable() {
+		return ErrSecretStoreUnavailable
+	}
+	if key == "" {
+		return errors.New("secret key cannot be empty")
+	}
+	cmd := exec.Command("secret-tool", "store", "--label="+l.serviceName, "service", l.serviceName, "key", key)
+	cmd.Stdin = bytes.NewReader(secret)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("secret-tool set error: %s (%w)", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// Delete clears a secret from Secret Service.
+func (l *LinuxSecretServiceStore) Delete(key string) error {
+	if !l.IsAvailable() {
+		return nil
+	}
+	cmd := exec.Command("secret-tool", "clear", "service", l.serviceName, "key", key)
+	_ = cmd.Run()
+	return nil
+}
+
+// IsAvailable reports true if running on Linux and secret-tool is in PATH.
+func (l *LinuxSecretServiceStore) IsAvailable() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	_, err := exec.LookPath("secret-tool")
+	return err == nil
+}
+
+// BackendName returns "linux-secret-service".
+func (l *LinuxSecretServiceStore) BackendName() string {
+	return "linux-secret-service"
+}
+
+// WindowsDPAPIStore uses Windows Data Protection API (DPAPI) to encrypt secrets
+// at rest scoped to the current user.
+type WindowsDPAPIStore struct {
+	storageDir string
+}
+
+// NewWindowsDPAPIStore creates a Windows DPAPI store. If storageDir is empty,
+// it uses %APPDATA%\sendbeam\secrets.
+func NewWindowsDPAPIStore(storageDir string) *WindowsDPAPIStore {
+	if storageDir == "" {
+		if configDir, err := os.UserConfigDir(); err == nil {
+			storageDir = filepath.Join(configDir, DefaultAppDirName, "secrets")
+		} else {
+			storageDir = filepath.Join(os.TempDir(), "sendbeam_secrets")
+		}
+	}
+	return &WindowsDPAPIStore{storageDir: storageDir}
+}
+
+func (w *WindowsDPAPIStore) keyPath(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return filepath.Join(w.storageDir, hex.EncodeToString(h[:])+".dpapi")
+}
+
+// EncodeDPAPICiphertextBlob formats DPAPI protected ciphertext into a Base64 string for disk storage.
+func EncodeDPAPICiphertextBlob(rawCiphertext []byte) string {
+	return base64.StdEncoding.EncodeToString(rawCiphertext)
+}
+
+// DecodeDPAPICiphertextBlob parses a Base64 string from disk into raw DPAPI ciphertext bytes.
+func DecodeDPAPICiphertextBlob(b64Ciphertext string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(strings.TrimSpace(b64Ciphertext))
+}
+
+// Get reads and decrypts a DPAPI-protected secret.
+func (w *WindowsDPAPIStore) Get(key string) ([]byte, error) {
+	if !w.IsAvailable() {
+		return nil, ErrSecretStoreUnavailable
+	}
+	p := w.keyPath(key)
+	encData, err := os.ReadFile(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrSecretNotFound
+		}
+		return nil, fmt.Errorf("read dpapi file: %w", err)
+	}
+
+	// Validate ciphertext format
+	if _, err := DecodeDPAPICiphertextBlob(string(encData)); err != nil {
+		return nil, fmt.Errorf("corrupt dpapi ciphertext file: %w", err)
+	}
+
+	// Unprotect via PowerShell ProtectedData reading Base64 ciphertext from stdin
+	// and outputting Base64 decrypted plaintext to stdout (no secrets in command line args).
+	script := `$in = [Console]::In.ReadToEnd().Trim(); if ([string]::IsNullOrEmpty($in)) { exit 1 }; $enc = [Convert]::FromBase64String($in); $raw = [System.Security.Cryptography.ProtectedData]::Unprotect($enc, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser); [Console]::Out.Write([Convert]::ToBase64String($raw))`
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd.Stdin = strings.NewReader(strings.TrimSpace(string(encData)))
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("dpapi unprotect error: %w", err)
+	}
+	dec64 := strings.TrimSpace(string(out))
+	return base64.StdEncoding.DecodeString(dec64)
+}
+
+// Set encrypts and writes a DPAPI-protected secret.
+func (w *WindowsDPAPIStore) Set(key string, secret []byte) error {
+	if !w.IsAvailable() {
+		return ErrSecretStoreUnavailable
+	}
+	if key == "" {
+		return errors.New("secret key cannot be empty")
+	}
+	if err := os.MkdirAll(w.storageDir, 0o700); err != nil {
+		return fmt.Errorf("create secrets dir: %w", err)
+	}
+
+	// Protect via PowerShell ProtectedData reading Base64 plaintext from stdin
+	// and outputting Base64 ciphertext to stdout (no secrets in command line args).
+	script := `$in = [Console]::In.ReadToEnd().Trim(); if ([string]::IsNullOrEmpty($in)) { exit 1 }; $raw = [Convert]::FromBase64String($in); $enc = [System.Security.Cryptography.ProtectedData]::Protect($raw, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser); [Console]::Out.Write([Convert]::ToBase64String($enc))`
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd.Stdin = strings.NewReader(base64.StdEncoding.EncodeToString(secret))
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("dpapi protect error: %w", err)
+	}
+
+	b64Ciphertext := strings.TrimSpace(string(out))
+	if _, err := DecodeDPAPICiphertextBlob(b64Ciphertext); err != nil {
+		return fmt.Errorf("invalid dpapi output ciphertext: %w", err)
+	}
+
+	p := w.keyPath(key)
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, []byte(b64Ciphertext), 0o600); err != nil {
+		return fmt.Errorf("write dpapi file: %w", err)
+	}
+	if err := os.Rename(tmp, p); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename dpapi file: %w", err)
+	}
+	return nil
+}
+
+// Delete removes a DPAPI-protected secret.
+func (w *WindowsDPAPIStore) Delete(key string) error {
+	if !w.IsAvailable() {
+		return nil
+	}
+	_ = os.Remove(w.keyPath(key))
+	return nil
+}
+
+// IsAvailable reports true when running on Windows and PowerShell is in PATH.
+func (w *WindowsDPAPIStore) IsAvailable() bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	_, err := exec.LookPath("powershell")
+	return err == nil
+}
+
+// BackendName returns "windows-dpapi".
+func (w *WindowsDPAPIStore) BackendName() string {
+	return "windows-dpapi"
+}
+
+// DefaultSecretStore resolves the appropriate OS-protected secret store
+// for the current platform. If none is available, it returns an UnavailableSecretStore
+// to fail closed rather than falling back to plaintext storage.
+func DefaultSecretStore() SecretStore {
+	switch runtime.GOOS {
+	case "darwin":
+		store := NewDarwinKeychainSecretStore("SendBeam")
+		if store.IsAvailable() {
+			return store
+		}
+		return NewUnavailableSecretStore("macOS Keychain unavailable")
+	case "windows":
+		store := NewWindowsDPAPIStore("")
+		if store.IsAvailable() {
+			return store
+		}
+		return NewUnavailableSecretStore("Windows DPAPI unavailable")
+	case "linux":
+		store := NewLinuxSecretServiceStore("SendBeam")
+		if store.IsAvailable() {
+			return store
+		}
+		return NewUnavailableSecretStore("Secret Service / secret-tool not available in Linux desktop session")
+	default:
+		return NewUnavailableSecretStore("native OS credential helper not configured for " + runtime.GOOS)
+	}
+}

--- a/packages/engine/trust/trust_store.go
+++ b/packages/engine/trust/trust_store.go
@@ -20,6 +20,9 @@ var (
 
 	// ErrTrustStoreClosed is returned when operating on a closed store.
 	ErrTrustStoreClosed = errors.New("trust store is closed")
+
+	// ErrCorruptTrustStore is returned when the trust database file exists but is empty or unparseable.
+	ErrCorruptTrustStore = errors.New("corrupt trust database file; refusing to overwrite")
 )
 
 // Store defines the interface for local trust management, peer policy, and revocation.
@@ -206,7 +209,7 @@ type trustFilePayload struct {
 	Devices   []*wire.TrustRecord `json:"devices"`
 }
 
-const currentTrustFileVersion = 1
+const currentTrustFileVersion = 2
 
 // NewFileTrustStore loads or initializes a FileTrustStore at the given path.
 func NewFileTrustStore(filePath string) (*FileTrustStore, error) {
@@ -221,7 +224,8 @@ func NewFileTrustStore(filePath string) (*FileTrustStore, error) {
 		devices:  make(map[string]*wire.TrustRecord),
 	}
 
-	if err := store.load(); err != nil {
+	needsMigration, err := store.load()
+	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			// Initialize empty file
 			if err := store.saveLocked(); err != nil {
@@ -232,30 +236,45 @@ func NewFileTrustStore(filePath string) (*FileTrustStore, error) {
 		return nil, fmt.Errorf("load trust db: %w", err)
 	}
 
+	if needsMigration {
+		if err := store.saveLocked(); err != nil {
+			return nil, fmt.Errorf("migrate trust db file: %w", err)
+		}
+	}
+
 	return store, nil
 }
 
-func (f *FileTrustStore) load() error {
+func (f *FileTrustStore) load() (bool, error) {
 	data, err := os.ReadFile(f.filePath)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(data) == 0 {
-		return nil
+		return false, fmt.Errorf("%w: file exists but is empty (0 bytes)", ErrCorruptTrustStore)
 	}
 
 	var payload trustFilePayload
 	if err := json.Unmarshal(data, &payload); err != nil {
-		return fmt.Errorf("parse trust db JSON: %w", err)
+		return false, fmt.Errorf("%w: parse trust db JSON: %v", ErrCorruptTrustStore, err)
 	}
 
+	needsMigration := payload.Version < currentTrustFileVersion
 	f.devices = make(map[string]*wire.TrustRecord)
 	for _, rec := range payload.Devices {
-		if rec != nil && rec.Validate() == nil {
-			f.devices[rec.DeviceID] = rec
+		if rec == nil {
+			continue
 		}
+		if rec.Relationship == "" {
+			rec.Relationship = wire.RelationshipContact
+			needsMigration = true
+		}
+		if err := rec.Validate(); err != nil {
+			return false, fmt.Errorf("%w: invalid trust record %q: %v", ErrCorruptTrustStore, rec.DeviceID, err)
+		}
+		f.devices[rec.DeviceID] = rec
 	}
-	return nil
+	return needsMigration, nil
 }
 
 func (f *FileTrustStore) saveLocked() error {
@@ -298,6 +317,16 @@ func (f *FileTrustStore) saveLocked() error {
 	}
 	if err := tmpFile.Close(); err != nil {
 		return fmt.Errorf("close temp trust db: %w", err)
+	}
+
+	// Verify temporary file before replacing live database (write -> verify -> switch)
+	verifyData, err := os.ReadFile(tmpName)
+	if err != nil {
+		return fmt.Errorf("verify temp trust db: %w", err)
+	}
+	var verifyPayload trustFilePayload
+	if err := json.Unmarshal(verifyData, &verifyPayload); err != nil {
+		return fmt.Errorf("verify unmarshal temp trust db: %w", err)
 	}
 
 	if err := os.Rename(tmpName, f.filePath); err != nil {

--- a/packages/protocol/src/browser-identity.ts
+++ b/packages/protocol/src/browser-identity.ts
@@ -43,12 +43,19 @@ export async function getOrCreateBrowserIdentity(customIdb?: IDBFactory): Promis
     req.onerror = () => reject(req.error ?? new Error('read identity failed'));
   });
 
-  if (existingSeedHex && existingSeedHex.length === 64) {
+  if (existingSeedHex !== undefined && existingSeedHex !== null) {
+    if (typeof existingSeedHex !== 'string' || existingSeedHex.trim().length !== 64) {
+      throw new Error(
+        'corrupt browser device identity: invalid seed length or format; refusing to regenerate',
+      );
+    }
     try {
-      const seed = hexToBytes(existingSeedHex);
+      const seed = hexToBytes(existingSeedHex.trim());
       return await createDeviceIdentityFromSeed(seed);
-    } catch {
-      // In case of corruption, generate fresh below
+    } catch (err) {
+      throw new Error(
+        `corrupt browser device identity: ${(err as Error).message}; refusing to regenerate`,
+      );
     }
   }
 

--- a/packages/protocol/src/indexeddb-secret-store.ts
+++ b/packages/protocol/src/indexeddb-secret-store.ts
@@ -51,16 +51,23 @@ export class IndexedDBSecretStore implements SecretResolver {
     const db = await this.getDb();
     return new Promise((resolve, reject) => {
       const tx = db.transaction([SECRETS_STORE_NAME], 'readonly');
-      const req = tx.objectStore(SECRETS_STORE_NAME).get(deviceId);
+      const req = tx.objectStore(SECRETS_STORE_NAME).get(deviceIDKey(deviceId));
       req.onsuccess = () => {
         const val = req.result as string | undefined;
-        if (!val) {
+        if (val === undefined || val === null) {
           resolve(null);
         } else {
           try {
-            resolve(hexToBytes(val));
-          } catch {
-            resolve(null);
+            const bytes = hexToBytes(val);
+            if (bytes.length === 0) {
+              reject(new Error(`corrupt pair secret for device ${deviceId}: empty secret bytes`));
+              return;
+            }
+            resolve(bytes);
+          } catch (err) {
+            reject(
+              new Error(`corrupt pair secret for device ${deviceId}: ${(err as Error).message}`),
+            );
           }
         }
       };
@@ -69,6 +76,12 @@ export class IndexedDBSecretStore implements SecretResolver {
   }
 
   async setPairSecret(deviceId: string, secret: Uint8Array): Promise<void> {
+    if (!deviceId || deviceId.trim() === '') {
+      throw new Error('invalid deviceId for pair secret');
+    }
+    if (secret.length === 0) {
+      throw new Error('invalid pair secret length: secret cannot be empty');
+    }
     const db = await this.getDb();
     const hex = bytesToHex(secret);
     return new Promise((resolve, reject) => {

--- a/packages/protocol/src/indexeddb-stores.test.ts
+++ b/packages/protocol/src/indexeddb-stores.test.ts
@@ -199,4 +199,42 @@ describe('IndexedDB Trust & Secret Stores and Capability Probing', () => {
     expect(bytesToHex(id2.publicKey)).toBe(bytesToHex(id1.publicKey));
     expect(bytesToHex(id2.privateKey)).toBe(bytesToHex(id1.privateKey));
   });
+
+  it('refuses to regenerate browser node identity when stored seed is corrupt', async () => {
+    // Inject corrupt seed in the identity database
+    const db = await new Promise<IDBDatabase>((resolve) => {
+      const req = fakeIdb.open('sendbeam-identity', 1);
+      req.onsuccess = () => resolve(req.result as IDBDatabase);
+    });
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction(['node_identity'], 'readwrite');
+      tx.objectStore('node_identity').put(
+        'not-a-valid-64-char-hex-seed',
+        'primary_device_identity',
+      );
+      tx.oncomplete = () => resolve();
+    });
+
+    // Must throw and refuse to regenerate
+    await expect(getOrCreateBrowserIdentity(fakeIdb as unknown as IDBFactory)).rejects.toThrow(
+      /corrupt browser device identity/,
+    );
+  });
+
+  it('rejects corrupt pair secrets on retrieval', async () => {
+    const secretStore = new IndexedDBSecretStore(fakeIdb as unknown as IDBFactory);
+
+    // Inject invalid hex into secrets store
+    const db = await new Promise<IDBDatabase>((resolve) => {
+      const req = fakeIdb.open('sendbeam-secrets', 1);
+      req.onsuccess = () => resolve(req.result as IDBDatabase);
+    });
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction(['pair_secrets'], 'readwrite');
+      tx.objectStore('pair_secrets').put('this-is-not-hex', 'sb-dev-test');
+      tx.oncomplete = () => resolve();
+    });
+
+    await expect(secretStore.getPairSecret('sb-dev-test')).rejects.toThrow(/corrupt pair secret/);
+  });
 });

--- a/packages/protocol/src/trust-store.test.ts
+++ b/packages/protocol/src/trust-store.test.ts
@@ -85,7 +85,42 @@ describe('trust store & policy', () => {
         autoAccept: false,
       },
     };
-
     await expect(store.addOrUpdateDevice(badRecord)).rejects.toThrow();
+
+    // Missing pair credential ref
+    const noCredRecord: TrustRecord = {
+      deviceId: id.deviceId,
+      publicKey: bytesToHex(id.publicKey),
+      localLabel: 'No Cred Peer',
+      pairCredentialRef: '',
+      capabilities: [],
+      firstSeenAt: new Date().toISOString(),
+      lastSeenAt: new Date().toISOString(),
+      revoked: false,
+      policy: { autoAccept: false },
+    };
+    await expect(store.addOrUpdateDevice(noCredRecord)).rejects.toThrow(/pairCredentialRef/);
+
+    // Cluster member without cluster ID
+    const badClusterRecord: TrustRecord = {
+      deviceId: id.deviceId,
+      publicKey: bytesToHex(id.publicKey),
+      localLabel: 'Cluster Peer',
+      pairCredentialRef: 'cred-123',
+      relationship: 'cluster_member',
+      capabilities: [],
+      firstSeenAt: new Date().toISOString(),
+      lastSeenAt: new Date().toISOString(),
+      revoked: false,
+      policy: { autoAccept: false },
+    };
+    await expect(store.addOrUpdateDevice(badClusterRecord)).rejects.toThrow(/clusterId required/);
+
+    // Valid cluster member with cluster ID
+    const validClusterRecord: TrustRecord = {
+      ...badClusterRecord,
+      clusterId: 'sb-cluster-123',
+    };
+    await expect(store.addOrUpdateDevice(validClusterRecord)).resolves.toBeUndefined();
   });
 });

--- a/packages/protocol/src/trust-store.ts
+++ b/packages/protocol/src/trust-store.ts
@@ -30,11 +30,18 @@ export function defaultTrustPolicy(): TrustPolicy {
   };
 }
 
+export const RELATIONSHIP_CONTACT = 'contact';
+export const RELATIONSHIP_CLUSTER_MEMBER = 'cluster_member';
+export const RELATIONSHIP_CLUSTER_OWNER = 'cluster_owner';
+export type TrustRelationship = 'contact' | 'cluster_member' | 'cluster_owner';
+
 export interface TrustRecord {
   deviceId: string;
   publicKey: string; // 64-char lowercase hex string (32 bytes)
   localLabel: string;
   pairCredentialRef: string;
+  relationship?: TrustRelationship;
+  clusterId?: string;
   capabilities: string[];
   firstSeenAt: string; // ISO 8601 string
   lastSeenAt: string; // ISO 8601 string
@@ -66,6 +73,27 @@ export async function validateTrustRecord(record: TrustRecord): Promise<void> {
   }
   if (!record.localLabel || record.localLabel.trim() === '') {
     throw new Error('invalid trust record: local label cannot be empty');
+  }
+  if (!record.pairCredentialRef || record.pairCredentialRef.trim() === '') {
+    throw new Error('invalid trust record: pairCredentialRef cannot be empty');
+  }
+  if (record.relationship !== undefined) {
+    if (
+      record.relationship !== RELATIONSHIP_CONTACT &&
+      record.relationship !== RELATIONSHIP_CLUSTER_MEMBER &&
+      record.relationship !== RELATIONSHIP_CLUSTER_OWNER
+    ) {
+      throw new Error(`invalid trust record: invalid relationship ${record.relationship}`);
+    }
+    if (
+      (record.relationship === RELATIONSHIP_CLUSTER_MEMBER ||
+        record.relationship === RELATIONSHIP_CLUSTER_OWNER) &&
+      (!record.clusterId || record.clusterId.trim() === '')
+    ) {
+      throw new Error(
+        `invalid trust record: clusterId required for cluster relationship ${record.relationship}`,
+      );
+    }
   }
   if (!record.firstSeenAt) {
     throw new Error('invalid trust record: firstSeenAt must be set');

--- a/packages/wire/trust_record.go
+++ b/packages/wire/trust_record.go
@@ -19,6 +19,13 @@ const (
 	CapRelayFall  = "relay_fallback"
 )
 
+// Relationship constants define authorization scopes between paired devices (ADR 0010 §4.2).
+const (
+	RelationshipContact       = "contact"
+	RelationshipClusterMember = "cluster_member"
+	RelationshipClusterOwner  = "cluster_owner"
+)
+
 var (
 	// ErrInvalidTrustRecord indicates a trust record with invalid fields.
 	ErrInvalidTrustRecord = errors.New("invalid trust record")
@@ -62,6 +69,8 @@ type TrustRecord struct {
 	PublicKey         string      `json:"public_key"` // hex-encoded 32-byte Ed25519 public key
 	LocalLabel        string      `json:"local_label"`
 	PairCredentialRef string      `json:"pair_credential_ref"`
+	Relationship      string      `json:"relationship,omitempty"`
+	ClusterID         string      `json:"cluster_id,omitempty"`
 	Capabilities      []string    `json:"capabilities"`
 	FirstSeenAt       time.Time   `json:"first_seen_at"`
 	LastSeenAt        time.Time   `json:"last_seen_at"`
@@ -91,6 +100,18 @@ func (r *TrustRecord) Validate() error {
 	}
 	if strings.TrimSpace(r.LocalLabel) == "" {
 		return fmt.Errorf("%w: local label cannot be empty", ErrInvalidTrustRecord)
+	}
+	if strings.TrimSpace(r.PairCredentialRef) == "" {
+		return fmt.Errorf("%w: pair_credential_ref cannot be empty", ErrInvalidTrustRecord)
+	}
+	if r.Relationship == "" {
+		r.Relationship = RelationshipContact
+	}
+	if r.Relationship != RelationshipContact && r.Relationship != RelationshipClusterMember && r.Relationship != RelationshipClusterOwner {
+		return fmt.Errorf("%w: invalid relationship %q (must be contact, cluster_member, or cluster_owner)", ErrInvalidTrustRecord, r.Relationship)
+	}
+	if (r.Relationship == RelationshipClusterMember || r.Relationship == RelationshipClusterOwner) && strings.TrimSpace(r.ClusterID) == "" {
+		return fmt.Errorf("%w: cluster_id required for cluster relationship %q", ErrInvalidTrustRecord, r.Relationship)
 	}
 	if r.FirstSeenAt.IsZero() {
 		return fmt.Errorf("%w: first_seen_at must be set", ErrInvalidTrustRecord)

--- a/packages/wire/trust_record_test.go
+++ b/packages/wire/trust_record_test.go
@@ -93,4 +93,30 @@ func TestTrustRecordValidation(t *testing.T) {
 	if err := rootPolicyRecord.Validate(); err == nil {
 		t.Errorf("expected validation failure for root auto accept dir")
 	}
+
+	// Empty PairCredentialRef should fail
+	noCredRecord := *validRecord
+	noCredRecord.PairCredentialRef = ""
+	if err := noCredRecord.Validate(); err == nil {
+		t.Errorf("expected validation failure for empty pair credential ref")
+	}
+
+	// Relationship validation
+	clusterRecord := *validRecord
+	clusterRecord.Relationship = RelationshipClusterMember
+	clusterRecord.ClusterID = ""
+	if err := clusterRecord.Validate(); err == nil {
+		t.Errorf("expected validation failure for cluster_member without cluster_id")
+	}
+
+	clusterRecord.ClusterID = "sb-cluster-12345"
+	if err := clusterRecord.Validate(); err != nil {
+		t.Fatalf("valid cluster record failed: %v", err)
+	}
+
+	badRelRecord := *validRecord
+	badRelRecord.Relationship = "super_admin"
+	if err := badRelRecord.Validate(); err == nil {
+		t.Errorf("expected validation failure for invalid relationship")
+	}
 }


### PR DESCRIPTION
### Summary

• Logical ID / milestone: V19-PR03 (v1.9 Trusted Handoffs)
• Goal: Unified pairing and identity persistence with protected native credential adapters, fail-closed crash-safe migration, and explicit browser/headless limits.
• Dependencies: PR #180, PR #181
• Baseline SHA: 22b842b

### Production Path Before / After

• Before:
  • Device trust records had unvalidated pair credential references and no relationship/cluster model.
  • Corrupt or 0-byte identity files could be silently overwritten or regenerated, destroying device identity.
  • Desktop stored pairing secrets in plaintext JSON on disk (`secrets.json`) with unhandled delete failures.
  • No unified credential store abstraction or crash-safe migration from plaintext to OS-protected storage.
  • Browser identity seeds in IndexedDB could be overwritten if corrupt.
• After:
  • Standardized TrustRecord across wire (Go) and protocol (TS) with required non-empty PairCredentialRef, relationship validation (`contact`, `cluster_member`, `cluster_owner`), and cluster ID enforcement.
  • Go IdentityManager and TS browser identity fail closed on 0-byte or corrupted identity files/seeds; strictly refuse regeneration or overwrite.
  • Unified CredentialStore interface with ProtectedCredentialStore backing macOS Keychain (`/usr/bin/security`), Windows DPAPI, and Linux Secret Service (`secret-tool`). Desktop runtime strictly refuses silent plaintext downgrade.
  • Crash-safe `MigrateLegacyFileSecrets` migrates legacy `secrets.json` into protected storage using a write-verify-switch workflow with disk zeroization.
  • Headless `FileSecretStore` with `0600` POSIX file permissions for CLI/headless environments with explicit security boundaries documented.
  • IndexedDB SecretStore in web protocol hardened against corrupt values.
  • Complete persistence architecture and security limits documented in `docs/state-storage.md`.

### Changed Areas

• `packages/wire/trust_record.go`: Relationship constants, ClusterID, PairCredentialRef validation.
• `packages/wire/trust_record_test.go`: Schema validation tests.
• `packages/protocol/src/trust-store.ts` & `test.ts`: TypeScript TrustRecord validation and relationship invariants.
• `packages/protocol/src/browser-identity.ts`: Hardened browser identity fail-closed on corrupt seeds.
• `packages/protocol/src/indexeddb-secret-store.ts` & `test.ts`: Hardened IndexedDB secret validation.
• `packages/engine/trust/secret_store.go`: OS-protected SecretStore implementations (Keychain, DPAPI, Secret Service, Memory, Unavailable).
• `packages/engine/trust/credential_store.go` & `test.go`: CredentialStore interface, ProtectedCredentialStore, FileSecretStore, and MigrateLegacyFileSecrets.
• `packages/engine/trust/identity_manager.go` & `test.go`: Refuse identity regeneration on corrupt reads.
• `packages/engine/trust/trust_store.go`: Schema v2 migration and atomic write-verify.
• `packages/engine/trust/pairing_coordinator.go`: Atomic persistence of credentials and trust records with rollback.
• `apps/desktop/internal/config/secret_store.go`: Re-export credential store from engine/trust.
• `apps/desktop/internal/engine/device_service.go` & `test.go`: Integrated CredentialStore, legacy migration, and error checks on purge.
• `apps/cli/cmd/sendbeam/trust_config.go` & `unpair.go`: Integrated FileSecretStore and purge error checking.
• `docs/state-storage.md`: Updated architecture documentation with explicit limits.

### Explicit Exclusions

• Does not modify rendezvous / signaling servers or protocol wire formats.
• Does not implement remote revocation propagation (V19-PR04).