### PR TITLE
feat(trust): authorized signed tombstones and mesh revocation lifecycle

### DIFF
--- a/apps/cli/cmd/sendbeam/pair.go
+++ b/apps/cli/cmd/sendbeam/pair.go
@@ -109,6 +109,9 @@ func executePair(args []string, stdout, stderr io.Writer) int {
 	}
 
 	coordinator := trust.NewPairingCoordinator(env.IdentityMgr, env.TrustStore)
+	if env.Tombstones != nil {
+		coordinator.SetTombstoneStore(env.Tombstones)
+	}
 
 	positionals := fs.Args()
 	isJoiner := len(positionals) > 0
@@ -172,6 +175,10 @@ func executePair(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if err != nil {
+		if errors.Is(err, wire.ErrTrustedPeerRevoked) {
+			_, _ = fmt.Fprintln(stderr, "pairing error: device has been revoked or tombstoned")
+			return 1
+		}
 		if errors.Is(err, trust.ErrKeyConflict) {
 			_, _ = fmt.Fprintln(stderr, "pairing error: device ID already exists with a different public key")
 			return 1

--- a/apps/cli/cmd/sendbeam/send.go
+++ b/apps/cli/cmd/sendbeam/send.go
@@ -320,7 +320,7 @@ func runBroadcastSend(filePaths []string, toDevices []string, server string, ins
 			_, _ = fmt.Fprintf(stderr, "sendbeam send: %v\n", err)
 			return 1
 		}
-		if dev.Revoked {
+		if dev.Revoked || (env.Tombstones != nil && env.Tombstones.HasTombstone(ctx, dev.DeviceID)) {
 			_, _ = fmt.Fprintf(stderr, "sendbeam send: trust for device %q is revoked\n", dev.LocalLabel)
 			return 1
 		}

--- a/apps/cli/cmd/sendbeam/trust_config.go
+++ b/apps/cli/cmd/sendbeam/trust_config.go
@@ -17,6 +17,7 @@ const (
 	trustFileName       = "trust.json"
 	identityKeyFileName = "identity.key"
 	secretsFileName     = "secrets.json"
+	tombstonesFileName  = "tombstones.json"
 )
 
 // FileSecretResolver is an alias to trust.FileSecretStore for headless CLI environments.
@@ -27,12 +28,13 @@ func NewFileSecretResolver(path string) (*FileSecretResolver, error) {
 	return trust.NewFileSecretStore(path)
 }
 
-// CLIEnvironment provides shared access to local device identity, trust store, and secret store.
+// CLIEnvironment provides shared access to local device identity, trust store, secret store, and tombstone store.
 type CLIEnvironment struct {
 	ConfigDir   string
 	IdentityMgr *trust.IdentityManager
 	TrustStore  trust.Store
 	Secrets     *FileSecretResolver
+	Tombstones  *trust.FileTombstoneStore
 }
 
 // InitCLIEnvironment loads or creates the default CLI trust environment.
@@ -68,11 +70,18 @@ func InitCLIEnvironment(customDir string) (*CLIEnvironment, error) {
 		return nil, fmt.Errorf("init secrets store: %w", err)
 	}
 
+	tombstonesPath := filepath.Join(dir, tombstonesFileName)
+	tombstones, err := trust.NewFileTombstoneStore(tombstonesPath)
+	if err != nil {
+		return nil, fmt.Errorf("init tombstones store: %w", err)
+	}
+
 	return &CLIEnvironment{
 		ConfigDir:   dir,
 		IdentityMgr: idMgr,
 		TrustStore:  trustStore,
 		Secrets:     secrets,
+		Tombstones:  tombstones,
 	}, nil
 }
 

--- a/apps/cli/cmd/sendbeam/unpair.go
+++ b/apps/cli/cmd/sendbeam/unpair.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/sendbeam/wire"
 )
 
 type UnpairJSONView struct {
@@ -71,20 +73,60 @@ func executeUnpair(args []string, stdin io.Reader, stdout, stderr io.Writer) int
 		}
 	}
 
-	if *purge {
-		if err := env.TrustStore.UnpairDevice(ctx, dev.DeviceID); err != nil {
-			_, _ = fmt.Fprintf(stderr, "error deleting device from trust store: %v\n", err)
+	if wire.ValidateDeviceID(dev.DeviceID) {
+		id, err := env.IdentityMgr.GetOrCreateIdentity()
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "error getting local identity: %v\n", err)
 			return 1
 		}
-		if err := env.Secrets.DeleteSecret(dev.DeviceID); err != nil {
-			_, _ = fmt.Fprintf(stderr, "error deleting device secret: %v\n", err)
+
+		seq := dev.RevocationSeq + 1
+		if seq == 1 && dev.RevocationSeq == 0 {
+			seq = 1
+		}
+
+		rec, err := wire.SignRevocation(id, dev.DeviceID, seq, time.Now().UTC())
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "error signing revocation record: %v\n", err)
 			return 1
+		}
+
+		if env.Tombstones != nil {
+			if err := env.Tombstones.StoreTombstone(ctx, rec); err != nil {
+				_, _ = fmt.Fprintf(stderr, "error storing tombstone: %v\n", err)
+				return 1
+			}
+		}
+
+		if *purge {
+			if err := env.TrustStore.UnpairDevice(ctx, dev.DeviceID); err != nil {
+				_, _ = fmt.Fprintf(stderr, "error deleting device from trust store: %v\n", err)
+				return 1
+			}
+		} else {
+			if err := env.TrustStore.RevokeDeviceWithRecord(ctx, rec); err != nil {
+				_, _ = fmt.Fprintf(stderr, "error revoking device in trust store: %v\n", err)
+				return 1
+			}
 		}
 	} else {
-		if err := env.TrustStore.RevokeDevice(ctx, dev.DeviceID); err != nil {
-			_, _ = fmt.Fprintf(stderr, "error revoking device in trust store: %v\n", err)
-			return 1
+		if *purge {
+			if err := env.TrustStore.UnpairDevice(ctx, dev.DeviceID); err != nil {
+				_, _ = fmt.Fprintf(stderr, "error deleting device from trust store: %v\n", err)
+				return 1
+			}
+		} else {
+			if err := env.TrustStore.RevokeDevice(ctx, dev.DeviceID); err != nil {
+				_, _ = fmt.Fprintf(stderr, "error revoking device in trust store: %v\n", err)
+				return 1
+			}
 		}
+	}
+
+	// Always delete pairwise secrets upon revocation/unpairing to prevent re-authentication
+	if err := env.Secrets.DeleteSecret(dev.DeviceID); err != nil {
+		_, _ = fmt.Fprintf(stderr, "error deleting device secret: %v\n", err)
+		return 1
 	}
 
 	if *jsonOutput {

--- a/apps/cli/cmd/sendbeam/unpair_test.go
+++ b/apps/cli/cmd/sendbeam/unpair_test.go
@@ -37,6 +37,11 @@ func TestUnpairCommand(t *testing.T) {
 		Policy:            wire.DefaultTrustPolicy(),
 	})
 
+	secStore, _ := trust.NewFileSecretStore(filepath.Join(tmpDir, "secrets.json"))
+	var kPair [32]byte
+	kPair[0] = 0x99
+	_ = secStore.SetSecret(devAlice, kPair[:])
+
 	// Cancel interactive prompt
 	var stdin, stdout, stderr bytes.Buffer
 	stdin.WriteString("n\n")
@@ -60,6 +65,18 @@ func TestUnpairCommand(t *testing.T) {
 	rec, _ := storeAfterRevoke.GetDevice(ctx, devAlice)
 	if rec == nil || !rec.Revoked {
 		t.Errorf("expected device to be revoked in store")
+	}
+
+	// Verify tombstone is saved
+	tombAfter, err := trust.NewFileTombstoneStore(filepath.Join(tmpDir, "tombstones.json"))
+	if err != nil || !tombAfter.HasTombstone(ctx, devAlice) {
+		t.Errorf("expected tombstone in tombstones.json, err: %v", err)
+	}
+
+	// Verify secret is deleted
+	secAfter, _ := trust.NewFileSecretStore(filepath.Join(tmpDir, "secrets.json"))
+	if _, err := secAfter.ResolvePairSecret(ctx, devAlice, ""); err == nil {
+		t.Errorf("expected secret to be deleted from secrets.json upon unpair")
 	}
 
 	// Purge with --yes and --json

--- a/apps/desktop/internal/engine/device_service.go
+++ b/apps/desktop/internal/engine/device_service.go
@@ -52,6 +52,7 @@ type DeviceService struct {
 	store        trust.Store
 	secrets      trust.CredentialStore
 	coordinator  *trust.PairingCoordinator
+	tombstones   trust.TombstoneStore
 	lanDiscovery *discovery.LanDiscoveryService
 	activePeers  map[string]discoveredPeerInfo // deviceID -> info
 	configDir    string
@@ -105,7 +106,14 @@ func NewDeviceServiceWithCredentials(emit func(name string, data any), customCon
 		}
 	}
 
+	tombstonesPath := filepath.Join(dir, "tombstones.json")
+	tombstoneStore, err := trust.NewFileTombstoneStore(tombstonesPath)
+	if err != nil {
+		return nil, fmt.Errorf("init tombstone store: %w", err)
+	}
+
 	coordinator := trust.NewPairingCoordinatorWithCredentials(idMgr, trustStore, secrets)
+	coordinator.SetTombstoneStore(tombstoneStore)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -121,6 +129,7 @@ func NewDeviceServiceWithCredentials(emit func(name string, data any), customCon
 		store:        trustStore,
 		secrets:      secrets,
 		coordinator:  coordinator,
+		tombstones:   tombstoneStore,
 		lanDiscovery: lanDiscovery,
 		activePeers:  make(map[string]discoveredPeerInfo),
 		configDir:    dir,
@@ -165,7 +174,8 @@ func (s *DeviceService) ListTrustedDevices() ([]TrustedDeviceView, error) {
 		status := "offline"
 		var directEndpoint string
 
-		if dev.Revoked {
+		isRevoked := dev.Revoked || (s.tombstones != nil && s.tombstones.HasTombstone(ctx, dev.DeviceID))
+		if isRevoked {
 			status = "revoked"
 		} else if peer, ok := s.activePeers[dev.DeviceID]; ok && now.Sub(peer.lastSeen) < 30*time.Second {
 			status = "lan_direct"
@@ -185,7 +195,7 @@ func (s *DeviceService) ListTrustedDevices() ([]TrustedDeviceView, error) {
 			Fingerprint:    dev.Fingerprint(),
 			PublicKey:      dev.PublicKey,
 			Status:         status,
-			Revoked:        dev.Revoked,
+			Revoked:        isRevoked,
 			LastSeenAt:     lastSeen,
 			FirstSeenAt:    dev.FirstSeenAt.UTC().Format(time.RFC3339),
 			Capabilities:   dev.Capabilities,
@@ -247,17 +257,57 @@ func (s *DeviceService) UnpairDevice(deviceID string, purge bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if purge {
-		if err := s.store.UnpairDevice(ctx, deviceID); err != nil {
+	if wire.ValidateDeviceID(deviceID) {
+		id, err := s.idMgr.GetOrCreateIdentity()
+		if err != nil {
+			return fmt.Errorf("get local identity: %w", err)
+		}
+
+		dev, err := s.store.GetDevice(ctx, deviceID)
+		if err != nil && !errors.Is(err, trust.ErrDeviceNotFound) {
 			return err
 		}
-		if err := s.secrets.DeletePairSecret(ctx, deviceID); err != nil && !errors.Is(err, trust.ErrSecretStoreUnavailable) {
-			return fmt.Errorf("delete pair secret: %w", err)
+
+		seq := uint64(1)
+		if dev != nil && dev.RevocationSeq > 0 {
+			seq = dev.RevocationSeq + 1
+		}
+
+		rec, err := wire.SignRevocation(id, deviceID, seq, time.Now().UTC())
+		if err != nil {
+			return fmt.Errorf("sign revocation record: %w", err)
+		}
+
+		if s.tombstones != nil {
+			if err := s.tombstones.StoreTombstone(ctx, rec); err != nil {
+				return fmt.Errorf("store tombstone: %w", err)
+			}
+		}
+
+		if purge {
+			if err := s.store.UnpairDevice(ctx, deviceID); err != nil {
+				return err
+			}
+		} else {
+			if err := s.store.RevokeDeviceWithRecord(ctx, rec); err != nil {
+				return err
+			}
 		}
 	} else {
-		if err := s.store.RevokeDevice(ctx, deviceID); err != nil {
-			return err
+		if purge {
+			if err := s.store.UnpairDevice(ctx, deviceID); err != nil {
+				return err
+			}
+		} else {
+			if err := s.store.RevokeDevice(ctx, deviceID); err != nil {
+				return err
+			}
 		}
+	}
+
+	// Deletion errors are fatal; both purge and non-purge paths delete pair credentials
+	if err := s.secrets.DeletePairSecret(ctx, deviceID); err != nil && !errors.Is(err, trust.ErrDeviceNotFound) && !errors.Is(err, trust.ErrSecretNotFound) && !errors.Is(err, trust.ErrSecretStoreUnavailable) {
+		return fmt.Errorf("delete pair secret: %w", err)
 	}
 
 	s.mu.Lock()

--- a/apps/desktop/internal/engine/device_service_test.go
+++ b/apps/desktop/internal/engine/device_service_test.go
@@ -173,3 +173,66 @@ func TestDeviceService_LegacyMigrationAndCredentials(t *testing.T) {
 	}
 }
 
+func TestDeviceService_UnpairTombstoneAndCredentialDeletion(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	devID := wire.DeriveDeviceID(pub)
+
+	memStore := trust.NewMemoryCredentialStore()
+	svc, err := NewDeviceServiceWithCredentials(nil, tmpDir, memStore)
+	if err != nil {
+		t.Fatalf("NewDeviceServiceWithCredentials failed: %v", err)
+	}
+	defer svc.Close()
+
+	rec := &wire.TrustRecord{
+		DeviceID:          devID,
+		PublicKey:         hex.EncodeToString(pub),
+		LocalLabel:        "Canonical Peer",
+		PairCredentialRef: "cred-canonical",
+		FirstSeenAt:       time.Now().UTC(),
+		Policy:            wire.DefaultTrustPolicy(),
+	}
+	if err := svc.store.AddOrUpdateDevice(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+	var secret [32]byte
+	secret[0] = 0x42
+	if err := memStore.SetPairSecret(ctx, devID, "cred-canonical", secret[:]); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Unpair without purge (revocation path)
+	if err := svc.UnpairDevice(devID, false); err != nil {
+		t.Fatalf("UnpairDevice failed: %v", err)
+	}
+
+	// Secret must be deleted even in non-purge revocation path!
+	if _, err := memStore.ResolvePairSecret(ctx, devID, "cred-canonical"); err == nil {
+		t.Fatal("expected secret to be deleted upon non-purge revocation")
+	}
+
+	// Tombstone must be persisted
+	tombstones, err := trust.NewFileTombstoneStore(filepath.Join(tmpDir, "tombstones.json"))
+	if err != nil {
+		t.Fatalf("open tombstones: %v", err)
+	}
+	if !tombstones.HasTombstone(ctx, devID) {
+		t.Fatal("expected tombstone to be stored for revoked peer")
+	}
+
+	// Device listing must show revoked
+	views, err := svc.ListTrustedDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || !views[0].Revoked || views[0].Status != "revoked" {
+		t.Fatalf("expected 1 revoked device, got: %+v", views)
+	}
+}
+

--- a/packages/engine/trust/pairing_coordinator.go
+++ b/packages/engine/trust/pairing_coordinator.go
@@ -46,9 +46,10 @@ type PairingResult struct {
 
 // PairingCoordinator drives the multi-step pairing ceremony on both initiator and responder sides.
 type PairingCoordinator struct {
-	idMgr     *IdentityManager
-	store     Store
-	credStore CredentialStore
+	idMgr      *IdentityManager
+	store      Store
+	credStore  CredentialStore
+	tombstones TombstoneStore
 }
 
 // NewPairingCoordinator creates a new PairingCoordinator.
@@ -57,6 +58,11 @@ func NewPairingCoordinator(idMgr *IdentityManager, store Store) *PairingCoordina
 		idMgr: idMgr,
 		store: store,
 	}
+}
+
+// SetTombstoneStore sets the TombstoneStore for persistent tombstone checking (ADR 0010 §4.5).
+func (p *PairingCoordinator) SetTombstoneStore(tombstones TombstoneStore) {
+	p.tombstones = tombstones
 }
 
 // NewPairingCoordinatorWithCredentials creates a PairingCoordinator that atomically manages both device trust and credentials.
@@ -339,8 +345,16 @@ func (p *PairingCoordinator) AcceptPairing(ctx context.Context, transport Pairin
 }
 
 func (p *PairingCoordinator) checkConflict(ctx context.Context, deviceID, deviceName string, pubKey ed25519.PublicKey) error {
+	// ADR 0010 §4.5: If the peer has an active tombstone record, reject pairing fail-closed
+	if p.tombstones != nil && p.tombstones.HasTombstone(ctx, deviceID) {
+		return wire.ErrTrustedPeerRevoked
+	}
+
 	existing, err := p.store.GetDevice(ctx, deviceID)
 	if err == nil && existing != nil {
+		if existing.Revoked {
+			return wire.ErrTrustedPeerRevoked
+		}
 		existingPub, err := hex.DecodeString(existing.PublicKey)
 		if err == nil && !bytes.Equal(existingPub, pubKey) {
 			return ErrKeyConflict

--- a/packages/engine/trust/revocation_sync_test.go
+++ b/packages/engine/trust/revocation_sync_test.go
@@ -105,6 +105,8 @@ func TestThreeDevice_MeshRevocationSync(t *testing.T) {
 	coordB := NewTrustedSessionCoordinator(NewMemoryIdentityManager(idB), storeB, resB)
 	coordC := NewTrustedSessionCoordinator(NewMemoryIdentityManager(idC), storeC, resC)
 
+	clusterID := "sb-cluster-owner-123"
+
 	// Populate Pairings:
 	// A is paired with B and C
 	_ = storeA.AddOrUpdateDevice(ctx, &wire.TrustRecord{
@@ -112,6 +114,8 @@ func TestThreeDevice_MeshRevocationSync(t *testing.T) {
 		PublicKey:         idB.PublicKeyHex(),
 		LocalLabel:        "Phone",
 		PairCredentialRef: refAB,
+		Relationship:      wire.RelationshipClusterMember,
+		ClusterID:         clusterID,
 		Capabilities:      []string{wire.CapTransferV1},
 		FirstSeenAt:       time.Now().UTC(),
 		Policy:            wire.DefaultTrustPolicy(),
@@ -121,6 +125,8 @@ func TestThreeDevice_MeshRevocationSync(t *testing.T) {
 		PublicKey:         idC.PublicKeyHex(),
 		LocalLabel:        "Workstation",
 		PairCredentialRef: refAC,
+		Relationship:      wire.RelationshipClusterMember,
+		ClusterID:         clusterID,
 		Capabilities:      []string{wire.CapTransferV1},
 		FirstSeenAt:       time.Now().UTC(),
 		Policy:            wire.DefaultTrustPolicy(),
@@ -132,6 +138,8 @@ func TestThreeDevice_MeshRevocationSync(t *testing.T) {
 		PublicKey:         idA.PublicKeyHex(),
 		LocalLabel:        "Laptop",
 		PairCredentialRef: refAB,
+		Relationship:      wire.RelationshipClusterMember,
+		ClusterID:         clusterID,
 		Capabilities:      []string{wire.CapTransferV1},
 		FirstSeenAt:       time.Now().UTC(),
 		Policy:            wire.DefaultTrustPolicy(),
@@ -141,6 +149,8 @@ func TestThreeDevice_MeshRevocationSync(t *testing.T) {
 		PublicKey:         idC.PublicKeyHex(),
 		LocalLabel:        "Workstation",
 		PairCredentialRef: refBC,
+		Relationship:      wire.RelationshipClusterMember,
+		ClusterID:         clusterID,
 		Capabilities:      []string{wire.CapTransferV1},
 		FirstSeenAt:       time.Now().UTC(),
 		Policy:            wire.DefaultTrustPolicy(),
@@ -152,6 +162,8 @@ func TestThreeDevice_MeshRevocationSync(t *testing.T) {
 		PublicKey:         idA.PublicKeyHex(),
 		LocalLabel:        "Laptop",
 		PairCredentialRef: refAC,
+		Relationship:      wire.RelationshipClusterMember,
+		ClusterID:         clusterID,
 		Capabilities:      []string{wire.CapTransferV1},
 		FirstSeenAt:       time.Now().UTC(),
 		Policy:            wire.DefaultTrustPolicy(),
@@ -161,6 +173,8 @@ func TestThreeDevice_MeshRevocationSync(t *testing.T) {
 		PublicKey:         idB.PublicKeyHex(),
 		LocalLabel:        "Phone",
 		PairCredentialRef: refBC,
+		Relationship:      wire.RelationshipClusterMember,
+		ClusterID:         clusterID,
 		Capabilities:      []string{wire.CapTransferV1},
 		FirstSeenAt:       time.Now().UTC(),
 		Policy:            wire.DefaultTrustPolicy(),
@@ -247,4 +261,270 @@ func TestThreeDevice_MeshRevocationSync(t *testing.T) {
 	if !errors.Is(err, wire.ErrTrustedPeerRevoked) {
 		t.Fatalf("expected ErrTrustedPeerRevoked, got: %v", err)
 	}
+}
+
+func newTestIdentity(t *testing.T, seedStr string) *wire.DeviceIdentity {
+	t.Helper()
+	seed := sha256.Sum256([]byte(seedStr))
+	priv := ed25519.NewKeyFromSeed(seed[:])
+	id, err := wire.NewDeviceIdentity(priv.Public().(ed25519.PublicKey), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func TestRevocation_UnauthorizedContactRejection(t *testing.T) {
+	ctx := context.Background()
+	idOwner := newTestIdentity(t, "seed-owner")
+	idContact := newTestIdentity(t, "seed-contact")
+	idTarget := newTestIdentity(t, "seed-target")
+
+	store := NewMemoryTrustStore()
+	tombstones := NewMemoryTombstoneStore()
+	credStore := NewMemoryCredentialStore()
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idContact.DeviceID,
+		PublicKey:         idContact.PublicKeyHex(),
+		LocalLabel:        "Contact Alice",
+		PairCredentialRef: "cred-contact",
+		Relationship:      wire.RelationshipContact,
+		FirstSeenAt:       time.Now().UTC(),
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idTarget.DeviceID,
+		PublicKey:         idTarget.PublicKeyHex(),
+		LocalLabel:        "Contact Bob",
+		PairCredentialRef: "cred-target",
+		Relationship:      wire.RelationshipContact,
+		FirstSeenAt:       time.Now().UTC(),
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	coord := NewTrustedSessionCoordinator(NewMemoryIdentityManager(idOwner), store, NewMemorySecretResolver())
+	coord.SetTombstoneStore(tombstones)
+	coord.SetCredentialStore(credStore)
+
+	// Contact Alice attempts to revoke Contact Bob
+	rec, err := wire.SignRevocation(idContact, idTarget.DeviceID, 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SignRevocation failed: %v", err)
+	}
+
+	err = coord.IngestRevocationRecord(ctx, rec)
+	if !errors.Is(err, wire.ErrRevocationUnauthorized) {
+		t.Fatalf("expected ErrRevocationUnauthorized, got: %v", err)
+	}
+
+	// Target Bob must remain trusted
+	if !store.IsTrusted(ctx, idTarget.DeviceID) {
+		t.Fatal("target Bob should remain trusted after unauthorized revocation attempt")
+	}
+}
+
+func TestRevocation_SelfTombstoneUnknownDevice(t *testing.T) {
+	ctx := context.Background()
+	idLocal := newTestIdentity(t, "seed-local")
+	idUnknown := newTestIdentity(t, "seed-unknown")
+
+	store := NewMemoryTrustStore()
+	tombstones := NewMemoryTombstoneStore()
+	coord := NewTrustedSessionCoordinator(NewMemoryIdentityManager(idLocal), store, NewMemorySecretResolver())
+	coord.SetTombstoneStore(tombstones)
+
+	// Unknown device signs a self-tombstone
+	rec, err := wire.SignSelfTombstone(idUnknown, 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SignSelfTombstone failed: %v", err)
+	}
+
+	// Ingest self-tombstone
+	err = coord.IngestRevocationRecord(ctx, rec)
+	if err != nil {
+		t.Fatalf("expected nil for valid self-tombstone of unknown device, got: %v", err)
+	}
+
+	// Tombstone store must now contain the record
+	if !tombstones.HasTombstone(ctx, idUnknown.DeviceID) {
+		t.Fatal("expected TombstoneStore to contain tombstone for unknown device")
+	}
+}
+
+func TestRevocation_ActiveSessionAbort(t *testing.T) {
+	ctx := context.Background()
+	idLocal := newTestIdentity(t, "seed-local-abort")
+	idPeer := newTestIdentity(t, "seed-peer-abort")
+
+	store := NewMemoryTrustStore()
+	tombstones := NewMemoryTombstoneStore()
+	credStore := NewMemoryCredentialStore()
+	resolver := NewMemorySecretResolver()
+
+	var dummyKey [32]byte
+	resolver.SetSecret(idPeer.DeviceID, dummyKey[:])
+	_ = credStore.SetPairSecret(ctx, idPeer.DeviceID, "cred-peer", dummyKey[:])
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idPeer.DeviceID,
+		PublicKey:         idPeer.PublicKeyHex(),
+		LocalLabel:        "Peer Bob",
+		PairCredentialRef: "cred-peer",
+		Relationship:      wire.RelationshipContact,
+		FirstSeenAt:       time.Now().UTC(),
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	coord := NewTrustedSessionCoordinator(NewMemoryIdentityManager(idLocal), store, resolver)
+	coord.SetTombstoneStore(tombstones)
+	coord.SetCredentialStore(credStore)
+
+	// Register active in-flight session
+	sessionCanceled := false
+	cancelFn := func() {
+		sessionCanceled = true
+	}
+	unregister := coord.RegisterActiveSession(idPeer.DeviceID, cancelFn)
+	defer unregister()
+
+	// Local device revokes Peer Bob
+	err := coord.RevokeDevice(ctx, idPeer.DeviceID)
+	if err != nil {
+		t.Fatalf("RevokeDevice failed: %v", err)
+	}
+
+	// Assert active session was immediately canceled
+	if !sessionCanceled {
+		t.Fatal("expected active session to be canceled on revocation")
+	}
+
+	// Credential secret must be deleted
+	_, err = credStore.ResolvePairSecret(ctx, idPeer.DeviceID, "cred-peer")
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("expected ErrSecretNotFound from deleted secret, got: %v", err)
+	}
+
+	// Peer must not be trusted
+	if store.IsTrusted(ctx, idPeer.DeviceID) {
+		t.Fatal("peer should not be trusted post-revocation")
+	}
+}
+
+func TestRevocation_MonotonicSequenceRollback(t *testing.T) {
+	ctx := context.Background()
+	idClusterOwner := newTestIdentity(t, "seed-cluster-owner-seq")
+	idClusterMember := newTestIdentity(t, "seed-cluster-member-seq")
+	idTarget := newTestIdentity(t, "seed-target-seq")
+
+	clusterID := "sb-cluster-seq-test"
+	store := NewMemoryTrustStore()
+
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idClusterOwner.DeviceID,
+		PublicKey:         idClusterOwner.PublicKeyHex(),
+		LocalLabel:        "Admin",
+		PairCredentialRef: "cred-admin",
+		Relationship:      wire.RelationshipClusterOwner,
+		ClusterID:         clusterID,
+		FirstSeenAt:       time.Now().UTC(),
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	_ = store.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idTarget.DeviceID,
+		PublicKey:         idTarget.PublicKeyHex(),
+		LocalLabel:        "Target",
+		PairCredentialRef: "cred-target",
+		Relationship:      wire.RelationshipClusterMember,
+		ClusterID:         clusterID,
+		FirstSeenAt:       time.Now().UTC(),
+		Revoked:           true,
+		RevocationSeq:     2,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	coord := NewTrustedSessionCoordinator(NewMemoryIdentityManager(idClusterMember), store, NewMemorySecretResolver())
+	coord.SetClusterID(clusterID)
+
+	// Admin attempts to submit seq 2 (equal to current seq 2) -> SeqRollback
+	recEq, err := wire.SignRevocation(idClusterOwner, idTarget.DeviceID, 2, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := coord.IngestRevocationRecord(ctx, recEq); !errors.Is(err, wire.ErrRevocationSeqRollback) {
+		t.Fatalf("expected ErrRevocationSeqRollback on equal seq, got: %v", err)
+	}
+
+	// Admin attempts to submit seq 1 (lower than current seq 2) -> SeqRollback
+	recLow, err := wire.SignRevocation(idClusterOwner, idTarget.DeviceID, 1, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := coord.IngestRevocationRecord(ctx, recLow); !errors.Is(err, wire.ErrRevocationSeqRollback) {
+		t.Fatalf("expected ErrRevocationSeqRollback on lower seq, got: %v", err)
+	}
+
+	// Admin submits seq 3 -> succeeds
+	recHigh, err := wire.SignRevocation(idClusterOwner, idTarget.DeviceID, 3, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := coord.IngestRevocationRecord(ctx, recHigh); err != nil {
+		t.Fatalf("expected seq 3 to succeed, got: %v", err)
+	}
+
+	updated, err := store.GetDevice(ctx, idTarget.DeviceID)
+	if err != nil || updated.RevocationSeq != 3 {
+		t.Fatalf("expected target seq 3, got: %v, seq %d", err, updated.RevocationSeq)
+	}
+}
+
+func TestPairingCoordinator_RejectsTombstonedPeer(t *testing.T) {
+	ctx := context.Background()
+	idLocal := newTestIdentity(t, "seed-pair-local")
+	idTombstoned := newTestIdentity(t, "seed-pair-tombstoned")
+
+	store := NewMemoryTrustStore()
+	tombstones := NewMemoryTombstoneStore()
+	credStore := NewMemoryCredentialStore()
+
+	// Store tombstone for idTombstoned
+	tombstoneRec, err := wire.SignSelfTombstone(idTombstoned, 1, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tombstones.StoreTombstone(ctx, tombstoneRec); err != nil {
+		t.Fatal(err)
+	}
+
+	coord := NewPairingCoordinatorWithCredentials(NewMemoryIdentityManager(idLocal), store, credStore)
+	coord.SetTombstoneStore(tombstones)
+
+	pipe1, pipe2 := newMockPairingPipe()
+	masterKey := []byte("01234567890123456789012345678901")
+
+	errCh := make(chan error, 1)
+	go func() {
+		// Peer acts as initiator with idTombstoned
+		initCoord := NewPairingCoordinator(NewMemoryIdentityManager(idTombstoned), NewMemoryTrustStore())
+		_, err := initCoord.InitiatePairing(ctx, pipe1, PairingSessionConfig{
+			DeviceName:   "Tombstoned Device",
+			Capabilities: []string{wire.CapTransferV1},
+			MasterKey:    masterKey,
+		})
+		errCh <- err
+	}()
+
+	_, err = coord.AcceptPairing(ctx, pipe2, PairingSessionConfig{
+		DeviceName:   "Local Device",
+		Capabilities: []string{wire.CapTransferV1},
+		MasterKey:    masterKey,
+	})
+	if err == nil {
+		t.Fatal("expected pairing coordinator to reject tombstoned peer")
+	}
+	if !errors.Is(err, wire.ErrTrustedPeerRevoked) {
+		t.Fatalf("expected ErrTrustedPeerRevoked, got: %v", err)
+	}
+	<-errCh
 }

--- a/packages/engine/trust/tombstone_store.go
+++ b/packages/engine/trust/tombstone_store.go
@@ -1,0 +1,288 @@
+// Package trust manages local device cryptographic identity, paired device trust records, and persistent tombstones.
+package trust
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/sendbeam/wire"
+)
+
+var (
+	// ErrTombstoneNotFound indicates no tombstone record exists for the requested device ID.
+	ErrTombstoneNotFound = errors.New("tombstone not found")
+
+	// ErrCorruptTombstoneStore indicates corrupted or unparseable tombstone storage on disk.
+	// Invariant: corrupt tombstone databases must NEVER be silently overwritten or regenerated.
+	ErrCorruptTombstoneStore = errors.New("corrupt tombstone store; refusing to overwrite or parse")
+)
+
+// TombstoneStore defines persistent and in-memory storage and querying of signed revocation tombstones (ADR 0010 §4.5).
+type TombstoneStore interface {
+	StoreTombstone(ctx context.Context, record *wire.RevocationRecord) error
+	GetTombstone(ctx context.Context, deviceID string) (*wire.RevocationRecord, error)
+	HasTombstone(ctx context.Context, deviceID string) bool
+	ListTombstones(ctx context.Context) ([]*wire.RevocationRecord, error)
+}
+
+// MemoryTombstoneStore is an in-memory thread-safe implementation of TombstoneStore for tests and ephemeral sessions.
+type MemoryTombstoneStore struct {
+	mu         sync.RWMutex
+	tombstones map[string]*wire.RevocationRecord
+}
+
+// NewMemoryTombstoneStore creates a new MemoryTombstoneStore.
+func NewMemoryTombstoneStore() *MemoryTombstoneStore {
+	return &MemoryTombstoneStore{
+		tombstones: make(map[string]*wire.RevocationRecord),
+	}
+}
+
+// StoreTombstone records a signed RevocationRecord into the tombstone store, enforcing monotonic sequence numbers.
+func (m *MemoryTombstoneStore) StoreTombstone(_ context.Context, record *wire.RevocationRecord) error {
+	if record == nil {
+		return wire.ErrInvalidRevocationRecord
+	}
+	if err := record.Validate(); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existing, ok := m.tombstones[record.RevokedDeviceID]
+	if ok && existing.RevokerDeviceID == record.RevokerDeviceID {
+		if record.Seq <= existing.Seq {
+			return wire.ErrRevocationSeqRollback
+		}
+	}
+
+	recCopy := *record
+	m.tombstones[record.RevokedDeviceID] = &recCopy
+	return nil
+}
+
+// GetTombstone retrieves a tombstone record by device ID.
+func (m *MemoryTombstoneStore) GetTombstone(_ context.Context, deviceID string) (*wire.RevocationRecord, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	rec, ok := m.tombstones[deviceID]
+	if !ok {
+		return nil, ErrTombstoneNotFound
+	}
+	recCopy := *rec
+	return &recCopy, nil
+}
+
+// HasTombstone reports whether a device ID has an active tombstone record.
+func (m *MemoryTombstoneStore) HasTombstone(_ context.Context, deviceID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, ok := m.tombstones[deviceID]
+	return ok
+}
+
+// ListTombstones returns all stored tombstone records.
+func (m *MemoryTombstoneStore) ListTombstones(_ context.Context) ([]*wire.RevocationRecord, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]*wire.RevocationRecord, 0, len(m.tombstones))
+	for _, rec := range m.tombstones {
+		recCopy := *rec
+		out = append(out, &recCopy)
+	}
+	return out, nil
+}
+
+type tombstoneFilePayload struct {
+	Version    int                      `json:"version"`
+	Tombstones []*wire.RevocationRecord `json:"tombstones"`
+}
+
+// FileTombstoneStore persists signed revocation tombstones to disk with 0600 permissions
+// using atomic write-verify-switch (ADR 0010 §4.5).
+type FileTombstoneStore struct {
+	filePath   string
+	mu         sync.RWMutex
+	tombstones map[string]*wire.RevocationRecord
+}
+
+// NewFileTombstoneStore loads or creates a persistent FileTombstoneStore at filePath.
+func NewFileTombstoneStore(filePath string) (*FileTombstoneStore, error) {
+	cleanPath := filepath.Clean(filePath)
+	dir := filepath.Dir(cleanPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create tombstone dir: %w", err)
+	}
+
+	store := &FileTombstoneStore{
+		filePath:   cleanPath,
+		tombstones: make(map[string]*wire.RevocationRecord),
+	}
+
+	if err := store.loadLocked(); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+func (f *FileTombstoneStore) loadLocked() error {
+	content, err := os.ReadFile(f.filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read tombstone file: %w", err)
+	}
+
+	if len(content) == 0 {
+		return fmt.Errorf("%w: tombstone file exists but is empty (0 bytes)", ErrCorruptTombstoneStore)
+	}
+
+	var payload tombstoneFilePayload
+	if err := json.Unmarshal(content, &payload); err != nil {
+		return fmt.Errorf("%w: parse tombstone json: %v", ErrCorruptTombstoneStore, err)
+	}
+
+	for _, rec := range payload.Tombstones {
+		if rec == nil {
+			continue
+		}
+		if err := rec.Validate(); err != nil {
+			return fmt.Errorf("%w: invalid tombstone entry for device %q: %v", ErrCorruptTombstoneStore, rec.RevokedDeviceID, err)
+		}
+		recCopy := *rec
+		f.tombstones[rec.RevokedDeviceID] = &recCopy
+	}
+
+	return nil
+}
+
+func (f *FileTombstoneStore) saveLocked() error {
+	records := make([]*wire.RevocationRecord, 0, len(f.tombstones))
+	for _, rec := range f.tombstones {
+		recCopy := *rec
+		records = append(records, &recCopy)
+	}
+
+	payload := tombstoneFilePayload{
+		Version:    1,
+		Tombstones: records,
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal tombstones: %w", err)
+	}
+
+	dir := filepath.Dir(f.filePath)
+	tmpFile, err := os.CreateTemp(dir, "tombstones.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp tombstone file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := tmpFile.Chmod(0600); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("chmod temp tombstone file: %w", err)
+	}
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write temp tombstone file: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("sync temp tombstone file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close temp tombstone file: %w", err)
+	}
+
+	// Verify before replacing live database (write -> verify -> switch)
+	verifyData, err := os.ReadFile(tmpName)
+	if err != nil {
+		return fmt.Errorf("verify temp tombstone file: %w", err)
+	}
+	var verifyPayload tombstoneFilePayload
+	if err := json.Unmarshal(verifyData, &verifyPayload); err != nil {
+		return fmt.Errorf("verify unmarshal temp tombstone file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, f.filePath); err != nil {
+		return fmt.Errorf("atomic rename tombstone file: %w", err)
+	}
+
+	return nil
+}
+
+// StoreTombstone records a signed RevocationRecord and flushes atomically to disk.
+func (f *FileTombstoneStore) StoreTombstone(_ context.Context, record *wire.RevocationRecord) error {
+	if record == nil {
+		return wire.ErrInvalidRevocationRecord
+	}
+	if err := record.Validate(); err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	existing, ok := f.tombstones[record.RevokedDeviceID]
+	if ok && existing.RevokerDeviceID == record.RevokerDeviceID {
+		if record.Seq <= existing.Seq {
+			return wire.ErrRevocationSeqRollback
+		}
+	}
+
+	recCopy := *record
+	f.tombstones[record.RevokedDeviceID] = &recCopy
+	return f.saveLocked()
+}
+
+// GetTombstone retrieves a tombstone record by device ID from disk cache.
+func (f *FileTombstoneStore) GetTombstone(_ context.Context, deviceID string) (*wire.RevocationRecord, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	rec, ok := f.tombstones[deviceID]
+	if !ok {
+		return nil, ErrTombstoneNotFound
+	}
+	recCopy := *rec
+	return &recCopy, nil
+}
+
+// HasTombstone reports whether a device ID exists in the tombstone store.
+func (f *FileTombstoneStore) HasTombstone(_ context.Context, deviceID string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	_, ok := f.tombstones[deviceID]
+	return ok
+}
+
+// ListTombstones returns all stored tombstone records.
+func (f *FileTombstoneStore) ListTombstones(_ context.Context) ([]*wire.RevocationRecord, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	out := make([]*wire.RevocationRecord, 0, len(f.tombstones))
+	for _, rec := range f.tombstones {
+		recCopy := *rec
+		out = append(out, &recCopy)
+	}
+	return out, nil
+}

--- a/packages/engine/trust/tombstone_store_test.go
+++ b/packages/engine/trust/tombstone_store_test.go
@@ -1,0 +1,172 @@
+package trust
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sendbeam/wire"
+)
+
+func TestMemoryTombstoneStore(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryTombstoneStore()
+
+	seedA := sha256.Sum256([]byte("seed-tombstone-test-alice"))
+	privA := ed25519.NewKeyFromSeed(seedA[:])
+	idA, err := wire.NewDeviceIdentity(privA.Public().(ed25519.PublicKey), privA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetID := "sb-dev-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	now := time.Now().UTC()
+
+	// Store sequence 5
+	rec5, err := wire.SignRevocation(idA, targetID, 5, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.StoreTombstone(ctx, rec5); err != nil {
+		t.Fatalf("StoreTombstone failed: %v", err)
+	}
+
+	if !store.HasTombstone(ctx, targetID) {
+		t.Fatal("expected HasTombstone to return true")
+	}
+	if store.HasTombstone(ctx, "sb-dev-unknown000000000000000000000000000000000000000000000000000000") {
+		t.Fatal("expected HasTombstone to return false for unknown device")
+	}
+
+	got, err := store.GetTombstone(ctx, targetID)
+	if err != nil {
+		t.Fatalf("GetTombstone failed: %v", err)
+	}
+	if got.Seq != 5 || got.RevokedDeviceID != targetID {
+		t.Fatalf("unexpected tombstone retrieved: %+v", got)
+	}
+
+	// Rollback attempt: seq 3 <= 5 fails with ErrRevocationSeqRollback
+	rec3, err := wire.SignRevocation(idA, targetID, 3, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.StoreTombstone(ctx, rec3); !errors.Is(err, wire.ErrRevocationSeqRollback) {
+		t.Fatalf("expected ErrRevocationSeqRollback on lower sequence, got %v", err)
+	}
+
+	// Replay attempt: seq 5 <= 5 fails with ErrRevocationSeqRollback
+	if err := store.StoreTombstone(ctx, rec5); !errors.Is(err, wire.ErrRevocationSeqRollback) {
+		t.Fatalf("expected ErrRevocationSeqRollback on identical sequence, got %v", err)
+	}
+
+	// Forward update: seq 6 > 5 succeeds
+	rec6, err := wire.SignRevocation(idA, targetID, 6, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.StoreTombstone(ctx, rec6); err != nil {
+		t.Fatalf("forward sequence StoreTombstone failed: %v", err)
+	}
+	got6, _ := store.GetTombstone(ctx, targetID)
+	if got6.Seq != 6 {
+		t.Fatalf("expected seq 6, got %d", got6.Seq)
+	}
+
+	// Self-tombstone
+	selfTomb, err := wire.SignSelfTombstone(idA, 1, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.StoreTombstone(ctx, selfTomb); err != nil {
+		t.Fatalf("StoreTombstone for self-tombstone failed: %v", err)
+	}
+	if !store.HasTombstone(ctx, idA.DeviceID) {
+		t.Fatal("expected HasTombstone for self-tombstone to be true")
+	}
+
+	list, err := store.ListTombstones(ctx)
+	if err != nil {
+		t.Fatalf("ListTombstones failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 tombstones, got %d", len(list))
+	}
+}
+
+func TestFileTombstoneStore(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "tombstones.json")
+
+	store, err := NewFileTombstoneStore(filePath)
+	if err != nil {
+		t.Fatalf("NewFileTombstoneStore failed: %v", err)
+	}
+
+	seedA := sha256.Sum256([]byte("seed-file-tombstone-alice"))
+	privA := ed25519.NewKeyFromSeed(seedA[:])
+	idA, err := wire.NewDeviceIdentity(privA.Public().(ed25519.PublicKey), privA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetID := "sb-dev-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	now := time.Now().UTC()
+
+	rec, err := wire.SignRevocation(idA, targetID, 1, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.StoreTombstone(ctx, rec); err != nil {
+		t.Fatalf("StoreTombstone failed: %v", err)
+	}
+
+	// Check file permissions are 0600
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("expected 0600 permissions on tombstone file, got %o", perm)
+	}
+
+	// Reload from disk into fresh store instance
+	reloaded, err := NewFileTombstoneStore(filePath)
+	if err != nil {
+		t.Fatalf("reload NewFileTombstoneStore failed: %v", err)
+	}
+	if !reloaded.HasTombstone(ctx, targetID) {
+		t.Fatal("reloaded store missing tombstone")
+	}
+
+	got, err := reloaded.GetTombstone(ctx, targetID)
+	if err != nil || got.Seq != 1 {
+		t.Fatalf("unexpected reloaded tombstone: %+v, err: %v", got, err)
+	}
+
+	// Monotonic sequence rollback check
+	staleRec, err := wire.SignRevocation(idA, targetID, 1, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reloaded.StoreTombstone(ctx, staleRec); !errors.Is(err, wire.ErrRevocationSeqRollback) {
+		t.Fatalf("expected ErrRevocationSeqRollback on disk store, got %v", err)
+	}
+
+	// Corrupt file handling: write invalid JSON
+	corruptPath := filepath.Join(tmpDir, "corrupt_tombstones.json")
+	if err := os.WriteFile(corruptPath, []byte("not-valid-json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewFileTombstoneStore(corruptPath); !errors.Is(err, ErrCorruptTombstoneStore) {
+		t.Fatalf("expected ErrCorruptTombstoneStore on corrupt file, got %v", err)
+	}
+}

--- a/packages/engine/trust/trusted_session.go
+++ b/packages/engine/trust/trusted_session.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/sendbeam/wire"
@@ -51,10 +52,11 @@ type TrustedSessionConfig struct {
 	Capabilities []string
 }
 
-// TrustedSessionResult contains the authenticated peer's trust record and derived directional keys.
+// TrustedSessionResult contains the authenticated peer's trust record, derived directional keys, and session lifecycle guard.
 type TrustedSessionResult struct {
 	PeerRecord *wire.TrustRecord
 	Keys       *wire.TrustedSessionKeys
+	Unregister func()
 }
 
 // TrustedSessionCoordinator manages mutual challenge-response authentication between paired devices.
@@ -62,7 +64,14 @@ type TrustedSessionCoordinator struct {
 	idMgr       *IdentityManager
 	store       Store
 	resolver    SecretResolver
+	credStore   CredentialStore
+	tombstones  TombstoneStore
+	clusterID   string
 	replayCache *wire.NonceReplayCache
+
+	activeMu       sync.Mutex
+	activeSessions map[string]map[int64]context.CancelFunc
+	nextSessionID  int64
 }
 
 // NewTrustedSessionCoordinator creates a new TrustedSessionCoordinator.
@@ -75,6 +84,78 @@ func NewTrustedSessionCoordinator(idMgr *IdentityManager, store Store, resolver 
 	}
 }
 
+// SetTombstoneStore sets the TombstoneStore for persistent tombstone checking (ADR 0010 §4.5).
+func (c *TrustedSessionCoordinator) SetTombstoneStore(tombstones TombstoneStore) {
+	c.tombstones = tombstones
+}
+
+// SetCredentialStore sets the CredentialStore for pair secret lifecycle management (ADR 0010 §4).
+func (c *TrustedSessionCoordinator) SetCredentialStore(credStore CredentialStore) {
+	c.credStore = credStore
+}
+
+// SetClusterID sets the local owner cluster ID for transitive mesh authorization checks (ADR 0010 §4.2).
+func (c *TrustedSessionCoordinator) SetClusterID(clusterID string) {
+	c.clusterID = clusterID
+}
+
+// RegisterActiveSession registers an active in-flight session with a peer device.
+// Returns an unregister function that must be called when the session terminates.
+func (c *TrustedSessionCoordinator) RegisterActiveSession(peerDeviceID string, cancel context.CancelFunc) func() {
+	c.activeMu.Lock()
+	defer c.activeMu.Unlock()
+
+	if c.activeSessions == nil {
+		c.activeSessions = make(map[string]map[int64]context.CancelFunc)
+	}
+
+	c.nextSessionID++
+	id := c.nextSessionID
+
+	if c.activeSessions[peerDeviceID] == nil {
+		c.activeSessions[peerDeviceID] = make(map[int64]context.CancelFunc)
+	}
+	c.activeSessions[peerDeviceID][id] = cancel
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			c.activeMu.Lock()
+			defer c.activeMu.Unlock()
+			if m, ok := c.activeSessions[peerDeviceID]; ok {
+				delete(m, id)
+				if len(m) == 0 {
+					delete(c.activeSessions, peerDeviceID)
+				}
+			}
+		})
+	}
+}
+
+// AbortActiveSessions immediately invokes the cancel functions for all in-flight sessions
+// registered for the specified target device ID, returning the number of aborted sessions (ADR 0010 §4.4 rule 10).
+func (c *TrustedSessionCoordinator) AbortActiveSessions(targetDeviceID string) int {
+	c.activeMu.Lock()
+	m, ok := c.activeSessions[targetDeviceID]
+	if !ok || len(m) == 0 {
+		c.activeMu.Unlock()
+		return 0
+	}
+	delete(c.activeSessions, targetDeviceID)
+	cancels := make([]context.CancelFunc, 0, len(m))
+	for _, fn := range m {
+		if fn != nil {
+			cancels = append(cancels, fn)
+		}
+	}
+	c.activeMu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+	return len(cancels)
+}
+
 // InitiateTrustedSession executes the initiator role of the trusted-session authentication handshake.
 func (c *TrustedSessionCoordinator) InitiateTrustedSession(ctx context.Context, transport PairingTransport, cfg TrustedSessionConfig) (*TrustedSessionResult, error) {
 	if transport == nil {
@@ -82,6 +163,11 @@ func (c *TrustedSessionCoordinator) InitiateTrustedSession(ctx context.Context, 
 	}
 	if cfg.PeerDeviceID == "" {
 		return nil, errors.New("peer device ID required")
+	}
+
+	// ADR 0010 §4.5: Check if peer has an active tombstone
+	if c.tombstones != nil && c.tombstones.HasTombstone(ctx, cfg.PeerDeviceID) {
+		return nil, wire.ErrTrustedPeerRevoked
 	}
 
 	record, err := c.store.GetDevice(ctx, cfg.PeerDeviceID)
@@ -252,6 +338,12 @@ func (c *TrustedSessionCoordinator) AcceptTrustedSession(ctx context.Context, tr
 		return nil, errors.New("expected trusted auth init message")
 	}
 
+	// ADR 0010 §4.5: Check if initiator has an active tombstone
+	if c.tombstones != nil && c.tombstones.HasTombstone(ctx, initMsg.InitiatorDeviceID) {
+		_ = c.sendRejection(ctx, transport, "revoked")
+		return nil, wire.ErrTrustedPeerRevoked
+	}
+
 	record, err := c.store.GetDevice(ctx, initMsg.InitiatorDeviceID)
 	if err != nil {
 		_ = c.sendRejection(ctx, transport, "rejected")
@@ -394,7 +486,8 @@ func (c *TrustedSessionCoordinator) sendRejection(ctx context.Context, transport
 	return transport.SendMessage(ctx, data)
 }
 
-// RevokeDevice explicitly revokes trust for a peer, creates a signed RevocationRecord, and updates the local trust store.
+// RevokeDevice explicitly revokes trust for a peer, creates a signed RevocationRecord, updates the local trust store,
+// stores a tombstone, removes pair credentials, and terminates active sessions (ADR 0010 §4).
 func (c *TrustedSessionCoordinator) RevokeDevice(ctx context.Context, targetDeviceID string) error {
 	id, err := c.idMgr.GetOrCreateIdentity()
 	if err != nil {
@@ -416,43 +509,154 @@ func (c *TrustedSessionCoordinator) RevokeDevice(ctx context.Context, targetDevi
 		return fmt.Errorf("sign revocation record: %w", err)
 	}
 
-	return c.store.RevokeDeviceWithRecord(ctx, rec)
+	if err := c.store.RevokeDeviceWithRecord(ctx, rec); err != nil {
+		return err
+	}
+
+	if c.tombstones != nil {
+		_ = c.tombstones.StoreTombstone(ctx, rec)
+	}
+
+	if c.credStore != nil {
+		_ = c.credStore.DeletePairSecret(ctx, targetDeviceID)
+	}
+
+	c.AbortActiveSessions(targetDeviceID)
+
+	return nil
+}
+
+// RevokeSelf creates, signs, and records a self-tombstone announcing that this local device is retired or compromised (ADR 0010 §4.2).
+func (c *TrustedSessionCoordinator) RevokeSelf(ctx context.Context) (*wire.RevocationRecord, error) {
+	id, err := c.idMgr.GetOrCreateIdentity()
+	if err != nil {
+		return nil, fmt.Errorf("get local identity: %w", err)
+	}
+
+	rec, err := wire.SignSelfTombstone(id, 1, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("sign self-tombstone: %w", err)
+	}
+
+	if c.tombstones != nil {
+		_ = c.tombstones.StoreTombstone(ctx, rec)
+	}
+
+	c.AbortActiveSessions(id.DeviceID)
+
+	return rec, nil
+}
+
+// IngestRevocationRecord validates, checks authorization, and applies a signed RevocationRecord
+// in strict adherence to ADR 0010 §4.4 (10-step ingestion algorithm).
+func (c *TrustedSessionCoordinator) IngestRevocationRecord(ctx context.Context, record *wire.RevocationRecord) error {
+	if record == nil {
+		return wire.ErrInvalidRevocationRecord
+	}
+
+	// 1. Parse and validate record syntax and sequence (Seq > 0)
+	if err := record.Validate(); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	isSelf := record.IsSelfTombstone()
+	var isLocal bool
+	var revokerPubBytes []byte
+	if c.idMgr != nil {
+		if localID, err := c.idMgr.GetOrCreateIdentity(); err == nil && localID != nil {
+			if record.RevokerDeviceID == localID.DeviceID {
+				isLocal = true
+				revokerPubBytes = localID.PublicKey
+			}
+		}
+	}
+
+	// 2. Retrieve Revoker A
+	if !isLocal {
+		revoker, err := c.store.GetDevice(ctx, record.RevokerDeviceID)
+		if err != nil || revoker == nil {
+			if isSelf {
+				// Case 2a: Self-tombstone for unknown device:
+				// Record in persistent tombstone cache to prevent future pairing.
+				if c.tombstones != nil {
+					_ = c.tombstones.StoreTombstone(ctx, record)
+				}
+				return nil
+			}
+			// Unknown revoker for third-party device -> fail-closed
+			return wire.ErrRevokerUntrusted
+		}
+
+		// 3. Check if Revoker A is already revoked locally
+		if revoker.Revoked {
+			return wire.ErrRevokerUntrusted
+		}
+
+		// 4. AUTHORIZATION CHECK (ADR 0010 §4.2 / §4.4)
+		if !isSelf {
+			// External contact attempting third-party revocation -> rejected fail-closed
+			if revoker.Relationship != wire.RelationshipClusterMember && revoker.Relationship != wire.RelationshipClusterOwner {
+				return wire.ErrRevocationUnauthorized
+			}
+			if revoker.ClusterID == "" {
+				return wire.ErrRevocationUnauthorized
+			}
+			if c.clusterID != "" && revoker.ClusterID != c.clusterID {
+				return wire.ErrRevocationUnauthorized
+			}
+		}
+
+		pub, err := hex.DecodeString(revoker.PublicKey)
+		if err != nil || len(pub) != ed25519.PublicKeySize {
+			return wire.ErrRevocationSignatureFailed
+		}
+		revokerPubBytes = pub
+	}
+
+	// 5. Retrieve Target B from local trust store
+	target, err := c.store.GetDevice(ctx, record.RevokedDeviceID)
+	if err != nil || target == nil {
+		// Target B is not in local trust store:
+		// Record tombstone in persistent deny-list to prevent future pairing.
+		if c.tombstones != nil {
+			_ = c.tombstones.StoreTombstone(ctx, record)
+		}
+		return nil
+	}
+
+	// 6. Verify Ed25519 signature of A over Challenge_Revoke
+	if err := wire.VerifyRevocation(record, revokerPubBytes, wire.MaxRevocationTimestampSkew, now); err != nil {
+		return err
+	}
+
+	// 7. Sequence monotonicity check
+	if target.Revoked && target.RevocationSeq > 0 && record.Seq <= target.RevocationSeq {
+		return wire.ErrRevocationSeqRollback
+	}
+
+	// 9. Apply revocation to B in trust store
+	if err := c.store.RevokeDeviceWithRecord(ctx, record); err != nil {
+		return err
+	}
+
+	if c.tombstones != nil {
+		_ = c.tombstones.StoreTombstone(ctx, record)
+	}
+
+	if c.credStore != nil {
+		_ = c.credStore.DeletePairSecret(ctx, record.RevokedDeviceID)
+	}
+
+	// 10. Abort any active in-flight transfer sessions with Target B
+	c.AbortActiveSessions(record.RevokedDeviceID)
+
+	return nil
 }
 
 // processIncomingRevocations parses, authenticates, and applies signed RevocationRecords from trusted peers.
 func (c *TrustedSessionCoordinator) processIncomingRevocations(ctx context.Context, revocations []wire.RevocationRecord, _ string) {
-	if len(revocations) == 0 {
-		return
-	}
-	now := time.Now().UTC()
-	for _, rec := range revocations {
-		// 1. Structure validation
-		if err := rec.Validate(); err != nil {
-			continue
-		}
-
-		// 2. Direct pairing prerequisite: Revoker must exist in local trust store
-		revokerRec, err := c.store.GetDevice(ctx, rec.RevokerDeviceID)
-		if err != nil || revokerRec == nil {
-			continue // ignore claims from revokers we have never directly paired with
-		}
-
-		// 3. Revoker must be active (not revoked)
-		if revokerRec.Revoked {
-			continue // revoked devices cannot submit revocations
-		}
-
-		// 4. Verify signature against stored revoker public key
-		pubKey, err := hex.DecodeString(revokerRec.PublicKey)
-		if err != nil || len(pubKey) != ed25519.PublicKeySize {
-			continue
-		}
-
-		if err := wire.VerifyRevocation(&rec, pubKey, wire.MaxRevocationTimestampSkew, now); err != nil {
-			continue
-		}
-
-		// 5. Apply revocation to local store
-		_ = c.store.RevokeDeviceWithRecord(ctx, &rec)
+	for i := range revocations {
+		_ = c.IngestRevocationRecord(ctx, &revocations[i])
 	}
 }

--- a/packages/protocol/src/attack-matrix.test.ts
+++ b/packages/protocol/src/attack-matrix.test.ts
@@ -699,7 +699,7 @@ describe('SendBeam v1.8 Attack-Matrix & Adversarial Security Campaign', () => {
     expect(await verifyPairingConfirmTag(kPair1, devAttacker.deviceId, tagBob1)).toBe(false);
 
     // 3. Bit-flipped / forged tag
-    const badTag = '00' + tagBob1.slice(2);
+    const badTag = (tagBob1.startsWith('00') ? 'ff' : '00') + tagBob1.slice(2);
     expect(await verifyPairingConfirmTag(kPair1, devB.deviceId, badTag)).toBe(false);
 
     // 4. Malformed tag length

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -17,3 +17,8 @@ export const ErrorCode = {
   Internal: 'INTERNAL',
 } as const;
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+export const ERR_REVOCATION_UNAUTHORIZED = 'revocation record is unauthorized';
+export const ERR_REVOCATION_SEQ_ROLLBACK = 'revocation sequence number rollback';
+export const ERR_TRUSTED_PEER_REVOKED = 'trusted peer device is revoked';
+export const ERR_UNKNOWN_REVOKER = 'revocation revoker is not an active trusted peer';

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -38,3 +38,5 @@ export * from './indexeddb-trust-store.js';
 export * from './indexeddb-secret-store.js';
 export * from './browser-identity.js';
 export * from './revocation.js';
+export * from './tombstone-store.js';
+export * from './indexeddb-tombstone-store.js';

--- a/packages/protocol/src/indexeddb-tombstone-store.ts
+++ b/packages/protocol/src/indexeddb-tombstone-store.ts
@@ -1,0 +1,96 @@
+/**
+ * Persistent TombstoneStore implementation over IndexedDB (ADR 0010 §4.5).
+ */
+
+import { ERR_REVOCATION_SEQ_ROLLBACK } from './errors.js';
+import { type RevocationRecord, validateRevocationRecord } from './revocation.js';
+import type { TombstoneStore } from './tombstone-store.js';
+
+export const TOMBSTONE_DB_NAME = 'sendbeam-tombstones';
+export const TOMBSTONES_STORE = 'tombstones';
+
+export class IndexedDBTombstoneStore implements TombstoneStore {
+  private readonly customIdb: IDBFactory | undefined;
+  private dbPromise: Promise<IDBDatabase> | undefined;
+
+  constructor(customIdb?: IDBFactory) {
+    this.customIdb = customIdb;
+  }
+
+  private getDb(): Promise<IDBDatabase> {
+    if (!this.dbPromise) {
+      this.dbPromise = new Promise((resolve, reject) => {
+        const idb = this.customIdb ?? (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+        if (!idb) {
+          reject(new Error('IndexedDB is unavailable in this environment'));
+          return;
+        }
+
+        const req = idb.open(TOMBSTONE_DB_NAME, 1);
+        req.onupgradeneeded = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains(TOMBSTONES_STORE)) {
+            db.createObjectStore(TOMBSTONES_STORE, { keyPath: 'revoked_device_id' });
+          }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error('failed to open tombstone database'));
+      });
+    }
+    return this.dbPromise;
+  }
+
+  async storeTombstone(record: RevocationRecord): Promise<void> {
+    validateRevocationRecord(record);
+    const db = await this.getDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([TOMBSTONES_STORE], 'readwrite');
+      const store = tx.objectStore(TOMBSTONES_STORE);
+      const getReq = store.get(record.revoked_device_id);
+      getReq.onsuccess = () => {
+        const existing = getReq.result as RevocationRecord | undefined;
+        if (
+          existing &&
+          existing.revoker_device_id === record.revoker_device_id &&
+          record.seq <= existing.seq
+        ) {
+          tx.abort();
+          reject(new Error(ERR_REVOCATION_SEQ_ROLLBACK));
+          return;
+        }
+        store.put(record);
+      };
+      getReq.onerror = () => {
+        tx.abort();
+        reject(getReq.error ?? new Error('failed to read existing tombstone'));
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('failed to store tombstone'));
+    });
+  }
+
+  async getTombstone(deviceId: string): Promise<RevocationRecord | null> {
+    const db = await this.getDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([TOMBSTONES_STORE], 'readonly');
+      const req = tx.objectStore(TOMBSTONES_STORE).get(deviceId);
+      req.onsuccess = () => resolve((req.result as RevocationRecord) ?? null);
+      req.onerror = () => reject(req.error ?? new Error('failed to get tombstone'));
+    });
+  }
+
+  async hasTombstone(deviceId: string): Promise<boolean> {
+    const tomb = await this.getTombstone(deviceId);
+    return tomb !== null;
+  }
+
+  async listTombstones(): Promise<RevocationRecord[]> {
+    const db = await this.getDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([TOMBSTONES_STORE], 'readonly');
+      const req = tx.objectStore(TOMBSTONES_STORE).getAll();
+      req.onsuccess = () => resolve((req.result as RevocationRecord[]) ?? []);
+      req.onerror = () => reject(req.error ?? new Error('failed to list tombstones'));
+    });
+  }
+}

--- a/packages/protocol/src/indexeddb-trust-store.ts
+++ b/packages/protocol/src/indexeddb-trust-store.ts
@@ -7,6 +7,13 @@
  */
 
 import {
+  ERR_REVOCATION_SEQ_ROLLBACK,
+  ERR_REVOCATION_UNAUTHORIZED,
+  ERR_UNKNOWN_REVOKER,
+} from './errors.js';
+import {
+  RELATIONSHIP_CLUSTER_MEMBER,
+  RELATIONSHIP_CLUSTER_OWNER,
   type TrustPolicy,
   type TrustRecord,
   type TrustStore,
@@ -120,34 +127,73 @@ export class IndexedDBTrustStore implements TrustStore {
     return new Promise((resolve, reject) => {
       const tx = db.transaction([TRUST_DEVICES_STORE], 'readwrite');
       const store = tx.objectStore(TRUST_DEVICES_STORE);
-      const req = store.get(record.revoked_device_id);
-      req.onsuccess = () => {
-        const rec = req.result as TrustRecord | undefined;
-        if (!rec) {
-          // If the revoked device is not directly in our local store, do not fail
-          resolve();
-          return;
-        }
-        if (rec.revoked && rec.revokedBy === record.revoker_device_id) {
-          if (rec.revocationSeq && record.seq <= rec.revocationSeq) {
-            tx.abort();
-            reject(new Error('revocation sequence number rollback'));
+
+      const isSelf = record.revoker_device_id === record.revoked_device_id;
+      const finishRevocation = () => {
+        const targetReq = store.get(record.revoked_device_id);
+        targetReq.onsuccess = () => {
+          const rec = targetReq.result as TrustRecord | undefined;
+          if (!rec) {
+            resolve();
             return;
           }
-        }
-        rec.revoked = true;
-        rec.revokedAt = record.timestamp;
-        rec.revokedBy = record.revoker_device_id;
-        rec.revocationSeq = record.seq;
-        rec.revocationSig = record.signature;
-        store.put(rec);
+          if (rec.revoked && rec.revocationSeq && record.seq <= rec.revocationSeq) {
+            tx.abort();
+            reject(new Error(ERR_REVOCATION_SEQ_ROLLBACK));
+            return;
+          }
+          rec.revoked = true;
+          rec.revokedAt = record.timestamp;
+          rec.revokedBy = record.revoker_device_id;
+          rec.revocationSeq = record.seq;
+          rec.revocationSig = record.signature;
+          store.put(rec);
+        };
+        targetReq.onerror = () => {
+          tx.abort();
+          reject(targetReq.error ?? new Error('revokeDeviceWithRecord read target failed'));
+        };
       };
-      req.onerror = () => {
-        tx.abort();
-        reject(req.error ?? new Error(`revokeDeviceWithRecord read failed`));
-      };
+
+      if (!isSelf) {
+        const revokerReq = store.get(record.revoker_device_id);
+        revokerReq.onsuccess = () => {
+          const revoker = revokerReq.result as TrustRecord | undefined;
+          if (!revoker) {
+            tx.abort();
+            reject(new Error(ERR_UNKNOWN_REVOKER));
+            return;
+          }
+          if (revoker.revoked) {
+            tx.abort();
+            reject(new Error('revocation revoker is revoked'));
+            return;
+          }
+          if (
+            revoker.relationship !== RELATIONSHIP_CLUSTER_MEMBER &&
+            revoker.relationship !== RELATIONSHIP_CLUSTER_OWNER
+          ) {
+            tx.abort();
+            reject(new Error(ERR_REVOCATION_UNAUTHORIZED));
+            return;
+          }
+          if (!revoker.clusterId || revoker.clusterId.trim() === '') {
+            tx.abort();
+            reject(new Error(ERR_REVOCATION_UNAUTHORIZED));
+            return;
+          }
+          finishRevocation();
+        };
+        revokerReq.onerror = () => {
+          tx.abort();
+          reject(revokerReq.error ?? new Error('revokeDeviceWithRecord read revoker failed'));
+        };
+      } else {
+        finishRevocation();
+      }
+
       tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error ?? new Error(`revokeDeviceWithRecord failed`));
+      tx.onerror = () => reject(tx.error ?? new Error('revokeDeviceWithRecord failed'));
     });
   }
 

--- a/packages/protocol/src/revocation.test.ts
+++ b/packages/protocol/src/revocation.test.ts
@@ -6,7 +6,9 @@ import { bytesToHex, hexToBytes } from './bytes.js';
 import { createDeviceIdentityFromSeed } from './identity.js';
 import {
   buildRevocationChallenge,
+  isSelfTombstone,
   signRevocation,
+  signSelfTombstone,
   validateRevocationRecord,
   verifyRevocation,
   type RevocationRecord,
@@ -75,10 +77,17 @@ describe('Revocation Records & Cross-Language Vectors', () => {
     const valid = await verifyRevocation(rec, id.publicKey, 5 * 60 * 1000, now);
     expect(valid).toBe(true);
 
-    // Reject self-revocation
-    await expect(signRevocation(id, id.deviceId, 1, now)).rejects.toThrow(
-      'cannot revoke self in mesh sync',
-    );
+    // Self-tombstone (ADR 0010 §4.2)
+    const selfTomb = await signRevocation(id, id.deviceId, 1, now);
+    expect(selfTomb.revoker_device_id).toBe(id.deviceId);
+    expect(selfTomb.revoked_device_id).toBe(id.deviceId);
+    expect(isSelfTombstone(selfTomb)).toBe(true);
+    validateRevocationRecord(selfTomb);
+    expect(await verifyRevocation(selfTomb, id.publicKey, 5 * 60 * 1000, now)).toBe(true);
+
+    const selfTombHelper = await signSelfTombstone(id, 2, now);
+    expect(isSelfTombstone(selfTombHelper)).toBe(true);
+    expect(selfTombHelper.seq).toBe(2);
 
     // Reject tampered signature
     const tamperedSig: RevocationRecord = {

--- a/packages/protocol/src/revocation.ts
+++ b/packages/protocol/src/revocation.ts
@@ -78,9 +78,6 @@ export async function signRevocation(
   if (!validateDeviceId(revokedDeviceId)) {
     throw new Error(`invalid revoked device id: ${revokedDeviceId}`);
   }
-  if (identity.deviceId === revokedDeviceId) {
-    throw new Error('cannot revoke self in mesh sync');
-  }
   if (!Number.isInteger(seq) || seq <= 0) {
     throw new Error('seq must be a positive integer > 0');
   }
@@ -99,7 +96,29 @@ export async function signRevocation(
 }
 
 /**
+ * Sign a new self-tombstone RevocationRecord announcing this device's own revocation (ADR 0010 §4.2).
+ */
+export async function signSelfTombstone(
+  identity: DeviceIdentity,
+  seq: number,
+  now = new Date(),
+): Promise<RevocationRecord> {
+  if (!identity) throw new Error('invalid identity: null or undefined');
+  return signRevocation(identity, identity.deviceId, seq, now);
+}
+
+/**
+ * Returns true if the revocation record is a self-tombstone where the revoker revokes itself (ADR 0010 §4.2).
+ */
+export function isSelfTombstone(record: RevocationRecord): boolean {
+  return (
+    !!record && !!record.revoker_device_id && record.revoker_device_id === record.revoked_device_id
+  );
+}
+
+/**
  * Validate the structural integrity of a RevocationRecord.
+ * Under ADR 0010 §4.2, self-tombstones (revoker_device_id === revoked_device_id) are structurally valid.
  */
 export function validateRevocationRecord(record: RevocationRecord): void {
   if (!record) throw new Error('invalid revocation record: null or undefined');
@@ -108,9 +127,6 @@ export function validateRevocationRecord(record: RevocationRecord): void {
   }
   if (!validateDeviceId(record.revoked_device_id)) {
     throw new Error(`invalid revoked device id: ${record.revoked_device_id}`);
-  }
-  if (record.revoker_device_id === record.revoked_device_id) {
-    throw new Error('cannot revoke self in mesh sync');
   }
   if (!Number.isInteger(record.seq) || record.seq <= 0) {
     throw new Error('seq must be a positive integer > 0');
@@ -166,4 +182,117 @@ export async function verifyRevocation(
   );
 
   return verifyDeviceSignature(revokerPublicKey, challenge, sigBytes);
+}
+
+import {
+  ERR_REVOCATION_SEQ_ROLLBACK,
+  ERR_REVOCATION_UNAUTHORIZED,
+  ERR_UNKNOWN_REVOKER,
+} from './errors.js';
+import type { TombstoneStore } from './tombstone-store.js';
+import {
+  RELATIONSHIP_CLUSTER_MEMBER,
+  RELATIONSHIP_CLUSTER_OWNER,
+  type TrustStore,
+} from './trust-store.js';
+
+export interface IngestRevocationOptions {
+  tombstoneStore?: TombstoneStore;
+  localClusterId?: string;
+  localDeviceId?: string;
+  localPublicKey?: Uint8Array;
+  now?: Date;
+  onAbortSession?: (deviceId: string) => void;
+}
+
+/**
+ * Ingest and verify an incoming mesh RevocationRecord in accordance with ADR 0010 §4.4.
+ */
+export async function ingestRevocationRecord(
+  record: RevocationRecord,
+  trustStore: TrustStore,
+  options?: IngestRevocationOptions,
+): Promise<void> {
+  // 1. Syntax validation
+  validateRevocationRecord(record);
+
+  const now = options?.now ?? new Date();
+  const isSelf = record.revoker_device_id === record.revoked_device_id;
+  const isLocal = Boolean(
+    options?.localDeviceId && record.revoker_device_id === options.localDeviceId,
+  );
+
+  // 2. Retrieve Revoker A from local trust store
+  let revokerPubBytes: Uint8Array;
+  if (isLocal && options?.localPublicKey) {
+    revokerPubBytes = options.localPublicKey;
+  } else {
+    const revoker = await trustStore.getDevice(record.revoker_device_id);
+    if (!revoker) {
+      if (isSelf) {
+        if (options?.tombstoneStore) {
+          await options.tombstoneStore.storeTombstone(record);
+        }
+        return;
+      }
+      throw new Error(ERR_UNKNOWN_REVOKER);
+    }
+
+    // 3. Check if Revoker A is already revoked locally
+    if (revoker.revoked) {
+      throw new Error('revocation revoker is revoked');
+    }
+
+    // 4. Authorization check
+    if (!isSelf && !isLocal) {
+      if (
+        revoker.relationship !== RELATIONSHIP_CLUSTER_MEMBER &&
+        revoker.relationship !== RELATIONSHIP_CLUSTER_OWNER
+      ) {
+        throw new Error(ERR_REVOCATION_UNAUTHORIZED);
+      }
+      if (!revoker.clusterId || revoker.clusterId.trim() === '') {
+        throw new Error(ERR_REVOCATION_UNAUTHORIZED);
+      }
+      if (options?.localClusterId && revoker.clusterId !== options.localClusterId) {
+        throw new Error(ERR_REVOCATION_UNAUTHORIZED);
+      }
+    }
+    revokerPubBytes = hexToBytes(revoker.publicKey);
+  }
+
+  // 5. Retrieve Target B from local trust store
+  const target = await trustStore.getDevice(record.revoked_device_id);
+  if (!target) {
+    if (options?.tombstoneStore) {
+      await options.tombstoneStore.storeTombstone(record);
+    }
+    return;
+  }
+
+  // 6. Verify Ed25519 signature
+  const sigValid = await verifyRevocation(
+    record,
+    revokerPubBytes,
+    MAX_REVOCATION_TIMESTAMP_SKEW_MS,
+    now,
+  );
+  if (!sigValid) {
+    throw new Error('trusted-session signature verification failed');
+  }
+
+  // 7. Sequence monotonicity check
+  if (target.revoked && target.revocationSeq && record.seq <= target.revocationSeq) {
+    throw new Error(ERR_REVOCATION_SEQ_ROLLBACK);
+  }
+
+  // 9. Apply revocation to Target B in trust store
+  await trustStore.revokeDeviceWithRecord(record);
+
+  if (options?.tombstoneStore) {
+    await options.tombstoneStore.storeTombstone(record);
+  }
+
+  // 10. Abort active sessions
+  options?.onAbortSession?.(record.revoked_device_id);
 }

--- a/packages/protocol/src/tombstone-store.test.ts
+++ b/packages/protocol/src/tombstone-store.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { bytesToHex } from './bytes.js';
+import {
+  ERR_REVOCATION_SEQ_ROLLBACK,
+  ERR_REVOCATION_UNAUTHORIZED,
+  ERR_UNKNOWN_REVOKER,
+} from './errors.js';
+import { createDeviceIdentityFromSeed } from './identity.js';
+import { IndexedDBTombstoneStore } from './indexeddb-tombstone-store.js';
+import {
+  ingestRevocationRecord,
+  isSelfTombstone,
+  signRevocation,
+  signSelfTombstone,
+} from './revocation.js';
+import { MemoryTombstoneStore } from './tombstone-store.js';
+import {
+  MemoryTrustStore,
+  RELATIONSHIP_CLUSTER_MEMBER,
+  RELATIONSHIP_CONTACT,
+} from './trust-store.js';
+
+class MockObjectStore {
+  constructor(public data = new Map<string, unknown>()) {}
+  get(key: string) {
+    const req: Record<string, unknown> = {
+      result: this.data.get(key),
+      onsuccess: null,
+      onerror: null,
+    };
+    queueMicrotask(() => (req.onsuccess as ((ev?: unknown) => void) | null)?.());
+    return req;
+  }
+  getAll() {
+    const req: Record<string, unknown> = {
+      result: Array.from(this.data.values()),
+      onsuccess: null,
+      onerror: null,
+    };
+    queueMicrotask(() => (req.onsuccess as ((ev?: unknown) => void) | null)?.());
+    return req;
+  }
+  put(value: unknown, key?: string) {
+    const k = key || (value as { revoked_device_id?: string })?.revoked_device_id || 'default';
+    this.data.set(k, value);
+    const req: Record<string, unknown> = {
+      onsuccess: null,
+      onerror: null,
+    };
+    queueMicrotask(() => (req.onsuccess as ((ev?: unknown) => void) | null)?.());
+    return req;
+  }
+  delete(key: string) {
+    this.data.delete(key);
+  }
+}
+
+class MockDatabase {
+  stores = new Map<string, MockObjectStore>();
+  objectStoreNames = {
+    contains: (name: string) => this.stores.has(name),
+  };
+  createObjectStore(name: string) {
+    const store = new MockObjectStore();
+    this.stores.set(name, store);
+    return store;
+  }
+  transaction(storeNames: string[], _mode: string) {
+    void _mode;
+    const firstStore = this.stores.get(storeNames[0]!) || this.createObjectStore(storeNames[0]!);
+    let aborted = false;
+    const tx: Record<string, unknown> = {
+      objectStore: (_name: string) => {
+        void _name;
+        return firstStore;
+      },
+      oncomplete: null,
+      onerror: null,
+      error: null,
+      abort: () => {
+        aborted = true;
+      },
+    };
+    setTimeout(() => {
+      if (!aborted) {
+        (tx.oncomplete as ((ev?: unknown) => void) | null)?.();
+      } else {
+        (tx.onerror as ((ev?: unknown) => void) | null)?.();
+      }
+    }, 0);
+    return tx;
+  }
+}
+
+class MockIDBFactory {
+  databases = new Map<string, MockDatabase>();
+  open(name: string, version: number) {
+    void version;
+    const db = this.databases.get(name) || new MockDatabase();
+    this.databases.set(name, db);
+    const req: Record<string, unknown> = {
+      result: db,
+      onsuccess: null,
+      onerror: null,
+      onupgradeneeded: null,
+    };
+    queueMicrotask(() => {
+      (req.onupgradeneeded as ((ev?: unknown) => void) | null)?.();
+      (req.onsuccess as ((ev?: unknown) => void) | null)?.();
+    });
+    return req;
+  }
+}
+
+describe('TombstoneStore and Authorization Lifecycle (ADR 0010)', () => {
+  let idAlice: Awaited<ReturnType<typeof createDeviceIdentityFromSeed>>;
+  let idBob: Awaited<ReturnType<typeof createDeviceIdentityFromSeed>>;
+  let idEve: Awaited<ReturnType<typeof createDeviceIdentityFromSeed>>;
+
+  beforeEach(async () => {
+    idAlice = await createDeviceIdentityFromSeed(new Uint8Array(32).fill(1));
+    idBob = await createDeviceIdentityFromSeed(new Uint8Array(32).fill(2));
+    idEve = await createDeviceIdentityFromSeed(new Uint8Array(32).fill(3));
+  });
+
+  it('MemoryTombstoneStore stores and enforces monotonic sequence rollback', async () => {
+    const store = new MemoryTombstoneStore();
+    const now = new Date('2026-09-07T06:00:00Z');
+
+    const recSeq5 = await signRevocation(idAlice, idBob.deviceId, 5, now);
+    await store.storeTombstone(recSeq5);
+
+    expect(await store.hasTombstone(idBob.deviceId)).toBe(true);
+    expect(await store.hasTombstone(idEve.deviceId)).toBe(false);
+
+    const retrieved = await store.getTombstone(idBob.deviceId);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved?.seq).toBe(5);
+
+    // Rollback attempt (seq 3 <= 5) is rejected
+    const recSeq3 = await signRevocation(idAlice, idBob.deviceId, 3, now);
+    await expect(store.storeTombstone(recSeq3)).rejects.toThrow(ERR_REVOCATION_SEQ_ROLLBACK);
+
+    // Identical sequence (seq 5 <= 5) is rejected
+    await expect(store.storeTombstone(recSeq5)).rejects.toThrow(ERR_REVOCATION_SEQ_ROLLBACK);
+
+    // Forward sequence (seq 6 > 5) succeeds
+    const recSeq6 = await signRevocation(idAlice, idBob.deviceId, 6, now);
+    await store.storeTombstone(recSeq6);
+    const updated = await store.getTombstone(idBob.deviceId);
+    expect(updated?.seq).toBe(6);
+
+    // Self-tombstone
+    const selfTomb = await signSelfTombstone(idAlice, 1, now);
+    expect(isSelfTombstone(selfTomb)).toBe(true);
+    await store.storeTombstone(selfTomb);
+    expect(await store.hasTombstone(idAlice.deviceId)).toBe(true);
+
+    const all = await store.listTombstones();
+    expect(all.length).toBe(2);
+  });
+
+  it('IndexedDBTombstoneStore stores and enforces monotonic sequence', async () => {
+    const mockIdb = new MockIDBFactory();
+    const store = new IndexedDBTombstoneStore(mockIdb as unknown as IDBFactory);
+    const now = new Date('2026-09-07T06:00:00Z');
+
+    const rec = await signRevocation(idAlice, idBob.deviceId, 10, now);
+    await store.storeTombstone(rec);
+
+    expect(await store.hasTombstone(idBob.deviceId)).toBe(true);
+    const retrieved = await store.getTombstone(idBob.deviceId);
+    expect(retrieved?.seq).toBe(10);
+
+    const stale = await signRevocation(idAlice, idBob.deviceId, 4, now);
+    await expect(store.storeTombstone(stale)).rejects.toThrow(ERR_REVOCATION_SEQ_ROLLBACK);
+  });
+
+  it('Authorization: External contacts cannot revoke third parties across mesh', async () => {
+    const trustStore = new MemoryTrustStore();
+    const tombstoneStore = new MemoryTombstoneStore();
+    const now = new Date().toISOString();
+
+    // Alice is an external contact
+    await trustStore.addOrUpdateDevice({
+      deviceId: idAlice.deviceId,
+      publicKey: bytesToHex(idAlice.publicKey),
+      localLabel: 'Alice Contact',
+      pairCredentialRef: 'cred-alice',
+      relationship: RELATIONSHIP_CONTACT,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      revoked: false,
+    });
+
+    // Bob is another contact
+    await trustStore.addOrUpdateDevice({
+      deviceId: idBob.deviceId,
+      publicKey: bytesToHex(idBob.publicKey),
+      localLabel: 'Bob Contact',
+      pairCredentialRef: 'cred-bob',
+      relationship: RELATIONSHIP_CONTACT,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      revoked: false,
+    });
+
+    // Alice tries to revoke Bob -> MUST BE REJECTED fail-closed with ERR_REVOCATION_UNAUTHORIZED
+    const aliceRevokingBob = await signRevocation(idAlice, idBob.deviceId, 1);
+    await expect(
+      ingestRevocationRecord(aliceRevokingBob, trustStore, { tombstoneStore }),
+    ).rejects.toThrow(ERR_REVOCATION_UNAUTHORIZED);
+
+    // Bob MUST remain trusted
+    expect(await trustStore.isTrusted(idBob.deviceId)).toBe(true);
+    expect(await tombstoneStore.hasTombstone(idBob.deviceId)).toBe(false);
+
+    // But Alice CAN revoke herself (self-tombstone is universally authorized)
+    const aliceSelfTomb = await signSelfTombstone(idAlice, 1);
+    await ingestRevocationRecord(aliceSelfTomb, trustStore, { tombstoneStore });
+    expect(await trustStore.isTrusted(idAlice.deviceId)).toBe(false);
+    expect(await tombstoneStore.hasTombstone(idAlice.deviceId)).toBe(true);
+  });
+
+  it('Authorization: Cluster member can revoke devices within cluster and abort sessions', async () => {
+    const trustStore = new MemoryTrustStore();
+    const tombstoneStore = new MemoryTombstoneStore();
+    const now = new Date().toISOString();
+    const clusterId = 'sb-cluster-test-123';
+
+    // Alice and Bob are cluster members
+    await trustStore.addOrUpdateDevice({
+      deviceId: idAlice.deviceId,
+      publicKey: bytesToHex(idAlice.publicKey),
+      localLabel: 'Alice Laptop',
+      pairCredentialRef: 'cred-alice',
+      relationship: RELATIONSHIP_CLUSTER_MEMBER,
+      clusterId,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      revoked: false,
+    });
+
+    await trustStore.addOrUpdateDevice({
+      deviceId: idBob.deviceId,
+      publicKey: bytesToHex(idBob.publicKey),
+      localLabel: 'Bob Phone',
+      pairCredentialRef: 'cred-bob',
+      relationship: RELATIONSHIP_CLUSTER_MEMBER,
+      clusterId,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      revoked: false,
+    });
+
+    let abortedDevice = '';
+    const aliceRevokingBob = await signRevocation(idAlice, idBob.deviceId, 1);
+    await ingestRevocationRecord(aliceRevokingBob, trustStore, {
+      tombstoneStore,
+      localClusterId: clusterId,
+      onAbortSession: (devId) => {
+        abortedDevice = devId;
+      },
+    });
+
+    expect(await trustStore.isTrusted(idBob.deviceId)).toBe(false);
+    expect(await tombstoneStore.hasTombstone(idBob.deviceId)).toBe(true);
+    expect(abortedDevice).toBe(idBob.deviceId);
+
+    const bob = await trustStore.getDevice(idBob.deviceId);
+    expect(bob?.revoked).toBe(true);
+    expect(bob?.revokedBy).toBe(idAlice.deviceId);
+  });
+
+  it('Unknown revoker self-tombstone is saved to deny-list to prevent future pairing', async () => {
+    const trustStore = new MemoryTrustStore();
+    const tombstoneStore = new MemoryTombstoneStore();
+
+    // Unknown device Eve emits self-tombstone
+    const eveSelfTomb = await signSelfTombstone(idEve, 1);
+    await ingestRevocationRecord(eveSelfTomb, trustStore, { tombstoneStore });
+
+    // Eve is not in trustStore, but is now denied in tombstoneStore
+    expect(await tombstoneStore.hasTombstone(idEve.deviceId)).toBe(true);
+
+    // But an unknown device trying to revoke Bob fails closed
+    const eveRevokingBob = await signRevocation(idEve, idBob.deviceId, 1);
+    await expect(
+      ingestRevocationRecord(eveRevokingBob, trustStore, { tombstoneStore }),
+    ).rejects.toThrow(ERR_UNKNOWN_REVOKER);
+  });
+});

--- a/packages/protocol/src/tombstone-store.ts
+++ b/packages/protocol/src/tombstone-store.ts
@@ -1,0 +1,50 @@
+/**
+ * Persistent and in-memory storage for signed revocation tombstones (ADR 0010 §4.5).
+ */
+
+import { ERR_REVOCATION_SEQ_ROLLBACK } from './errors.js';
+import { type RevocationRecord, validateRevocationRecord } from './revocation.js';
+
+/**
+ * TombstoneStore defines the interface for persisting and querying signed revocation tombstones.
+ */
+export interface TombstoneStore {
+  storeTombstone(record: RevocationRecord): Promise<void>;
+  getTombstone(deviceId: string): Promise<RevocationRecord | null>;
+  hasTombstone(deviceId: string): Promise<boolean>;
+  listTombstones(): Promise<RevocationRecord[]>;
+}
+
+/**
+ * MemoryTombstoneStore is an in-memory implementation of TombstoneStore.
+ */
+export class MemoryTombstoneStore implements TombstoneStore {
+  private readonly tombstones = new Map<string, RevocationRecord>();
+
+  async storeTombstone(record: RevocationRecord): Promise<void> {
+    validateRevocationRecord(record);
+    const existing = this.tombstones.get(record.revoked_device_id);
+    if (
+      existing &&
+      existing.revoker_device_id === record.revoker_device_id &&
+      record.seq <= existing.seq
+    ) {
+      throw new Error(ERR_REVOCATION_SEQ_ROLLBACK);
+    }
+    this.tombstones.set(record.revoked_device_id, { ...record });
+  }
+
+  async getTombstone(deviceId: string): Promise<RevocationRecord | null> {
+    const rec = this.tombstones.get(deviceId);
+    if (!rec) return null;
+    return { ...rec };
+  }
+
+  async hasTombstone(deviceId: string): Promise<boolean> {
+    return this.tombstones.has(deviceId);
+  }
+
+  async listTombstones(): Promise<RevocationRecord[]> {
+    return Array.from(this.tombstones.values()).map((r) => ({ ...r }));
+  }
+}

--- a/packages/protocol/src/trust-store.ts
+++ b/packages/protocol/src/trust-store.ts
@@ -105,6 +105,10 @@ export async function validateTrustRecord(record: TrustRecord): Promise<void> {
   }
 }
 
+import {
+  ERR_REVOCATION_SEQ_ROLLBACK,
+  ERR_REVOCATION_UNAUTHORIZED,
+} from './errors.js';
 import { type RevocationRecord, validateRevocationRecord } from './revocation.js';
 
 /**
@@ -155,14 +159,33 @@ export class MemoryTrustStore implements TrustStore {
 
   async revokeDeviceWithRecord(record: RevocationRecord): Promise<void> {
     validateRevocationRecord(record);
+
+    // ADR 0010 §4.4: If revoker is in the store, verify it is not revoked and not an unauthorized contact
+    const isSelf = record.revoker_device_id === record.revoked_device_id;
+    if (!isSelf) {
+      const revoker = this.records.get(record.revoker_device_id);
+      if (revoker) {
+        if (revoker.revoked) {
+          throw new Error('revocation revoker is revoked');
+        }
+        if (
+          revoker.relationship !== RELATIONSHIP_CLUSTER_MEMBER &&
+          revoker.relationship !== RELATIONSHIP_CLUSTER_OWNER
+        ) {
+          throw new Error(ERR_REVOCATION_UNAUTHORIZED);
+        }
+        if (!revoker.clusterId || revoker.clusterId.trim() === '') {
+          throw new Error(ERR_REVOCATION_UNAUTHORIZED);
+        }
+      }
+    }
+
     const rec = this.records.get(record.revoked_device_id);
     if (!rec) {
       return;
     }
-    if (rec.revoked && rec.revokedBy === record.revoker_device_id) {
-      if (rec.revocationSeq && record.seq <= rec.revocationSeq) {
-        throw new Error('revocation sequence number rollback');
-      }
+    if (rec.revoked && rec.revocationSeq && record.seq <= rec.revocationSeq) {
+      throw new Error(ERR_REVOCATION_SEQ_ROLLBACK);
     }
     rec.revoked = true;
     rec.revokedAt = record.timestamp;

--- a/packages/protocol/src/trust-store.ts
+++ b/packages/protocol/src/trust-store.ts
@@ -105,10 +105,7 @@ export async function validateTrustRecord(record: TrustRecord): Promise<void> {
   }
 }
 
-import {
-  ERR_REVOCATION_SEQ_ROLLBACK,
-  ERR_REVOCATION_UNAUTHORIZED,
-} from './errors.js';
+import { ERR_REVOCATION_SEQ_ROLLBACK, ERR_REVOCATION_UNAUTHORIZED } from './errors.js';
 import { type RevocationRecord, validateRevocationRecord } from './revocation.js';
 
 /**

--- a/packages/wire/revocation.go
+++ b/packages/wire/revocation.go
@@ -17,22 +17,22 @@ const (
 
 var (
 	// ErrInvalidRevocationRecord indicates a malformed or structurally invalid revocation record.
-	ErrInvalidRevocationRecord = errors.New("invalid revocation record")
+	ErrInvalidRevocationRecord = Errorf(CodeProtocol, "invalid revocation record")
 
 	// ErrRevocationSignatureFailed indicates that the Ed25519 signature in a revocation record failed verification.
-	ErrRevocationSignatureFailed = errors.New("revocation signature verification failed")
+	ErrRevocationSignatureFailed = Errorf(CodeAuth, "revocation signature verification failed")
 
-	// ErrRevocationSelfRevoke indicates a revocation record where the revoker and revoked device IDs are identical.
+	// ErrRevocationSelfRevoke indicates a revocation record where the revoker and revoked device IDs are identical (deprecated: self-tombstones are valid under ADR 0010).
 	ErrRevocationSelfRevoke = errors.New("cannot revoke self in mesh sync")
 
 	// ErrRevocationSeqRollback indicates a revocation sequence number that is less than or equal to an existing record.
-	ErrRevocationSeqRollback = errors.New("revocation sequence number rollback")
+	ErrRevocationSeqRollback = Errorf(CodeProtocol, "revocation sequence number rollback")
 
 	// ErrRevocationTimestampSkew indicates that the revocation timestamp is outside acceptable clock skew boundaries.
-	ErrRevocationTimestampSkew = errors.New("revocation timestamp outside acceptable window")
+	ErrRevocationTimestampSkew = Errorf(CodeAuth, "revocation timestamp outside acceptable window")
 
 	// ErrRevokerUntrusted indicates that the device submitting a revocation is not an active trusted peer.
-	ErrRevokerUntrusted = errors.New("revocation revoker is not an active trusted peer")
+	ErrRevokerUntrusted = Errorf(CodeAuth, "revocation revoker is not an active trusted peer")
 )
 
 // RevocationRecord represents a cryptographically signed statement asserting that a peer device has been revoked.
@@ -42,6 +42,14 @@ type RevocationRecord struct {
 	Seq             uint64 `json:"seq"`
 	Timestamp       string `json:"timestamp"` // RFC 3339 UTC format
 	Signature       string `json:"signature"` // hex-encoded Ed25519 signature
+}
+
+// IsSelfTombstone returns true if the revocation record is a self-tombstone where the revoker revokes itself (ADR 0010 §4.2).
+func (r *RevocationRecord) IsSelfTombstone() bool {
+	if r == nil {
+		return false
+	}
+	return r.RevokerDeviceID != "" && r.RevokerDeviceID == r.RevokedDeviceID
 }
 
 // BuildRevocationChallenge constructs the canonical binary payload signed by the revoker device.
@@ -60,15 +68,13 @@ func BuildRevocationChallenge(revokerID, revokedID string, seq uint64, timestamp
 }
 
 // SignRevocation creates and signs a new RevocationRecord with the revoker's DeviceIdentity.
+// Under ADR 0010 §4.2, RevokerDeviceID == RevokedDeviceID is permitted and creates an authorized self-tombstone.
 func SignRevocation(id *DeviceIdentity, revokedDeviceID string, seq uint64, now time.Time) (*RevocationRecord, error) {
 	if id == nil {
 		return nil, ErrInvalidIdentity
 	}
 	if !ValidateDeviceID(revokedDeviceID) {
 		return nil, fmt.Errorf("%w: invalid revoked device id %q", ErrInvalidRevocationRecord, revokedDeviceID)
-	}
-	if id.DeviceID == revokedDeviceID {
-		return nil, ErrRevocationSelfRevoke
 	}
 	if seq == 0 {
 		return nil, fmt.Errorf("%w: seq must be greater than 0", ErrInvalidRevocationRecord)
@@ -91,7 +97,16 @@ func SignRevocation(id *DeviceIdentity, revokedDeviceID string, seq uint64, now 
 	}, nil
 }
 
+// SignSelfTombstone creates and signs a new self-tombstone RevocationRecord announcing this device's own revocation (ADR 0010 §4.2).
+func SignSelfTombstone(id *DeviceIdentity, seq uint64, now time.Time) (*RevocationRecord, error) {
+	if id == nil {
+		return nil, ErrInvalidIdentity
+	}
+	return SignRevocation(id, id.DeviceID, seq, now)
+}
+
 // Validate checks the structural syntax and field constraints of a RevocationRecord.
+// Under ADR 0010 §4.2, self-tombstones (RevokerDeviceID == RevokedDeviceID) are structurally valid.
 func (r *RevocationRecord) Validate() error {
 	if r == nil {
 		return ErrInvalidRevocationRecord
@@ -101,9 +116,6 @@ func (r *RevocationRecord) Validate() error {
 	}
 	if !ValidateDeviceID(r.RevokedDeviceID) {
 		return fmt.Errorf("%w: invalid revoked device id %q", ErrInvalidRevocationRecord, r.RevokedDeviceID)
-	}
-	if r.RevokerDeviceID == r.RevokedDeviceID {
-		return ErrRevocationSelfRevoke
 	}
 	if r.Seq == 0 {
 		return fmt.Errorf("%w: seq must be > 0", ErrInvalidRevocationRecord)

--- a/packages/wire/revocation_fuzz_test.go
+++ b/packages/wire/revocation_fuzz_test.go
@@ -61,8 +61,8 @@ func FuzzRevocationRecord(f *testing.F) {
 			if !ValidateDeviceID(rec.RevokedDeviceID) {
 				t.Fatalf("Validate() passed with invalid revoked device ID %q", rec.RevokedDeviceID)
 			}
-			if rec.RevokerDeviceID == rec.RevokedDeviceID {
-				t.Fatalf("Validate() passed with self-revocation %q", rec.RevokerDeviceID)
+			if rec.RevokerDeviceID == rec.RevokedDeviceID && !rec.IsSelfTombstone() {
+				t.Fatalf("Validate() passed self-tombstone but IsSelfTombstone() is false")
 			}
 			if rec.Seq == 0 {
 				t.Fatalf("Validate() passed with Seq == 0")

--- a/packages/wire/revocation_test.go
+++ b/packages/wire/revocation_test.go
@@ -96,10 +96,28 @@ func TestRevocationRecord_ValidationAndErrors(t *testing.T) {
 		t.Fatalf("VerifyRevocation failed: %v", err)
 	}
 
-	// Self-revocation attempt rejected
-	_, err = SignRevocation(id, id.DeviceID, 1, now)
-	if err == nil {
-		t.Fatal("expected SignRevocation to reject self-revocation")
+	// Self-tombstone (ADR 0010 §4.2) succeeds and validates
+	selfTomb, err := SignRevocation(id, id.DeviceID, 1, now)
+	if err != nil {
+		t.Fatalf("expected SignRevocation to permit self-tombstone: %v", err)
+	}
+	if !selfTomb.IsSelfTombstone() {
+		t.Fatal("expected selfTomb.IsSelfTombstone() to be true")
+	}
+	if err := selfTomb.Validate(); err != nil {
+		t.Fatalf("expected self-tombstone Validate to succeed: %v", err)
+	}
+	if err := VerifyRevocation(selfTomb, id.PublicKey, 5*time.Minute, now); err != nil {
+		t.Fatalf("expected VerifyRevocation to succeed for self-tombstone: %v", err)
+	}
+
+	// SignSelfTombstone convenience helper
+	selfTomb2, err := SignSelfTombstone(id, 2, now)
+	if err != nil {
+		t.Fatalf("SignSelfTombstone failed: %v", err)
+	}
+	if !selfTomb2.IsSelfTombstone() || selfTomb2.Seq != 2 {
+		t.Fatalf("unexpected selfTomb2: %+v", selfTomb2)
 	}
 
 	// Seq = 0 rejected

--- a/packages/wire/trusted_auth.go
+++ b/packages/wire/trusted_auth.go
@@ -71,7 +71,7 @@ var (
 	ErrTrustedPeerMismatch = errors.New("trusted-session peer device ID mismatch")
 
 	// ErrTrustedPeerRevoked indicates that the peer device has been revoked in local trust store.
-	ErrTrustedPeerRevoked = errors.New("trusted peer device is revoked")
+	ErrTrustedPeerRevoked = Errorf(CodeAuth, "trusted peer device is revoked")
 
 	// ErrTrustedRejected indicates that the peer explicitly rejected the trusted session.
 	ErrTrustedRejected = errors.New("trusted session was rejected by peer")


### PR DESCRIPTION
### Summary
Implements ADR 0010 §4 and §5 authorized signed tombstones, peer relationship authorization boundaries, persistent tombstone storage, pairwise secret deletion, and active-session termination across all SendBeam layers.

- **Wire Primitives & Verification**: Universal self-tombstones (`RevokerDeviceID == RevokedDeviceID`), challenge formatting, and validation.
- **Protocol (TS)**: `TombstoneStore` and `IndexedDBTombstoneStore`, 10-step ingestion verification algorithm (`ingestRevocationRecord`), contact revocation fail-closed enforcement with `ERR_REVOCATION_UNAUTHORIZED`.
- **Engine (Go)**: `TombstoneStore`, `MemoryTombstoneStore`, and atomic `FileTombstoneStore` (`tombstones.json`, 0600 permissions, monotonic sequence rollback rejection), session registration and immediate abort (`RegisterActiveSession`, `AbortActiveSessions`), pairing coordination conflict check against tombstones.
- **CLI & Desktop Integration**: Tombstone store initialization in `CLIEnvironment` and `DeviceService`, non-purge and purge credential deletion, rejection of revoked/tombstoned devices during pairing and sending.

Delivers [V19-PR04] of the v1.8 → v2.0 roadmap.