### PR TITLE
feat(rendezvous): ephemeral opaque rendezvous and truthful presence

### DIFF
--- a/apps/server/internal/signal/hub.go
+++ b/apps/server/internal/signal/hub.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/sendbeam/wire"
 )
 
 // Hub owns every room and the goroutine that reaps idle ones. A room holds at most
@@ -19,6 +20,7 @@ type Hub struct {
 
 	mu                sync.Mutex
 	rooms             map[int]*room
+	handleRooms       map[string]*room
 	draining          bool
 	drainCh           chan struct{}
 	activeConns       int
@@ -36,6 +38,7 @@ type Hub struct {
 
 type room struct {
 	number     int
+	handle     string
 	offerer    *peer
 	joiner     *peer
 	lastSeen   time.Time
@@ -54,6 +57,7 @@ func NewHub(ctx context.Context, cfg Config, logger *slog.Logger) *Hub {
 		logger:         orDiscard(logger),
 		trustedProxies: trusted,
 		rooms:          make(map[int]*room),
+		handleRooms:    make(map[string]*room),
 		drainCh:        make(chan struct{}),
 		errors:         make(map[string]int64),
 		messages:       make(map[string]int64),
@@ -61,6 +65,16 @@ func NewHub(ctx context.Context, cfg Config, logger *slog.Logger) *Hub {
 	}
 	go h.reap(ctx)
 	return h
+}
+
+func (h *Hub) getRoomLocked(p *peer) *room {
+	if p.handle != "" {
+		return h.handleRooms[p.handle]
+	}
+	if p.room >= 0 {
+		return h.rooms[p.room]
+	}
+	return nil
 }
 
 func stringsJoin(elems []string, sep string) string {
@@ -108,6 +122,17 @@ func (h *Hub) Drain(ctx context.Context) error {
 			delete(h.rooms, n)
 		}
 	}
+	for handle, r := range h.handleRooms {
+		if r.offerer == nil || r.joiner == nil {
+			if r.offerer != nil {
+				unpairedPeers = append(unpairedPeers, r.offerer)
+			}
+			if r.joiner != nil {
+				unpairedPeers = append(unpairedPeers, r.joiner)
+			}
+			delete(h.handleRooms, handle)
+		}
+	}
 	h.mu.Unlock()
 
 	for _, p := range unpairedPeers {
@@ -130,7 +155,7 @@ func (h *Hub) Drain(ctx context.Context) error {
 
 	for {
 		h.mu.Lock()
-		count := len(h.rooms)
+		count := len(h.rooms) + len(h.handleRooms)
 		h.mu.Unlock()
 		if count == 0 {
 			return nil
@@ -149,6 +174,15 @@ func (h *Hub) Drain(ctx context.Context) error {
 					remaining = append(remaining, r.joiner)
 				}
 				delete(h.rooms, n)
+			}
+			for handle, r := range h.handleRooms {
+				if r.offerer != nil {
+					remaining = append(remaining, r.offerer)
+				}
+				if r.joiner != nil {
+					remaining = append(remaining, r.joiner)
+				}
+				delete(h.handleRooms, handle)
 			}
 			h.mu.Unlock()
 
@@ -225,7 +259,7 @@ func (h *Hub) createRoom(p *peer, ip string) (int, string) {
 	if h.draining {
 		return -1, errDraining
 	}
-	if h.cfg.RateLimitEnabled && h.cfg.MaxRooms > 0 && len(h.rooms) >= h.cfg.MaxRooms {
+	if h.cfg.RateLimitEnabled && h.cfg.MaxRooms > 0 && (len(h.rooms)+len(h.handleRooms)) >= h.cfg.MaxRooms {
 		return -1, errRoomLimit
 	}
 
@@ -241,6 +275,76 @@ func (h *Hub) createRoom(p *peer, ip string) (int, string) {
 	p.role = roleOfferer
 	h.roomsCreatedTotal++
 	return n, ""
+}
+
+// rendezvous seats p into an opaque handle room. If the handle room does not exist,
+// it is created with p as the first peer (default roleOfferer unless roleJoiner is requested).
+// If the handle room exists with one peer, p is seated as the complementary peer.
+// If the room is full, it is refused with errRoomFull.
+func (h *Hub) rendezvous(p *peer, handle string, role string, ip string) (*peer, string) {
+	if !wire.ValidateRendezvousHandle(handle) {
+		return nil, errInvalidHandle
+	}
+
+	tracker := h.getOrCreateIPTracker(ip)
+	if !tracker.allowJoin(h.cfg.RateLimitEnabled) {
+		return nil, errRateLimited
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.draining {
+		return nil, errDraining
+	}
+
+	if r, ok := h.handleRooms[handle]; ok {
+		if r.offerer != nil && r.joiner != nil {
+			tracker.recordFailedJoin(h.cfg.RateLimitEnabled)
+			return nil, errRoomFull
+		}
+
+		if r.offerer == nil {
+			r.offerer = p
+			p.role = roleOfferer
+			p.handle = handle
+			r.lastSeen = time.Now()
+			h.roomsPairedTotal++
+			return r.joiner, ""
+		}
+
+		r.joiner = p
+		p.role = roleJoiner
+		p.handle = handle
+		r.lastSeen = time.Now()
+		h.roomsPairedTotal++
+		return r.offerer, ""
+	}
+
+	if !tracker.allowRoomCreate(h.cfg.RateLimitEnabled) {
+		return nil, errRateLimited
+	}
+
+	if h.cfg.RateLimitEnabled && h.cfg.MaxRooms > 0 && (len(h.rooms)+len(h.handleRooms)) >= h.cfg.MaxRooms {
+		return nil, errRoomLimit
+	}
+
+	r := &room{
+		number:   -1,
+		handle:   handle,
+		lastSeen: time.Now(),
+	}
+	if role == roleJoiner {
+		r.joiner = p
+		p.role = roleJoiner
+	} else {
+		r.offerer = p
+		p.role = roleOfferer
+	}
+	p.handle = handle
+	h.handleRooms[handle] = r
+	h.roomsCreatedTotal++
+	return nil, ""
 }
 
 // join seats p as the joiner of an existing room and returns the offerer it paired
@@ -279,6 +383,15 @@ func (h *Hub) join(p *peer, number int, ip string) (*peer, string) {
 // reloaded and lost its ephemeral session. Only the slot for the claimed role may be
 // filled, and only if empty; the room and its number are unchanged.
 func (h *Hub) resume(p *peer, number int, role string, ip string) (*peer, string) {
+	return h.resumeInternal(p, number, "", role, ip)
+}
+
+// resumeHandle re-attaches p to a vacated slot of an existing (lingering) handle room.
+func (h *Hub) resumeHandle(p *peer, handle string, role string, ip string) (*peer, string) {
+	return h.resumeInternal(p, -1, handle, role, ip)
+}
+
+func (h *Hub) resumeInternal(p *peer, number int, handle string, role string, ip string) (*peer, string) {
 	if role != roleOfferer && role != roleJoiner {
 		return nil, errBadMessage
 	}
@@ -294,7 +407,17 @@ func (h *Hub) resume(p *peer, number int, role string, ip string) (*peer, string
 		return nil, errDraining
 	}
 
-	r, ok := h.rooms[number]
+	var r *room
+	var ok bool
+	if handle != "" {
+		if !wire.ValidateRendezvousHandle(handle) {
+			return nil, errInvalidHandle
+		}
+		r, ok = h.handleRooms[handle]
+	} else {
+		r, ok = h.rooms[number]
+	}
+
 	if !ok {
 		tracker.recordFailedJoin(h.cfg.RateLimitEnabled)
 		return nil, errUnknownRoom
@@ -313,7 +436,8 @@ func (h *Hub) resume(p *peer, number int, role string, ip string) (*peer, string
 		}
 		r.joiner = p
 	}
-	p.room = number
+	p.room = r.number
+	p.handle = r.handle
 	p.role = role
 	r.lastSeen = time.Now()
 	return roomPartner(r, p), ""
@@ -323,8 +447,8 @@ func (h *Hub) resume(p *peer, number int, role string, ip string) (*peer, string
 func (h *Hub) openRelay(p *peer) (other *peer, ready bool, code string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	r, ok := h.rooms[p.room]
-	if !ok {
+	r := h.getRoomLocked(p)
+	if r == nil {
 		return nil, false, errNotPaired
 	}
 	other = roomPartner(r, p)
@@ -343,8 +467,8 @@ func (h *Hub) grantRelayCredit(receiver *peer, requested int64) (*peer, int64, s
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	r, ok := h.rooms[receiver.room]
-	if !ok {
+	r := h.getRoomLocked(receiver)
+	if r == nil {
 		return nil, 0, errNotPaired
 	}
 	sender := roomPartner(r, receiver)
@@ -371,8 +495,8 @@ func (h *Hub) forwardRelay(sender *peer, data []byte) string {
 	}
 
 	h.mu.Lock()
-	r, ok := h.rooms[sender.room]
-	if !ok {
+	r := h.getRoomLocked(sender)
+	if r == nil {
 		h.mu.Unlock()
 		return errNotPaired
 	}
@@ -398,8 +522,8 @@ func (h *Hub) forwardRelay(sender *peer, data []byte) string {
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	r, ok = h.rooms[sender.room]
-	if !ok || roomPartner(r, sender) != other {
+	r = h.getRoomLocked(sender)
+	if r == nil || roomPartner(r, sender) != other {
 		return ""
 	}
 	sender.relayCredit -= size
@@ -424,8 +548,8 @@ func (h *Hub) partner(p *peer) *peer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	r, ok := h.rooms[p.room]
-	if !ok {
+	r := h.getRoomLocked(p)
+	if r == nil {
 		return nil
 	}
 	r.lastSeen = time.Now()
@@ -444,8 +568,8 @@ func (h *Hub) vacate(p *peer) *peer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	r, ok := h.rooms[p.room]
-	if !ok {
+	r := h.getRoomLocked(p)
+	if r == nil {
 		return nil
 	}
 	var other *peer
@@ -460,7 +584,11 @@ func (h *Hub) vacate(p *peer) *peer {
 		return nil
 	}
 	if other == nil {
-		delete(h.rooms, r.number)
+		if r.handle != "" {
+			delete(h.handleRooms, r.handle)
+		} else {
+			delete(h.rooms, r.number)
+		}
 		return nil
 	}
 	r.lastSeen = time.Now()
@@ -472,12 +600,16 @@ func (h *Hub) discard(p *peer) *peer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	r, ok := h.rooms[p.room]
-	if !ok {
+	r := h.getRoomLocked(p)
+	if r == nil {
 		return nil
 	}
 	other := roomPartner(r, p)
-	delete(h.rooms, r.number)
+	if r.handle != "" {
+		delete(h.handleRooms, r.handle)
+	} else {
+		delete(h.rooms, r.number)
+	}
 	return other
 }
 
@@ -509,6 +641,16 @@ func (h *Hub) reapOnce(now time.Time) {
 			delete(h.rooms, n)
 		}
 	}
+	for handle, r := range h.handleRooms {
+		timeout := h.cfg.IdleTimeout
+		if (r.offerer == nil || r.joiner == nil) && h.cfg.UnpairedTimeout > 0 {
+			timeout = h.cfg.UnpairedTimeout
+		}
+		if now.Sub(r.lastSeen) > timeout {
+			stale = append(stale, r)
+			delete(h.handleRooms, handle)
+		}
+	}
 	h.roomsReapedTotal += int64(len(stale))
 	h.mu.Unlock()
 
@@ -522,7 +664,11 @@ func (h *Hub) reapOnce(now time.Time) {
 	h.ipMu.Unlock()
 
 	for _, r := range stale {
-		h.logger.Info("signal: reaping idle room", "room", r.number)
+		if r.handle != "" {
+			h.logger.Info("signal: reaping idle handle room", "handle", r.handle)
+		} else {
+			h.logger.Info("signal: reaping idle room", "room", r.number)
+		}
 		for _, p := range []*peer{r.offerer, r.joiner} {
 			if p != nil {
 				p.close(byeFrame("idle timeout"))
@@ -535,5 +681,5 @@ func (h *Hub) reapOnce(now time.Time) {
 func (h *Hub) roomCount() int {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return len(h.rooms)
+	return len(h.rooms) + len(h.handleRooms)
 }

--- a/apps/server/internal/signal/message.go
+++ b/apps/server/internal/signal/message.go
@@ -21,11 +21,15 @@ const (
 	typeCreated       = "created"
 	typeJoin          = "join"
 	typePeerJoined    = "peer-joined"
+	typeRendezvous    = "rendezvous"
 	typePake          = "pake"
 	typeConfirm       = "confirm"
 	typeCaps          = "caps"
 	typeSDP           = "sdp"
 	typeICE           = "ice"
+	typeTrustedAuthInit    = "trusted_auth_init"
+	typeTrustedAuthResp    = "trusted_auth_response"
+	typeTrustedAuthConfirm = "trusted_auth_confirm"
 	typeRelayOpen     = "relay_open"
 	typeRelayRequired = "relay_required"
 	typeRelayReady    = "relay_ready"
@@ -51,13 +55,16 @@ const (
 )
 
 // forwardable is the set of peer→peer types the server relays without inspection.
-// SDP and ICE bodies are forwarded without being parsed.
+// SDP, ICE, and trusted_auth bodies are forwarded without being parsed.
 var forwardable = map[string]bool{
-	typePake:    true,
-	typeConfirm: true,
-	typeCaps:    true,
-	typeSDP:     true,
-	typeICE:     true,
+	typePake:               true,
+	typeConfirm:            true,
+	typeCaps:               true,
+	typeSDP:                true,
+	typeICE:                true,
+	typeTrustedAuthInit:    true,
+	typeTrustedAuthResp:    true,
+	typeTrustedAuthConfirm: true,
 }
 
 // Error codes carried in an error message's "code" field.
@@ -73,16 +80,18 @@ const (
 	errRelayNotReady = "relay_not_ready"
 	errRelayCredit   = "relay_credit"
 	errRelayLimit    = "relay_limit"
+	errInvalidHandle = "invalid_handle"
 )
 
 // clientMsg is the envelope the server parses from a client. Only type, room, and role
 // are read; the payloads of forwardable messages are relayed as raw bytes and never
 // decoded here, which is what keeps the server blind to handshake contents.
 type clientMsg struct {
-	Type  string `json:"type"`
-	Room  *int   `json:"room,omitempty"`
-	Role  string `json:"role,omitempty"`
-	Bytes int64  `json:"bytes,omitempty"`
+	Type   string `json:"type"`
+	Room   *int   `json:"room,omitempty"`
+	Handle string `json:"handle,omitempty"`
+	Role   string `json:"role,omitempty"`
+	Bytes  int64  `json:"bytes,omitempty"`
 }
 
 type relayMsg struct {
@@ -90,10 +99,11 @@ type relayMsg struct {
 	Bytes int64  `json:"bytes,omitempty"`
 }
 
-// createdMsg tells the offerer which room number the server allocated.
+// createdMsg tells the offerer which room number or handle the server allocated.
 type createdMsg struct {
-	Type string `json:"type"`
-	Room int    `json:"room"`
+	Type   string `json:"type"`
+	Room   *int   `json:"room,omitempty"`
+	Handle string `json:"handle,omitempty"`
 }
 
 // peerJoinedMsg notifies a socket that its room is now paired, with its own role.
@@ -110,8 +120,9 @@ type byeMsg struct {
 
 // resumedMsg confirms a peer re-attached to a lingering room's vacated slot.
 type resumedMsg struct {
-	Type string `json:"type"`
-	Room int    `json:"room"`
+	Type   string `json:"type"`
+	Room   *int   `json:"room,omitempty"`
+	Handle string `json:"handle,omitempty"`
 }
 
 // peerLeftMsg tells the surviving peer its partner's socket dropped. resumable reports
@@ -139,7 +150,11 @@ func mustJSON(v any) []byte {
 }
 
 func createdFrame(room int) []byte {
-	return mustJSON(createdMsg{Type: typeCreated, Room: room})
+	return mustJSON(createdMsg{Type: typeCreated, Room: &room})
+}
+
+func createdHandleFrame(handle string) []byte {
+	return mustJSON(createdMsg{Type: typeCreated, Handle: handle})
 }
 
 func peerJoinedFrame(role string) []byte {
@@ -151,7 +166,11 @@ func byeFrame(reason string) []byte {
 }
 
 func resumedFrame(room int) []byte {
-	return mustJSON(resumedMsg{Type: typeResumed, Room: room})
+	return mustJSON(resumedMsg{Type: typeResumed, Room: &room})
+}
+
+func resumedHandleFrame(handle string) []byte {
+	return mustJSON(resumedMsg{Type: typeResumed, Handle: handle})
 }
 
 func peerLeftFrame(resumable bool) []byte {
@@ -196,9 +215,11 @@ type Config struct {
 	// MaxRooms caps the global number of concurrent signaling rooms.
 	MaxRooms int
 
-	// IdleTimeout closes a socket that sends nothing for this long, and bounds how
-	// long an unpaired room lingers before the reaper frees it.
+	// IdleTimeout closes a socket that sends nothing for this long.
 	IdleTimeout time.Duration
+
+	// UnpairedTimeout bounds how long an unpaired room or handle registration lingers before the reaper frees it.
+	UnpairedTimeout time.Duration
 
 	// DrainTimeout is the maximum duration to wait for active transfers to drain during shutdown.
 	DrainTimeout time.Duration
@@ -241,6 +262,7 @@ func DefaultConfig() Config {
 		MaxConnsPerIP:        32,
 		MaxRooms:             5000,
 		IdleTimeout:          10 * time.Minute,
+		UnpairedTimeout:      5 * time.Minute,
 		DrainTimeout:         15 * time.Second,
 		MaxMessageBytes:      64 * 1024,
 		MsgBurst:             32,
@@ -291,6 +313,9 @@ func ConfigFromEnv() Config {
 	}
 	if d, ok := envDuration("SENDBEAM_SIGNAL_IDLE_TIMEOUT"); ok {
 		cfg.IdleTimeout = d
+	}
+	if d, ok := envDuration("SENDBEAM_SIGNAL_UNPAIRED_TIMEOUT"); ok {
+		cfg.UnpairedTimeout = d
 	}
 	if d, ok := envDuration("SENDBEAM_DRAIN_TIMEOUT"); ok {
 		cfg.DrainTimeout = d

--- a/apps/server/internal/signal/peer.go
+++ b/apps/server/internal/signal/peer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/sendbeam/wire"
 )
 
 const (
@@ -35,8 +36,9 @@ type peer struct {
 	logger   *slog.Logger
 	clientIP string
 
-	room int    // -1 until the peer creates or joins a room
-	role string // set on create/join
+	room   int    // -1 until the peer creates or joins a room
+	handle string // opaque rendezvous handle if in a handle room
+	role   string // set on create/join/rendezvous
 
 	send             chan outboundFrame
 	queueMu          sync.Mutex
@@ -131,7 +133,7 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 
 	switch m.Type {
 	case typeCreate:
-		if p.room >= 0 {
+		if p.room >= 0 || p.handle != "" {
 			p.fail(errProtocol, "already in a room")
 			return false
 		}
@@ -144,13 +146,57 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 		p.enqueue(createdFrame(room))
 		return true
 
-	case typeJoin:
-		if p.room >= 0 {
+	case typeRendezvous:
+		if p.room >= 0 || p.handle != "" {
 			p.fail(errProtocol, "already in a room")
 			return false
 		}
+		if m.Handle == "" || !wire.ValidateRendezvousHandle(m.Handle) {
+			p.fail(errInvalidHandle, "invalid rendezvous handle")
+			return false
+		}
+		other, code := p.hub.rendezvous(p, m.Handle, m.Role, p.clientIP)
+		if code != "" {
+			p.fail(code, "")
+			return false
+		}
+		if other != nil {
+			p.logger.Info("signal: handle paired", "handle", p.handle)
+			p.enqueue(peerJoinedFrame(p.role))
+			other.enqueue(peerJoinedFrame(other.role))
+		} else {
+			p.logger.Info("signal: handle registered", "handle", p.handle)
+			p.enqueue(createdHandleFrame(p.handle))
+		}
+		return true
+
+	case typeJoin:
+		if p.room >= 0 || p.handle != "" {
+			p.fail(errProtocol, "already in a room")
+			return false
+		}
+		if m.Handle != "" {
+			if !wire.ValidateRendezvousHandle(m.Handle) {
+				p.fail(errInvalidHandle, "invalid rendezvous handle")
+				return false
+			}
+			other, code := p.hub.rendezvous(p, m.Handle, m.Role, p.clientIP)
+			if code != "" {
+				p.fail(code, "")
+				return false
+			}
+			if other != nil {
+				p.logger.Info("signal: handle paired", "handle", p.handle)
+				p.enqueue(peerJoinedFrame(p.role))
+				other.enqueue(peerJoinedFrame(other.role))
+			} else {
+				p.logger.Info("signal: handle registered", "handle", p.handle)
+				p.enqueue(createdHandleFrame(p.handle))
+			}
+			return true
+		}
 		if m.Room == nil {
-			p.fail(errBadMessage, "join requires a room")
+			p.fail(errBadMessage, "join requires a room or handle")
 			return false
 		}
 		other, code := p.hub.join(p, *m.Room, p.clientIP)
@@ -164,21 +210,32 @@ func (p *peer) dispatch(data []byte, msgLimiter *tokenBucket) bool {
 		return true
 
 	case typeResume:
-		if p.room >= 0 {
+		if p.room >= 0 || p.handle != "" {
 			p.fail(errProtocol, "already in a room")
 			return false
 		}
-		if m.Room == nil {
-			p.fail(errBadMessage, "resume requires a room")
+		if m.Handle == "" && m.Room == nil {
+			p.fail(errBadMessage, "resume requires a room or handle")
 			return false
 		}
-		other, code := p.hub.resume(p, *m.Room, m.Role, p.clientIP)
+		var other *peer
+		var code string
+		if m.Handle != "" {
+			other, code = p.hub.resumeHandle(p, m.Handle, m.Role, p.clientIP)
+		} else {
+			other, code = p.hub.resume(p, *m.Room, m.Role, p.clientIP)
+		}
 		if code != "" {
 			p.fail(code, "")
 			return false
 		}
-		p.logger.Info("signal: room resumed", "room", p.room)
-		p.enqueue(resumedFrame(p.room))
+		if p.handle != "" {
+			p.logger.Info("signal: handle resumed", "handle", p.handle)
+			p.enqueue(resumedHandleFrame(p.handle))
+		} else {
+			p.logger.Info("signal: room resumed", "room", p.room)
+			p.enqueue(resumedFrame(p.room))
+		}
 		if other != nil {
 			other.enqueue(peerRejoinedFrame())
 		}

--- a/apps/server/internal/signal/room_fuzz_test.go
+++ b/apps/server/internal/signal/room_fuzz_test.go
@@ -24,6 +24,10 @@ func FuzzServerMessageValidation(f *testing.F) {
 		`{"type":"relay_credit","bytes":-100}`,
 		`{"type":"relay_credit","bytes":1048576}`,
 		`{"type":"bye","reason":"user"}`,
+		`{"type":"rendezvous","handle":"edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428"}`,
+		`{"type":"rendezvous","handle":"edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428","role":"joiner"}`,
+		`{"type":"join","handle":"edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428"}`,
+		`{"type":"resume","handle":"edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428","role":"offerer"}`,
 		`{}`,
 		`not-json`,
 	}
@@ -46,6 +50,10 @@ func FuzzServerMessageValidation(f *testing.F) {
 		if m.Room != nil {
 			_ = createdFrame(*m.Room)
 			_ = resumedFrame(*m.Room)
+		}
+		if m.Handle != "" {
+			_ = createdHandleFrame(m.Handle)
+			_ = resumedHandleFrame(m.Handle)
 		}
 		if m.Role != "" {
 			_ = peerJoinedFrame(m.Role)

--- a/apps/server/internal/signal/signal_test.go
+++ b/apps/server/internal/signal/signal_test.go
@@ -565,12 +565,220 @@ func TestRelayZeroPerFrameLoggingAndMetricsAudit(t *testing.T) {
 	}
 
 	// Audit aggregate byte accounting
-	hub.mu.Lock()
-	totalRelayed := hub.relayBytes
-	hub.mu.Unlock()
-
 	expectedBytes := int64(256 + 512 + 1024)
+	deadline := time.Now().Add(time.Second)
+	var totalRelayed int64
+	for time.Now().Before(deadline) {
+		hub.mu.Lock()
+		totalRelayed = hub.relayBytes
+		hub.mu.Unlock()
+		if totalRelayed == expectedBytes {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	if totalRelayed != expectedBytes {
 		t.Fatalf("aggregate relay bytes = %d, want %d", totalRelayed, expectedBytes)
 	}
 }
+
+func TestOpaqueHandleRendezvousAndTrustedAuth(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	offerer := mustDial(t, url)
+	joiner := mustDial(t, url)
+
+	handle := "edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428"
+
+	// 1. Offerer registers handle
+	offerer.send(map[string]any{
+		"type":   "rendezvous",
+		"handle": handle,
+		"role":   "offerer",
+	})
+	created := offerer.recv()
+	if created["type"] != "created" || created["handle"] != handle {
+		t.Fatalf("unexpected created response: %v", created)
+	}
+
+	// 2. Joiner pairs via same handle
+	joiner.send(map[string]any{
+		"type":   "rendezvous",
+		"handle": handle,
+		"role":   "joiner",
+	})
+
+	offJoined := offerer.recv()
+	if offJoined["type"] != "peer-joined" || offJoined["role"] != "offerer" {
+		t.Fatalf("offerer expected peer-joined, got %v", offJoined)
+	}
+
+	joinJoined := joiner.recv()
+	if joinJoined["type"] != "peer-joined" || joinJoined["role"] != "joiner" {
+		t.Fatalf("joiner expected peer-joined, got %v", joinJoined)
+	}
+
+	// 3. Forward trusted authentication frames peer-to-peer blindly
+	authInit := map[string]any{
+		"type":                "trusted_auth_init",
+		"protocol_version":    "sendbeam/3",
+		"initiator_device_id": "sb-dev-alice",
+		"responder_device_id": "sb-dev-bob",
+		"ephemeral_pub":       "deadbeef",
+		"nonce":               "cafebabe",
+		"capabilities":        []any{"padding", "resume"},
+	}
+	offerer.send(authInit)
+	gotInit := joiner.recv()
+	if gotInit["type"] != "trusted_auth_init" || gotInit["initiator_device_id"] != "sb-dev-alice" {
+		t.Fatalf("joiner received corrupt trusted_auth_init: %v", gotInit)
+	}
+
+	authResp := map[string]any{
+		"type":                "trusted_auth_response",
+		"protocol_version":    "sendbeam/3",
+		"status":              "accepted",
+		"responder_device_id": "sb-dev-bob",
+		"ephemeral_pub":       "feedface",
+		"nonce":               "baadf00d",
+	}
+	joiner.send(authResp)
+	gotResp := offerer.recv()
+	if gotResp["type"] != "trusted_auth_response" || gotResp["status"] != "accepted" {
+		t.Fatalf("offerer received corrupt trusted_auth_response: %v", gotResp)
+	}
+
+	authConfirm := map[string]any{
+		"type":     "trusted_auth_confirm",
+		"status":   "ready",
+		"auth_tag": "0102030405060708",
+	}
+	offerer.send(authConfirm)
+	gotConfirm := joiner.recv()
+	if gotConfirm["type"] != "trusted_auth_confirm" || gotConfirm["auth_tag"] != "0102030405060708" {
+		t.Fatalf("joiner received corrupt trusted_auth_confirm: %v", gotConfirm)
+	}
+}
+
+func TestOpaqueHandleRoomFullOnThirdPeer(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	c1 := mustDial(t, url)
+	c2 := mustDial(t, url)
+	c3 := mustDial(t, url)
+
+	handle := "edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428"
+
+	c1.send(map[string]any{"type": "rendezvous", "handle": handle})
+	_ = c1.recv() // created
+
+	c2.send(map[string]any{"type": "rendezvous", "handle": handle})
+	_ = c1.recv() // peer-joined
+	_ = c2.recv() // peer-joined
+
+	// Third peer attempts to join the same handle
+	c3.send(map[string]any{"type": "rendezvous", "handle": handle})
+	errResp := c3.recv()
+	if errResp["type"] != "error" || errResp["code"] != "room_full" {
+		t.Fatalf("expected room_full error, got %v", errResp)
+	}
+}
+
+func TestOpaqueHandleInvalidHandleRejection(t *testing.T) {
+	url := testServer(t, DefaultConfig())
+	c := mustDial(t, url)
+
+	// Short handle
+	c.send(map[string]any{"type": "rendezvous", "handle": "short-handle"})
+	errResp := c.recv()
+	if errResp["type"] != "error" || errResp["code"] != "invalid_handle" {
+		t.Fatalf("expected invalid_handle error for short handle, got %v", errResp)
+	}
+
+	// Upper-case hex handle
+	c2 := mustDial(t, url)
+	c2.send(map[string]any{"type": "rendezvous", "handle": "EDB08D40E1746A31D09E8EB428F709945FC514D0D6C16107F86DC17A28FD7428"})
+	errResp2 := c2.recv()
+	if errResp2["type"] != "error" || errResp2["code"] != "invalid_handle" {
+		t.Fatalf("expected invalid_handle error for uppercase handle, got %v", errResp2)
+	}
+}
+
+func TestOpaqueHandleResumeAndReconnect(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.IdleTimeout = 5 * time.Second
+	url := testServer(t, cfg)
+
+	offerer := mustDial(t, url)
+	joiner := mustDial(t, url)
+	handle := "edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428"
+
+	offerer.send(map[string]any{"type": "rendezvous", "handle": handle, "role": "offerer"})
+	_ = offerer.recv() // created
+
+	joiner.send(map[string]any{"type": "rendezvous", "handle": handle, "role": "joiner"})
+	_ = offerer.recv() // peer-joined
+	_ = joiner.recv()  // peer-joined
+
+	// Offerer socket drops unexpectedly
+	_ = offerer.conn.Close(websocket.StatusGoingAway, "network drop")
+
+	// Joiner should receive peer_left with resumable == true
+	left := joiner.recv()
+	if left["type"] != "peer_left" || left["resumable"] != true {
+		t.Fatalf("joiner expected peer_left resumable=true, got %v", left)
+	}
+
+	// Reconnecting offerer resumes into the handle room
+	reoff := mustDial(t, url)
+	reoff.send(map[string]any{
+		"type":   "resume",
+		"handle": handle,
+		"role":   "offerer",
+	})
+
+	resumed := reoff.recv()
+	if resumed["type"] != "resumed" || resumed["handle"] != handle {
+		t.Fatalf("reoff expected resumed with handle, got %v", resumed)
+	}
+
+	rejoined := joiner.recv()
+	if rejoined["type"] != "peer_rejoined" {
+		t.Fatalf("joiner expected peer_rejoined, got %v", rejoined)
+	}
+}
+
+func TestOpaqueHandleUnpairedExpiry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := DefaultConfig()
+	cfg.UnpairedTimeout = 50 * time.Millisecond
+	cfg.IdleTimeout = 50 * time.Millisecond
+	hub := NewHub(ctx, cfg, nil)
+	srv := httptest.NewServer(hub.Handler(ctx))
+	defer srv.Close()
+	url := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+
+	client := mustDial(t, url)
+	handle := "edb08d40e1746a31d09e8eb428f709945fc514d0d6c16107f86dc17a28fd7428"
+	client.send(map[string]any{"type": "rendezvous", "handle": handle})
+	_ = client.recv() // created
+
+	if hub.roomCount() != 1 {
+		t.Fatalf("roomCount = %d, want 1", hub.roomCount())
+	}
+
+	// Wait for reaper to sweep expired unpaired handle room
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		hub.reapOnce(time.Now())
+		if hub.roomCount() == 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if hub.roomCount() != 0 {
+		t.Fatalf("unpaired handle room was not reaped; count = %d", hub.roomCount())
+	}
+}
+

--- a/packages/engine/rendezvous/message.go
+++ b/packages/engine/rendezvous/message.go
@@ -17,17 +17,25 @@ import "encoding/json"
 // packages/protocol/src/signaling.ts exactly; the server forwards the peer→peer bodies
 // verbatim, so a mismatch here would break interop with a browser peer.
 const (
-	typeCreate     = "create"
-	typeCreated    = "created"
-	typeJoin       = "join"
-	typePeerJoined = "peer-joined"
-	typePake       = "pake"
-	typeConfirm    = "confirm"
-	typeCaps       = "caps"
-	typeSDP        = "sdp"
-	typeICE        = "ice"
-	typeBye        = "bye"
-	typeError      = "error"
+	typeCreate              = "create"
+	typeCreated             = "created"
+	typeJoin                = "join"
+	typePeerJoined          = "peer-joined"
+	typePake                = "pake"
+	typeConfirm             = "confirm"
+	typeCaps                = "caps"
+	typeSDP                 = "sdp"
+	typeICE                 = "ice"
+	typeBye                 = "bye"
+	typeError               = "error"
+	typeRendezvous          = "rendezvous"
+	typeResume              = "resume"
+	typeResumed             = "resumed"
+	typePeerRejoined        = "peer_rejoined"
+	typePeerLeft            = "peer_left"
+	typeTrustedAuthInit     = "trusted_auth_init"
+	typeTrustedAuthResponse = "trusted_auth_response"
+	typeTrustedAuthConfirm  = "trusted_auth_confirm"
 )
 
 // Relay control tags are exported for the adopted transfer transport. They remain outside the
@@ -71,6 +79,10 @@ type Message struct {
 	Code string `json:"code,omitempty"`
 	// Bytes carries bounded flow-control credit on relay_credit and credit messages.
 	Bytes int64 `json:"bytes,omitempty"`
+	// Handle carries the 64-character lowercase hex opaque handle on rendezvous and resume.
+	Handle string `json:"handle,omitempty"`
+	// Raw preserves verbatim wire bytes when unmarshaled or custom-encoded.
+	Raw []byte `json:"-"`
 }
 
 // Sink is the outbound half of the signaling channel the session drives.
@@ -85,7 +97,12 @@ type SinkFunc func(Message) error
 func (f SinkFunc) Send(m Message) error { return f(m) }
 
 // MarshalMessage encodes a signaling message to its JSON wire form.
-func MarshalMessage(m Message) ([]byte, error) { return json.Marshal(m) }
+func MarshalMessage(m Message) ([]byte, error) {
+	if len(m.Raw) > 0 {
+		return m.Raw, nil
+	}
+	return json.Marshal(m)
+}
 
 // NewSDP builds an authenticated sdp message. seq is the sender-monotonic sequence
 // number and mac the base64url authmac tag over the body. It is
@@ -108,6 +125,16 @@ func NewRelayCredit(bytes int64) Message {
 	return Message{Type: TypeRelayCredit, Bytes: bytes}
 }
 
+// NewRendezvous builds an opaque handle rendezvous message.
+func NewRendezvous(handle, role string) Message {
+	return Message{Type: typeRendezvous, Handle: handle, Role: role}
+}
+
+// NewResume builds an opaque handle resume message.
+func NewResume(handle, role string) Message {
+	return Message{Type: typeResume, Handle: handle, Role: role}
+}
+
 // UnmarshalMessage decodes a JSON signaling frame. A frame missing a type is rejected so
 // the session can fail cleanly rather than act on an empty tag.
 func UnmarshalMessage(data []byte) (Message, error) {
@@ -115,5 +142,6 @@ func UnmarshalMessage(data []byte) (Message, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return Message{}, err
 	}
+	m.Raw = append([]byte(nil), data...)
 	return m, nil
 }

--- a/packages/engine/rendezvous/message_test.go
+++ b/packages/engine/rendezvous/message_test.go
@@ -89,6 +89,27 @@ func TestRelayControlWireShapes(t *testing.T) {
 	}
 }
 
+func TestOpaqueHandleWireShapes(t *testing.T) {
+	handle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	rend, err := MarshalMessage(NewRendezvous(handle, "offerer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRend := `{"type":"rendezvous","role":"offerer","handle":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}`
+	if string(rend) != wantRend {
+		t.Fatalf("rendezvous wire shape = %s, want %s", string(rend), wantRend)
+	}
+
+	res, err := MarshalMessage(NewResume(handle, "joiner"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRes := `{"type":"resume","role":"joiner","handle":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}`
+	if string(res) != wantRes {
+		t.Fatalf("resume wire shape = %s, want %s", string(res), wantRes)
+	}
+}
+
 // TestMessageRoundTrip confirms an sdp message survives marshal→unmarshal intact,
 // including the pointer seq.
 func TestMessageRoundTrip(t *testing.T) {

--- a/packages/engine/rendezvous/opaque_session.go
+++ b/packages/engine/rendezvous/opaque_session.go
@@ -1,0 +1,505 @@
+package rendezvous
+
+import (
+	"context"
+	"crypto/ecdh"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+// OpaquePhase represents the current phase in an opaque rendezvous session.
+type OpaquePhase string
+
+// Opaque handshake phases.
+const (
+	OpaquePhaseIdle           OpaquePhase = "idle"
+	OpaquePhaseRendezvousSent OpaquePhase = "rendezvous_sent"
+	OpaquePhaseWaitingPeer    OpaquePhase = "waiting_peer"
+	OpaquePhasePaired         OpaquePhase = "paired"
+	OpaquePhaseAuthenticating OpaquePhase = "authenticating"
+	OpaquePhaseEstablished    OpaquePhase = "established"
+	OpaquePhaseFailed         OpaquePhase = "failed"
+)
+
+// OpaqueResult contains the output of a successfully completed opaque rendezvous session.
+type OpaqueResult struct {
+	Role           Role
+	Handle         string
+	PeerDeviceID   string
+	Master         []byte
+	SendKey        []byte
+	RecvKey        []byte
+	NegotiatedCaps []string
+}
+
+// OpaqueOptions configures an opaque rendezvous session.
+type OpaqueOptions struct {
+	Role              Role
+	Handle            string
+	LocalIdentity     *wire.DeviceIdentity
+	PeerDeviceID      string
+	PeerPublicKey     ed25519.PublicKey
+	KPair             []byte
+	PairCredentialRef string
+	LocalCaps         []string
+	Transport         Sink
+	OnPhase           func(OpaquePhase)
+	ReplayCache       *wire.NonceReplayCache
+	Tombstones        trust.TombstoneStore
+	TrustStore        trust.Store
+}
+
+// OpaqueSession drives the sendbeam/3 authenticated session handshake over an opaque rendezvous channel.
+type OpaqueSession struct {
+	opts   OpaqueOptions
+	phase  OpaquePhase
+	mu     sync.Mutex
+	done   chan struct{}
+	result *OpaqueResult
+	err    error
+
+	privKey  *ecdh.PrivateKey
+	pubBytes []byte
+	nonce    []byte
+	initMsg  *wire.TrustedAuthInit
+	master   []byte
+	sendKey  []byte
+	recvKey  []byte
+	negCaps  []string
+	selfConf bool
+	peerConf bool
+}
+
+// NewOpaqueSession creates a new OpaqueSession.
+func NewOpaqueSession(opts OpaqueOptions) *OpaqueSession {
+	return &OpaqueSession{
+		opts:  opts,
+		phase: OpaquePhaseIdle,
+		done:  make(chan struct{}),
+	}
+}
+
+// Phase returns the session's current phase.
+func (s *OpaqueSession) Phase() OpaquePhase {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.phase
+}
+
+func (s *OpaqueSession) setPhaseLocked(phase OpaquePhase) {
+	s.phase = phase
+	if s.opts.OnPhase != nil {
+		s.opts.OnPhase(phase)
+	}
+}
+
+// Start begins the opaque rendezvous session by validating the handle and sending a rendezvous message.
+func (s *OpaqueSession) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.phase != OpaquePhaseIdle {
+		return nil
+	}
+	if !wire.ValidateRendezvousHandle(s.opts.Handle) {
+		return s.failLocked(errors.New("invalid_handle"))
+	}
+	if s.opts.LocalIdentity == nil {
+		return s.failLocked(errors.New("local identity required"))
+	}
+	if len(s.opts.PeerPublicKey) != ed25519.PublicKeySize {
+		return s.failLocked(wire.ErrInvalidPublicKey)
+	}
+	if len(s.opts.KPair) == 0 {
+		return s.failLocked(errors.New("k_pair required"))
+	}
+
+	// Check tombstones if store is present
+	if s.opts.Tombstones != nil && s.opts.Tombstones.HasTombstone(context.Background(), s.opts.PeerDeviceID) {
+		return s.failLocked(wire.ErrTrustedPeerRevoked)
+	}
+
+	s.setPhaseLocked(OpaquePhaseRendezvousSent)
+	return s.opts.Transport.Send(NewRendezvous(s.opts.Handle, string(s.opts.Role)))
+}
+
+// Resume attempts to re-attach to an existing handle room after disconnect.
+func (s *OpaqueSession) Resume() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !wire.ValidateRendezvousHandle(s.opts.Handle) {
+		return s.failLocked(errors.New("invalid_handle"))
+	}
+	return s.opts.Transport.Send(NewResume(s.opts.Handle, string(s.opts.Role)))
+}
+
+// Handle processes an incoming signaling frame.
+func (s *OpaqueSession) Handle(m Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.phase == OpaquePhaseFailed || s.phase == OpaquePhaseEstablished {
+		return nil
+	}
+
+	switch m.Type {
+	case typeCreated:
+		if s.phase == OpaquePhaseRendezvousSent {
+			s.setPhaseLocked(OpaquePhaseWaitingPeer)
+		}
+		return nil
+
+	case typePeerJoined, typePeerRejoined:
+		return s.onPairedLocked()
+
+	case typeResumed:
+		return nil
+
+	case typePeerLeft:
+		return s.failLocked(errors.New("peer_left"))
+
+	case typeError:
+		code := m.Code
+		if code == "" {
+			code = "signaling_error"
+		}
+		return s.failLocked(fmt.Errorf("signaling error: %s", code))
+
+	case typeTrustedAuthInit:
+		return s.onTrustedAuthInitLocked(m)
+
+	case typeTrustedAuthResponse:
+		return s.onTrustedAuthResponseLocked(m)
+
+	case typeTrustedAuthConfirm:
+		return s.onTrustedAuthConfirmLocked(m)
+
+	default:
+		return nil
+	}
+}
+
+func (s *OpaqueSession) onPairedLocked() error {
+	s.setPhaseLocked(OpaquePhaseAuthenticating)
+	if s.opts.Role == RoleOfferer {
+		privA, pubA, err := wire.GenerateX25519KeyPair()
+		if err != nil {
+			return s.failLocked(err)
+		}
+		s.privKey = privA
+		s.pubBytes = pubA
+
+		nonceA := make([]byte, wire.TrustedAuthNonceSize)
+		if _, err := io.ReadFull(rand.Reader, nonceA); err != nil {
+			return s.failLocked(err)
+		}
+		s.nonce = nonceA
+
+		caps := s.opts.LocalCaps
+		if len(caps) == 0 {
+			caps = []string{"transfer.v1", "padding"}
+		}
+
+		var revocations []wire.RevocationRecord
+		if s.opts.TrustStore != nil {
+			if stored, err := s.opts.TrustStore.ListRevocations(context.Background()); err == nil {
+				for _, r := range stored {
+					if r != nil {
+						revocations = append(revocations, *r)
+					}
+				}
+			}
+		}
+
+		initMsg, err := wire.NewTrustedAuthInitV3(
+			s.opts.LocalIdentity,
+			s.opts.PeerDeviceID,
+			s.opts.PairCredentialRef,
+			s.opts.KPair,
+			caps,
+			pubA,
+			nonceA,
+			time.Now().UTC(),
+			revocations,
+		)
+		if err != nil {
+			return s.failLocked(err)
+		}
+		s.initMsg = initMsg
+
+		data, err := wire.EncodeTrustedAuthMessage(initMsg)
+		if err != nil {
+			return s.failLocked(err)
+		}
+		return s.opts.Transport.Send(Message{Type: typeTrustedAuthInit, Raw: data})
+	}
+	return nil
+}
+
+func (s *OpaqueSession) onTrustedAuthInitLocked(m Message) error {
+	if s.opts.Role != RoleJoiner {
+		return nil
+	}
+
+	rawData := m.Raw
+	if len(rawData) == 0 {
+		var err error
+		rawData, err = json.Marshal(m)
+		if err != nil {
+			return s.failLocked(err)
+		}
+	}
+
+	decoded, err := wire.DecodeTrustedAuthMessage(rawData)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	initMsg, ok := decoded.(*wire.TrustedAuthInit)
+	if !ok {
+		return s.failLocked(wire.ErrInvalidTrustedMessage)
+	}
+	s.initMsg = initMsg
+
+	now := time.Now().UTC()
+	peerEphemPub, peerNonce, err := wire.VerifyTrustedAuthInitV3(initMsg, s.opts.KPair, s.opts.PeerPublicKey, s.opts.LocalIdentity.DeviceID, now)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	if s.opts.ReplayCache != nil {
+		if err := s.opts.ReplayCache.CheckAndRecord(initMsg.InitiatorDeviceID, initMsg.Nonce, now); err != nil {
+			return s.failLocked(err)
+		}
+	}
+
+	privB, pubB, err := wire.GenerateX25519KeyPair()
+	if err != nil {
+		return s.failLocked(err)
+	}
+
+	nonceB := make([]byte, wire.TrustedAuthNonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonceB); err != nil {
+		return s.failLocked(err)
+	}
+
+	localCaps := s.opts.LocalCaps
+	if len(localCaps) == 0 {
+		localCaps = []string{"transfer.v1", "padding"}
+	}
+
+	var revocations []wire.RevocationRecord
+	if s.opts.TrustStore != nil {
+		if stored, err := s.opts.TrustStore.ListRevocations(context.Background()); err == nil {
+			for _, r := range stored {
+				if r != nil {
+					revocations = append(revocations, *r)
+				}
+			}
+		}
+	}
+
+	respMsg, err := wire.NewTrustedAuthResponseV3(s.opts.LocalIdentity, initMsg, s.opts.KPair, localCaps, pubB, nonceB, revocations)
+	if err != nil {
+		return s.failLocked(err)
+	}
+
+	respData, err := wire.EncodeTrustedAuthMessage(respMsg)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	if err := s.opts.Transport.Send(Message{Type: typeTrustedAuthResponse, Raw: respData}); err != nil {
+		return s.failLocked(err)
+	}
+
+	ssECDH, err := wire.ComputeX25519SharedSecret(privB, peerEphemPub)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	defer wire.ZeroizeBytes(ssECDH)
+
+	keys, err := wire.DeriveTrustedSessionKeysV3(s.opts.KPair, ssECDH, peerEphemPub, pubB, peerNonce, nonceB, initMsg.InitiatorDeviceID, s.opts.LocalIdentity.DeviceID, initMsg.Capabilities, localCaps)
+	if err != nil {
+		return s.failLocked(err)
+	}
+
+	s.master = keys.SessionMaster
+	// Joiner (responder): send is r2i, recv is i2r
+	s.sendKey = keys.ResponderToInitiatorKey
+	s.recvKey = keys.InitiatorToResponderKey
+	s.negCaps = keys.NegotiatedCapabilities
+
+	confMsg := wire.NewTrustedAuthConfirm(s.master, wire.DomainTrustedConfirmResp3, s.opts.LocalIdentity.DeviceID, true)
+	confData, err := wire.EncodeTrustedAuthMessage(confMsg)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	s.selfConf = true
+	if err := s.opts.Transport.Send(Message{Type: typeTrustedAuthConfirm, Raw: confData}); err != nil {
+		return s.failLocked(err)
+	}
+
+	return s.checkEstablishedLocked()
+}
+
+func (s *OpaqueSession) onTrustedAuthResponseLocked(m Message) error {
+	if s.opts.Role != RoleOfferer || s.initMsg == nil || s.privKey == nil {
+		return nil
+	}
+
+	rawData := m.Raw
+	if len(rawData) == 0 {
+		var err error
+		rawData, err = json.Marshal(m)
+		if err != nil {
+			return s.failLocked(err)
+		}
+	}
+
+	decoded, err := wire.DecodeTrustedAuthMessage(rawData)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	respMsg, ok := decoded.(*wire.TrustedAuthResponse)
+	if !ok {
+		return s.failLocked(wire.ErrInvalidTrustedMessage)
+	}
+
+	peerEphemPub, peerNonce, err := wire.VerifyTrustedAuthResponseV3(respMsg, s.initMsg, s.opts.KPair, s.opts.PeerPublicKey, s.opts.LocalIdentity.DeviceID)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	if s.opts.ReplayCache != nil {
+		if err := s.opts.ReplayCache.CheckAndRecord(respMsg.ResponderDeviceID, respMsg.Nonce, time.Now().UTC()); err != nil {
+			return s.failLocked(err)
+		}
+	}
+
+	ssECDH, err := wire.ComputeX25519SharedSecret(s.privKey, peerEphemPub)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	s.privKey = nil
+	defer wire.ZeroizeBytes(ssECDH)
+
+	keys, err := wire.DeriveTrustedSessionKeysV3(s.opts.KPair, ssECDH, s.pubBytes, peerEphemPub, s.nonce, peerNonce, s.opts.LocalIdentity.DeviceID, s.opts.PeerDeviceID, s.initMsg.Capabilities, respMsg.Capabilities)
+	if err != nil {
+		return s.failLocked(err)
+	}
+
+	s.master = keys.SessionMaster
+	// Offerer (initiator): send is i2r, recv is r2i
+	s.sendKey = keys.InitiatorToResponderKey
+	s.recvKey = keys.ResponderToInitiatorKey
+	s.negCaps = keys.NegotiatedCapabilities
+
+	confMsg := wire.NewTrustedAuthConfirm(s.master, wire.DomainTrustedConfirmInit3, s.opts.LocalIdentity.DeviceID, true)
+	confData, err := wire.EncodeTrustedAuthMessage(confMsg)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	s.selfConf = true
+	if err := s.opts.Transport.Send(Message{Type: typeTrustedAuthConfirm, Raw: confData}); err != nil {
+		return s.failLocked(err)
+	}
+
+	return s.checkEstablishedLocked()
+}
+
+func (s *OpaqueSession) onTrustedAuthConfirmLocked(m Message) error {
+	if len(s.master) == 0 {
+		return s.failLocked(errors.New("session master missing"))
+	}
+
+	rawData := m.Raw
+	if len(rawData) == 0 {
+		var err error
+		rawData, err = json.Marshal(m)
+		if err != nil {
+			return s.failLocked(err)
+		}
+	}
+
+	decoded, err := wire.DecodeTrustedAuthMessage(rawData)
+	if err != nil {
+		return s.failLocked(err)
+	}
+	confMsg, ok := decoded.(*wire.TrustedAuthConfirm)
+	if !ok {
+		return s.failLocked(wire.ErrInvalidTrustedMessage)
+	}
+
+	domain := wire.DomainTrustedConfirmResp3
+	if s.opts.Role == RoleJoiner {
+		domain = wire.DomainTrustedConfirmInit3
+	}
+
+	if err := wire.VerifyTrustedAuthConfirm(confMsg, s.master, domain, s.opts.PeerDeviceID); err != nil {
+		return s.failLocked(err)
+	}
+
+	s.peerConf = true
+	return s.checkEstablishedLocked()
+}
+
+func (s *OpaqueSession) checkEstablishedLocked() error {
+	if s.selfConf && s.peerConf && len(s.master) > 0 && len(s.sendKey) > 0 && len(s.recvKey) > 0 {
+		s.setPhaseLocked(OpaquePhaseEstablished)
+		s.result = &OpaqueResult{
+			Role:           s.opts.Role,
+			Handle:         s.opts.Handle,
+			PeerDeviceID:   s.opts.PeerDeviceID,
+			Master:         s.master,
+			SendKey:        s.sendKey,
+			RecvKey:        s.recvKey,
+			NegotiatedCaps: s.negCaps,
+		}
+		select {
+		case <-s.done:
+		default:
+			close(s.done)
+		}
+	}
+	return nil
+}
+
+func (s *OpaqueSession) failLocked(err error) error {
+	s.privKey = nil
+	s.setPhaseLocked(OpaquePhaseFailed)
+	s.err = err
+	select {
+	case <-s.done:
+	default:
+		close(s.done)
+	}
+	return err
+}
+
+// Wait blocks until the handshake finishes (either established or failed) and returns the result.
+func (s *OpaqueSession) Wait() (*OpaqueResult, error) {
+	<-s.done
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.result, nil
+}
+
+// Result returns the result if established, or nil if still in flight or failed.
+func (s *OpaqueSession) Result() (*OpaqueResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.result, nil
+}

--- a/packages/engine/rendezvous/opaque_session_test.go
+++ b/packages/engine/rendezvous/opaque_session_test.go
@@ -1,0 +1,240 @@
+package rendezvous
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"sync"
+	"testing"
+
+	"github.com/sendbeam/wire"
+)
+
+type mockSink struct {
+	mu   sync.Mutex
+	msgs []Message
+}
+
+func (m *mockSink) Send(msg Message) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.msgs = append(m.msgs, msg)
+	return nil
+}
+
+func (m *mockSink) GetMsgs() []Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]Message, len(m.msgs))
+	copy(cp, m.msgs)
+	return cp
+}
+
+func TestOpaqueSessionMouthToEar(t *testing.T) {
+	// Generate identities for Alice (Offerer) and Bob (Joiner)
+	idAlice, err := wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatalf("GenerateDeviceIdentity Alice: %v", err)
+	}
+	idBob, err := wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatalf("GenerateDeviceIdentity Bob: %v", err)
+	}
+
+	kPair := sha256.Sum256([]byte("shared-kpair-12345"))
+	validHandle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	sinkAlice := &mockSink{}
+	sinkBob := &mockSink{}
+
+	optsAlice := OpaqueOptions{
+		Role:              RoleOfferer,
+		Handle:            validHandle,
+		LocalIdentity:     idAlice,
+		PeerDeviceID:      idBob.DeviceID,
+		PeerPublicKey:     idBob.PublicKey,
+		KPair:             kPair[:],
+		PairCredentialRef: "cred-1",
+		Transport:         sinkAlice,
+	}
+
+	optsBob := OpaqueOptions{
+		Role:              RoleJoiner,
+		Handle:            validHandle,
+		LocalIdentity:     idBob,
+		PeerDeviceID:      idAlice.DeviceID,
+		PeerPublicKey:     idAlice.PublicKey,
+		KPair:             kPair[:],
+		PairCredentialRef: "cred-1",
+		Transport:         sinkBob,
+	}
+
+	sessionAlice := NewOpaqueSession(optsAlice)
+	sessionBob := NewOpaqueSession(optsBob)
+
+	// 1. Alice starts
+	if err := sessionAlice.Start(); err != nil {
+		t.Fatalf("sessionAlice.Start: %v", err)
+	}
+	if sessionAlice.Phase() != OpaquePhaseRendezvousSent {
+		t.Fatalf("expected OpaquePhaseRendezvousSent, got %v", sessionAlice.Phase())
+	}
+	msgsAlice := sinkAlice.GetMsgs()
+	if len(msgsAlice) != 1 || msgsAlice[0].Type != typeRendezvous || msgsAlice[0].Handle != validHandle {
+		t.Fatalf("unexpected rendezvous msg: %+v", msgsAlice)
+	}
+
+	// Server sends created to Alice
+	if err := sessionAlice.Handle(Message{Type: typeCreated, Handle: validHandle}); err != nil {
+		t.Fatalf("sessionAlice.Handle(created): %v", err)
+	}
+	if sessionAlice.Phase() != OpaquePhaseWaitingPeer {
+		t.Fatalf("expected OpaquePhaseWaitingPeer, got %v", sessionAlice.Phase())
+	}
+
+	// 2. Bob starts
+	if err := sessionBob.Start(); err != nil {
+		t.Fatalf("sessionBob.Start: %v", err)
+	}
+	if sessionBob.Phase() != OpaquePhaseRendezvousSent {
+		t.Fatalf("expected OpaquePhaseRendezvousSent, got %v", sessionBob.Phase())
+	}
+
+	// Server signals peer-joined to Alice
+	if err := sessionAlice.Handle(Message{Type: typePeerJoined, Role: "offerer"}); err != nil {
+		t.Fatalf("sessionAlice.Handle(peer-joined): %v", err)
+	}
+	if sessionAlice.Phase() != OpaquePhaseAuthenticating {
+		t.Fatalf("expected OpaquePhaseAuthenticating, got %v", sessionAlice.Phase())
+	}
+
+	// Alice emitted trusted_auth_init
+	msgsAlice = sinkAlice.GetMsgs()
+	if len(msgsAlice) != 2 || msgsAlice[1].Type != typeTrustedAuthInit {
+		t.Fatalf("expected trusted_auth_init, got %+v", msgsAlice)
+	}
+	initMsg := msgsAlice[1]
+
+	// Bob receives trusted_auth_init
+	if err := sessionBob.Handle(initMsg); err != nil {
+		t.Fatalf("sessionBob.Handle(init): %v", err)
+	}
+
+	// Bob emitted trusted_auth_response and trusted_auth_confirm
+	msgsBob := sinkBob.GetMsgs()
+	if len(msgsBob) != 3 {
+		t.Fatalf("expected 3 msgs from Bob, got %d", len(msgsBob))
+	}
+	if msgsBob[1].Type != typeTrustedAuthResponse || msgsBob[2].Type != typeTrustedAuthConfirm {
+		t.Fatalf("unexpected msgs from Bob: %+v", msgsBob)
+	}
+	respMsg := msgsBob[1]
+	bobConfirm := msgsBob[2]
+
+	// Alice receives trusted_auth_response
+	if err := sessionAlice.Handle(respMsg); err != nil {
+		t.Fatalf("sessionAlice.Handle(resp): %v", err)
+	}
+
+	// Alice emitted trusted_auth_confirm
+	msgsAlice = sinkAlice.GetMsgs()
+	if len(msgsAlice) != 3 || msgsAlice[2].Type != typeTrustedAuthConfirm {
+		t.Fatalf("expected trusted_auth_confirm from Alice, got %+v", msgsAlice)
+	}
+	aliceConfirm := msgsAlice[2]
+
+	// Mutual confirmation
+	if err := sessionAlice.Handle(bobConfirm); err != nil {
+		t.Fatalf("sessionAlice.Handle(bobConfirm): %v", err)
+	}
+	if err := sessionBob.Handle(aliceConfirm); err != nil {
+		t.Fatalf("sessionBob.Handle(aliceConfirm): %v", err)
+	}
+
+	// Both should be established!
+	if sessionAlice.Phase() != OpaquePhaseEstablished {
+		t.Fatalf("expected Alice established, got %v", sessionAlice.Phase())
+	}
+	if sessionBob.Phase() != OpaquePhaseEstablished {
+		t.Fatalf("expected Bob established, got %v", sessionBob.Phase())
+	}
+
+	resAlice, err := sessionAlice.Wait()
+	if err != nil {
+		t.Fatalf("sessionAlice.Wait: %v", err)
+	}
+	resBob, err := sessionBob.Wait()
+	if err != nil {
+		t.Fatalf("sessionBob.Wait: %v", err)
+	}
+
+	// Verify session keys match
+	if !bytes.Equal(resAlice.Master, resBob.Master) {
+		t.Fatalf("session master mismatch between Alice and Bob")
+	}
+	if !bytes.Equal(resAlice.SendKey, resBob.RecvKey) {
+		t.Fatalf("directional key mismatch: Alice SendKey != Bob RecvKey")
+	}
+	if !bytes.Equal(resAlice.RecvKey, resBob.SendKey) {
+		t.Fatalf("directional key mismatch: Alice RecvKey != Bob SendKey")
+	}
+	if resAlice.Role != RoleOfferer || resBob.Role != RoleJoiner {
+		t.Fatalf("role mismatch")
+	}
+	if resAlice.Handle != validHandle || resBob.Handle != validHandle {
+		t.Fatalf("handle mismatch")
+	}
+	if resAlice.PeerDeviceID != idBob.DeviceID || resBob.PeerDeviceID != idAlice.DeviceID {
+		t.Fatalf("peer device ID mismatch")
+	}
+}
+
+func TestOpaqueSessionInvalidHandle(t *testing.T) {
+	id, _ := wire.GenerateDeviceIdentity()
+	pub, _, _ := ed25519.GenerateKey(nil)
+	kPair := make([]byte, 32)
+
+	session := NewOpaqueSession(OpaqueOptions{
+		Role:          RoleOfferer,
+		Handle:        "short-handle",
+		LocalIdentity: id,
+		PeerDeviceID:  "dev-peer",
+		PeerPublicKey: pub,
+		KPair:         kPair,
+		Transport:     &mockSink{},
+	})
+
+	err := session.Start()
+	if err == nil {
+		t.Fatalf("expected error on invalid handle")
+	}
+	if session.Phase() != OpaquePhaseFailed {
+		t.Fatalf("expected failed phase, got %v", session.Phase())
+	}
+}
+
+func TestOpaqueSessionPeerLeft(t *testing.T) {
+	id, _ := wire.GenerateDeviceIdentity()
+	pub, _, _ := ed25519.GenerateKey(nil)
+	kPair := make([]byte, 32)
+	validHandle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	session := NewOpaqueSession(OpaqueOptions{
+		Role:          RoleOfferer,
+		Handle:        validHandle,
+		LocalIdentity: id,
+		PeerDeviceID:  "dev-peer",
+		PeerPublicKey: pub,
+		KPair:         kPair,
+		Transport:     &mockSink{},
+	})
+
+	_ = session.Start()
+	err := session.Handle(Message{Type: typePeerLeft})
+	if err == nil {
+		t.Fatalf("expected error on peer_left")
+	}
+	if session.Phase() != OpaquePhaseFailed {
+		t.Fatalf("expected failed phase, got %v", session.Phase())
+	}
+}

--- a/packages/engine/rendezvous/presence_coordinator.go
+++ b/packages/engine/rendezvous/presence_coordinator.go
@@ -3,17 +3,41 @@ package rendezvous
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/sendbeam/engine/trust"
 	"github.com/sendbeam/wire"
 )
 
+// PresenceStatus represents truthful presence state for a trusted peer.
+type PresenceStatus string
+
+// Truthful presence status constants.
+const (
+	PresenceOffline    PresenceStatus = "offline"
+	PresenceDiscovered PresenceStatus = "discovered"
+	PresenceConnecting PresenceStatus = "connecting"
+	PresenceConnected  PresenceStatus = "connected"
+)
+
+// PeerPresenceRecord stores the latest truthful presence observation for a peer.
+type PeerPresenceRecord struct {
+	DeviceID  string
+	Status    PresenceStatus
+	Handle    string
+	LastSeen  time.Time
+	ExpiresAt time.Time
+}
+
 // PresenceCoordinator manages opaque handle calculation and inbound presence verification.
 type PresenceCoordinator struct {
 	store       trust.Store
 	resolver    trust.SecretResolver
 	epochWindow time.Duration
+
+	mu      sync.RWMutex
+	records map[string]*PeerPresenceRecord
 }
 
 // NewPresenceCoordinator creates a new PresenceCoordinator.
@@ -25,6 +49,7 @@ func NewPresenceCoordinator(store trust.Store, resolver trust.SecretResolver, ep
 		store:       store,
 		resolver:    resolver,
 		epochWindow: epochWindow,
+		records:     make(map[string]*PeerPresenceRecord),
 	}
 }
 
@@ -73,12 +98,95 @@ func (c *PresenceCoordinator) MatchInboundPresence(ctx context.Context, handle s
 		if wire.MatchRendezvousHandle(kPair, handle, now, c.epochWindow) {
 			if len(proof) > 0 && len(nonce) > 0 {
 				if wire.VerifyPresenceProof(kPair, handle, nonce, proof) {
+					c.RecordPeerDiscovered(dev.DeviceID, handle, now)
 					return dev.DeviceID, true
 				}
 			} else {
+				c.RecordPeerDiscovered(dev.DeviceID, handle, now)
 				return dev.DeviceID, true
 			}
 		}
 	}
 	return "", false
+}
+
+// RecordPeerDiscovered marks a peer as discovered with an expiration window.
+func (c *PresenceCoordinator) RecordPeerDiscovered(deviceID, handle string, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records[deviceID] = &PeerPresenceRecord{
+		DeviceID:  deviceID,
+		Status:    PresenceDiscovered,
+		Handle:    handle,
+		LastSeen:  now,
+		ExpiresAt: now.Add(c.epochWindow),
+	}
+}
+
+// SetPeerConnecting marks a peer transition into active connection establishment.
+func (c *PresenceCoordinator) SetPeerConnecting(deviceID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rec, ok := c.records[deviceID]
+	if !ok {
+		rec = &PeerPresenceRecord{DeviceID: deviceID}
+		c.records[deviceID] = rec
+	}
+	rec.Status = PresenceConnecting
+}
+
+// SetPeerConnected marks a peer as actively connected.
+func (c *PresenceCoordinator) SetPeerConnected(deviceID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rec, ok := c.records[deviceID]
+	if !ok {
+		rec = &PeerPresenceRecord{DeviceID: deviceID}
+		c.records[deviceID] = rec
+	}
+	rec.Status = PresenceConnected
+	rec.LastSeen = time.Now()
+}
+
+// SetPeerDisconnected marks a peer as disconnected/offline.
+func (c *PresenceCoordinator) SetPeerDisconnected(deviceID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rec, ok := c.records[deviceID]
+	if ok {
+		rec.Status = PresenceOffline
+	}
+}
+
+// GetPeerPresence queries truthful presence for a device. If a discovered peer's epoch
+// has elapsed without a refreshed handle, it truthfully reports PresenceOffline.
+func (c *PresenceCoordinator) GetPeerPresence(deviceID string, now time.Time) PresenceStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	rec, ok := c.records[deviceID]
+	if !ok {
+		return PresenceOffline
+	}
+	if rec.Status == PresenceConnected || rec.Status == PresenceConnecting {
+		return rec.Status
+	}
+	if rec.Status == PresenceDiscovered {
+		if !rec.ExpiresAt.IsZero() && now.After(rec.ExpiresAt) {
+			// Truthful presence: discovery is ephemeral. Once the epoch window expires, report offline.
+			return PresenceOffline
+		}
+		return PresenceDiscovered
+	}
+	return PresenceOffline
+}
+
+// PruneExpired removes presence records that have expired.
+func (c *PresenceCoordinator) PruneExpired(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, rec := range c.records {
+		if rec.Status == PresenceDiscovered && !rec.ExpiresAt.IsZero() && now.After(rec.ExpiresAt) {
+			delete(c.records, id)
+		}
+	}
 }

--- a/packages/engine/rendezvous/presence_coordinator_test.go
+++ b/packages/engine/rendezvous/presence_coordinator_test.go
@@ -83,4 +83,37 @@ func TestPresenceCoordinator(t *testing.T) {
 	if validTampered {
 		t.Errorf("tampered proof should not be valid")
 	}
+
+	// Truthful presence check: since MatchInboundPresence succeeded, devAlice is discovered
+	if status := coord.GetPeerPresence(devAlice, now); status != PresenceDiscovered {
+		t.Errorf("expected PresenceDiscovered, got %v", status)
+	}
+
+	// Truthful presence: 20 minutes later (> 15 min epoch window), must be PresenceOffline
+	if status := coord.GetPeerPresence(devAlice, now.Add(20*time.Minute)); status != PresenceOffline {
+		t.Errorf("expected PresenceOffline after epoch window expiry, got %v", status)
+	}
+
+	// State transitions
+	coord.SetPeerConnecting(devAlice)
+	if status := coord.GetPeerPresence(devAlice, now.Add(20*time.Minute)); status != PresenceConnecting {
+		t.Errorf("expected PresenceConnecting, got %v", status)
+	}
+
+	coord.SetPeerConnected(devAlice)
+	if status := coord.GetPeerPresence(devAlice, now.Add(20*time.Minute)); status != PresenceConnected {
+		t.Errorf("expected PresenceConnected, got %v", status)
+	}
+
+	coord.SetPeerDisconnected(devAlice)
+	if status := coord.GetPeerPresence(devAlice, now.Add(20*time.Minute)); status != PresenceOffline {
+		t.Errorf("expected PresenceOffline, got %v", status)
+	}
+
+	// Re-record discovered and test PruneExpired
+	coord.RecordPeerDiscovered(devAlice, handleAlice, now)
+	coord.PruneExpired(now.Add(20 * time.Minute))
+	if status := coord.GetPeerPresence(devAlice, now); status != PresenceOffline {
+		t.Errorf("expected record pruned and offline, got %v", status)
+	}
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -40,3 +40,4 @@ export * from './browser-identity.js';
 export * from './revocation.js';
 export * from './tombstone-store.js';
 export * from './indexeddb-tombstone-store.js';
+export * from './opaque-rendezvous.js';

--- a/packages/protocol/src/indexeddb-secret-store.ts
+++ b/packages/protocol/src/indexeddb-secret-store.ts
@@ -16,6 +16,28 @@ export interface SecretResolver {
   resolvePairSecret(deviceId: string, credentialRef: string): Promise<Uint8Array | null>;
 }
 
+export class MemorySecretResolver implements SecretResolver {
+  private readonly secrets = new Map<string, Uint8Array>();
+
+  setSecret(deviceId: string, secret: Uint8Array): void {
+    this.secrets.set(deviceId, new Uint8Array(secret));
+  }
+
+  async getPairSecret(deviceId: string): Promise<Uint8Array | null> {
+    const s = this.secrets.get(deviceId);
+    return s ? new Uint8Array(s) : null;
+  }
+
+  async resolvePairSecret(deviceId: string, _credentialRef: string): Promise<Uint8Array | null> {
+    void _credentialRef;
+    return this.getPairSecret(deviceId);
+  }
+
+  async deleteSecret(deviceId: string): Promise<void> {
+    this.secrets.delete(deviceId);
+  }
+}
+
 export class IndexedDBSecretStore implements SecretResolver {
   private readonly customIdb: IDBFactory | undefined;
   private dbPromise: Promise<IDBDatabase> | undefined;

--- a/packages/protocol/src/opaque-rendezvous.test.ts
+++ b/packages/protocol/src/opaque-rendezvous.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { hexToBytes } from './bytes.js';
+import { createDeviceIdentityFromSeed } from './identity.js';
+import { OpaqueRendezvousSession } from './opaque-rendezvous.js';
+
+describe('OpaqueRendezvousSession (sendbeam/3)', () => {
+  const seedInit = hexToBytes('1111111111111111111111111111111111111111111111111111111111111111');
+  const seedResp = hexToBytes('2222222222222222222222222222222222222222222222222222222222222222');
+  const kPair = hexToBytes('3333333333333333333333333333333333333333333333333333333333333333');
+  const validHandle = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  it('rejects invalid handle on start', async () => {
+    const idInit = await createDeviceIdentityFromSeed(seedInit);
+    const session = new OpaqueRendezvousSession({
+      role: 'offerer',
+      handle: 'invalid-handle',
+      localIdentity: idInit,
+      peerDeviceId: 'peer-id',
+      peerPublicKey: 'peer-pk',
+      kPair,
+      pairCredentialRef: 'cred-1',
+      send: () => {},
+    });
+
+    await session.start();
+    expect(session.getPhase()).toBe('failed');
+    await expect(session.result).rejects.toThrow('invalid_handle');
+  });
+
+  it('completes mutual sendbeam/3 authentication between offerer and joiner', async () => {
+    const idInit = await createDeviceIdentityFromSeed(seedInit);
+    const idResp = await createDeviceIdentityFromSeed(seedResp);
+
+    const offererOutbox: Record<string, unknown>[] = [];
+    const joinerOutbox: Record<string, unknown>[] = [];
+
+    const offererSession = new OpaqueRendezvousSession({
+      role: 'offerer',
+      handle: validHandle,
+      localIdentity: idInit,
+      peerDeviceId: idResp.deviceId,
+      peerPublicKey: idResp.publicKey,
+      kPair,
+      pairCredentialRef: 'cred-1',
+      send: (msg) => {
+        offererOutbox.push(msg as Record<string, unknown>);
+      },
+    });
+
+    const joinerSession = new OpaqueRendezvousSession({
+      role: 'joiner',
+      handle: validHandle,
+      localIdentity: idResp,
+      peerDeviceId: idInit.deviceId,
+      peerPublicKey: idInit.publicKey,
+      kPair,
+      pairCredentialRef: 'cred-1',
+      send: (msg) => {
+        joinerOutbox.push(msg as Record<string, unknown>);
+      },
+    });
+
+    // 1. Offerer starts and sends rendezvous message
+    await offererSession.start();
+    expect(offererSession.getPhase()).toBe('rendezvous_sent');
+    expect(offererOutbox[0]).toEqual({
+      type: 'rendezvous',
+      handle: validHandle,
+      role: 'offerer',
+    });
+
+    // Server acknowledges offerer room creation
+    await offererSession.handleMessage({ type: 'created', handle: validHandle });
+    expect(offererSession.getPhase()).toBe('waiting_peer');
+
+    // 2. Joiner starts and sends rendezvous message
+    await joinerSession.start();
+    expect(joinerSession.getPhase()).toBe('rendezvous_sent');
+    expect(joinerOutbox[0]).toEqual({
+      type: 'rendezvous',
+      handle: validHandle,
+      role: 'joiner',
+    });
+
+    // Server signals pairing to offerer
+    await offererSession.handleMessage({ type: 'peer-joined' });
+    expect(offererSession.getPhase()).toBe('authenticating');
+    // Offerer should have emitted trusted_auth_init
+    const initMsg = offererOutbox[1];
+    expect(initMsg.type).toBe('trusted_auth_init');
+    expect(initMsg.protocol_version).toBe('sendbeam/3');
+
+    // Joiner receives trusted_auth_init
+    await joinerSession.handleMessage(initMsg);
+    // Joiner should have emitted trusted_auth_response and trusted_auth_confirm
+    const respMsg = joinerOutbox[1];
+    expect(respMsg.type).toBe('trusted_auth_response');
+    expect(respMsg.status).toBe('accepted');
+    const joinerConfirmMsg = joinerOutbox[2];
+    expect(joinerConfirmMsg.type).toBe('trusted_auth_confirm');
+    expect(joinerConfirmMsg.status).toBe('ready');
+
+    // Offerer receives trusted_auth_response
+    await offererSession.handleMessage(respMsg);
+    // Offerer should have emitted trusted_auth_confirm
+    const offererConfirmMsg = offererOutbox[2];
+    expect(offererConfirmMsg.type).toBe('trusted_auth_confirm');
+    expect(offererConfirmMsg.status).toBe('ready');
+
+    // Mutual confirmation exchange
+    await offererSession.handleMessage(joinerConfirmMsg);
+    await joinerSession.handleMessage(offererConfirmMsg);
+
+    // Both should be established!
+    expect(offererSession.getPhase()).toBe('established');
+    expect(joinerSession.getPhase()).toBe('established');
+
+    const offererRes = await offererSession.result;
+    const joinerRes = await joinerSession.result;
+
+    // Verify session keys match bidirectionally
+    expect(offererRes.master).toEqual(joinerRes.master);
+    expect(offererRes.sendKey).toEqual(joinerRes.recvKey);
+    expect(offererRes.recvKey).toEqual(joinerRes.sendKey);
+    expect(offererRes.role).toBe('offerer');
+    expect(joinerRes.role).toBe('joiner');
+    expect(offererRes.handle).toBe(validHandle);
+    expect(joinerRes.handle).toBe(validHandle);
+  });
+
+  it('fails when peer sends invalid auth tag', async () => {
+    const idInit = await createDeviceIdentityFromSeed(seedInit);
+    const idResp = await createDeviceIdentityFromSeed(seedResp);
+
+    const offererSession = new OpaqueRendezvousSession({
+      role: 'offerer',
+      handle: validHandle,
+      localIdentity: idInit,
+      peerDeviceId: idResp.deviceId,
+      peerPublicKey: idResp.publicKey,
+      kPair,
+      pairCredentialRef: 'cred-1',
+      send: () => {},
+    });
+
+    await offererSession.start();
+    await offererSession.handleMessage({ type: 'created', handle: validHandle });
+    await offererSession.handleMessage({ type: 'peer-joined' });
+
+    // Tampered response
+    await offererSession.handleMessage({
+      type: 'trusted_auth_response',
+      protocol_version: 'sendbeam/3',
+      status: 'accepted',
+      responder_device_id: idResp.deviceId,
+      ephemeral_pub: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      nonce: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      signature: '00'.repeat(64),
+      auth_tag: '00'.repeat(32),
+    });
+
+    expect(offererSession.getPhase()).toBe('failed');
+    await expect(offererSession.result).rejects.toThrow();
+  });
+
+  it('fails when signaling returns error or peer leaves prematurely', async () => {
+    const idInit = await createDeviceIdentityFromSeed(seedInit);
+    const session = new OpaqueRendezvousSession({
+      role: 'offerer',
+      handle: validHandle,
+      localIdentity: idInit,
+      peerDeviceId: 'peer-id',
+      peerPublicKey: 'peer-pk',
+      kPair,
+      pairCredentialRef: 'cred-1',
+      send: () => {},
+    });
+
+    await session.start();
+    await session.handleMessage({ type: 'peer_left' });
+    expect(session.getPhase()).toBe('failed');
+    await expect(session.result).rejects.toThrow('peer_left');
+  });
+});

--- a/packages/protocol/src/opaque-rendezvous.ts
+++ b/packages/protocol/src/opaque-rendezvous.ts
@@ -1,0 +1,378 @@
+/**
+ * Ephemeral opaque rendezvous state machine (V19-PR05).
+ * Connects time-windowed opaque handles to authenticated forward-secret sessions (sendbeam/3).
+ */
+
+import type { Role } from './signaling.js';
+import { validateRendezvousHandle } from './presence.js';
+import type { DeviceIdentity } from './identity.js';
+import {
+  DOMAIN_TRUSTED_CONFIRM_INIT_3,
+  DOMAIN_TRUSTED_CONFIRM_RESP_3,
+  createTrustedAuthConfirm,
+  createTrustedAuthInitV3,
+  createTrustedAuthResponseV3,
+  deriveTrustedSessionKeysV3,
+  verifyTrustedAuthConfirm,
+  verifyTrustedAuthInitV3,
+  verifyTrustedAuthResponseV3,
+  type TrustedAuthConfirm,
+  type TrustedAuthInit,
+  type TrustedAuthResponse,
+} from './trusted-auth.js';
+import { x25519 } from '@noble/curves/ed25519.js';
+import { bytesToHex, hexToBytes } from './bytes.js';
+import { randomBytes } from './webcrypto.js';
+
+export type OpaqueRendezvousPhase =
+  | 'idle'
+  | 'rendezvous_sent'
+  | 'waiting_peer'
+  | 'paired'
+  | 'authenticating'
+  | 'established'
+  | 'failed';
+
+export interface OpaqueRendezvousResult {
+  readonly role: Role;
+  readonly handle: string;
+  readonly master: Uint8Array;
+  readonly sendKey: Uint8Array;
+  readonly recvKey: Uint8Array;
+  readonly negotiatedCaps: string[];
+  readonly peerDeviceId: string;
+}
+
+export interface OpaqueRendezvousOptions {
+  readonly role: Role;
+  readonly handle: string;
+  readonly localIdentity: DeviceIdentity;
+  readonly peerDeviceId: string;
+  readonly peerPublicKey: string | Uint8Array;
+  readonly kPair: Uint8Array;
+  readonly pairCredentialRef: string;
+  readonly localCapabilities?: string[] | undefined;
+  readonly send: (msg: unknown) => Promise<void> | void;
+  readonly onPhase?: ((phase: OpaqueRendezvousPhase) => void) | undefined;
+  readonly timeoutMs?: number | undefined;
+}
+
+function getPeerPubKeyBytes(peerPublicKey: string | Uint8Array): Uint8Array {
+  return typeof peerPublicKey === 'string' ? hexToBytes(peerPublicKey) : peerPublicKey;
+}
+
+export class OpaqueRendezvousSession {
+  private phase: OpaqueRendezvousPhase = 'idle';
+  private readonly options: OpaqueRendezvousOptions;
+  private privScalar?: Uint8Array | undefined;
+  private pubHex?: string | undefined;
+  private nonceHex?: string | undefined;
+  private initMsg?: TrustedAuthInit | undefined;
+  private sessionMaster?: Uint8Array | undefined;
+  private sendKey?: Uint8Array | undefined;
+  private recvKey?: Uint8Array | undefined;
+  private negotiatedCaps?: string[] | undefined;
+  private peerConfirmed = false;
+  private selfConfirmed = false;
+
+  private resolvePromise?: ((result: OpaqueRendezvousResult) => void) | undefined;
+  private rejectPromise?: ((err: Error) => void) | undefined;
+  readonly result: Promise<OpaqueRendezvousResult>;
+
+  constructor(options: OpaqueRendezvousOptions) {
+    this.options = options;
+    this.result = new Promise<OpaqueRendezvousResult>((resolve, reject) => {
+      this.resolvePromise = resolve;
+      this.rejectPromise = reject;
+    });
+  }
+
+  getPhase(): OpaqueRendezvousPhase {
+    return this.phase;
+  }
+
+  private setPhase(newPhase: OpaqueRendezvousPhase): void {
+    this.phase = newPhase;
+    this.options.onPhase?.(newPhase);
+  }
+
+  async start(): Promise<void> {
+    if (this.phase !== 'idle') {
+      return;
+    }
+    if (!validateRendezvousHandle(this.options.handle)) {
+      this.fail(new Error('invalid_handle'));
+      return;
+    }
+
+    this.setPhase('rendezvous_sent');
+    await this.options.send({
+      type: 'rendezvous',
+      handle: this.options.handle,
+      role: this.options.role,
+    });
+  }
+
+  async resume(): Promise<void> {
+    if (!validateRendezvousHandle(this.options.handle)) {
+      this.fail(new Error('invalid_handle'));
+      return;
+    }
+    await this.options.send({
+      type: 'resume',
+      handle: this.options.handle,
+      role: this.options.role,
+    });
+  }
+
+  async handleMessage(msg: unknown): Promise<void> {
+    if (this.phase === 'failed' || this.phase === 'established') {
+      return;
+    }
+
+    const m = msg as Record<string, unknown>;
+    try {
+      switch (m['type']) {
+        case 'created':
+          if (this.phase === 'rendezvous_sent') {
+            this.setPhase('waiting_peer');
+          }
+          break;
+
+        case 'peer-joined':
+          this.setPhase('paired');
+          await this.onPaired();
+          break;
+
+        case 'resumed':
+          // Re-attached to lingering room; proceed with auth if paired
+          break;
+
+        case 'peer_rejoined':
+          // Partner re-attached; re-run auth
+          this.setPhase('paired');
+          await this.onPaired();
+          break;
+
+        case 'peer_left':
+          this.fail(new Error('peer_left'));
+          break;
+
+        case 'error':
+          this.fail(new Error(typeof m['code'] === 'string' ? m['code'] : 'signaling_error'));
+          break;
+
+        case 'trusted_auth_init':
+          await this.onTrustedAuthInit(msg as TrustedAuthInit);
+          break;
+
+        case 'trusted_auth_response':
+          await this.onTrustedAuthResponse(msg as TrustedAuthResponse);
+          break;
+
+        case 'trusted_auth_confirm':
+          await this.onTrustedAuthConfirm(msg as TrustedAuthConfirm);
+          break;
+
+        default:
+          break;
+      }
+    } catch (err: unknown) {
+      this.fail(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  private async onPaired(): Promise<void> {
+    this.setPhase('authenticating');
+    if (this.options.role === 'offerer') {
+      // Offerer acts as initiator
+      const priv = x25519.utils.randomSecretKey();
+      this.privScalar = priv;
+      const pub = x25519.getPublicKey(priv);
+      this.pubHex = bytesToHex(pub);
+      const nonce = randomBytes(32);
+      this.nonceHex = bytesToHex(nonce);
+
+      const init = await createTrustedAuthInitV3(
+        this.options.localIdentity,
+        this.options.peerDeviceId,
+        this.options.pairCredentialRef,
+        this.options.kPair,
+        this.options.localCapabilities ?? ['transfer.v1', 'padding'],
+        pub,
+        nonce,
+      );
+      this.initMsg = init;
+      await this.options.send(init);
+    }
+  }
+
+  private async onTrustedAuthInit(init: TrustedAuthInit): Promise<void> {
+    if (this.options.role !== 'joiner') {
+      return;
+    }
+    this.initMsg = init;
+
+    // Verify init message
+    const peerPubBytes = getPeerPubKeyBytes(this.options.peerPublicKey);
+    const { ephemeralPub: peerEphemPub, nonce: peerNonce } = await verifyTrustedAuthInitV3(
+      init,
+      this.options.kPair,
+      peerPubBytes,
+      this.options.localIdentity.deviceId,
+    );
+
+    // Generate responder ephemeral keypair
+    const privB = x25519.utils.randomSecretKey();
+    const pubB = x25519.getPublicKey(privB);
+    const nonceB = randomBytes(32);
+
+    const localCaps = this.options.localCapabilities ?? ['transfer.v1', 'padding'];
+
+    const response = await createTrustedAuthResponseV3(
+      this.options.localIdentity,
+      init,
+      this.options.kPair,
+      localCaps,
+      pubB,
+      nonceB,
+    );
+    await this.options.send(response);
+
+    // Derive session keys
+    const ss = x25519.getSharedSecret(privB, peerEphemPub);
+    // Zeroize privB
+    privB.fill(0);
+
+    const keys = await deriveTrustedSessionKeysV3(
+      this.options.kPair,
+      ss,
+      peerEphemPub,
+      pubB,
+      peerNonce,
+      nonceB,
+      init.initiator_device_id,
+      this.options.localIdentity.deviceId,
+      init.capabilities,
+      localCaps,
+    );
+
+    this.sessionMaster = keys.sessionMaster;
+    // For joiner (responder): sendKey is r2i, recvKey is i2r
+    this.sendKey = keys.responderToInitiatorKey;
+    this.recvKey = keys.initiatorToResponderKey;
+    this.negotiatedCaps = keys.negotiatedCapabilities;
+
+    // Send confirmation
+    const confirm = await createTrustedAuthConfirm(
+      this.sessionMaster,
+      DOMAIN_TRUSTED_CONFIRM_RESP_3,
+      this.options.localIdentity.deviceId,
+      true,
+    );
+    this.selfConfirmed = true;
+    await this.options.send(confirm);
+    this.checkEstablished();
+  }
+
+  private async onTrustedAuthResponse(resp: TrustedAuthResponse): Promise<void> {
+    if (this.options.role !== 'offerer' || !this.initMsg || !this.privScalar) {
+      return;
+    }
+    if (resp.status !== 'accepted' || !resp.ephemeral_pub || !resp.nonce) {
+      throw new Error(`peer_rejected_auth: ${resp.status}`);
+    }
+
+    const peerPubBytes = getPeerPubKeyBytes(this.options.peerPublicKey);
+    const { ephemeralPub: peerEphemPub, nonce: peerNonce } = await verifyTrustedAuthResponseV3(
+      resp,
+      this.initMsg,
+      this.options.kPair,
+      peerPubBytes,
+      this.options.localIdentity.deviceId,
+    );
+
+    const ss = x25519.getSharedSecret(this.privScalar, peerEphemPub);
+    // Zeroize privScalar
+    this.privScalar.fill(0);
+    this.privScalar = undefined;
+
+    const myEphemPub = hexToBytes(this.pubHex!);
+    const myNonce = hexToBytes(this.nonceHex!);
+
+    const keys = await deriveTrustedSessionKeysV3(
+      this.options.kPair,
+      ss,
+      myEphemPub,
+      peerEphemPub,
+      myNonce,
+      peerNonce,
+      this.options.localIdentity.deviceId,
+      this.options.peerDeviceId,
+      this.initMsg.capabilities,
+      resp.capabilities ?? [],
+    );
+
+    this.sessionMaster = keys.sessionMaster;
+    // For offerer (initiator): sendKey is i2r, recvKey is r2i
+    this.sendKey = keys.initiatorToResponderKey;
+    this.recvKey = keys.responderToInitiatorKey;
+    this.negotiatedCaps = keys.negotiatedCapabilities;
+
+    // Send confirmation
+    const confirm = await createTrustedAuthConfirm(
+      this.sessionMaster,
+      DOMAIN_TRUSTED_CONFIRM_INIT_3,
+      this.options.localIdentity.deviceId,
+      true,
+    );
+    this.selfConfirmed = true;
+    await this.options.send(confirm);
+    this.checkEstablished();
+  }
+
+  private async onTrustedAuthConfirm(confirm: TrustedAuthConfirm): Promise<void> {
+    if (!this.sessionMaster) {
+      throw new Error('session_master_missing');
+    }
+
+    const domain =
+      this.options.role === 'offerer'
+        ? DOMAIN_TRUSTED_CONFIRM_RESP_3
+        : DOMAIN_TRUSTED_CONFIRM_INIT_3;
+    await verifyTrustedAuthConfirm(confirm, this.sessionMaster, domain, this.options.peerDeviceId);
+
+    this.peerConfirmed = true;
+    this.checkEstablished();
+  }
+
+  private checkEstablished(): void {
+    if (
+      this.selfConfirmed &&
+      this.peerConfirmed &&
+      this.sessionMaster &&
+      this.sendKey &&
+      this.recvKey
+    ) {
+      this.setPhase('established');
+      this.resolvePromise?.({
+        role: this.options.role,
+        handle: this.options.handle,
+        master: this.sessionMaster,
+        sendKey: this.sendKey,
+        recvKey: this.recvKey,
+        negotiatedCaps: this.negotiatedCaps ?? [],
+        peerDeviceId: this.options.peerDeviceId,
+      });
+    }
+  }
+
+  private fail(err: Error): void {
+    if (this.privScalar) {
+      this.privScalar.fill(0);
+      this.privScalar = undefined;
+    }
+    this.setPhase('failed');
+    this.rejectPromise?.(err);
+  }
+}

--- a/packages/protocol/src/presence.test.ts
+++ b/packages/protocol/src/presence.test.ts
@@ -9,8 +9,14 @@ import {
   deriveRendezvousHandle,
   deriveRendezvousHandlesWithSkew,
   matchLanBeaconTag,
+  matchRendezvousHandle,
+  validateRendezvousHandle,
   verifyPresenceProof,
+  PresenceCoordinator,
 } from './presence.js';
+import { MemoryTrustStore, defaultTrustPolicy } from './trust-store.js';
+import { MemorySecretResolver } from './indexeddb-secret-store.js';
+import { createDeviceIdentityFromSeed } from './identity.js';
 
 interface PresenceVector {
   name: string;
@@ -94,5 +100,125 @@ describe('Presence and LAN discovery cross-language vector validation (sendbeam/
       bytesToHex(new Uint8Array(32)),
     );
     expect(proofValid).toBe(false);
+  });
+
+  describe('validateRendezvousHandle', () => {
+    it('accepts valid 64-char lowercase hex handles', () => {
+      expect(
+        validateRendezvousHandle(
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        ),
+      ).toBe(true);
+    });
+
+    it('rejects invalid handles', () => {
+      expect(validateRendezvousHandle('')).toBe(false);
+      expect(validateRendezvousHandle('short')).toBe(false);
+      expect(
+        validateRendezvousHandle(
+          '0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef',
+        ),
+      ).toBe(false); // uppercase
+      expect(
+        validateRendezvousHandle(
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg',
+        ),
+      ).toBe(false); // non-hex
+      expect(
+        validateRendezvousHandle(
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef00',
+        ),
+      ).toBe(false); // too long
+    });
+  });
+
+  describe('matchRendezvousHandle', () => {
+    it('matches handles within skew window and rejects outside window', async () => {
+      const kPair = hexToBytes('8b4c642283597de370a8313836bcc86ca6718f0d71fa4f301134d3f049da2848');
+      const now = 1700000000000;
+      const epochIndex = Math.floor(now / DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS);
+
+      const currentHandle = await deriveRendezvousHandle(kPair, epochIndex);
+      const prevHandle = await deriveRendezvousHandle(kPair, epochIndex - 1);
+      const nextHandle = await deriveRendezvousHandle(kPair, epochIndex + 1);
+      const oldHandle = await deriveRendezvousHandle(kPair, epochIndex - 5);
+
+      expect(await matchRendezvousHandle(kPair, currentHandle, now)).toBe(true);
+      expect(await matchRendezvousHandle(kPair, prevHandle, now)).toBe(true);
+      expect(await matchRendezvousHandle(kPair, nextHandle, now)).toBe(true);
+      expect(await matchRendezvousHandle(kPair, oldHandle, now)).toBe(false);
+    });
+  });
+
+  describe('PresenceCoordinator and truthful presence', () => {
+    it('manages truthful presence lifecycle and enforces epoch expiry', async () => {
+      const trustStore = new MemoryTrustStore();
+      const secretResolver = new MemorySecretResolver();
+      const coordinator = new PresenceCoordinator(trustStore, secretResolver, 30_000);
+
+      const seed = hexToBytes('4444444444444444444444444444444444444444444444444444444444444444');
+      const id = await createDeviceIdentityFromSeed(seed);
+      const deviceId = id.deviceId;
+      const kPair = hexToBytes('8b4c642283597de370a8313836bcc86ca6718f0d71fa4f301134d3f049da2848');
+      const credRef = 'cred_1';
+
+      await trustStore.addOrUpdateDevice({
+        deviceId,
+        localLabel: 'Peer 1',
+        publicKey: bytesToHex(id.publicKey),
+        pairCredentialRef: credRef,
+        pairingRole: 'offerer',
+        capabilities: ['transfer.v1'],
+        trustedAt: new Date().toISOString(),
+        firstSeenAt: new Date().toISOString(),
+        policy: defaultTrustPolicy(),
+      });
+      secretResolver.setSecret(deviceId, kPair);
+
+      const t0 = 1700000000000;
+      const activeHandlesMap = await coordinator.getActiveHandles(t0);
+      const activeHandles = activeHandlesMap.get(deviceId)!;
+      expect(activeHandles).toBeDefined();
+      expect(activeHandles.length).toBe(3);
+
+      // Initially peer is offline
+      expect(coordinator.getPeerPresence(deviceId, t0)).toBe('offline');
+
+      // Match incoming handle
+      const match = await coordinator.matchInboundPresence(
+        activeHandles[0]!,
+        undefined,
+        undefined,
+        t0,
+      );
+      expect(match).not.toBeNull();
+      expect(match!.deviceId).toBe(deviceId);
+
+      // Status should now be 'discovered'
+      expect(coordinator.getPeerPresence(deviceId, t0)).toBe('discovered');
+
+      // Check within epoch window (t0 + 15s)
+      expect(coordinator.getPeerPresence(deviceId, t0 + 15_000)).toBe('discovered');
+
+      // Truthful presence: once epoch window expires (t0 + 31s), status must be 'offline'
+      expect(coordinator.getPeerPresence(deviceId, t0 + 31_000)).toBe('offline');
+
+      // Transition to connecting
+      coordinator.setPeerConnecting(deviceId);
+      expect(coordinator.getPeerPresence(deviceId, t0 + 31_000)).toBe('connecting');
+
+      // Transition to connected
+      coordinator.setPeerConnected(deviceId);
+      expect(coordinator.getPeerPresence(deviceId, t0 + 31_000)).toBe('connected');
+
+      // Transition to disconnected
+      coordinator.setPeerDisconnected(deviceId);
+      expect(coordinator.getPeerPresence(deviceId, t0 + 31_000)).toBe('offline');
+
+      // Prune expired
+      coordinator.recordPeerDiscovered(deviceId, activeHandles[0]!, t0);
+      coordinator.pruneExpired(t0 + 31_000);
+      expect(coordinator.getPeerPresence(deviceId, t0 + 31_000)).toBe('offline');
+    });
   });
 });

--- a/packages/protocol/src/presence.ts
+++ b/packages/protocol/src/presence.ts
@@ -6,6 +6,8 @@
 
 import { bytesToHex, concatBytes, utf8 } from './bytes.js';
 import { hmacSha256 } from './webcrypto.js';
+import type { TrustStore } from './trust-store.js';
+import type { SecretResolver } from './indexeddb-secret-store.js';
 
 export const DOMAIN_RENDEZVOUS_HANDLE = 'sendbeam/2 rendezvous-handle:';
 export const DOMAIN_PRESENCE_PROOF = 'sendbeam/2 presence-proof:';
@@ -156,4 +158,195 @@ export async function matchLanBeaconTag(
     }
   }
   return false;
+}
+
+/**
+ * Validate that a handle is a 64-character lowercase hexadecimal string.
+ */
+export function validateRendezvousHandle(handle: string): boolean {
+  if (typeof handle !== 'string' || handle.length !== 64) {
+    return false;
+  }
+  for (let i = 0; i < handle.length; i++) {
+    const c = handle.charCodeAt(i);
+    if ((c < 48 || c > 57) && (c < 97 || c > 102)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Check whether an advertised handle matches kPair candidate epochs.
+ */
+export async function matchRendezvousHandle(
+  kPair: Uint8Array,
+  handle: string,
+  t?: Date | number,
+  windowMs = DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+): Promise<boolean> {
+  if (!validateRendezvousHandle(handle)) {
+    return false;
+  }
+  const candidates = await deriveRendezvousHandlesWithSkew(kPair, t, windowMs);
+  for (const cand of candidates) {
+    if (constantTimeHexEqual(cand, handle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Truthful presence states for paired peers.
+ */
+export type PresenceStatus = 'offline' | 'discovered' | 'connecting' | 'connected';
+
+export interface PeerPresenceRecord {
+  readonly deviceId: string;
+  readonly status: PresenceStatus;
+  readonly handle?: string | undefined;
+  readonly lastSeenMs?: number | undefined;
+  readonly expiresAtMs?: number | undefined;
+}
+
+/**
+ * PresenceCoordinator manages opaque handle calculation, proof validation,
+ * and truthful presence state transitions with epoch-bound expiry.
+ */
+export class PresenceCoordinator {
+  private readonly records = new Map<string, PeerPresenceRecord>();
+
+  constructor(
+    private readonly trustStore: TrustStore,
+    private readonly secretResolver: SecretResolver,
+    private readonly epochWindowMs: number = DEFAULT_RENDEZVOUS_EPOCH_WINDOW_MS,
+  ) {}
+
+  /**
+   * Returns active candidate handles for all non-revoked paired devices.
+   */
+  async getActiveHandles(nowMs: number = Date.now()): Promise<Map<string, string[]>> {
+    const devices = await this.trustStore.listDevices();
+    const result = new Map<string, string[]>();
+    for (const dev of devices) {
+      if (dev.revoked) continue;
+      const kPair = await this.secretResolver.resolvePairSecret(
+        dev.deviceId,
+        dev.pairCredentialRef,
+      );
+      if (!kPair || kPair.length === 0) continue;
+      const handles = await deriveRendezvousHandlesWithSkew(kPair, nowMs, this.epochWindowMs);
+      result.set(dev.deviceId, handles);
+    }
+    return result;
+  }
+
+  /**
+   * Matches an incoming handle and optional HMAC proof against known paired devices.
+   */
+  async matchInboundPresence(
+    handle: string,
+    nonce?: Uint8Array,
+    proof?: string,
+    nowMs: number = Date.now(),
+  ): Promise<{ deviceId: string; verified: boolean } | null> {
+    if (!validateRendezvousHandle(handle)) {
+      return null;
+    }
+    const devices = await this.trustStore.listDevices();
+    for (const dev of devices) {
+      if (dev.revoked) continue;
+      const kPair = await this.secretResolver.resolvePairSecret(
+        dev.deviceId,
+        dev.pairCredentialRef,
+      );
+      if (!kPair || kPair.length === 0) continue;
+
+      if (await matchRendezvousHandle(kPair, handle, nowMs, this.epochWindowMs)) {
+        if (proof && nonce && nonce.length > 0) {
+          if (await verifyPresenceProof(kPair, handle, nonce, proof)) {
+            this.recordPeerDiscovered(dev.deviceId, handle, nowMs);
+            return { deviceId: dev.deviceId, verified: true };
+          }
+        } else {
+          this.recordPeerDiscovered(dev.deviceId, handle, nowMs);
+          return { deviceId: dev.deviceId, verified: true };
+        }
+      }
+    }
+    return null;
+  }
+
+  recordPeerDiscovered(deviceId: string, handle: string, nowMs: number = Date.now()): void {
+    this.records.set(deviceId, {
+      deviceId,
+      status: 'discovered',
+      handle,
+      lastSeenMs: nowMs,
+      expiresAtMs: nowMs + this.epochWindowMs,
+    });
+  }
+
+  setPeerConnecting(deviceId: string): void {
+    const existing = this.records.get(deviceId);
+    this.records.set(deviceId, {
+      deviceId,
+      status: 'connecting',
+      handle: existing?.handle,
+      lastSeenMs: existing?.lastSeenMs ?? Date.now(),
+      expiresAtMs: existing?.expiresAtMs,
+    });
+  }
+
+  setPeerConnected(deviceId: string): void {
+    const existing = this.records.get(deviceId);
+    this.records.set(deviceId, {
+      deviceId,
+      status: 'connected',
+      handle: existing?.handle,
+      lastSeenMs: Date.now(),
+    });
+  }
+
+  setPeerDisconnected(deviceId: string): void {
+    const existing = this.records.get(deviceId);
+    this.records.set(deviceId, {
+      deviceId,
+      status: 'offline',
+      handle: existing?.handle,
+      lastSeenMs: existing?.lastSeenMs,
+    });
+  }
+
+  /**
+   * Truthful presence query. If discovery epoch expired, returns 'offline'.
+   */
+  getPeerPresence(deviceId: string, nowMs: number = Date.now()): PresenceStatus {
+    const rec = this.records.get(deviceId);
+    if (!rec) return 'offline';
+    if (rec.status === 'connected' || rec.status === 'connecting') {
+      return rec.status;
+    }
+    if (rec.status === 'discovered') {
+      if (rec.expiresAtMs && nowMs > rec.expiresAtMs) {
+        // Truthful presence: discovery is ephemeral. Once epoch window expires, return offline!
+        return 'offline';
+      }
+      return 'discovered';
+    }
+    return 'offline';
+  }
+
+  pruneExpired(nowMs: number = Date.now()): void {
+    for (const [id, rec] of this.records.entries()) {
+      if (rec.status === 'discovered' && rec.expiresAtMs && nowMs > rec.expiresAtMs) {
+        this.records.set(id, {
+          deviceId: id,
+          status: 'offline',
+          lastSeenMs: rec.lastSeenMs,
+        });
+      }
+    }
+  }
 }

--- a/packages/protocol/src/rendezvous.ts
+++ b/packages/protocol/src/rendezvous.ts
@@ -254,6 +254,9 @@ export class RendezvousSession {
     if (this.settled) return;
     switch (msg.type) {
       case 'created':
+        if (msg.room === undefined) {
+          throw new RendezvousError('protocol', 'created message missing room number');
+        }
         return this.onCreated(msg.room);
       case 'peer-joined':
         return this.onPeerJoined(msg.role);

--- a/packages/protocol/src/signaling.ts
+++ b/packages/protocol/src/signaling.ts
@@ -13,16 +13,25 @@ export interface CreateMsg {
   type: 'create';
 }
 
-/** Server → sender: room allocated (smallest free number); waiting for a peer. */
+/** Server → sender: room allocated (smallest free number) or handle registered; waiting for a peer. */
 export interface CreatedMsg {
   type: 'created';
-  room: number;
+  room?: number;
+  handle?: string;
 }
 
-/** Receiver → server: pair with an existing room. */
+/** Receiver → server: pair with an existing room or handle. */
 export interface JoinMsg {
   type: 'join';
-  room: number;
+  room?: number;
+  handle?: string;
+}
+
+/** Client → server: pair or register on an opaque 64-hex rendezvous handle. */
+export interface RendezvousMsg {
+  type: 'rendezvous';
+  handle: string;
+  role?: Role;
 }
 
 /** Server → both: the two sockets are now paired. Carries this peer's role. */
@@ -118,14 +127,16 @@ export interface ByeMsg {
  */
 export interface ResumeMsg {
   type: 'resume';
-  room: number;
+  room?: number;
+  handle?: string;
   role: Role;
 }
 
 /** Server → client: a {@link ResumeMsg} was accepted; the partner state follows. */
 export interface ResumedMsg {
   type: 'resumed';
-  room: number;
+  room?: number;
+  handle?: string;
 }
 
 /**
@@ -163,13 +174,15 @@ export type SignalErrorCode =
   | 'rate_limited'
   | 'too_large'
   | 'bad_message'
-  | 'expired';
+  | 'expired'
+  | 'invalid_handle';
 
 /** All JSON signaling messages. */
 export type SignalMsg =
   | CreateMsg
   | CreatedMsg
   | JoinMsg
+  | RendezvousMsg
   | PeerJoinedMsg
   | PakeMsg
   | ConfirmMsg


### PR DESCRIPTION
[V19-PR05] Ephemeral opaque rendezvous connected to authenticated sessions; expiry, concurrency, reconnect, rate limits and truthful presence

### Summary of Deliverable
1. **Blind Signaling Server (`apps/server/internal/signal`)**:
   - Added ephemeral opaque handle room support (`type: "rendezvous"`, `type: "resume"`) with independent room lifecycle.
   - Enforced 64-char lowercase hex handle validation, token-bucket IP rate limits, and 1:1 pairing constraints.
   - Added blind peer-to-peer forwarding for authenticated handshake frames (`trusted_auth_init`, `trusted_auth_response`, `trusted_auth_confirm`).
   - Swept expired unpaired handle rooms via configurable `UnpairedTimeout` and idle paired rooms via `IdleTimeout`.
   - Updated `Drain` to await active transfer drainage across both handle and numeric room pools.

2. **Protocol Layer (`packages/protocol`)**:
   - Added `validateRendezvousHandle`, `matchRendezvousHandle`, and `PresenceCoordinator` with truthful presence lifecycle (`offline` | `discovered` | `connecting` | `connected`) and epoch window expiry enforcement.
   - Implemented `OpaqueRendezvousSession` coordinating offerer/joiner states, mutual `sendbeam/3` forward-secret authentication, session key derivation, and confirmation exchange.
   - Added `MemorySecretResolver` for test and ephemeral session key resolution.

3. **Engine Layer (`packages/engine/rendezvous`)**:
   - Added `PresenceStatus` (`PresenceOffline`, `PresenceDiscovered`, `PresenceConnecting`, `PresenceConnected`) and `PeerPresenceRecord` tracking to `PresenceCoordinator`.
   - Truthful presence bounds: once discovery epoch expires, status truthfully reports `PresenceOffline`.
   - Implemented `OpaqueSession` executing `sendbeam/3` authenticated session handshake over signaling opaque handles.
   - Extended signaling envelope (`Message`) with `Handle` and `Raw` support.