### PR TITLE
feat(receiver): shared native receiver for CLI listen and desktop

### DIFF
--- a/apps/cli/cmd/sendbeam/listen.go
+++ b/apps/cli/cmd/sendbeam/listen.go
@@ -1,30 +1,45 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
-	"github.com/sendbeam/engine/discovery"
+	"github.com/sendbeam/engine/receiver"
+	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/wire"
 )
 
 func runListen(args []string) int {
-	return executeListen(args, os.Stdout, os.Stderr)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return executeListenWithContext(ctx, args, os.Stdin, os.Stdout, os.Stderr)
 }
 
 func executeListen(args []string, stdout, stderr io.Writer) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return executeListenWithContext(ctx, args, os.Stdin, stdout, stderr)
+}
+
+func executeListenWithContext(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("listen", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	dest := fs.String("dest", ".", "directory to write received files into")
 	autoAccept := fs.Bool("auto-accept", false, "automatically accept transfers from trusted devices")
 	once := fs.Bool("once", false, "exit after completing a single transfer")
 	port := fs.Int("port", 53317, "local port for direct LAN peer discovery")
+	server := fs.String("server", "", "signaling server URL")
 	jsonOutput := fs.Bool("json", false, "output JSON format events")
 	configDir := fs.String("config-dir", "", "path to custom configuration directory")
 
@@ -37,6 +52,7 @@ func executeListen(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "error: invalid destination directory: %v\n", err)
 		return 2
 	}
+	_ = os.MkdirAll(absDest, 0700)
 
 	env, err := InitCLIEnvironment(*configDir)
 	if err != nil {
@@ -44,30 +60,148 @@ func executeListen(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	discCfg := discovery.Config{
-		AdvertisePort:  uint16(*port),
-		BeaconInterval: 3 * time.Second,
+	localID, err := env.IdentityMgr.GetOrCreateIdentity()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error getting local identity: %v\n", err)
+		return 1
 	}
-	lanService := discovery.NewLanDiscoveryService(discCfg, env.TrustStore, env.Secrets)
 
-	lanService.OnPeerDiscovered(func(peer discovery.DiscoveredPeer) {
-		rec, err := env.TrustStore.GetDevice(ctx, peer.DeviceID)
-		label := peer.DeviceID
-		if err == nil && rec != nil {
-			label = rec.LocalLabel
-		}
+	tombstones := env.Tombstones
+
+	serverURL := *server
+	if serverURL == "" {
+		serverURL = defaultServer
+	}
+
+	consentHandler := func(cctx context.Context, req receiver.ConsentRequest) (receiver.ConsentDecision, error) {
 		if *jsonOutput {
-			_, _ = fmt.Fprintf(stdout, `{"event":"peer_discovered","device_id":%q,"label":%q,"ip":%q,"port":%d}`+"\n",
-				peer.DeviceID, label, peer.IP.String(), peer.Port)
-		} else {
-			s := newStyleFromWriter(stdout)
-			_, _ = fmt.Fprintf(stdout, "[%s] Discovered trusted peer %s (%s:%d)\n",
-				time.Now().Format("15:04:05"), s.bold(label), peer.IP.String(), peer.Port)
+			evt := map[string]any{
+				"event":          "consent_requested",
+				"transfer_id":    req.TransferID,
+				"peer_device_id": req.PeerDeviceID,
+				"peer_label":     req.PeerLabel,
+				"files":          req.Files,
+				"total_size":     req.TotalSize,
+				"dest_dir":       req.DestDir,
+			}
+			enc, _ := json.Marshal(evt)
+			_, _ = fmt.Fprintln(stdout, string(enc))
+
+			scanner := bufio.NewScanner(stdin)
+			if scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if strings.HasPrefix(line, "{") {
+					var dec receiver.ConsentDecision
+					if json.Unmarshal([]byte(line), &dec) == nil {
+						return dec, nil
+					}
+				}
+				if strings.EqualFold(line, "y") || strings.EqualFold(line, "yes") {
+					return receiver.ConsentDecision{Accepted: true, DestDir: req.DestDir}, nil
+				}
+				return receiver.ConsentDecision{Accepted: false, Reason: "declined"}, nil
+			}
+			return receiver.ConsentDecision{Accepted: false, Reason: "no response on stdin"}, nil
 		}
+
+		s := newStyleFromWriter(stdout)
+		_, _ = fmt.Fprintf(stdout, "\n%s from %s (%s):\n", s.bold("Incoming transfer"), s.bold(req.PeerLabel), req.PeerDeviceID)
+		for _, f := range req.Files {
+			_, _ = fmt.Fprintf(stdout, "  • %s (%s)\n", f.Name, humanBytes(f.Size))
+		}
+		_, _ = fmt.Fprintf(stdout, "Total: %d file(s), %s\n", len(req.Files), humanBytes(req.TotalSize))
+		_, _ = fmt.Fprintf(stdout, "Accept transfer into %s? [y/N]: ", req.DestDir)
+
+		scanner := bufio.NewScanner(stdin)
+		if scanner.Scan() {
+			ans := strings.TrimSpace(scanner.Text())
+			if strings.EqualFold(ans, "y") || strings.EqualFold(ans, "yes") {
+				return receiver.ConsentDecision{Accepted: true, DestDir: req.DestDir}, nil
+			}
+		}
+		return receiver.ConsentDecision{Accepted: false, Reason: "declined by user"}, nil
+	}
+
+	listener, err := receiver.NewListener(receiver.Config{
+		DestDir:        absDest,
+		AutoAccept:     *autoAccept,
+		Once:           *once,
+		Port:           uint16(*port),
+		Server:         serverURL,
+		Identity:       localID,
+		TrustStore:     env.TrustStore,
+		Secrets:        env.Secrets,
+		Tombstones:     tombstones,
+		ConsentHandler: consentHandler,
+		OnPeerDiscovered: func(peer receiver.DiscoveredPeer) {
+			rec, err := env.TrustStore.GetDevice(ctx, peer.DeviceID)
+			label := peer.DeviceID
+			if err == nil && rec != nil {
+				label = rec.LocalLabel
+			}
+			if *jsonOutput {
+				_, _ = fmt.Fprintf(stdout, `{"event":"peer_discovered","device_id":%q,"label":%q,"ip":%q,"port":%d}`+"\n",
+					peer.DeviceID, label, peer.IP.String(), peer.Port)
+			} else {
+				s := newStyleFromWriter(stdout)
+				_, _ = fmt.Fprintf(stdout, "[%s] Discovered trusted peer %s (%s:%d)\n",
+					time.Now().Format("15:04:05"), s.bold(label), peer.IP.String(), peer.Port)
+			}
+		},
+		OnTransferStart: func(transferID string, peerDeviceID string, manifest wire.Manifest) {
+			rec, _ := env.TrustStore.GetDevice(ctx, peerDeviceID)
+			label := peerDeviceID
+			if rec != nil {
+				label = rec.LocalLabel
+			}
+			if *jsonOutput {
+				_, _ = fmt.Fprintf(stdout, `{"event":"transfer_started","transfer_id":%q,"peer_device_id":%q,"total_size":%d}`+"\n",
+					transferID, peerDeviceID, manifest.TotalSize)
+			} else {
+				s := newStyleFromWriter(stdout)
+				_, _ = fmt.Fprintf(stdout, "[%s] Receiving transfer %s from %s (%d files, %s)...\n",
+					time.Now().Format("15:04:05"), s.bold(transferID), s.bold(label), len(manifest.Files), humanBytes(manifest.TotalSize))
+			}
+		},
+		OnProgress: func(peerDeviceID string, ackBytes int64) {
+			if *jsonOutput {
+				_, _ = fmt.Fprintf(stdout, `{"event":"progress","peer_device_id":%q,"acknowledged_bytes":%d}`+"\n",
+					peerDeviceID, ackBytes)
+			}
+		},
+		OnTransferComplete: func(peerDeviceID string, outcome *transfer.Outcome) {
+			rec, _ := env.TrustStore.GetDevice(ctx, peerDeviceID)
+			label := peerDeviceID
+			if rec != nil {
+				label = rec.LocalLabel
+			}
+			if *jsonOutput {
+				_, _ = fmt.Fprintf(stdout, `{"event":"transfer_complete","peer_device_id":%q,"name":%q,"size":%d,"digest":%q,"path":%q}`+"\n",
+					peerDeviceID, outcome.Name, outcome.Size, outcome.Digest, outcome.Path)
+			} else {
+				s := newStyleFromWriter(stdout)
+				_, _ = fmt.Fprintf(stdout, "[%s] Transfer complete from %s: %s (%s) -> %s\n",
+					time.Now().Format("15:04:05"), s.bold(label), s.bold(outcome.Name), humanBytes(outcome.Size), outcome.Path)
+				_, _ = fmt.Fprintf(stdout, "[%s] Whole-file SHA-256: %s (%s)\n",
+					time.Now().Format("15:04:05"), s.bold(outcome.Digest), s.green("Verified"))
+			}
+		},
+		OnTransferError: func(peerDeviceID string, err error) {
+			if *jsonOutput {
+				_, _ = fmt.Fprintf(stdout, `{"event":"transfer_error","peer_device_id":%q,"error":%q}`+"\n",
+					peerDeviceID, err.Error())
+			} else {
+				s := newStyleFromWriter(stdout)
+				_, _ = fmt.Fprintf(stdout, "[%s] %s with peer %s: %v\n",
+					time.Now().Format("15:04:05"), s.red("Transfer error"), peerDeviceID, err)
+			}
+		},
 	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	defer listener.Close()
 
 	if !*jsonOutput {
 		s := newStyleFromWriter(stdout)
@@ -82,17 +216,16 @@ func executeListen(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintln(stdout, s.dim("Press Ctrl+C to stop."))
 	}
 
-	if *once {
-		// In once mode, run listener with timeout or until canceled
-		select {
-		case <-ctx.Done():
-			return 0
-		case <-time.After(100 * time.Millisecond):
-			return 0
-		}
+	startErr := listener.Start(ctx)
+	if startErr != nil && !errors.Is(startErr, context.Canceled) && !errors.Is(startErr, context.DeadlineExceeded) {
+		_, _ = fmt.Fprintf(stderr, "listener error: %v\n", startErr)
+		return 1
 	}
 
-	// Run background service until context cancellation
-	_ = lanService.Start(ctx)
+	if *once && listener.VerifiedDeliveries() >= 1 && !*jsonOutput {
+		s := newStyleFromWriter(stdout)
+		_, _ = fmt.Fprintln(stdout, s.green("Single verified delivery completed. Exiting."))
+	}
+
 	return 0
 }

--- a/apps/cli/cmd/sendbeam/listen.go
+++ b/apps/cli/cmd/sendbeam/listen.go
@@ -21,9 +21,7 @@ import (
 )
 
 func runListen(args []string) int {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-	return executeListenWithContext(ctx, args, os.Stdin, os.Stdout, os.Stderr)
+	return executeListen(args, os.Stdout, os.Stderr)
 }
 
 func executeListen(args []string, stdout, stderr io.Writer) int {
@@ -73,7 +71,7 @@ func executeListenWithContext(ctx context.Context, args []string, stdin io.Reade
 		serverURL = defaultServer
 	}
 
-	consentHandler := func(cctx context.Context, req receiver.ConsentRequest) (receiver.ConsentDecision, error) {
+	consentHandler := func(_ context.Context, req receiver.ConsentRequest) (receiver.ConsentDecision, error) {
 		if *jsonOutput {
 			evt := map[string]any{
 				"event":          "consent_requested",
@@ -201,7 +199,7 @@ func executeListenWithContext(ctx context.Context, args []string, stdin io.Reade
 		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	if !*jsonOutput {
 		s := newStyleFromWriter(stdout)

--- a/apps/cli/cmd/sendbeam/listen_test.go
+++ b/apps/cli/cmd/sendbeam/listen_test.go
@@ -2,27 +2,68 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestListenCommand(t *testing.T) {
+func TestListenCommand_ContextCancellation(t *testing.T) {
 	tmpDir := t.TempDir()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
 	var stdout, stderr bytes.Buffer
-	code := executeListen([]string{"--config-dir", tmpDir, "--once", "--dest", tmpDir}, &stdout, &stderr)
+	code := executeListenWithContext(ctx, []string{"--config-dir", tmpDir, "--once", "--dest", tmpDir}, nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("listen exit code %d, stderr: %s", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "SendBeam Trusted Listener") {
 		t.Errorf("expected header, got: %s", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "Destination:") {
+		t.Errorf("expected Destination in output, got: %s", stdout.String())
+	}
+}
 
-	// Test with --json
-	stdout.Reset()
-	stderr.Reset()
-	code = executeListen([]string{"--config-dir", tmpDir, "--once", "--json", "--dest", tmpDir}, &stdout, &stderr)
+func TestListenCommand_JSONOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	code := executeListenWithContext(ctx, []string{"--config-dir", tmpDir, "--once", "--json", "--dest", tmpDir}, nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("listen --json exit code %d, stderr: %s", code, stderr.String())
+	}
+	// In JSON mode, human header should not be printed
+	if strings.Contains(stdout.String(), "SendBeam Trusted Listener") {
+		t.Errorf("expected no plain text header in JSON mode, got: %s", stdout.String())
+	}
+}
+
+func TestListenCommand_InvalidArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeListenWithContext(context.Background(), []string{"--unknown-flag"}, nil, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("expected exit code 2 for invalid flags, got %d", code)
+	}
+}
+
+func TestListenCommand_AutoAcceptFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	code := executeListenWithContext(ctx, []string{"--config-dir", tmpDir, "--auto-accept", "--dest", tmpDir}, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("listen exit code %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Auto-Accept: Enabled") {
+		t.Errorf("expected Auto-Accept: Enabled, got: %s", stdout.String())
 	}
 }

--- a/apps/desktop/internal/engine/transfer_service.go
+++ b/apps/desktop/internal/engine/transfer_service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pion/webrtc/v4"
 	"github.com/sendbeam/desktop/internal/config"
 	"github.com/sendbeam/desktop/internal/lifecycle"
+	"github.com/sendbeam/engine/receiver"
 	"github.com/sendbeam/engine/rendezvous"
 	"github.com/sendbeam/engine/transfer"
 	"github.com/sendbeam/engine/wsclient"
@@ -38,6 +39,9 @@ import (
 // transfer update. The payload is a TransferEvent snapshot; the frontend
 // re-renders from the latest snapshot per transfer id.
 const TransferEventName = "sendbeam:transfer"
+
+// ConsentEventName is emitted to the frontend when incoming transfer consent is requested.
+const ConsentEventName = "sendbeam:consent"
 
 // DefaultServer mirrors the CLI's default signaling server, so a desktop peer
 // pairs with CLI and browser peers of the same deployment out of the box.
@@ -170,6 +174,9 @@ type TransferService struct {
 	senderStore           *transfer.SenderStore
 	durableStoreFn        func(outDir string) (*transfer.DurableStore, error)
 	completedDestinations map[string]completedDestination
+
+	nativeReceiver       *receiver.Listener
+	nativeReceiverCancel context.CancelFunc
 }
 
 // SetPicker sets the native dialog picker provider (e.g. Wails dialogs).
@@ -808,7 +815,184 @@ func (s *TransferService) Shutdown(timeout time.Duration) error {
 		time.Sleep(20 * time.Millisecond)
 	}
 
+	s.mu.Lock()
+	nativeRecv := s.nativeReceiver
+	nativeCancel := s.nativeReceiverCancel
+	s.nativeReceiver = nil
+	s.nativeReceiverCancel = nil
+	s.mu.Unlock()
+
+	if nativeCancel != nil {
+		nativeCancel()
+	}
+	if nativeRecv != nil {
+		_ = nativeRecv.Close()
+	}
+
 	return nil
+}
+
+// StartNativeReceiver starts the background listener using the shared native receiver package.
+func (s *TransferService) StartNativeReceiver(cfg receiver.Config) error {
+	s.mu.Lock()
+	if s.nativeReceiver != nil {
+		s.mu.Unlock()
+		return errors.New("native receiver already running")
+	}
+
+	origStart := cfg.OnTransferStart
+	cfg.OnTransferStart = func(transferID string, peerDeviceID string, manifest wire.Manifest) {
+		if origStart != nil {
+			origStart(transferID, peerDeviceID, manifest)
+		}
+		files := make([]FileInfo, len(manifest.Files))
+		for i, f := range manifest.Files {
+			files[i] = FileInfo{Name: f.Name, Size: f.Size}
+		}
+		if s.emit != nil {
+			s.emit(TransferEventName, TransferEvent{
+				ID:         transferID,
+				Kind:       "manifest",
+				Files:      files,
+				TotalBytes: manifest.TotalSize,
+				FilesTotal: len(manifest.Files),
+				State:      "running",
+			})
+		}
+	}
+
+	origProgress := cfg.OnFileProgress
+	cfg.OnFileProgress = func(peerDeviceID string, fileIdx int, fileBytes, ackBytes int64) {
+		if origProgress != nil {
+			origProgress(peerDeviceID, fileIdx, fileBytes, ackBytes)
+		}
+	}
+
+	origComplete := cfg.OnTransferComplete
+	cfg.OnTransferComplete = func(peerDeviceID string, outcome *transfer.Outcome) {
+		if origComplete != nil {
+			origComplete(peerDeviceID, outcome)
+		}
+		if outcome != nil {
+			s.recordCompleted(outcome.TransferID, completedDestination{
+				Path: outcome.Path,
+				Root: cfg.DestDir,
+			})
+			if s.emit != nil {
+				s.emit(TransferEventName, TransferEvent{
+					ID:        outcome.TransferID,
+					Kind:      "done",
+					Digest:    outcome.Digest,
+					OutDir:    cfg.DestDir,
+					OutPath:   outcome.Path,
+					State:     "completed",
+					Percent:   100,
+					DoneBytes: outcome.Size,
+				})
+			}
+			if s.notifier != nil {
+				s.notifier.NotifySuccess("Transfer Complete", fmt.Sprintf("Received %s", outcome.Name), outcome.Path)
+			}
+		}
+	}
+
+	origErr := cfg.OnTransferError
+	cfg.OnTransferError = func(peerDeviceID string, err error) {
+		if origErr != nil {
+			origErr(peerDeviceID, err)
+		}
+		if s.emit != nil {
+			s.emit(TransferEventName, TransferEvent{
+				Kind:   "error",
+				Error:  err.Error(),
+				State:  "error",
+				Failed: true,
+			})
+		}
+	}
+
+	origConsentReq := cfg.OnConsentRequested
+	cfg.OnConsentRequested = func(req receiver.ConsentRequest) {
+		if origConsentReq != nil {
+			origConsentReq(req)
+		}
+		if s.emit != nil {
+			s.emit(ConsentEventName, req)
+			s.emit(TransferEventName, TransferEvent{
+				ID:         req.TransferID,
+				Kind:       "consent_requested",
+				TotalBytes: req.TotalSize,
+				OutDir:     req.DestDir,
+				State:      "waiting_consent",
+			})
+		}
+	}
+
+	listener, err := receiver.NewListener(cfg)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.nativeReceiver = listener
+	s.nativeReceiverCancel = cancel
+	s.mu.Unlock()
+
+	go func() {
+		_ = listener.Start(ctx)
+	}()
+
+	return nil
+}
+
+// StopNativeReceiver stops the background listener.
+func (s *TransferService) StopNativeReceiver() error {
+	s.mu.Lock()
+	listener := s.nativeReceiver
+	cancel := s.nativeReceiverCancel
+	s.nativeReceiver = nil
+	s.nativeReceiverCancel = nil
+	s.mu.Unlock()
+
+	if listener == nil {
+		return nil
+	}
+	if cancel != nil {
+		cancel()
+	}
+	return listener.Close()
+}
+
+// NativeReceiver returns the active native receiver instance or nil.
+func (s *TransferService) NativeReceiver() *receiver.Listener {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nativeReceiver
+}
+
+// RespondConsent resolves a pending incoming transfer consent request.
+func (s *TransferService) RespondConsent(transferID string, decision receiver.ConsentDecision) error {
+	s.mu.Lock()
+	listener := s.nativeReceiver
+	s.mu.Unlock()
+
+	if listener == nil {
+		return errors.New("native receiver is not running")
+	}
+	return listener.RespondConsent(transferID, decision)
+}
+
+// PendingConsents returns all currently pending consent requests awaiting user decision.
+func (s *TransferService) PendingConsents() []receiver.ConsentRequest {
+	s.mu.Lock()
+	listener := s.nativeReceiver
+	s.mu.Unlock()
+
+	if listener == nil {
+		return nil
+	}
+	return listener.PendingConsent()
 }
 
 // control looks up the live Controls for id and applies fn.

--- a/apps/desktop/internal/engine/transfer_service_test.go
+++ b/apps/desktop/internal/engine/transfer_service_test.go
@@ -14,8 +14,10 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/engine/receiver"
 	"github.com/sendbeam/engine/rendezvous"
 	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/engine/trust"
 	"github.com/sendbeam/engine/wsclient"
 	"github.com/sendbeam/wire"
 )
@@ -576,5 +578,106 @@ func TestServiceInteropInviteLinkFormat(t *testing.T) {
 	link := inviteLink("wss://relay.example.com:8443/ws", "12-quick-brown")
 	if !strings.HasPrefix(link, "https://relay.example.com:8443/#12-quick-brown") {
 		t.Fatalf("unexpected invite link: %q", link)
+	}
+}
+
+func TestTransferService_NativeReceiverLifecycle(t *testing.T) {
+	sink := &eventSink{}
+	svc := NewTransferService(sink.emit, nil)
+
+	tmpDir := t.TempDir()
+	idPath := filepath.Join(tmpDir, "identity.key")
+	idMgr, err := trust.NewIdentityManager(idPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	localID, err := idMgr.GetOrCreateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	trustStore, err := trust.NewFileTrustStore(filepath.Join(tmpDir, "trust.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secStore := trust.NewMemoryCredentialStore()
+
+	cfg := receiver.Config{
+		DestDir:    tmpDir,
+		AutoAccept: true,
+		Identity:   localID,
+		TrustStore: trustStore,
+		Secrets:    secStore,
+		Port:       0, // disable LAN discovery in this test
+	}
+
+	if svc.NativeReceiver() != nil {
+		t.Fatal("expected nil native receiver before start")
+	}
+
+	if err := svc.StartNativeReceiver(cfg); err != nil {
+		t.Fatalf("StartNativeReceiver: %v", err)
+	}
+
+	if svc.NativeReceiver() == nil {
+		t.Fatal("expected non-nil native receiver after start")
+	}
+
+	// Double start should fail
+	if err := svc.StartNativeReceiver(cfg); err == nil {
+		t.Fatal("expected error on starting already running receiver")
+	}
+
+	if err := svc.StopNativeReceiver(); err != nil {
+		t.Fatalf("StopNativeReceiver: %v", err)
+	}
+
+	if svc.NativeReceiver() != nil {
+		t.Fatal("expected nil native receiver after stop")
+	}
+}
+
+func TestTransferService_PendingConsentAndRespond(t *testing.T) {
+	sink := &eventSink{}
+	svc := NewTransferService(sink.emit, nil)
+
+	// Calling when not running fails
+	err := svc.RespondConsent("tx-123", receiver.ConsentDecision{Accepted: true})
+	if err == nil {
+		t.Fatal("expected error when receiver is not running")
+	}
+
+	if consents := svc.PendingConsents(); consents != nil {
+		t.Fatalf("expected nil consents when not running, got %v", consents)
+	}
+
+	tmpDir := t.TempDir()
+	idMgr, _ := trust.NewIdentityManager(filepath.Join(tmpDir, "identity.key"))
+	localID, _ := idMgr.GetOrCreateIdentity()
+	trustStore, _ := trust.NewFileTrustStore(filepath.Join(tmpDir, "trust.json"))
+	secStore := trust.NewMemoryCredentialStore()
+
+	cfg := receiver.Config{
+		DestDir:    tmpDir,
+		Identity:   localID,
+		TrustStore: trustStore,
+		Secrets:    secStore,
+		Port:       0,
+	}
+
+	if err := svc.StartNativeReceiver(cfg); err != nil {
+		t.Fatalf("StartNativeReceiver: %v", err)
+	}
+	defer svc.StopNativeReceiver()
+
+	consents := svc.PendingConsents()
+	if len(consents) != 0 {
+		t.Fatalf("expected 0 pending consents initially, got %d", len(consents))
+	}
+
+	// Responding to unknown transfer returns error
+	err = svc.RespondConsent("nonexistent", receiver.ConsentDecision{Accepted: false})
+	if err == nil {
+		t.Fatal("expected error responding to nonexistent consent request")
 	}
 }

--- a/apps/desktop/internal/engine/transfer_service_test.go
+++ b/apps/desktop/internal/engine/transfer_service_test.go
@@ -668,7 +668,7 @@ func TestTransferService_PendingConsentAndRespond(t *testing.T) {
 	if err := svc.StartNativeReceiver(cfg); err != nil {
 		t.Fatalf("StartNativeReceiver: %v", err)
 	}
-	defer svc.StopNativeReceiver()
+	defer func() { _ = svc.StopNativeReceiver() }()
 
 	consents := svc.PendingConsents()
 	if len(consents) != 0 {

--- a/packages/engine/receiver/listener.go
+++ b/packages/engine/receiver/listener.go
@@ -1,3 +1,4 @@
+// Package receiver coordinates LAN discovery, opaque rendezvous listening, consent policy, and verified transfers.
 package receiver
 
 import (

--- a/packages/engine/receiver/listener.go
+++ b/packages/engine/receiver/listener.go
@@ -1,0 +1,438 @@
+package receiver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/sendbeam/engine/discovery"
+	"github.com/sendbeam/engine/rendezvous"
+	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/engine/wsclient"
+	"github.com/sendbeam/wire"
+)
+
+// Listener coordinates receiving incoming transfers from trusted peers across
+// LAN discovery and opaque rendezvous signaling.
+type Listener struct {
+	cfg        Config
+	coord      *rendezvous.PresenceCoordinator
+	lanService *discovery.LanDiscoveryService
+
+	mu              sync.Mutex
+	running         bool
+	closed          bool
+	verifiedCount   int
+	onceTriggered   bool
+	onceCh          chan struct{}
+	stopCh          chan struct{}
+	activeSessions  map[string]transfer.Signal
+	listeningHndls  map[string]bool
+	pendingConsents map[string]chan ConsentDecision
+	pendingReqs     map[string]ConsentRequest
+	replayCache     *wire.NonceReplayCache
+}
+
+// NewListener creates a new shared native receiver Listener.
+func NewListener(cfg Config) (*Listener, error) {
+	if cfg.Identity == nil {
+		return nil, errors.New("receiver: local device identity is required")
+	}
+	if cfg.TrustStore == nil {
+		return nil, errors.New("receiver: trust store is required")
+	}
+	if cfg.Secrets == nil {
+		return nil, errors.New("receiver: secret resolver/store is required")
+	}
+	if cfg.DestDir == "" {
+		cfg.DestDir = "."
+	}
+	absDest, err := filepath.Abs(cfg.DestDir)
+	if err != nil {
+		return nil, fmt.Errorf("receiver: invalid destination dir: %w", err)
+	}
+	cfg.DestDir = absDest
+
+	if cfg.EpochWindow <= 0 {
+		cfg.EpochWindow = wire.DefaultRendezvousEpochWindow
+	}
+	if cfg.BeaconInterval <= 0 {
+		cfg.BeaconInterval = 3 * time.Second
+	}
+
+	coord := rendezvous.NewPresenceCoordinator(cfg.TrustStore, cfg.Secrets, cfg.EpochWindow)
+
+	return &Listener{
+		cfg:             cfg,
+		coord:           coord,
+		onceCh:          make(chan struct{}),
+		stopCh:          make(chan struct{}),
+		activeSessions:  make(map[string]transfer.Signal),
+		listeningHndls:  make(map[string]bool),
+		pendingConsents: make(map[string]chan ConsentDecision),
+		pendingReqs:     make(map[string]ConsentRequest),
+		replayCache:     wire.NewNonceReplayCache(10 * time.Minute),
+	}, nil
+}
+
+// Start begins listening on LAN and signaling rendezvous channels.
+// In Once mode (--once), Start blocks until exactly ONE transfer completes with verified delivery.
+func (l *Listener) Start(ctx context.Context) error {
+	l.mu.Lock()
+	if l.running {
+		l.mu.Unlock()
+		return errors.New("receiver: already running")
+	}
+	l.running = true
+	l.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// 1. LAN Discovery Service
+	if l.cfg.Port > 0 {
+		discCfg := discovery.Config{
+			AdvertisePort:  l.cfg.Port,
+			BeaconInterval: l.cfg.BeaconInterval,
+			EpochWindow:    wire.DefaultLanBeaconEpochWindow,
+		}
+		l.lanService = discovery.NewLanDiscoveryService(discCfg, l.cfg.TrustStore, l.cfg.Secrets)
+		if l.cfg.PacketConn != nil {
+			l.lanService.SetPacketConn(l.cfg.PacketConn)
+		}
+		l.lanService.OnPeerDiscovered(func(peer discovery.DiscoveredPeer) {
+			if l.cfg.OnPeerDiscovered != nil {
+				l.cfg.OnPeerDiscovered(peer)
+			}
+		})
+		go func() {
+			_ = l.lanService.Start(ctx)
+		}()
+	}
+
+	// 2. Signaling Opaque Rendezvous Listeners
+	if l.cfg.Server != "" || l.cfg.Dialer != nil {
+		go l.rendezvousLoop(ctx)
+	}
+
+	if l.cfg.OnListening != nil {
+		l.cfg.OnListening()
+	}
+
+	// In Once mode, block until one verified delivery completes or context is cancelled
+	if l.cfg.Once {
+		select {
+		case <-l.onceCh:
+			_ = l.Close()
+			return nil
+		case <-l.stopCh:
+			return nil
+		case <-ctx.Done():
+			_ = l.Close()
+			return ctx.Err()
+		}
+	}
+
+	// In continuous mode, run until context cancellation or explicit Close
+	select {
+	case <-l.stopCh:
+		return nil
+	case <-ctx.Done():
+		_ = l.Close()
+		return ctx.Err()
+	}
+}
+
+func (l *Listener) dialSignal(ctx context.Context, serverURL string) (transfer.Signal, error) {
+	if l.cfg.Dialer != nil {
+		return l.cfg.Dialer(ctx, serverURL)
+	}
+	return wsclient.Dial(ctx, serverURL, wsclient.DialOptions{
+		InsecureSkipVerify: true,
+	})
+}
+
+func (l *Listener) rendezvousLoop(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	l.refreshHandles(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-l.stopCh:
+			return
+		case <-ticker.C:
+			l.refreshHandles(ctx)
+		}
+	}
+}
+
+func (l *Listener) refreshHandles(ctx context.Context) {
+	handlesMap, err := l.coord.GetActiveHandles(ctx, time.Now().UTC())
+	if err != nil || len(handlesMap) == 0 {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for deviceID, handles := range handlesMap {
+		for _, handle := range handles {
+			if l.listeningHndls[handle] {
+				continue
+			}
+			l.listeningHndls[handle] = true
+			go l.listenOnHandle(ctx, deviceID, handle)
+		}
+	}
+}
+
+func (l *Listener) listenOnHandle(ctx context.Context, peerDeviceID string, handle string) {
+	defer func() {
+		l.mu.Lock()
+		delete(l.listeningHndls, handle)
+		l.mu.Unlock()
+	}()
+
+	sig, err := l.dialSignal(ctx, l.cfg.Server)
+	if err != nil {
+		return
+	}
+	defer sig.Close()
+
+	sessionKey := fmt.Sprintf("%s:%s", peerDeviceID, handle)
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return
+	}
+	l.activeSessions[sessionKey] = sig
+	l.mu.Unlock()
+
+	defer func() {
+		l.mu.Lock()
+		delete(l.activeSessions, sessionKey)
+		l.mu.Unlock()
+	}()
+
+	// Register as joiner on opaque handle room
+	_ = sig.Send(rendezvous.Message{
+		Type:   "rendezvous",
+		Handle: handle,
+		Role:   "joiner",
+	})
+
+	_, _ = l.HandleIncomingSession(ctx, sig, peerDeviceID, handle)
+}
+
+// HandleIncomingSession runs a complete transfer receive session with a peer over sig.
+func (l *Listener) HandleIncomingSession(ctx context.Context, sig transfer.Signal, peerDeviceID string, handle string) (*transfer.Outcome, error) {
+	if l.cfg.Tombstones != nil && l.cfg.Tombstones.HasTombstone(ctx, peerDeviceID) {
+		sig.Close()
+		return nil, wire.ErrTrustedPeerRevoked
+	}
+
+	dev, err := l.cfg.TrustStore.GetDevice(ctx, peerDeviceID)
+	if err != nil || dev == nil {
+		sig.Close()
+		return nil, wire.ErrTrustedPeerMismatch
+	}
+	if dev.Revoked {
+		sig.Close()
+		return nil, wire.ErrTrustedPeerRevoked
+	}
+
+	kPair, err := l.cfg.Secrets.ResolvePairSecret(ctx, peerDeviceID, dev.PairCredentialRef)
+	if err != nil || len(kPair) == 0 {
+		sig.Close()
+		return nil, wire.Errorf(wire.CodeAuth, "resolve pair secret for %s: %v", peerDeviceID, err)
+	}
+
+	peerPubKey, err := wire.ParsePublicKeyHex(dev.PublicKey)
+	if err != nil {
+		sig.Close()
+		return nil, wire.Errorf(wire.CodeAuth, "decode peer public key: %v", err)
+	}
+
+	spec := transfer.Spec{
+		Opaque: &rendezvous.OpaqueOptions{
+			Role:              rendezvous.RoleJoiner,
+			Handle:            handle,
+			LocalIdentity:     l.cfg.Identity,
+			PeerDeviceID:      peerDeviceID,
+			PeerPublicKey:     peerPubKey,
+			KPair:             kPair,
+			PairCredentialRef: dev.PairCredentialRef,
+			LocalCaps:         []string{"sendbeam/3", "rendezvous", "resume"},
+			ReplayCache:       l.replayCache,
+			Tombstones:        l.cfg.Tombstones,
+			TrustStore:        l.cfg.TrustStore,
+		},
+		DestDir:      l.cfg.DestDir,
+		ForceRelay:   l.cfg.ForceRelay,
+		Private:      l.cfg.Private,
+		RelayJitter:  l.cfg.RelayJitter,
+		ICEServers:   l.cfg.ICEServers,
+		PeerDeviceID: peerDeviceID,
+		PeerLabel:    dev.LocalLabel,
+		Consent: func(cctx context.Context, req transfer.ConsentRequest) (transfer.ConsentDecision, error) {
+			return l.evaluateConsent(cctx, dev, req)
+		},
+		OnManifestSet: func(manifest wire.Manifest) {
+			if l.cfg.OnTransferStart != nil {
+				l.cfg.OnTransferStart(manifest.TransferID, peerDeviceID, manifest)
+			}
+		},
+		OnProgress: func(ack int64) {
+			if l.cfg.OnProgress != nil {
+				l.cfg.OnProgress(peerDeviceID, ack)
+			}
+		},
+		OnFileProgress: func(fileIdx int, fileBytes, ackBytes int64) {
+			if l.cfg.OnFileProgress != nil {
+				l.cfg.OnFileProgress(peerDeviceID, fileIdx, fileBytes, ackBytes)
+			}
+		},
+	}
+
+	outcome, err := transfer.Run(ctx, sig, spec)
+	if err != nil {
+		if l.cfg.OnTransferError != nil {
+			l.cfg.OnTransferError(peerDeviceID, err)
+		}
+		return nil, err
+	}
+
+	// Verified delivery!
+	l.mu.Lock()
+	l.verifiedCount++
+	l.mu.Unlock()
+
+	if l.cfg.OnTransferComplete != nil {
+		l.cfg.OnTransferComplete(peerDeviceID, outcome)
+	}
+
+	if l.cfg.Once {
+		l.triggerOnceComplete()
+	}
+
+	return outcome, nil
+}
+
+func (l *Listener) evaluateConsent(ctx context.Context, dev *wire.TrustRecord, req transfer.ConsentRequest) (transfer.ConsentDecision, error) {
+	manifest := wire.Manifest{
+		TransferID: req.TransferID,
+		Files:      req.Files,
+		TotalSize:  req.TotalSize,
+	}
+
+	return EvaluateConsent(ctx, l.cfg.TrustStore, l.cfg.Tombstones, l.cfg.AutoAccept, l.cfg.DestDir, dev.DeviceID, manifest, func(cctx context.Context, creq transfer.ConsentRequest) (transfer.ConsentDecision, error) {
+		if l.cfg.ConsentHandler != nil {
+			return l.cfg.ConsentHandler(cctx, creq)
+		}
+
+		// Asynchronous pending consent queue (desktop UI)
+		l.mu.Lock()
+		respCh := make(chan ConsentDecision, 1)
+		l.pendingConsents[creq.TransferID] = respCh
+		l.pendingReqs[creq.TransferID] = creq
+		l.mu.Unlock()
+
+		if l.cfg.OnConsentRequested != nil {
+			l.cfg.OnConsentRequested(creq)
+		}
+
+		defer func() {
+			l.mu.Lock()
+			delete(l.pendingConsents, creq.TransferID)
+			delete(l.pendingReqs, creq.TransferID)
+			l.mu.Unlock()
+		}()
+
+		select {
+		case decision := <-respCh:
+			return decision, nil
+		case <-cctx.Done():
+			return ConsentDecision{Accepted: false, Reason: "request timed out or cancelled"}, cctx.Err()
+		}
+	})
+}
+
+func (l *Listener) triggerOnceComplete() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.onceTriggered {
+		l.onceTriggered = true
+		select {
+		case <-l.onceCh:
+		default:
+			close(l.onceCh)
+		}
+	}
+}
+
+// VerifiedDeliveries returns the number of successfully verified incoming file deliveries.
+func (l *Listener) VerifiedDeliveries() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.verifiedCount
+}
+
+// PendingConsent returns a snapshot of all active consent requests awaiting a response.
+func (l *Listener) PendingConsent() []ConsentRequest {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]ConsentRequest, 0, len(l.pendingReqs))
+	for _, req := range l.pendingReqs {
+		out = append(out, req)
+	}
+	return out
+}
+
+// RespondConsent resolves a pending consent request with an acceptance or rejection decision.
+func (l *Listener) RespondConsent(transferID string, decision ConsentDecision) error {
+	l.mu.Lock()
+	ch, ok := l.pendingConsents[transferID]
+	l.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no pending consent request for transfer ID: %s", transferID)
+	}
+	select {
+	case ch <- decision:
+		return nil
+	default:
+		return errors.New("consent response already sent")
+	}
+}
+
+// Close stops the listener and terminates all active sessions.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return nil
+	}
+	l.closed = true
+	l.running = false
+	select {
+	case <-l.stopCh:
+	default:
+		close(l.stopCh)
+	}
+	sessions := make([]transfer.Signal, 0, len(l.activeSessions))
+	for _, sig := range l.activeSessions {
+		sessions = append(sessions, sig)
+	}
+	l.mu.Unlock()
+
+	for _, sig := range sessions {
+		sig.Close()
+	}
+	return nil
+}

--- a/packages/engine/receiver/policy.go
+++ b/packages/engine/receiver/policy.go
@@ -1,0 +1,114 @@
+package receiver
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+// EvaluateConsent evaluates whether an incoming transfer should be auto-accepted or requires
+// user consent, strictly enforcing peer revocation and policy restrictions.
+func EvaluateConsent(
+	ctx context.Context,
+	store trust.Store,
+	tombstones trust.TombstoneStore,
+	globalAutoAccept bool,
+	defaultDestDir string,
+	peerDeviceID string,
+	manifest wire.Manifest,
+	handler ConsentHandler,
+) (ConsentDecision, error) {
+	// 1. Strict Revocation & Trust Enforcement (V19-PR04)
+	if tombstones != nil && tombstones.HasTombstone(ctx, peerDeviceID) {
+		return ConsentDecision{Accepted: false, Reason: "peer device is revoked"}, wire.ErrTrustedPeerRevoked
+	}
+
+	if store == nil {
+		return ConsentDecision{Accepted: false, Reason: "trust store not available"}, wire.ErrTrustedPeerMismatch
+	}
+
+	dev, err := store.GetDevice(ctx, peerDeviceID)
+	if err != nil || dev == nil {
+		return ConsentDecision{Accepted: false, Reason: "unrecognized peer device"}, wire.ErrTrustedPeerMismatch
+	}
+
+	if dev.Revoked {
+		return ConsentDecision{Accepted: false, Reason: "peer device is revoked"}, wire.ErrTrustedPeerRevoked
+	}
+
+	// 2. Global Auto-Accept (e.g. CLI --auto-accept flag)
+	if globalAutoAccept {
+		destDir := defaultDestDir
+		if dev.Policy.AutoAcceptDestDir != "" {
+			destDir = dev.Policy.AutoAcceptDestDir
+		}
+		return ConsentDecision{Accepted: true, DestDir: destDir}, nil
+	}
+
+	// 3. Peer-Specific Trust Policy (V16-PR04 / V19-PR06)
+	if dev.Policy.AutoAccept {
+		autoAcceptOK := true
+
+		// Check file size bounds
+		if dev.Policy.MaxFileSizeBytes > 0 && manifest.TotalSize > dev.Policy.MaxFileSizeBytes {
+			autoAcceptOK = false
+		}
+
+		// Check allowed MIME types / extensions
+		if autoAcceptOK && len(dev.Policy.AllowedMimeTypes) > 0 {
+			for _, file := range manifest.Files {
+				if !isMimeAllowed(file.Name, file.Mime, dev.Policy.AllowedMimeTypes) {
+					autoAcceptOK = false
+					break
+				}
+			}
+		}
+
+		if autoAcceptOK {
+			destDir := dev.Policy.AutoAcceptDestDir
+			if destDir == "" {
+				destDir = defaultDestDir
+			}
+			return ConsentDecision{Accepted: true, DestDir: destDir}, nil
+		}
+	}
+
+	// 4. Fall through to explicit user consent prompt
+	if handler == nil {
+		return ConsentDecision{Accepted: false, Reason: "no consent handler configured"}, nil
+	}
+
+	req := ConsentRequest{
+		TransferID:   manifest.TransferID,
+		PeerDeviceID: peerDeviceID,
+		PeerLabel:    dev.LocalLabel,
+		Files:        manifest.Files,
+		TotalSize:    manifest.TotalSize,
+		DestDir:      defaultDestDir,
+	}
+
+	return handler(ctx, req)
+}
+
+func isMimeAllowed(fileName, mime string, allowed []string) bool {
+	ext := strings.ToLower(filepath.Ext(fileName))
+	extWithoutDot := strings.TrimPrefix(ext, ".")
+	mime = strings.ToLower(mime)
+
+	for _, pattern := range allowed {
+		pattern = strings.ToLower(strings.TrimSpace(pattern))
+		if pattern == "" || pattern == "*" || pattern == "*/*" {
+			return true
+		}
+		if mime != "" && (mime == pattern || strings.HasPrefix(mime, strings.TrimSuffix(pattern, "*"))) {
+			return true
+		}
+		if extWithoutDot != "" && (extWithoutDot == pattern || ext == pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/engine/receiver/receiver_test.go
+++ b/packages/engine/receiver/receiver_test.go
@@ -207,14 +207,14 @@ func TestReceiverPolicyAutoAccept(t *testing.T) {
 		TrustStore: storeBob,
 		Secrets:    secretsBob,
 		Tombstones: tombstonesBob,
-		Dialer: func(ctx context.Context, url string) (transfer.Signal, error) {
+		Dialer: func(_ context.Context, _ string) (transfer.Signal, error) {
 			return relay.join, nil
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	payload := []byte("auto-accepted file content")
 	meta := wire.FileMeta{
@@ -300,7 +300,7 @@ func TestReceiverConsentPromptAccept(t *testing.T) {
 		TrustStore: storeBob,
 		Secrets:    secretsBob,
 		Tombstones: tombstonesBob,
-		ConsentHandler: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+		ConsentHandler: func(_ context.Context, req ConsentRequest) (ConsentDecision, error) {
 			promptCalled = true
 			if req.PeerDeviceID != idAlice.DeviceID {
 				t.Errorf("prompt PeerDeviceID = %q, want %q", req.PeerDeviceID, idAlice.DeviceID)
@@ -314,7 +314,7 @@ func TestReceiverConsentPromptAccept(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	payload := []byte("image bytes for photo")
 	meta := wire.FileMeta{
@@ -396,14 +396,14 @@ func TestReceiverConsentPromptDecline(t *testing.T) {
 		TrustStore: storeBob,
 		Secrets:    secretsBob,
 		Tombstones: tombstonesBob,
-		ConsentHandler: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+		ConsentHandler: func(_ context.Context, _ ConsentRequest) (ConsentDecision, error) {
 			return ConsentDecision{Accepted: false, Reason: "declined by user"}, nil
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	payload := []byte("super secret data")
 	meta := wire.FileMeta{
@@ -494,7 +494,7 @@ func TestReceiverRevokedPeerRejected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -529,7 +529,7 @@ func TestReceiverOnceModeSingleDelivery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	payload := []byte("once mode verified delivery")
 	meta := wire.FileMeta{
@@ -598,7 +598,7 @@ func TestReceiverOnceModeDeclinedDoesNotExit(t *testing.T) {
 	listener, err := NewListener(Config{
 		DestDir: destDir,
 		Once:    true, // --once mode
-		ConsentHandler: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+		ConsentHandler: func(_ context.Context, _ ConsentRequest) (ConsentDecision, error) {
 			if !acceptSecond {
 				return ConsentDecision{Accepted: false, Reason: "declined first"}, nil
 			}
@@ -612,7 +612,7 @@ func TestReceiverOnceModeDeclinedDoesNotExit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -710,7 +710,7 @@ func TestEvaluateConsentUnit(t *testing.T) {
 		t.Fatal(err)
 	}
 	handlerCalled := false
-	dec, err = EvaluateConsent(context.Background(), storeBob, tombstonesBob, false, "/default", idAlice.DeviceID, manifest, func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+	dec, err = EvaluateConsent(context.Background(), storeBob, tombstonesBob, false, "/default", idAlice.DeviceID, manifest, func(_ context.Context, _ ConsentRequest) (ConsentDecision, error) {
 		handlerCalled = true
 		return ConsentDecision{Accepted: false, Reason: "prompted"}, nil
 	})
@@ -729,7 +729,7 @@ func TestEvaluateConsentUnit(t *testing.T) {
 		t.Fatal(err)
 	}
 	handlerCalled = false
-	dec, err = EvaluateConsent(context.Background(), storeBob, tombstonesBob, false, "/default", idAlice.DeviceID, manifest, func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+	dec, err = EvaluateConsent(context.Background(), storeBob, tombstonesBob, false, "/default", idAlice.DeviceID, manifest, func(_ context.Context, _ ConsentRequest) (ConsentDecision, error) {
 		handlerCalled = true
 		return ConsentDecision{Accepted: false, Reason: "mime blocked"}, nil
 	})
@@ -766,7 +766,7 @@ func TestListenerPendingConsentAsync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	// Initially empty pending consent
 	if len(listener.PendingConsent()) != 0 {

--- a/packages/engine/receiver/receiver_test.go
+++ b/packages/engine/receiver/receiver_test.go
@@ -1,0 +1,782 @@
+package receiver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/engine/rendezvous"
+	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+// loopbackSignal couples two endpoints in-memory for testing
+type loopbackRelay struct {
+	mu            sync.Mutex
+	createdHandle string
+	created       chan struct{}
+	once          sync.Once
+	off           *loopbackEnd
+	join          *loopbackEnd
+}
+
+func newLoopbackRelay() *loopbackRelay {
+	r := &loopbackRelay{
+		created: make(chan struct{}),
+	}
+	r.off = &loopbackEnd{hub: r, role: "offerer", in: make(chan rendezvous.Message, 100), bin: make(chan []byte, 100), done: make(chan struct{})}
+	r.join = &loopbackEnd{hub: r, role: "joiner", in: make(chan rendezvous.Message, 100), bin: make(chan []byte, 100), done: make(chan struct{})}
+	return r
+}
+
+func (r *loopbackRelay) partner(e *loopbackEnd) *loopbackEnd {
+	if e == r.off {
+		return r.join
+	}
+	return r.off
+}
+
+func (r *loopbackRelay) route(from *loopbackEnd, m rendezvous.Message) {
+	switch m.Type {
+	case "rendezvous":
+		r.mu.Lock()
+		if r.createdHandle == "" {
+			r.createdHandle = m.Handle
+			r.mu.Unlock()
+			from.enqueue(rendezvous.Message{Type: "created", Handle: m.Handle})
+			r.once.Do(func() { close(r.created) })
+		} else {
+			r.mu.Unlock()
+			<-r.created
+			r.join.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.join.role})
+			r.off.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.off.role})
+		}
+	case rendezvous.TypeRelayOpen:
+		r.mu.Lock()
+		from.relayOpen = true
+		other := r.partner(from)
+		ready := other.relayOpen
+		r.mu.Unlock()
+		if ready {
+			from.enqueue(rendezvous.Message{Type: rendezvous.TypeRelayReady})
+			other.enqueue(rendezvous.Message{Type: rendezvous.TypeRelayReady})
+		} else {
+			other.enqueue(rendezvous.Message{Type: rendezvous.TypeRelayRequired})
+		}
+	case rendezvous.TypeRelayCredit:
+		r.partner(from).enqueue(rendezvous.Message{Type: rendezvous.TypeCredit, Bytes: m.Bytes})
+	default:
+		r.partner(from).enqueue(m)
+	}
+}
+
+type loopbackEnd struct {
+	hub       *loopbackRelay
+	role      string
+	in        chan rendezvous.Message
+	bin       chan []byte
+	relayOpen bool
+	once      sync.Once
+	done      chan struct{}
+}
+
+func (e *loopbackEnd) Send(m rendezvous.Message) error {
+	e.hub.route(e, m)
+	return nil
+}
+
+func (e *loopbackEnd) SendBinary(frame []byte) error {
+	e.hub.partner(e).enqueueBinary(frame)
+	return nil
+}
+
+func (e *loopbackEnd) Run(ctx context.Context, onMessage func(rendezvous.Message), onBinary func([]byte)) error {
+	for {
+		select {
+		case m := <-e.in:
+			onMessage(m)
+		case frame := <-e.bin:
+			onBinary(frame)
+		case <-e.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (e *loopbackEnd) Close() {
+	e.once.Do(func() { close(e.done) })
+}
+
+func (e *loopbackEnd) enqueue(m rendezvous.Message) {
+	select {
+	case e.in <- m:
+	case <-e.done:
+	}
+}
+
+func (e *loopbackEnd) enqueueBinary(frame []byte) {
+	select {
+	case e.bin <- append([]byte(nil), frame...):
+	case <-e.done:
+	}
+}
+
+// Helper to setup paired identities in test stores
+func setupPairedPeers(t *testing.T, tmpDir string) (idAlice, idBob *wire.DeviceIdentity, kPair []byte, storeBob trust.Store, secretsBob trust.CredentialStore, tombstonesBob trust.TombstoneStore) {
+	t.Helper()
+
+	var err error
+	idAlice, err = wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	idBob, err = wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kPair = bytes.Repeat([]byte{0x55}, 32)
+
+	trustPath := filepath.Join(tmpDir, "trust.json")
+	storeBob, err = trust.NewFileTrustStore(trustPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	memSecrets := trust.NewMemoryCredentialStore()
+	err = memSecrets.SetPairSecret(context.Background(), idAlice.DeviceID, "cred-alice", kPair)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretsBob = memSecrets
+
+	tombstonesPath := filepath.Join(tmpDir, "tombstones.json")
+	tombstonesBob, err = trust.NewFileTombstoneStore(tombstonesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Register Alice in Bob's trust store
+	recAlice := &wire.TrustRecord{
+		DeviceID:          idAlice.DeviceID,
+		PublicKey:         idAlice.PublicKeyHex(),
+		LocalLabel:        "Alice's Laptop",
+		PairCredentialRef: "cred-alice",
+		FirstSeenAt:       time.Now().UTC(),
+		LastSeenAt:        time.Now().UTC(),
+	}
+	err = storeBob.AddOrUpdateDevice(context.Background(), recAlice)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return idAlice, idBob, kPair, storeBob, secretsBob, tombstonesBob
+}
+
+func TestReceiverPolicyAutoAccept(t *testing.T) {
+	tmpDir := t.TempDir()
+	destDir := filepath.Join(tmpDir, "downloads")
+	_ = os.MkdirAll(destDir, 0700)
+
+	idAlice, idBob, kPair, storeBob, secretsBob, tombstonesBob := setupPairedPeers(t, tmpDir)
+	handle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	// Update Alice's policy in Bob's store: AutoAccept enabled with max 1MB
+	policy := wire.TrustPolicy{
+		AutoAccept:        true,
+		MaxFileSizeBytes:  1024 * 1024,
+		AutoAcceptDestDir: destDir,
+	}
+	if err := storeBob.UpdatePolicy(context.Background(), idAlice.DeviceID, policy); err != nil {
+		t.Fatal(err)
+	}
+
+	relay := newLoopbackRelay()
+
+	listener, err := NewListener(Config{
+		DestDir:    destDir,
+		Identity:   idBob,
+		TrustStore: storeBob,
+		Secrets:    secretsBob,
+		Tombstones: tombstonesBob,
+		Dialer: func(ctx context.Context, url string) (transfer.Signal, error) {
+			return relay.join, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	payload := []byte("auto-accepted file content")
+	meta := wire.FileMeta{
+		Name:         "doc.txt",
+		Size:         int64(len(payload)),
+		Mime:         "text/plain",
+		LastModified: 1_700_000_000_000,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *transfer.Outcome
+		err error
+	}
+	sendCh := make(chan result, 1)
+	recvCh := make(chan result, 1)
+
+	// Offerer (Alice)
+	go func() {
+		out, err := transfer.Run(ctx, relay.off, transfer.Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleOfferer,
+				Handle:            handle,
+				LocalIdentity:     idAlice,
+				PeerDeviceID:      idBob.DeviceID,
+				PeerPublicKey:     idBob.PublicKey,
+				KPair:             kPair,
+				PairCredentialRef: "cred-alice",
+			},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		})
+		sendCh <- result{out, err}
+	}()
+
+	// Joiner (Bob)
+	go func() {
+		out, err := listener.HandleIncomingSession(ctx, relay.join, idAlice.DeviceID, handle)
+		recvCh <- result{out, err}
+	}()
+
+	send := <-sendCh
+	recv := <-recvCh
+
+	if recv.err != nil {
+		t.Fatalf("receiver err: %v", recv.err)
+	}
+	if send.err != nil {
+		t.Fatalf("sender err: %v", send.err)
+	}
+
+	if send.out.Digest != recv.out.Digest {
+		t.Fatalf("digest mismatch: %s vs %s", send.out.Digest, recv.out.Digest)
+	}
+	if listener.VerifiedDeliveries() != 1 {
+		t.Fatalf("verified count = %d, want 1", listener.VerifiedDeliveries())
+	}
+
+	got, err := os.ReadFile(recv.out.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("content mismatch: got %q, want %q", got, payload)
+	}
+}
+
+func TestReceiverConsentPromptAccept(t *testing.T) {
+	tmpDir := t.TempDir()
+	destDir := filepath.Join(tmpDir, "received")
+
+	idAlice, idBob, kPair, storeBob, secretsBob, tombstonesBob := setupPairedPeers(t, tmpDir)
+	handle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	relay := newLoopbackRelay()
+
+	promptCalled := false
+	listener, err := NewListener(Config{
+		DestDir:    destDir,
+		Identity:   idBob,
+		TrustStore: storeBob,
+		Secrets:    secretsBob,
+		Tombstones: tombstonesBob,
+		ConsentHandler: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+			promptCalled = true
+			if req.PeerDeviceID != idAlice.DeviceID {
+				t.Errorf("prompt PeerDeviceID = %q, want %q", req.PeerDeviceID, idAlice.DeviceID)
+			}
+			if len(req.Files) != 1 || req.Files[0].Name != "photo.jpg" {
+				t.Errorf("prompt files = %+v", req.Files)
+			}
+			return ConsentDecision{Accepted: true}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	payload := []byte("image bytes for photo")
+	meta := wire.FileMeta{
+		Name:         "photo.jpg",
+		Size:         int64(len(payload)),
+		Mime:         "image/jpeg",
+		LastModified: 1_700_000_000_000,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *transfer.Outcome
+		err error
+	}
+	sendCh := make(chan result, 1)
+	recvCh := make(chan result, 1)
+
+	go func() {
+		out, err := transfer.Run(ctx, relay.off, transfer.Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleOfferer,
+				Handle:            handle,
+				LocalIdentity:     idAlice,
+				PeerDeviceID:      idBob.DeviceID,
+				PeerPublicKey:     idBob.PublicKey,
+				KPair:             kPair,
+				PairCredentialRef: "cred-alice",
+			},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		})
+		sendCh <- result{out, err}
+	}()
+
+	go func() {
+		out, err := listener.HandleIncomingSession(ctx, relay.join, idAlice.DeviceID, handle)
+		recvCh <- result{out, err}
+	}()
+
+	send := <-sendCh
+	recv := <-recvCh
+
+	if recv.err != nil {
+		t.Fatalf("receiver err: %v", recv.err)
+	}
+	if send.err != nil {
+		t.Fatalf("sender err: %v", send.err)
+	}
+	if !promptCalled {
+		t.Fatal("consent prompt was not invoked")
+	}
+	if send.out.Digest != recv.out.Digest {
+		t.Fatalf("digest mismatch: %s vs %s", send.out.Digest, recv.out.Digest)
+	}
+
+	got, err := os.ReadFile(recv.out.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("content mismatch: got %q, want %q", got, payload)
+	}
+}
+
+func TestReceiverConsentPromptDecline(t *testing.T) {
+	tmpDir := t.TempDir()
+	destDir := filepath.Join(tmpDir, "declined_dest")
+
+	idAlice, idBob, kPair, storeBob, secretsBob, tombstonesBob := setupPairedPeers(t, tmpDir)
+	handle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	relay := newLoopbackRelay()
+
+	listener, err := NewListener(Config{
+		DestDir:    destDir,
+		Identity:   idBob,
+		TrustStore: storeBob,
+		Secrets:    secretsBob,
+		Tombstones: tombstonesBob,
+		ConsentHandler: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+			return ConsentDecision{Accepted: false, Reason: "declined by user"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	payload := []byte("super secret data")
+	meta := wire.FileMeta{
+		Name:         "secret.key",
+		Size:         int64(len(payload)),
+		Mime:         "application/octet-stream",
+		LastModified: 1_700_000_000_000,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *transfer.Outcome
+		err error
+	}
+	sendCh := make(chan result, 1)
+	recvCh := make(chan result, 1)
+
+	go func() {
+		out, err := transfer.Run(ctx, relay.off, transfer.Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleOfferer,
+				Handle:            handle,
+				LocalIdentity:     idAlice,
+				PeerDeviceID:      idBob.DeviceID,
+				PeerPublicKey:     idBob.PublicKey,
+				KPair:             kPair,
+				PairCredentialRef: "cred-alice",
+			},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		})
+		sendCh <- result{out, err}
+	}()
+
+	go func() {
+		out, err := listener.HandleIncomingSession(ctx, relay.join, idAlice.DeviceID, handle)
+		recvCh <- result{out, err}
+	}()
+
+	send := <-sendCh
+	recv := <-recvCh
+
+	if recv.err == nil {
+		t.Fatal("expected receiver error due to declined consent, got nil")
+	}
+	if send.err == nil {
+		t.Fatal("expected sender error due to declined consent, got nil")
+	}
+
+	if listener.VerifiedDeliveries() != 0 {
+		t.Fatalf("verified deliveries = %d, want 0", listener.VerifiedDeliveries())
+	}
+
+	// Verify no files or journals were written to destDir
+	entries, _ := os.ReadDir(destDir)
+	if len(entries) != 0 {
+		t.Fatalf("expected empty destDir, found: %+v", entries)
+	}
+}
+
+func TestReceiverRevokedPeerRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	idAlice, idBob, _, storeBob, secretsBob, tombstonesBob := setupPairedPeers(t, tmpDir)
+	handle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	// Revoke Alice in Bob's store
+	recAlice, err := storeBob.GetDevice(context.Background(), idAlice.DeviceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recAlice.Revoked = true
+	now := time.Now().UTC()
+	recAlice.RevokedAt = &now
+	if err := storeBob.AddOrUpdateDevice(context.Background(), recAlice); err != nil {
+		t.Fatal(err)
+	}
+
+	relay := newLoopbackRelay()
+	listener, err := NewListener(Config{
+		DestDir:    tmpDir,
+		Identity:   idBob,
+		TrustStore: storeBob,
+		Secrets:    secretsBob,
+		Tombstones: tombstonesBob,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, recvErr := listener.HandleIncomingSession(ctx, relay.join, idAlice.DeviceID, handle)
+	if recvErr == nil {
+		t.Fatal("expected error for revoked peer, got nil")
+	}
+	if !errors.Is(recvErr, wire.ErrTrustedPeerRevoked) {
+		t.Fatalf("expected ErrTrustedPeerRevoked, got %v", recvErr)
+	}
+}
+
+func TestReceiverOnceModeSingleDelivery(t *testing.T) {
+	tmpDir := t.TempDir()
+	destDir := filepath.Join(tmpDir, "once_dest")
+
+	idAlice, idBob, kPair, storeBob, secretsBob, tombstonesBob := setupPairedPeers(t, tmpDir)
+	handle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	relay := newLoopbackRelay()
+
+	listener, err := NewListener(Config{
+		DestDir:    destDir,
+		AutoAccept: true,
+		Once:       true, // --once mode!
+		Identity:   idBob,
+		TrustStore: storeBob,
+		Secrets:    secretsBob,
+		Tombstones: tombstonesBob,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	payload := []byte("once mode verified delivery")
+	meta := wire.FileMeta{
+		Name:         "once.txt",
+		Size:         int64(len(payload)),
+		Mime:         "text/plain",
+		LastModified: 1_700_000_000_000,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	listenerDone := make(chan error, 1)
+	go func() {
+		// Start in Once mode blocks until 1 verified delivery!
+		err := listener.Start(ctx)
+		listenerDone <- err
+	}()
+
+	// Simulate incoming transfer session on relay
+	go func() {
+		// Offerer sends
+		go func() {
+			_, _ = transfer.Run(ctx, relay.off, transfer.Spec{
+				Opaque: &rendezvous.OpaqueOptions{
+					Role:              rendezvous.RoleOfferer,
+					Handle:            handle,
+					LocalIdentity:     idAlice,
+					PeerDeviceID:      idBob.DeviceID,
+					PeerPublicKey:     idBob.PublicKey,
+					KPair:             kPair,
+					PairCredentialRef: "cred-alice",
+				},
+				Source:     wire.BytesSource(payload, meta, 64*1024),
+				ICEServers: []webrtc.ICEServer{},
+			})
+		}()
+
+		// Listener handles incoming session
+		_, _ = listener.HandleIncomingSession(ctx, relay.join, idAlice.DeviceID, handle)
+	}()
+
+	select {
+	case err := <-listenerDone:
+		if err != nil {
+			t.Fatalf("listener.Start returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener.Start did not terminate after single verified delivery in Once mode")
+	}
+
+	if listener.VerifiedDeliveries() != 1 {
+		t.Fatalf("verified deliveries = %d, want 1", listener.VerifiedDeliveries())
+	}
+}
+
+func TestReceiverOnceModeDeclinedDoesNotExit(t *testing.T) {
+	tmpDir := t.TempDir()
+	destDir := filepath.Join(tmpDir, "once_dest2")
+
+	idAlice, idBob, kPair, storeBob, secretsBob, tombstonesBob := setupPairedPeers(t, tmpDir)
+	handle1 := "1111111111111111111111111111111111111111111111111111111111111111"
+	handle2 := "2222222222222222222222222222222222222222222222222222222222222222"
+
+	acceptSecond := false
+	listener, err := NewListener(Config{
+		DestDir: destDir,
+		Once:    true, // --once mode
+		ConsentHandler: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+			if !acceptSecond {
+				return ConsentDecision{Accepted: false, Reason: "declined first"}, nil
+			}
+			return ConsentDecision{Accepted: true}, nil
+		},
+		Identity:   idBob,
+		TrustStore: storeBob,
+		Secrets:    secretsBob,
+		Tombstones: tombstonesBob,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	listenerDone := make(chan error, 1)
+	go func() {
+		err := listener.Start(ctx)
+		listenerDone <- err
+	}()
+
+	relay1 := newLoopbackRelay()
+	payload1 := []byte("first transfer")
+	meta1 := wire.FileMeta{Name: "file1.txt", Size: int64(len(payload1))}
+
+	// First transfer attempt (declined)
+	go func() {
+		_, _ = transfer.Run(ctx, relay1.off, transfer.Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role: rendezvous.RoleOfferer, Handle: handle1, LocalIdentity: idAlice,
+				PeerDeviceID: idBob.DeviceID, PeerPublicKey: idBob.PublicKey, KPair: kPair,
+			},
+			Source: wire.BytesSource(payload1, meta1, 64*1024), ICEServers: []webrtc.ICEServer{},
+		})
+	}()
+	_, _ = listener.HandleIncomingSession(ctx, relay1.join, idAlice.DeviceID, handle1)
+
+	// Ensure listener is STILL running after decline
+	select {
+	case <-listenerDone:
+		t.Fatal("listener exited early after declined transfer; --once means one verified delivery!")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: still listening!
+	}
+
+	if listener.VerifiedDeliveries() != 0 {
+		t.Fatalf("expected 0 verified deliveries after decline, got %d", listener.VerifiedDeliveries())
+	}
+
+	// Now send second transfer and accept it
+	acceptSecond = true
+	relay2 := newLoopbackRelay()
+	payload2 := []byte("second transfer verified")
+	meta2 := wire.FileMeta{Name: "file2.txt", Size: int64(len(payload2))}
+
+	go func() {
+		_, _ = transfer.Run(ctx, relay2.off, transfer.Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role: rendezvous.RoleOfferer, Handle: handle2, LocalIdentity: idAlice,
+				PeerDeviceID: idBob.DeviceID, PeerPublicKey: idBob.PublicKey, KPair: kPair,
+			},
+			Source: wire.BytesSource(payload2, meta2, 64*1024), ICEServers: []webrtc.ICEServer{},
+		})
+	}()
+	_, _ = listener.HandleIncomingSession(ctx, relay2.join, idAlice.DeviceID, handle2)
+
+	select {
+	case err := <-listenerDone:
+		if err != nil {
+			t.Fatalf("listener.Start error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener did not exit after accepted verified delivery in once mode")
+	}
+
+	if listener.VerifiedDeliveries() != 1 {
+		t.Fatalf("expected 1 verified delivery, got %d", listener.VerifiedDeliveries())
+	}
+}
+
+func TestEvaluateConsentUnit(t *testing.T) {
+	tmpDir := t.TempDir()
+	idAlice, idBob, _, storeBob, _, tombstonesBob := setupPairedPeers(t, tmpDir)
+
+	manifest := wire.Manifest{
+		TransferID: "t-123",
+		Files: []wire.FileEntry{
+			{Idx: 0, Name: "doc.pdf", Size: 500, Mime: "application/pdf"},
+		},
+		TotalSize: 500,
+	}
+
+	// 1. Global auto-accept
+	dec, err := EvaluateConsent(context.Background(), storeBob, tombstonesBob, true, "/default", idAlice.DeviceID, manifest, nil)
+	if err != nil || !dec.Accepted || dec.DestDir != "/default" {
+		t.Fatalf("expected global auto accept, got dec=%+v err=%v", dec, err)
+	}
+
+	// 2. Peer auto-accept with size limit exceeded
+	err = storeBob.UpdatePolicy(context.Background(), idAlice.DeviceID, wire.TrustPolicy{
+		AutoAccept:        true,
+		AutoAcceptDestDir: "/dest",
+		MaxFileSizeBytes:  100, // file is 500, so exceeded
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handlerCalled := false
+	dec, err = EvaluateConsent(context.Background(), storeBob, tombstonesBob, false, "/default", idAlice.DeviceID, manifest, func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+		handlerCalled = true
+		return ConsentDecision{Accepted: false, Reason: "prompted"}, nil
+	})
+	if err != nil || !handlerCalled || dec.Accepted {
+		t.Fatalf("expected fallback to handler due to size limit, got dec=%+v err=%v", dec, err)
+	}
+
+	// 3. Peer auto-accept with allowed mime types
+	err = storeBob.UpdatePolicy(context.Background(), idAlice.DeviceID, wire.TrustPolicy{
+		AutoAccept:        true,
+		AutoAcceptDestDir: "/dest",
+		MaxFileSizeBytes:  1000,
+		AllowedMimeTypes:  []string{"image/png"}, // file is application/pdf, so mime disallowed
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handlerCalled = false
+	dec, err = EvaluateConsent(context.Background(), storeBob, tombstonesBob, false, "/default", idAlice.DeviceID, manifest, func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+		handlerCalled = true
+		return ConsentDecision{Accepted: false, Reason: "mime blocked"}, nil
+	})
+	if err != nil || !handlerCalled || dec.Accepted {
+		t.Fatalf("expected fallback to handler due to mime, got dec=%+v err=%v", dec, err)
+	}
+
+	// 4. Tombstone revocation
+	now := time.Now().UTC()
+	tombstone, err := wire.SignRevocation(idBob, idAlice.DeviceID, 1, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tombstonesBob.StoreTombstone(context.Background(), tombstone); err != nil {
+		t.Fatal(err)
+	}
+	dec, err = EvaluateConsent(context.Background(), storeBob, tombstonesBob, true, "/default", idAlice.DeviceID, manifest, nil)
+	if !errors.Is(err, wire.ErrTrustedPeerRevoked) {
+		t.Fatalf("expected ErrTrustedPeerRevoked from tombstone, got err=%v", err)
+	}
+}
+
+func TestListenerPendingConsentAsync(t *testing.T) {
+	tmpDir := t.TempDir()
+	_, idBob, _, storeBob, secretsBob, tombstonesBob := setupPairedPeers(t, tmpDir)
+
+	listener, err := NewListener(Config{
+		DestDir:    tmpDir,
+		Identity:   idBob,
+		TrustStore: storeBob,
+		Secrets:    secretsBob,
+		Tombstones: tombstonesBob,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	// Initially empty pending consent
+	if len(listener.PendingConsent()) != 0 {
+		t.Fatalf("expected 0 pending consent requests, got %d", len(listener.PendingConsent()))
+	}
+
+	// Unknown transfer ID respond returns error
+	err = listener.RespondConsent("nonexistent", ConsentDecision{Accepted: true})
+	if err == nil {
+		t.Fatal("expected error responding to nonexistent consent request")
+	}
+}
+

--- a/packages/engine/receiver/types.go
+++ b/packages/engine/receiver/types.go
@@ -12,9 +12,13 @@ import (
 	"github.com/sendbeam/wire"
 )
 
-// Re-export transfer consent types for consumers of receiver package
+// ConsentRequest aliases transfer.ConsentRequest for consumers of the receiver package.
 type ConsentRequest = transfer.ConsentRequest
+
+// ConsentDecision aliases transfer.ConsentDecision for consumers of the receiver package.
 type ConsentDecision = transfer.ConsentDecision
+
+// ConsentHandler aliases transfer.ConsentHandler for consumers of the receiver package.
 type ConsentHandler = transfer.ConsentHandler
 
 // DiscoveredPeer aliases discovery.DiscoveredPeer

--- a/packages/engine/receiver/types.go
+++ b/packages/engine/receiver/types.go
@@ -1,0 +1,98 @@
+package receiver
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/sendbeam/engine/discovery"
+	"github.com/sendbeam/engine/transfer"
+	"github.com/sendbeam/engine/trust"
+	"github.com/sendbeam/wire"
+)
+
+// Re-export transfer consent types for consumers of receiver package
+type ConsentRequest = transfer.ConsentRequest
+type ConsentDecision = transfer.ConsentDecision
+type ConsentHandler = transfer.ConsentHandler
+
+// DiscoveredPeer aliases discovery.DiscoveredPeer
+type DiscoveredPeer = discovery.DiscoveredPeer
+
+// TransferProgress contains snapshot progress for an in-flight receive.
+type TransferProgress struct {
+	TransferID        string `json:"transferId"`
+	PeerDeviceID      string `json:"peerDeviceId"`
+	AcknowledgedBytes int64  `json:"acknowledgedBytes"`
+	FileIdx           int    `json:"fileIdx"`
+	FileBytes         int64  `json:"fileBytes"`
+	FileSize          int64  `json:"fileSize"`
+}
+
+// Config configures the shared native receiver.
+type Config struct {
+	// DestDir is the root directory where accepted files are saved.
+	DestDir string
+
+	// AutoAccept when true automatically accepts transfers from trusted devices.
+	AutoAccept bool
+
+	// Once when true causes the receiver to stop listening after ONE verified delivery.
+	Once bool
+
+	// Server is the signaling server WebSocket URL (e.g. wss://localhost:8443/ws).
+	Server string
+
+	// Port is the UDP port for direct local network (LAN) peer discovery.
+	Port uint16
+
+	// BeaconInterval is the interval between LAN discovery beacons.
+	BeaconInterval time.Duration
+
+	// EpochWindow is the time window for opaque rendezvous handles and LAN beacons.
+	EpochWindow time.Duration
+
+	// ICEServers configures WebRTC ICE STUN/TURN servers.
+	ICEServers []webrtc.ICEServer
+
+	// ForceRelay forces transfer over signaling relay without direct WebRTC.
+	ForceRelay bool
+
+	// Private enables traffic padding negotiation (V17-PR03).
+	Private bool
+
+	// RelayJitter adds optional timing jitter for relay frames (V17-PR04).
+	RelayJitter time.Duration
+
+	// Identity is the local device identity.
+	Identity *wire.DeviceIdentity
+
+	// TrustStore manages trusted paired devices.
+	TrustStore trust.Store
+
+	// Secrets provides access to pairwise keys and credentials.
+	Secrets trust.CredentialStore
+
+	// Tombstones checks authorization of revoked devices.
+	Tombstones trust.TombstoneStore
+
+	// Dialer optionally overrides how the receiver connects to signaling server.
+	Dialer func(ctx context.Context, url string) (transfer.Signal, error)
+
+	// PacketConn optionally overrides the UDP socket for LAN discovery (useful in tests).
+	PacketConn net.PacketConn
+
+	// ConsentHandler is invoked when explicit user consent is required.
+	ConsentHandler ConsentHandler
+
+	// Event hooks
+	OnPeerDiscovered   func(peer DiscoveredPeer)
+	OnConsentRequested func(req ConsentRequest)
+	OnTransferStart    func(transferID string, peerDeviceID string, manifest wire.Manifest)
+	OnProgress         func(peerDeviceID string, acknowledgedBytes int64)
+	OnFileProgress     func(peerDeviceID string, fileIdx int, fileBytes, ackBytes int64)
+	OnTransferComplete func(peerDeviceID string, outcome *transfer.Outcome)
+	OnTransferError    func(peerDeviceID string, err error)
+	OnListening        func()
+}

--- a/packages/engine/rendezvous/opaque_session.go
+++ b/packages/engine/rendezvous/opaque_session.go
@@ -88,6 +88,11 @@ func NewOpaqueSession(opts OpaqueOptions) *OpaqueSession {
 	}
 }
 
+// Done returns a channel that is closed when the session settles (established or failed).
+func (s *OpaqueSession) Done() <-chan struct{} {
+	return s.done
+}
+
 // Phase returns the session's current phase.
 func (s *OpaqueSession) Phase() OpaquePhase {
 	s.mu.Lock()

--- a/packages/engine/transfer/consent.go
+++ b/packages/engine/transfer/consent.go
@@ -1,0 +1,171 @@
+package transfer
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sendbeam/wire"
+)
+
+// ConsentRequest carries the incoming transfer manifest and peer identity for a consent decision.
+type ConsentRequest struct {
+	TransferID   string           `json:"transferId"`
+	PeerDeviceID string           `json:"peerDeviceId"`
+	PeerLabel    string           `json:"peerLabel"`
+	Files        []wire.FileEntry `json:"files"`
+	TotalSize    int64            `json:"totalSize"`
+	DestDir      string           `json:"destDir"`
+}
+
+// ConsentDecision reports the user or policy acceptance decision for an incoming transfer.
+type ConsentDecision struct {
+	Accepted bool   `json:"accepted"`
+	DestDir  string `json:"destDir,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// ConsentHandler evaluates or prompts for consent for an incoming transfer.
+type ConsentHandler func(ctx context.Context, req ConsentRequest) (ConsentDecision, error)
+
+// consentDestination delays DurableDestination creation until consent has been evaluated and
+// approved upon manifest arrival. If consent is declined, no directory or file is touched on disk.
+type consentDestination struct {
+	ctx          context.Context
+	specDestDir  string
+	consent      ConsentHandler
+	peerDeviceID string
+	peerLabel    string
+	resumeCtx    *ResumeContext
+
+	mu               sync.Mutex
+	actual           *DurableDestination
+	resumeAuthorized bool
+	targetDestDir    string
+}
+
+func (c *consentDestination) ExpectResume(transferID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.actual != nil {
+		c.actual.ExpectResume(transferID)
+	}
+}
+
+func (c *consentDestination) SetResumeAuthorized() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.resumeAuthorized = true
+	if c.actual != nil {
+		c.actual.SetResumeAuthorized()
+	}
+}
+
+func (c *consentDestination) Prepare(manifest wire.Manifest) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	targetDir := c.specDestDir
+	if c.consent != nil {
+		req := ConsentRequest{
+			TransferID:   manifest.TransferID,
+			PeerDeviceID: c.peerDeviceID,
+			PeerLabel:    c.peerLabel,
+			Files:        manifest.Files,
+			TotalSize:    manifest.TotalSize,
+			DestDir:      targetDir,
+		}
+		decision, err := c.consent(c.ctx, req)
+		if err != nil {
+			return wire.Errorf(wire.CodeAuth, "transfer consent error: %v", err)
+		}
+		if !decision.Accepted {
+			reason := decision.Reason
+			if reason == "" {
+				reason = "transfer declined by user"
+			}
+			return wire.Errorf(wire.CodeAuth, "%s", reason)
+		}
+		if decision.DestDir != "" {
+			targetDir = decision.DestDir
+		}
+	}
+
+	actual, err := NewDurableDestination(targetDir)
+	if err != nil {
+		return wire.NewTransferError(wire.FailSinkError, err.Error())
+	}
+	if c.resumeCtx != nil {
+		actual.ExpectResume(c.resumeCtx.TransferID)
+	}
+	if c.resumeAuthorized {
+		actual.SetResumeAuthorized()
+	}
+
+	if err := actual.Prepare(manifest); err != nil {
+		return err
+	}
+
+	c.actual = actual
+	c.targetDestDir = targetDir
+	return nil
+}
+
+func (c *consentDestination) Open(file wire.FileEntry) (wire.Sink, error) {
+	c.mu.Lock()
+	actual := c.actual
+	c.mu.Unlock()
+	if actual == nil {
+		return nil, wire.NewTransferError(wire.FailSinkError, "destination not prepared")
+	}
+	return actual.Open(file)
+}
+
+func (c *consentDestination) Close() error {
+	c.mu.Lock()
+	actual := c.actual
+	c.mu.Unlock()
+	if actual == nil {
+		return nil
+	}
+	return actual.Close()
+}
+
+func (c *consentDestination) Abort(reason string) error {
+	c.mu.Lock()
+	actual := c.actual
+	c.mu.Unlock()
+	if actual == nil {
+		return nil
+	}
+	return actual.Abort(reason)
+}
+
+func (c *consentDestination) ResumeStateFor(manifest wire.Manifest) (*wire.ReceiverResume, error) {
+	c.mu.Lock()
+	actual := c.actual
+	c.mu.Unlock()
+	if actual == nil {
+		return nil, nil
+	}
+	return actual.ResumeStateFor(manifest)
+}
+
+func (c *consentDestination) AttachResumeSecret(manifest wire.Manifest, resumeRoot []byte) error {
+	c.mu.Lock()
+	actual := c.actual
+	c.mu.Unlock()
+	if actual == nil {
+		return nil
+	}
+	return actual.AttachResumeSecret(manifest, resumeRoot)
+}
+
+func (c *consentDestination) Path(fileIdx int) string {
+	c.mu.Lock()
+	actual := c.actual
+	c.mu.Unlock()
+	if actual == nil {
+		return ""
+	}
+	return actual.Path(fileIdx)
+}

--- a/packages/engine/transfer/driver.go
+++ b/packages/engine/transfer/driver.go
@@ -51,6 +51,17 @@ type Controls interface {
 // Source; a receiving (joiner) spec sets DestDir.
 type Spec struct {
 	Session rendezvous.Options
+	// Opaque, when set, drives a sendbeam/3 authenticated forward-secret session over opaque handles.
+	// When non-nil, Session is ignored and Opaque is used instead.
+	Opaque *rendezvous.OpaqueOptions
+	// Consent, when set, is invoked on the receiver when a manifest arrives to decide whether
+	// to accept or decline the transfer and optionally override the destination directory.
+	// If it returns Accepted: false or an error, the transfer aborts cleanly without writing data.
+	Consent ConsentHandler
+	// PeerDeviceID is the authenticated peer's device ID for consent and logging.
+	PeerDeviceID string
+	// PeerLabel is the human-readable peer label for consent prompts.
+	PeerLabel string
 	// Source is the file to send; required for an offerer, ignored for a joiner.
 	Source wire.FileSource
 	// Sources is an ordered multi-file/folder set. Set either Source or Sources.
@@ -143,12 +154,13 @@ type ResumeResult struct {
 
 // Outcome is the result of a completed transfer.
 type Outcome struct {
-	Handshake *rendezvous.Result `json:"-"`
-	Name      string             `json:"name"`
-	Size      int64              `json:"size"`
-	Digest    string             `json:"digest"`         // whole-file SHA-256 (hex); identical on both peers
-	Path      string             `json:"path,omitempty"` // receiver: the written file; empty for a sender
-	Files     []FileOutcome      `json:"files,omitempty"`
+	Handshake  *rendezvous.Result `json:"-"`
+	TransferID string             `json:"transferId,omitempty"`
+	Name       string             `json:"name"`
+	Size       int64              `json:"size"`
+	Digest     string             `json:"digest"`         // whole-file SHA-256 (hex); identical on both peers
+	Path       string             `json:"path,omitempty"` // receiver: the written file; empty for a sender
+	Files      []FileOutcome      `json:"files,omitempty"`
 }
 
 // FileOutcome is one source or received destination within an Outcome.
@@ -175,8 +187,10 @@ type driver struct {
 	sig  Signal
 	spec Spec
 
-	mu   sync.Mutex // serializes every socket write (session, sendOffer, pion's ICE goroutine)
-	sess *rendezvous.Session
+	mu           sync.Mutex // serializes every socket write (session, sendOffer, pion's ICE goroutine)
+	sess         *rendezvous.Session
+	opaqueSess   *rendezvous.OpaqueSession
+	opaqueResult *rendezvous.OpaqueResult
 
 	// peer and res are set once, by the read-loop goroutine, at establishment; peerCh publishes
 	// the peer to run once it exists.
@@ -218,33 +232,49 @@ func (d *driver) SendBinary(frame []byte) error {
 }
 
 func (d *driver) run(ctx context.Context) (*Outcome, error) {
-	opts := d.spec.Session
-	opts.Transport = d
-	if d.spec.Private {
-		var localCaps rendezvous.Caps
-		if opts.LocalCaps != nil {
-			localCaps = *opts.LocalCaps
-		} else {
-			localCaps = rendezvous.DefaultCaps()
+	if d.spec.Opaque != nil {
+		opts := *d.spec.Opaque
+		opts.Transport = d
+		d.opaqueSess = rendezvous.NewOpaqueSession(opts)
+		go func() {
+			<-d.opaqueSess.Done()
+			if _, err := d.opaqueSess.Result(); err != nil {
+				d.sig.Close()
+			}
+		}()
+	} else {
+		opts := d.spec.Session
+		opts.Transport = d
+		if d.spec.Private {
+			var localCaps rendezvous.Caps
+			if opts.LocalCaps != nil {
+				localCaps = *opts.LocalCaps
+			} else {
+				localCaps = rendezvous.DefaultCaps()
+			}
+			padded := localCaps.WithPadding()
+			opts.LocalCaps = &padded
 		}
-		padded := localCaps.WithPadding()
-		opts.LocalCaps = &padded
+		d.sess = rendezvous.New(opts)
+		go func() {
+			<-d.sess.Done()
+			if _, err := d.sess.Result(); err != nil {
+				d.sig.Close()
+			}
+		}()
 	}
-	d.sess = rendezvous.New(opts)
-
-	// On a handshake failure, close the socket so the read loop unblocks; on success keep it
-	// open — WebRTC signaling still needs it.
-	go func() {
-		<-d.sess.Done()
-		if _, err := d.sess.Result(); err != nil {
-			d.sig.Close()
-		}
-	}()
 
 	readErr := make(chan error, 1)
 	go func() { readErr <- d.sig.Run(ctx, d.route, d.routeBinary) }()
 
-	d.sess.Start()
+	if d.opaqueSess != nil {
+		if err := d.opaqueSess.Start(); err != nil {
+			d.sig.Close()
+			return nil, err
+		}
+	} else {
+		d.sess.Start()
+	}
 
 	var peer *rtc.Peer
 	select {
@@ -252,15 +282,25 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	case err := <-readErr:
 		// The socket ended before the peer was built: surface the handshake failure, or a raw
 		// transport error if it dropped mid-handshake.
-		if _, herr := d.sess.Result(); herr != nil {
-			return nil, herr
+		if d.opaqueSess != nil {
+			if _, herr := d.opaqueSess.Result(); herr != nil {
+				return nil, herr
+			}
+		} else {
+			if _, herr := d.sess.Result(); herr != nil {
+				return nil, herr
+			}
 		}
 		if err == nil {
 			err = wire.Errorf(wire.CodeConnection, "transfer: signaling closed before the channel opened")
 		}
 		return nil, err
 	case <-ctx.Done():
-		d.sess.Abort("cancelled")
+		if d.opaqueSess != nil {
+			d.sig.Close()
+		} else {
+			d.sess.Abort("cancelled")
+		}
 		return nil, ctx.Err()
 	}
 
@@ -492,6 +532,102 @@ func (d *driver) route(m rendezvous.Message) {
 		if d.peer != nil {
 			d.peer.Accept(m)
 		}
+		return
+	}
+	if d.opaqueSess != nil {
+		select {
+		case <-d.opaqueSess.Done():
+		default:
+			_ = d.opaqueSess.Handle(m)
+		}
+		if d.res != nil {
+			return
+		}
+		select {
+		case <-d.opaqueSess.Done():
+		default:
+			return // still handshaking
+		}
+		ores, err := d.opaqueSess.Result()
+		if err != nil {
+			return // handshake failed; watcher goroutine closes socket
+		}
+		d.mu.Lock()
+		if d.res != nil {
+			d.mu.Unlock()
+			return
+		}
+		d.opaqueResult = ores
+		keys, err := wire.DeriveTransferKeys(ores.Master)
+		if err != nil {
+			d.mu.Unlock()
+			d.sig.Close()
+			return
+		}
+		caps := rendezvous.DefaultCaps()
+		if containsString(ores.NegotiatedCaps, wire.PaddingCapability) {
+			caps = caps.WithPadding()
+		}
+		res := &rendezvous.Result{
+			Role:        ores.Role,
+			Master:      ores.Master,
+			Keys:        keys,
+			LocalCaps:   caps,
+			RemoteCaps:  caps,
+			SendCounter: 0,
+			RecvCounter: 0,
+		}
+		d.res = res
+		d.mu.Unlock()
+
+		var peer *rtc.Peer
+		if !d.spec.ForceRelay {
+			authKeys := wire.SignalAuthKeys{
+				Sign:   ores.SendKey,
+				Verify: ores.RecvKey,
+			}
+			var perr error
+			d.pol = NewAdaptivePolicy(0)
+			peer, perr = rtc.NewPeer(rtc.PeerOptions{
+				Role:       ores.Role,
+				Auth:       rtc.NewSignalAuthenticator(0, authKeys),
+				Send:       d.Send,
+				ICEServers: d.spec.ICEServers,
+				OnICEState: func(s rtc.ICEState) {
+					ev := AdaptiveEvent{
+						Gathering:          adaptiveGathering(s.Gathering.String()),
+						Connection:         adaptiveConnection(s.Connection.String()),
+						HasServerReflexive: s.HasServerReflexive,
+						HasAnyCandidate:    s.HasAnyCandidate,
+					}
+					if d.pol.Observe(ev) == DecisionWarmRelay {
+						select {
+						case d.warmSignal <- struct{}{}:
+						default:
+						}
+					}
+				},
+				OnRecovering: func(rec bool) { d.reportRecovering(rec) },
+				OnRecoverFailed: func() {
+					d.mu.Lock()
+					ad := d.adaptive
+					d.mu.Unlock()
+					if ad != nil {
+						ad.FallbackToRelay()
+					}
+				},
+			})
+			if perr != nil {
+				d.sig.Close()
+				return
+			}
+		}
+		d.relay = relaytransport.New(d)
+		if d.spec.RelayJitter > 0 {
+			d.relay.SetJitter(d.spec.RelayJitter)
+		}
+		d.peer = peer
+		d.peerCh <- peer
 		return
 	}
 	d.sess.Handle(m)
@@ -775,6 +911,7 @@ func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervi
 		}
 	}
 	paddingNegotiated := containsString(res.LocalCaps.Features, wire.PaddingCapability) && containsString(res.RemoteCaps.Features, wire.PaddingCapability)
+	var sentTransferID string
 	sender := wire.NewSender(wire.SenderOptions{
 		Files:            sources,
 		Send:             conn.Send,
@@ -793,6 +930,7 @@ func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervi
 		TransferID:    d.spec.TransferID,
 		NewTransferID: newTransferID,
 		OnManifest: func(manifest wire.Manifest) error {
+			sentTransferID = manifest.TransferID
 			// The record (stable id + source identity) is persisted first; only then is the
 			// resume credential attached — both strictly before the manifest frame goes out.
 			if onManifest != nil {
@@ -831,7 +969,7 @@ func (d *driver) send(ctx context.Context, conn dataConn, sv *supervisor.Supervi
 		files[i] = FileOutcome{Name: meta.Name, Size: meta.Size}
 		total += meta.Size
 	}
-	return &Outcome{Name: files[0].Name, Size: total, Digest: digest, Files: files}, nil
+	return &Outcome{TransferID: sentTransferID, Name: files[0].Name, Size: total, Digest: digest, Files: files}, nil
 }
 
 func containsString(values []string, want string) bool {
@@ -844,10 +982,37 @@ func containsString(values []string, want string) bool {
 }
 
 func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supervisor, res *rendezvous.Result, sendDir, recvDir wire.DirectionalKey, sendStart, recvStart uint64, preamble *wire.ResumePreamble) (*Outcome, error) {
-	destination, err := NewDurableDestination(d.spec.DestDir)
-	if err != nil {
-		return nil, wire.NewTransferError(wire.FailSinkError, err.Error())
+	var destination interface {
+		wire.Destination
+		ResumeStateFor(manifest wire.Manifest) (*wire.ReceiverResume, error)
+		AttachResumeSecret(manifest wire.Manifest, resumeRoot []byte) error
+		Path(fileIdx int) string
+		ExpectResume(transferID string)
+		SetResumeAuthorized()
 	}
+
+	if d.spec.Consent != nil {
+		peerID := d.spec.PeerDeviceID
+		if peerID == "" && d.opaqueResult != nil {
+			peerID = d.opaqueResult.PeerDeviceID
+		}
+		destWrapper := &consentDestination{
+			ctx:          ctx,
+			specDestDir:  d.spec.DestDir,
+			consent:      d.spec.Consent,
+			peerDeviceID: peerID,
+			peerLabel:    d.spec.PeerLabel,
+			resumeCtx:    d.spec.Resume,
+		}
+		destination = destWrapper
+	} else {
+		actual, err := NewDurableDestination(d.spec.DestDir)
+		if err != nil {
+			return nil, wire.NewTransferError(wire.FailSinkError, err.Error())
+		}
+		destination = actual
+	}
+
 	// V13-PR08: an explicit resume attempt pre-selects its interrupted journal locally; its
 	// verified progress is reused only after resume-auth succeeds in this session.
 	if d.spec.Resume != nil {
@@ -879,6 +1044,7 @@ func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supe
 	// documents for ReceiverResume.
 	var sharedResume wire.ReceiverResume
 	paddingNegotiated := containsString(res.LocalCaps.Features, wire.PaddingCapability) && containsString(res.RemoteCaps.Features, wire.PaddingCapability)
+	var receivedTransferID string
 	receiver := wire.NewReceiver(wire.ReceiverOptions{
 		Send:             conn.Send,
 		SendDir:          sendDir,
@@ -893,6 +1059,7 @@ func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supe
 		OnResume:         d.spec.OnResumeProgress,
 		OnStateChange:    d.spec.OnStateChange,
 		OnManifestSet: func(manifest wire.Manifest) error {
+			receivedTransferID = manifest.TransferID
 			if d.spec.OnManifestSet != nil {
 				d.spec.OnManifestSet(manifest)
 			}
@@ -945,6 +1112,7 @@ func (d *driver) receive(ctx context.Context, conn dataConn, sv *supervisor.Supe
 		files[i] = FileOutcome{Name: file.Name, Size: file.Size, Digest: result.Digests[i], Path: destination.Path(file.Idx)}
 	}
 	return &Outcome{
+		TransferID: receivedTransferID,
 		Name: result.File.Name, Size: result.TotalSize, Digest: result.Digest,
 		Path: destination.Path(result.File.Idx), Files: files,
 	}, nil

--- a/packages/engine/transfer/driver_test.go
+++ b/packages/engine/transfer/driver_test.go
@@ -21,13 +21,14 @@ import (
 // partner. It lets a complete offerer↔joiner exchange — SPAKE2 handshake, authenticated
 // SDP/ICE, and the sealed file transfer — run in one process with no sockets.
 type relay struct {
-	off      *relayEnd
-	join     *relayEnd
-	room     int
-	created  chan struct{} // closed once the offerer has created the room
-	once     sync.Once
-	mu       sync.Mutex
-	captured [][]byte
+	off           *relayEnd
+	join          *relayEnd
+	room          int
+	createdHandle string
+	created       chan struct{} // closed once the offerer has created the room
+	once          sync.Once
+	mu            sync.Mutex
+	captured      [][]byte
 }
 
 func newRelay() *relay {
@@ -60,6 +61,19 @@ func (r *relay) route(from *relayEnd, m rendezvous.Message) {
 		<-r.created
 		r.join.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.join.role})
 		r.off.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.off.role})
+	case "rendezvous":
+		r.mu.Lock()
+		if r.createdHandle == "" {
+			r.createdHandle = m.Handle
+			r.mu.Unlock()
+			from.enqueue(rendezvous.Message{Type: "created", Handle: m.Handle})
+			r.once.Do(func() { close(r.created) })
+		} else {
+			r.mu.Unlock()
+			<-r.created
+			r.join.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.join.role})
+			r.off.enqueue(rendezvous.Message{Type: "peer-joined", Role: r.off.role})
+		}
 	case rendezvous.TypeRelayOpen:
 		r.mu.Lock()
 		from.relayOpen = true
@@ -668,3 +682,200 @@ func TestDriverAuthenticatedCrossSessionResume(t *testing.T) {
 		t.Fatalf("sender record still present after discard: ok=%v err=%v", ok, err)
 	}
 }
+
+func TestDriverOpaqueSessionTransfersFileWithConsent(t *testing.T) {
+	hub := newRelay()
+
+	idAlice, err := wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	idBob, err := wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kPair := bytes.Repeat([]byte{0x42}, 32)
+	handle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	payload := []byte("hello from opaque session transfer with mutual consent")
+	meta := wire.FileMeta{
+		Name:         "hello.txt",
+		Size:         int64(len(payload)),
+		Mime:         "text/plain",
+		LastModified: 1_700_000_000_000,
+	}
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *Outcome
+		err error
+	}
+	sendDone := make(chan result, 1)
+	recvDone := make(chan result, 1)
+
+	consentCalled := false
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleOfferer,
+				Handle:            handle,
+				LocalIdentity:     idAlice,
+				PeerDeviceID:      idBob.DeviceID,
+				PeerPublicKey:     idBob.PublicKey,
+				KPair:             kPair,
+				PairCredentialRef: "cred-1",
+			},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		})
+		sendDone <- result{out, err}
+	}()
+
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleJoiner,
+				Handle:            handle,
+				LocalIdentity:     idBob,
+				PeerDeviceID:      idAlice.DeviceID,
+				PeerPublicKey:     idAlice.PublicKey,
+				KPair:             kPair,
+				PairCredentialRef: "cred-1",
+			},
+			DestDir: dir,
+			Consent: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+				consentCalled = true
+				if req.PeerDeviceID != idAlice.DeviceID {
+					t.Errorf("consent peer device id = %q, want %q", req.PeerDeviceID, idAlice.DeviceID)
+				}
+				if len(req.Files) != 1 || req.Files[0].Name != "hello.txt" {
+					t.Errorf("consent files mismatch: %+v", req.Files)
+				}
+				return ConsentDecision{Accepted: true}, nil
+			},
+			ICEServers: []webrtc.ICEServer{},
+		})
+		recvDone <- result{out, err}
+	}()
+
+	send := <-sendDone
+	recv := <-recvDone
+
+	if recv.err != nil {
+		t.Fatalf("receiver: %v", recv.err)
+	}
+	if send.err != nil {
+		t.Fatalf("sender: %v", send.err)
+	}
+	if !consentCalled {
+		t.Fatal("consent handler was not called")
+	}
+
+	if send.out.Digest != recv.out.Digest {
+		t.Errorf("digests differ: sender %s, receiver %s", send.out.Digest, recv.out.Digest)
+	}
+	if recv.out.Name != "hello.txt" {
+		t.Errorf("received name = %q, want hello.txt", recv.out.Name)
+	}
+	got, err := os.ReadFile(recv.out.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("content mismatch: got %q, want %q", got, payload)
+	}
+}
+
+func TestDriverOpaqueSessionDeclinedConsent(t *testing.T) {
+	hub := newRelay()
+
+	idAlice, err := wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	idBob, err := wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kPair := bytes.Repeat([]byte{0x42}, 32)
+	handle := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	payload := []byte("declined payload should not be written")
+	meta := wire.FileMeta{
+		Name:         "declined.txt",
+		Size:         int64(len(payload)),
+		Mime:         "text/plain",
+		LastModified: 1_700_000_000_000,
+	}
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	type result struct {
+		out *Outcome
+		err error
+	}
+	sendDone := make(chan result, 1)
+	recvDone := make(chan result, 1)
+
+	go func() {
+		out, err := Run(ctx, hub.off, Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleOfferer,
+				Handle:            handle,
+				LocalIdentity:     idAlice,
+				PeerDeviceID:      idBob.DeviceID,
+				PeerPublicKey:     idBob.PublicKey,
+				KPair:             kPair,
+				PairCredentialRef: "cred-1",
+			},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		})
+		sendDone <- result{out, err}
+	}()
+
+	go func() {
+		out, err := Run(ctx, hub.join, Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleJoiner,
+				Handle:            handle,
+				LocalIdentity:     idBob,
+				PeerDeviceID:      idAlice.DeviceID,
+				PeerPublicKey:     idAlice.PublicKey,
+				KPair:             kPair,
+				PairCredentialRef: "cred-1",
+			},
+			DestDir: dir,
+			Consent: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+				return ConsentDecision{Accepted: false, Reason: "declined by recipient"}, nil
+			},
+			ICEServers: []webrtc.ICEServer{},
+		})
+		recvDone <- result{out, err}
+	}()
+
+	send := <-sendDone
+	recv := <-recvDone
+
+	if recv.err == nil {
+		t.Fatal("expected receiver error due to declined consent, got nil")
+	}
+	if send.err == nil {
+		t.Fatal("expected sender error due to declined consent, got nil")
+	}
+
+	// Verify nothing was written to the destination directory
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty destDir, found %d entries: %+v", len(entries), entries)
+	}
+}
+

--- a/packages/engine/transfer/driver_test.go
+++ b/packages/engine/transfer/driver_test.go
@@ -746,7 +746,7 @@ func TestDriverOpaqueSessionTransfersFileWithConsent(t *testing.T) {
 				PairCredentialRef: "cred-1",
 			},
 			DestDir: dir,
-			Consent: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+			Consent: func(_ context.Context, req ConsentRequest) (ConsentDecision, error) {
 				consentCalled = true
 				if req.PeerDeviceID != idAlice.DeviceID {
 					t.Errorf("consent peer device id = %q, want %q", req.PeerDeviceID, idAlice.DeviceID)
@@ -851,7 +851,7 @@ func TestDriverOpaqueSessionDeclinedConsent(t *testing.T) {
 				PairCredentialRef: "cred-1",
 			},
 			DestDir: dir,
-			Consent: func(ctx context.Context, req ConsentRequest) (ConsentDecision, error) {
+			Consent: func(_ context.Context, _ ConsentRequest) (ConsentDecision, error) {
 				return ConsentDecision{Accepted: false, Reason: "declined by recipient"}, nil
 			},
 			ICEServers: []webrtc.ICEServer{},


### PR DESCRIPTION
## Summary

This pull request implements the shared native receiver deliverable for `v1.9` Trusted Handoffs (`V19-PR06`), providing a unified native listening engine that powers both the CLI `listen` command and the desktop backend.

### Key Components & Invariants
1. **Deferred Manifest & Consent Enforcement (`packages/engine/transfer/consent.go`)**:
   - Implements `consentDestination` wrapping `DurableDestination`. File creation and journal allocation are strictly deferred until manifest evaluation and consent approval.
   - Rejection leaves no journals, partials, or directories behind, ensuring zero disk or privacy leakage.
2. **Transfer Driver Opaque Session Support (`packages/engine/transfer/driver.go`)**:
   - Extends `transfer.Spec` with `Opaque *rendezvous.OpaqueOptions`, `Consent ConsentHandler`, `PeerDeviceID`, and `PeerLabel`.
   - Runs `sendbeam/3` forward-secret authenticated key exchange over opaque handles for file transfers alongside existing `sendbeam/1`.
   - Populates `TransferID` in completed transfer outcomes.
3. **Shared Native Receiver Package (`packages/engine/receiver`)**:
   - Coordinates LAN discovery beacons and opaque signaling handles.
   - Strict revocation and policy enforcement (`TombstoneStore` and `TrustStore`). Auto-accepts trusted peers according to fine-grained policy constraints (size limits, MIME types, subpaths) while prompting user consent for other transfers.
   - Asynchronous pending consent queue for UI integration (`PendingConsent`, `RespondConsent`, and `OnConsentRequested` callback).
   - Strict `--once` semantic guarantee: terminates only upon **one verified delivery** with whole-file SHA-256 validation. Connection errors or declined transfers continue listening.
4. **CLI Listen Real Implementation (`apps/cli/cmd/sendbeam/listen.go`)**:
   - Replaces previous stub with `receiver.NewListener`.
   - Supports interactive terminal consent prompts, streaming `--json` event outputs, and verified single delivery exit.
5. **Desktop Engine Integration (`apps/desktop/internal/engine`)**:
   - Added native receiver lifecycle to `TransferService` (`StartNativeReceiver`, `StopNativeReceiver`, `NativeReceiver`, `RespondConsent`, `PendingConsents`).
   - Hooks receiver events into the desktop presentation seam, firing `sendbeam:transfer` and `sendbeam:consent` events with OS notifications on verified completion.

### Verification
- Full test suites pass with race detection enabled (`-race`):
  - `packages/wire`: ok (100% pass)
  - `packages/engine` (including `receiver`, `transfer`, `rendezvous`, `trust`): ok (100% pass)
  - `apps/server`: ok (100% pass)
  - `apps/cli`: ok (100% pass)
  - `apps/desktop` internal engine: ok (100% pass)
- Web & monorepo checks pass:
  - `pnpm run format:check`: ok
  - `pnpm run lint`: ok (0 warnings)
  - `pnpm run typecheck`: ok (0 errors)
  - `pnpm run test`: ok (27/27 test files, 237/237 tests pass)
  - `pnpm run build`: ok
- Branding guard: passed (no stale references).