### PR TITLE
feat(cli): targeted and broadcast delivery with bound peer identity

### DIFF
--- a/apps/cli/cmd/sendbeam/send.go
+++ b/apps/cli/cmd/sendbeam/send.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -53,6 +54,7 @@ func executeSend(args []string, stdout, stderr io.Writer) int {
 	jitter := fs.Duration("jitter", 0, "maximum random scheduling jitter for relay frames (e.g. 15ms)")
 	jsonOutput := fs.Bool("json", false, "output structured JSON result")
 	concurrency := fs.Int("concurrency", 4, "maximum concurrent target transfers")
+	timeout := fs.Duration("timeout", 0, "per-target transfer timeout (e.g. 30s; 0 = unlimited)")
 	configDir := fs.String("config-dir", "", "path to custom configuration directory")
 
 	rawPositionals := parseArgs(fs, args)
@@ -75,7 +77,7 @@ func executeSend(args []string, stdout, stderr io.Writer) int {
 		return runSingleInteractiveSend(filePaths, *server, *insecure, *words, *relayOnly, iceServer, *privateMode, *jitter, *jsonOutput, stdout, stderr)
 	}
 
-	return runBroadcastSend(filePaths, toDevices, *server, *insecure, *relayOnly, iceServer, *privateMode, *jitter, *jsonOutput, *concurrency, *configDir, stdout, stderr)
+	return runBroadcastSend(filePaths, toDevices, *server, *insecure, *relayOnly, iceServer, *privateMode, *jitter, *jsonOutput, *concurrency, *timeout, *configDir, stdout, stderr)
 }
 
 func runSingleInteractiveSend(filePaths []string, server string, insecure bool, words int, relayOnly bool, iceServer iceServerList, privateMode bool, jitter time.Duration, jsonOutput bool, stdout, stderr io.Writer) int {
@@ -287,10 +289,16 @@ func runSingleInteractiveSend(filePaths []string, server string, insecure bool, 
 	return 0
 }
 
-func runBroadcastSend(filePaths []string, toDevices []string, server string, insecure bool, relayOnly bool, iceServer iceServerList, privateMode bool, jitter time.Duration, jsonOutput bool, concurrency int, configDir string, stdout, stderr io.Writer) int {
+func runBroadcastSend(filePaths []string, toDevices []string, server string, insecure bool, relayOnly bool, iceServer iceServerList, privateMode bool, jitter time.Duration, jsonOutput bool, concurrency int, timeout time.Duration, configDir string, stdout, stderr io.Writer) int {
 	env, err := InitCLIEnvironment(configDir)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "sendbeam send: %v\n", err)
+		return 1
+	}
+
+	localID, err := env.IdentityMgr.GetOrCreateIdentity()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sendbeam send: identity error: %v\n", err)
 		return 1
 	}
 
@@ -311,6 +319,8 @@ func runBroadcastSend(filePaths []string, toDevices []string, server string, ins
 	type resolvedDev struct {
 		targetName string
 		record     *wire.TrustRecord
+		kPair      []byte
+		peerPubKey ed25519.PublicKey
 	}
 	var resolved []resolvedDev
 
@@ -324,7 +334,22 @@ func runBroadcastSend(filePaths []string, toDevices []string, server string, ins
 			_, _ = fmt.Fprintf(stderr, "sendbeam send: trust for device %q is revoked\n", dev.LocalLabel)
 			return 1
 		}
-		resolved = append(resolved, resolvedDev{targetName: tName, record: dev})
+		kPair, err := env.Secrets.ResolvePairSecret(ctx, dev.DeviceID, dev.PairCredentialRef)
+		if err != nil || len(kPair) == 0 {
+			_, _ = fmt.Fprintf(stderr, "sendbeam send: failed to resolve pair secret for device %q: %v\n", dev.LocalLabel, err)
+			return 1
+		}
+		peerPubKey, err := wire.ParsePublicKeyHex(dev.PublicKey)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "sendbeam send: invalid public key for device %q: %v\n", dev.LocalLabel, err)
+			return 1
+		}
+		resolved = append(resolved, resolvedDev{
+			targetName: tName,
+			record:     dev,
+			kPair:      kPair,
+			peerPubKey: peerPubKey,
+		})
 	}
 
 	s := newStyleFromWriter(stderr)
@@ -336,37 +361,59 @@ func runBroadcastSend(filePaths []string, toDevices []string, server string, ins
 		}
 	}
 
+	dialWriter := stderr
+	if jsonOutput {
+		dialWriter = io.Discard
+	}
+
+	replayCache := wire.NewNonceReplayCache(5 * time.Minute)
+
 	targets := make([]transfer.BroadcastTarget, len(resolved))
 	for i, r := range resolved {
-		var sig transfer.Signal
-		client, err := dial(ctx, server, insecure, stderr)
-		if err != nil {
-			sig = &offlineSignal{err: fmt.Errorf("peer offline: %w", err)}
-		} else {
-			sig = client
+		rec := r.record
+		kPair := r.kPair
+		peerPubKey := r.peerPubKey
+
+		handle := wire.DeriveRendezvousHandleForTime(kPair, time.Now().UTC(), wire.DefaultRendezvousEpochWindow)
+
+		opaqueOpts := &rendezvous.OpaqueOptions{
+			Role:              rendezvous.RoleOfferer,
+			Handle:            handle,
+			LocalIdentity:     localID,
+			PeerDeviceID:      rec.DeviceID,
+			PeerPublicKey:     peerPubKey,
+			KPair:             kPair,
+			PairCredentialRef: rec.PairCredentialRef,
+			LocalCaps:         []string{"sendbeam/3", "rendezvous", "resume"},
+			ReplayCache:       replayCache,
+			Tombstones:        env.Tombstones,
+			TrustStore:        env.TrustStore,
 		}
 
-		session := rendezvous.Options{
-			Role: rendezvous.RoleOfferer,
+		spec := transfer.Spec{
+			Opaque:       opaqueOpts,
+			PeerDeviceID: rec.DeviceID,
+			PeerLabel:    rec.LocalLabel,
+			Sources:      sources,
+			ICEServers:   ice,
+			ForceRelay:   relayOnly,
+			Private:      privateMode,
+			RelayJitter:  jitter,
 		}
 
 		targets[i] = transfer.BroadcastTarget{
-			ID:     r.record.DeviceID,
-			Label:  r.record.LocalLabel,
-			Signal: sig,
-			Spec: transfer.Spec{
-				Session:     session,
-				Sources:     sources,
-				ICEServers:  ice,
-				ForceRelay:  relayOnly,
-				Private:     privateMode,
-				RelayJitter: jitter,
+			ID:    rec.DeviceID,
+			Label: rec.LocalLabel,
+			Dial: func(dialCtx context.Context) (transfer.Signal, error) {
+				return dial(dialCtx, server, insecure, dialWriter)
 			},
+			Spec: spec,
 		}
 	}
 
 	broadcastResult := transfer.RunBroadcast(ctx, targets, transfer.BroadcastOptions{
-		Concurrency: concurrency,
+		Concurrency:   concurrency,
+		TargetTimeout: timeout,
 		OnTargetStart: func(target transfer.BroadcastTarget) {
 			if !jsonOutput {
 				_, _ = fmt.Fprintf(stderr, "[%s] Starting transfer to %s...\n", time.Now().Format("15:04:05"), s.cyan(target.Label))
@@ -446,14 +493,3 @@ func renderBroadcastTable(w io.Writer, results []transfer.TargetResult, totalSiz
 	}
 	_, _ = fmt.Fprintln(w)
 }
-
-type offlineSignal struct {
-	err error
-}
-
-func (s *offlineSignal) Send(rendezvous.Message) error { return s.err }
-func (s *offlineSignal) SendBinary([]byte) error       { return s.err }
-func (s *offlineSignal) Run(context.Context, func(rendezvous.Message), func([]byte)) error {
-	return s.err
-}
-func (s *offlineSignal) Close() {}

--- a/apps/cli/cmd/sendbeam/send_test.go
+++ b/apps/cli/cmd/sendbeam/send_test.go
@@ -137,6 +137,8 @@ func TestExecuteSend_MultipleTargetArgParsing(t *testing.T) {
 		LastSeenAt:        now,
 		Policy:            wire.DefaultTrustPolicy(),
 	})
+	_ = env.Secrets.SetPairSecret(ctx, dev1, "cred-1", bytes.Repeat([]byte{0x01}, 32))
+	_ = env.Secrets.SetPairSecret(ctx, dev2, "cred-2", bytes.Repeat([]byte{0x02}, 32))
 
 	testFile := filepath.Join(tmpDir, "report.pdf")
 	if err := os.WriteFile(testFile, []byte("fake-pdf-content"), 0600); err != nil {
@@ -448,6 +450,362 @@ func TestExecuteSend_JSONSuccess_NoSecretsExposed(t *testing.T) {
 	}
 }
 
+func TestExecuteSend_MissingPairSecret(t *testing.T) {
+	tmpDir := t.TempDir()
+	env, err := InitCLIEnvironment(tmpDir)
+	if err != nil {
+		t.Fatalf("init cli env: %v", err)
+	}
+
+	pub, _, _ := ed25519.GenerateKey(nil)
+	devID := wire.DeriveDeviceID(pub)
+	now := time.Now().UTC()
+
+	ctx := context.Background()
+	_ = env.TrustStore.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          devID,
+		PublicKey:         hex.EncodeToString(pub),
+		LocalLabel:        "secretless-peer",
+		PairCredentialRef: "missing-ref",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("payload"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeSend([]string{
+		"--config-dir", env.ConfigDir,
+		testFile,
+		"@secretless-peer",
+	}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for missing secret, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "failed to resolve pair secret") {
+		t.Fatalf("expected 'failed to resolve pair secret' in stderr, got: %s", stderr.String())
+	}
+}
+
+func TestExecuteSend_TargetDevice_SuccessfulSend(t *testing.T) {
+	srv := httptest.NewServer(newTestBlindHub())
+	defer srv.Close()
+	wsServerURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	senderDir := t.TempDir()
+	envSender, err := InitCLIEnvironment(senderDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	senderID, err := envSender.IdentityMgr.GetOrCreateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receiverDir := t.TempDir()
+	envReceiver, err := InitCLIEnvironment(receiverDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiverID, err := envReceiver.IdentityMgr.GetOrCreateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Shared 32-byte pairwise secret
+	kPair := bytes.Repeat([]byte{0x77}, 32)
+	now := time.Now().UTC()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Configure sender trust in receiver
+	_ = envSender.TrustStore.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          receiverID.DeviceID,
+		PublicKey:         receiverID.PublicKeyHex(),
+		LocalLabel:        "WorkLaptop",
+		PairCredentialRef: "cred-recv",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	_ = envSender.Secrets.SetPairSecret(ctx, receiverID.DeviceID, "cred-recv", kPair)
+
+	// Configure receiver trust in sender
+	_ = envReceiver.TrustStore.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          senderID.DeviceID,
+		PublicKey:         senderID.PublicKeyHex(),
+		LocalLabel:        "DesktopRig",
+		PairCredentialRef: "cred-send",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	_ = envReceiver.Secrets.SetPairSecret(ctx, senderID.DeviceID, "cred-send", kPair)
+
+	payload := []byte("confidential-targeted-send-payload-999")
+	testFile := filepath.Join(senderDir, "document.pdf")
+	if err := os.WriteFile(testFile, payload, 0600); err != nil {
+		t.Fatal(err)
+	}
+	hasher := sha256.New()
+	hasher.Write(payload)
+	expectedDigest := hex.EncodeToString(hasher.Sum(nil))
+
+	handle := wire.DeriveRendezvousHandleForTime(kPair, time.Now().UTC(), wire.DefaultRendezvousEpochWindow)
+
+	// Start receiver listening on handle
+	recvDestDir := t.TempDir()
+	recvDone := make(chan struct{})
+	var recvOutcome *transfer.Outcome
+	var recvErr error
+
+	go func() {
+		defer close(recvDone)
+		receiverSig, err := wsclient.NewReconnectingSignal(ctx, wsServerURL, wsclient.DialOptions{})
+		if err != nil {
+			recvErr = err
+			return
+		}
+		defer receiverSig.Close()
+
+		recvOutcome, recvErr = transfer.Run(ctx, receiverSig, transfer.Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleJoiner,
+				Handle:            handle,
+				LocalIdentity:     receiverID,
+				PeerDeviceID:      senderID.DeviceID,
+				PeerPublicKey:     senderID.PublicKey,
+				KPair:             kPair,
+				PairCredentialRef: "cred-send",
+				LocalCaps:         []string{"sendbeam/3", "rendezvous", "resume"},
+				ReplayCache:       wire.NewNonceReplayCache(5 * time.Minute),
+				Tombstones:        envReceiver.Tombstones,
+				TrustStore:        envReceiver.TrustStore,
+			},
+			DestDir:    recvDestDir,
+			ForceRelay: true,
+		})
+	}()
+
+	// Small pause for receiver to seat in handle room
+	time.Sleep(50 * time.Millisecond)
+
+	var stdout, stderr bytes.Buffer
+	sendCode := executeSend([]string{
+		"--config-dir", envSender.ConfigDir,
+		"--server", wsServerURL,
+		"--relay-only",
+		"--json",
+		testFile,
+		"@WorkLaptop",
+	}, &stdout, &stderr)
+
+	if sendCode != 0 {
+		t.Fatalf("executeSend targeted failed with code %d. stdout: %s, stderr: %s", sendCode, stdout.String(), stderr.String())
+	}
+
+	select {
+	case <-recvDone:
+		if recvErr != nil {
+			t.Fatalf("receiver failed: %v", recvErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for receiver")
+	}
+
+	var res transfer.BroadcastResult
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("unmarshal json: %v. Output: %s", err, stdout.String())
+	}
+
+	if !res.AllOk {
+		t.Fatalf("expected AllOk=true, got %+v", res)
+	}
+	if len(res.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res.Results))
+	}
+	r := res.Results[0]
+	if r.Status != transfer.StatusOk {
+		t.Errorf("status = %s, want ok", r.Status)
+	}
+	if r.Digest != expectedDigest {
+		t.Errorf("digest = %s, want %s", r.Digest, expectedDigest)
+	}
+	if recvOutcome == nil || recvOutcome.Digest != expectedDigest {
+		t.Errorf("receiver digest = %v, want %s", recvOutcome, expectedDigest)
+	}
+
+	// Verify received file on disk
+	gotFile, err := os.ReadFile(recvOutcome.Path)
+	if err != nil {
+		t.Fatalf("read received file: %v", err)
+	}
+	if !bytes.Equal(gotFile, payload) {
+		t.Errorf("received payload mismatch: got %q, want %q", string(gotFile), string(payload))
+	}
+}
+
+func TestExecuteSend_Broadcast_MixedOutcomes(t *testing.T) {
+	srv := httptest.NewServer(newTestBlindHub())
+	defer srv.Close()
+	wsServerURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	senderDir := t.TempDir()
+	envSender, err := InitCLIEnvironment(senderDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	senderID, err := envSender.IdentityMgr.GetOrCreateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Peer 1: Accepts and succeeds
+	idPeer1, err := wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kPair1 := bytes.Repeat([]byte{0x11}, 32)
+	now := time.Now().UTC()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	_ = envSender.TrustStore.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idPeer1.DeviceID,
+		PublicKey:         idPeer1.PublicKeyHex(),
+		LocalLabel:        "accepting-peer",
+		PairCredentialRef: "cred-1",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	_ = envSender.Secrets.SetPairSecret(ctx, idPeer1.DeviceID, "cred-1", kPair1)
+
+	// Peer 2: Declined / Refused
+	idPeer2, err := wire.GenerateDeviceIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kPair2 := bytes.Repeat([]byte{0x22}, 32)
+	_ = envSender.TrustStore.AddOrUpdateDevice(ctx, &wire.TrustRecord{
+		DeviceID:          idPeer2.DeviceID,
+		PublicKey:         idPeer2.PublicKeyHex(),
+		LocalLabel:        "declining-peer",
+		PairCredentialRef: "cred-2",
+		FirstSeenAt:       now,
+		LastSeenAt:        now,
+		Policy:            wire.DefaultTrustPolicy(),
+	})
+	_ = envSender.Secrets.SetPairSecret(ctx, idPeer2.DeviceID, "cred-2", kPair2)
+
+	payload := []byte("broadcast-mixed-data-12345")
+	testFile := filepath.Join(senderDir, "bundle.bin")
+	if err := os.WriteFile(testFile, payload, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start accepting receiver (Peer 1)
+	handle1 := wire.DeriveRendezvousHandleForTime(kPair1, time.Now().UTC(), wire.DefaultRendezvousEpochWindow)
+	recvDir1 := t.TempDir()
+	recvDone1 := make(chan struct{})
+	go func() {
+		defer close(recvDone1)
+		sig1, err := wsclient.NewReconnectingSignal(ctx, wsServerURL, wsclient.DialOptions{})
+		if err != nil {
+			return
+		}
+		defer sig1.Close()
+		_, _ = transfer.Run(ctx, sig1, transfer.Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleJoiner,
+				Handle:            handle1,
+				LocalIdentity:     idPeer1,
+				PeerDeviceID:      senderID.DeviceID,
+				PeerPublicKey:     senderID.PublicKey,
+				KPair:             kPair1,
+				PairCredentialRef: "cred-1",
+				LocalCaps:         []string{"sendbeam/3", "rendezvous", "resume"},
+			},
+			DestDir:    recvDir1,
+			ForceRelay: true,
+		})
+	}()
+
+	// Start declining receiver (Peer 2)
+	handle2 := wire.DeriveRendezvousHandleForTime(kPair2, time.Now().UTC(), wire.DefaultRendezvousEpochWindow)
+	recvDir2 := t.TempDir()
+	recvDone2 := make(chan struct{})
+	go func() {
+		defer close(recvDone2)
+		sig2, err := wsclient.NewReconnectingSignal(ctx, wsServerURL, wsclient.DialOptions{})
+		if err != nil {
+			return
+		}
+		defer sig2.Close()
+		_, _ = transfer.Run(ctx, sig2, transfer.Spec{
+			Opaque: &rendezvous.OpaqueOptions{
+				Role:              rendezvous.RoleJoiner,
+				Handle:            handle2,
+				LocalIdentity:     idPeer2,
+				PeerDeviceID:      senderID.DeviceID,
+				PeerPublicKey:     senderID.PublicKey,
+				KPair:             kPair2,
+				PairCredentialRef: "cred-2",
+				LocalCaps:         []string{"sendbeam/3", "rendezvous", "resume"},
+			},
+			DestDir:    recvDir2,
+			ForceRelay: true,
+			Consent: func(_ context.Context, _ transfer.ConsentRequest) (transfer.ConsentDecision, error) {
+				return transfer.ConsentDecision{Accepted: false, Reason: "declined by user"}, nil
+			},
+		})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	var stdout, stderr bytes.Buffer
+	sendCode := executeSend([]string{
+		"--config-dir", envSender.ConfigDir,
+		"--server", wsServerURL,
+		"--relay-only",
+		"--json",
+		testFile,
+		"@accepting-peer",
+		"@declining-peer",
+	}, &stdout, &stderr)
+
+	if sendCode != 1 {
+		t.Fatalf("expected exit code 1 on mixed outcomes, got %d. stdout: %s, stderr: %s", sendCode, stdout.String(), stderr.String())
+	}
+
+	<-recvDone1
+	<-recvDone2
+
+	var res transfer.BroadcastResult
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("unmarshal json: %v. Output: %s", err, stdout.String())
+	}
+
+	if res.AllOk {
+		t.Errorf("expected AllOk=false")
+	}
+	if len(res.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(res.Results))
+	}
+
+	if res.Results[0].Status != transfer.StatusOk {
+		t.Errorf("peer 1 status = %s, want ok (err: %s)", res.Results[0].Status, res.Results[0].Error)
+	}
+	if res.Results[1].Status != transfer.StatusRefused {
+		t.Errorf("peer 2 status = %s, want refused (err: %s)", res.Results[1].Status, res.Results[1].Error)
+	}
+}
+
 type codeCapturingWriter struct {
 	mu     sync.Mutex
 	buf    bytes.Buffer
@@ -481,9 +839,10 @@ func (w *codeCapturingWriter) String() string {
 }
 
 type testBlindHub struct {
-	mu    sync.Mutex
-	rooms map[int]*testHubRoom
-	next  int
+	mu          sync.Mutex
+	rooms       map[int]*testHubRoom
+	handleRooms map[string]*testHubRoom
+	next        int
 }
 
 type testHubRoom struct {
@@ -513,7 +872,10 @@ func (p *testHubPeer) forward(ctx context.Context, typ websocket.MessageType, da
 }
 
 func newTestBlindHub() *testBlindHub {
-	return &testBlindHub{rooms: make(map[int]*testHubRoom)}
+	return &testBlindHub{
+		rooms:       make(map[int]*testHubRoom),
+		handleRooms: make(map[string]*testHubRoom),
+	}
 }
 
 func (h *testBlindHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -554,6 +916,40 @@ func (h *testBlindHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		switch msg.Type {
+		case "rendezvous":
+			if msg.Handle == "" {
+				return
+			}
+			h.mu.Lock()
+			r, exists := h.handleRooms[msg.Handle]
+			if !exists {
+				r = &testHubRoom{}
+				h.handleRooms[msg.Handle] = r
+			}
+			room = r
+			var otherPeer *testHubPeer
+			if msg.Role == string(rendezvous.RoleJoiner) {
+				room.joiner = self
+				role = rendezvous.RoleJoiner
+				otherPeer = room.offerer
+			} else {
+				room.offerer = self
+				role = rendezvous.RoleOfferer
+				otherPeer = room.joiner
+			}
+			h.mu.Unlock()
+
+			if otherPeer != nil {
+				self.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(role)})
+				otherRole := rendezvous.RoleOfferer
+				if role == rendezvous.RoleOfferer {
+					otherRole = rendezvous.RoleJoiner
+				}
+				otherPeer.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(otherRole)})
+			} else {
+				self.send(ctx, rendezvous.Message{Type: "created", Handle: msg.Handle})
+			}
+
 		case "create":
 			h.mu.Lock()
 			id := h.next

--- a/packages/engine/transfer/broadcast.go
+++ b/packages/engine/transfer/broadcast.go
@@ -28,10 +28,11 @@ const (
 
 // BroadcastTarget specifies one destination in a multi-device broadcast.
 type BroadcastTarget struct {
-	ID     string // Unique target identifier (e.g. DeviceID, label)
-	Label  string // Human-readable label (e.g. "Work Laptop")
-	Signal Signal // The adopted signaling connection for this target
-	Spec   Spec   // Transfer specification for this target
+	ID     string                                    // Unique target identifier (e.g. DeviceID, label)
+	Label  string                                    // Human-readable label (e.g. "Work Laptop")
+	Signal Signal                                    // The adopted signaling connection for this target (optional if Dial is provided)
+	Dial   func(ctx context.Context) (Signal, error) // Lazy dialer invoked within bounded concurrency
+	Spec   Spec                                      // Transfer specification for this target
 }
 
 // PublicOutcome is an allowlisted, secret-free summary of a completed transfer for public JSON serialization.
@@ -93,6 +94,8 @@ type BroadcastResult struct {
 type BroadcastOptions struct {
 	// Concurrency limits the number of parallel target transfers. Default is 4.
 	Concurrency int
+	// TargetTimeout limits the duration of an individual target transfer (dial + transfer), if > 0.
+	TargetTimeout time.Duration
 	// OnTargetStart is called when a target's transfer begins.
 	OnTargetStart func(target BroadcastTarget)
 	// OnTargetProgress reports progress for a specific target.
@@ -116,7 +119,8 @@ func ClassifyBroadcastError(err error) (BroadcastStatus, string) {
 	// Explicit device/peer refusal or revocation
 	if errors.Is(err, wire.ErrTrustedRejected) || errors.Is(err, wire.ErrTrustedPeerRevoked) ||
 		strings.Contains(lower, "transfer refused") || strings.Contains(lower, "peer refused") ||
-		strings.Contains(lower, "declined") || strings.Contains(lower, "rejected") {
+		strings.Contains(lower, "declined") || strings.Contains(lower, "rejected") ||
+		strings.Contains(lower, "canceled") || strings.Contains(lower, "cancelled") {
 		return StatusRefused, msg
 	}
 
@@ -180,8 +184,59 @@ func RunBroadcast(ctx context.Context, targets []BroadcastTarget, opts Broadcast
 			}
 			defer func() { <-sem }()
 
+			start := time.Now()
+
+			targetCtx := ctx
+			var cancelTarget context.CancelFunc
+			if opts.TargetTimeout > 0 {
+				targetCtx, cancelTarget = context.WithTimeout(ctx, opts.TargetTimeout)
+				defer cancelTarget()
+			}
+
 			if opts.OnTargetStart != nil {
 				opts.OnTargetStart(tgt)
+			}
+
+			sig := tgt.Signal
+			var closeSig func()
+			if sig == nil {
+				if tgt.Dial == nil {
+					dur := time.Since(start).Milliseconds()
+					results[idx] = TargetResult{
+						TargetID:   tgt.ID,
+						Label:      tgt.Label,
+						Status:     StatusFailed,
+						DurationMs: dur,
+						Error:      "no signal or dialer provided",
+					}
+					if opts.OnTargetComplete != nil {
+						opts.OnTargetComplete(tgt.ID, results[idx])
+					}
+					return
+				}
+				dialedSig, dialErr := tgt.Dial(targetCtx)
+				if dialErr != nil {
+					dur := time.Since(start).Milliseconds()
+					status, errMsg := ClassifyBroadcastError(dialErr)
+					results[idx] = TargetResult{
+						TargetID:   tgt.ID,
+						Label:      tgt.Label,
+						Status:     status,
+						DurationMs: dur,
+						Error:      errMsg,
+					}
+					if opts.OnTargetComplete != nil {
+						opts.OnTargetComplete(tgt.ID, results[idx])
+					}
+					return
+				}
+				sig = dialedSig
+				closeSig = func() {
+					dialedSig.Close()
+				}
+			}
+			if closeSig != nil {
+				defer closeSig()
 			}
 
 			// Wrap callbacks for target-specific progress reporting
@@ -205,8 +260,7 @@ func RunBroadcast(ctx context.Context, targets []BroadcastTarget, opts Broadcast
 				}
 			}
 
-			start := time.Now()
-			out, err := Run(ctx, tgt.Signal, specCopy)
+			out, err := Run(targetCtx, sig, specCopy)
 			dur := time.Since(start).Milliseconds()
 
 			if err == nil && out != nil {

--- a/packages/engine/transfer/broadcast_test.go
+++ b/packages/engine/transfer/broadcast_test.go
@@ -329,6 +329,202 @@ func TestBroadcastResult_JSON_NoSecretsExposed(t *testing.T) {
 	}
 }
 
+func TestBroadcast_LazyDialer_BoundedConcurrency(t *testing.T) {
+	numTargets := 6
+	concurrencyLimit := 2
+
+	var dialing atomic.Int64
+	var maxDialing atomic.Int64
+	var mu sync.Mutex
+
+	targets := make([]BroadcastTarget, numTargets)
+	for i := 0; i < numTargets; i++ {
+		idx := i
+		targets[i] = BroadcastTarget{
+			ID:    fmt.Sprintf("dev-%d", idx),
+			Label: fmt.Sprintf("Dev %d", idx),
+			Dial: func(_ context.Context) (Signal, error) {
+				cur := dialing.Add(1)
+				mu.Lock()
+				if cur > maxDialing.Load() {
+					maxDialing.Store(cur)
+				}
+				mu.Unlock()
+
+				time.Sleep(40 * time.Millisecond)
+				dialing.Add(-1)
+				return nil, errors.New("dial error: connection refused")
+			},
+			Spec: Spec{
+				Session: rendezvous.Options{Role: rendezvous.RoleOfferer, Words: fmt.Sprintf("w-%d", idx)},
+			},
+		}
+	}
+
+	ctx := context.Background()
+	res := RunBroadcast(ctx, targets, BroadcastOptions{
+		Concurrency: concurrencyLimit,
+	})
+
+	if res.AllOk {
+		t.Fatal("expected AllOk=false")
+	}
+	if maxDialing.Load() > int64(concurrencyLimit) {
+		t.Fatalf("observed dialing concurrency %d exceeded limit %d", maxDialing.Load(), concurrencyLimit)
+	}
+	for _, r := range res.Results {
+		if r.Status != StatusOffline {
+			t.Errorf("target %s status = %s, want offline", r.TargetID, r.Status)
+		}
+	}
+}
+
+func TestBroadcast_LazyDialer_DialErrorIsolation(t *testing.T) {
+	payload := []byte("broadcast-lazy-dial-payload")
+	meta := wire.FileMeta{Name: "lazy.txt", Size: int64(len(payload)), Mime: "text/plain"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Target 1: Dial succeeds and transfer completes
+	hub1 := newRelay()
+	destDir1 := t.TempDir()
+	recvDone1 := make(chan struct{})
+	go func() {
+		defer close(recvDone1)
+		_, _ = Run(ctx, hub1.join, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-lazy-pass"},
+			DestDir:    destDir1,
+			ICEServers: []webrtc.ICEServer{},
+		})
+	}()
+
+	target1 := BroadcastTarget{
+		ID:    "dev-1-pass",
+		Label: "Dev 1",
+		Dial: func(_ context.Context) (Signal, error) {
+			return hub1.off, nil
+		},
+		Spec: Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "lazy-pass"},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		},
+	}
+
+	// Target 2: Dial returns network connection refused (offline)
+	target2 := BroadcastTarget{
+		ID:    "dev-2-conn-refused",
+		Label: "Dev 2",
+		Dial: func(_ context.Context) (Signal, error) {
+			return nil, errors.New("dial tcp 127.0.0.1:1: connect: connection refused")
+		},
+	}
+
+	// Target 3: Dial returns peer refused/revoked
+	target3 := BroadcastTarget{
+		ID:    "dev-3-refused",
+		Label: "Dev 3",
+		Dial: func(_ context.Context) (Signal, error) {
+			return nil, wire.ErrTrustedRejected
+		},
+	}
+
+	// Target 4: Missing signal and dialer
+	target4 := BroadcastTarget{
+		ID:    "dev-4-no-dialer",
+		Label: "Dev 4",
+	}
+
+	targets := []BroadcastTarget{target1, target2, target3, target4}
+	res := RunBroadcast(ctx, targets, BroadcastOptions{
+		Concurrency: 4,
+	})
+
+	if res.AllOk {
+		t.Fatal("expected AllOk=false")
+	}
+	if len(res.Results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(res.Results))
+	}
+
+	// Target 1 must succeed despite 2, 3, and 4 failing
+	if res.Results[0].Status != StatusOk {
+		t.Errorf("target 1 status = %s, want ok (err: %s)", res.Results[0].Status, res.Results[0].Error)
+	}
+	if res.Results[1].Status != StatusOffline {
+		t.Errorf("target 2 status = %s, want offline (err: %s)", res.Results[1].Status, res.Results[1].Error)
+	}
+	if res.Results[2].Status != StatusRefused {
+		t.Errorf("target 3 status = %s, want refused (err: %s)", res.Results[2].Status, res.Results[2].Error)
+	}
+	if res.Results[3].Status != StatusFailed {
+		t.Errorf("target 4 status = %s, want failed (err: %s)", res.Results[3].Status, res.Results[3].Error)
+	}
+
+	<-recvDone1
+}
+
+func TestBroadcast_TargetTimeout(t *testing.T) {
+	payload := []byte("broadcast-timeout-payload")
+	meta := wire.FileMeta{Name: "quick.txt", Size: int64(len(payload)), Mime: "text/plain"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Target 1: Quick success
+	hub1 := newRelay()
+	destDir1 := t.TempDir()
+	recvDone1 := make(chan struct{})
+	go func() {
+		defer close(recvDone1)
+		_, _ = Run(ctx, hub1.join, Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleJoiner, Code: "7-quick-pass"},
+			DestDir:    destDir1,
+			ICEServers: []webrtc.ICEServer{},
+		})
+	}()
+
+	target1 := BroadcastTarget{
+		ID:     "dev-quick",
+		Label:  "Quick",
+		Signal: hub1.off,
+		Spec: Spec{
+			Session:    rendezvous.Options{Role: rendezvous.RoleOfferer, Words: "quick-pass"},
+			Source:     wire.BytesSource(payload, meta, 64*1024),
+			ICEServers: []webrtc.ICEServer{},
+		},
+	}
+
+	// Target 2: Dial hangs until context deadline
+	target2 := BroadcastTarget{
+		ID:    "dev-hanging",
+		Label: "Hanging",
+		Dial: func(dialCtx context.Context) (Signal, error) {
+			<-dialCtx.Done()
+			return nil, dialCtx.Err()
+		},
+	}
+
+	targets := []BroadcastTarget{target1, target2}
+	res := RunBroadcast(ctx, targets, BroadcastOptions{
+		Concurrency:   2,
+		TargetTimeout: 100 * time.Millisecond,
+	})
+
+	if res.AllOk {
+		t.Fatal("expected AllOk=false")
+	}
+	if res.Results[0].Status != StatusOk {
+		t.Errorf("target 1 status = %s, want ok", res.Results[0].Status)
+	}
+	if res.Results[1].Status != StatusOffline {
+		t.Errorf("target 2 status = %s, want offline (timeout)", res.Results[1].Status)
+	}
+
+	<-recvDone1
+}
+
 // --- Mocks for broadcast tests ---
 
 type mockClosedSignal struct{}

--- a/packages/engine/transfer/consent.go
+++ b/packages/engine/transfer/consent.go
@@ -83,7 +83,7 @@ func (c *consentDestination) Prepare(manifest wire.Manifest) error {
 			if reason == "" {
 				reason = "transfer declined by user"
 			}
-			return wire.Errorf(wire.CodeAuth, "%s", reason)
+			return wire.NewTransferError(wire.FailCanceled, reason)
 		}
 		if decision.DestDir != "" {
 			targetDir = decision.DestDir

--- a/packages/engine/transfer/driver.go
+++ b/packages/engine/transfer/driver.go
@@ -235,6 +235,9 @@ func (d *driver) run(ctx context.Context) (*Outcome, error) {
 	if d.spec.Opaque != nil {
 		opts := *d.spec.Opaque
 		opts.Transport = d
+		if d.spec.Private && !containsString(opts.LocalCaps, wire.PaddingCapability) {
+			opts.LocalCaps = append(append([]string{}, opts.LocalCaps...), wire.PaddingCapability)
+		}
 		d.opaqueSess = rendezvous.NewOpaqueSession(opts)
 		go func() {
 			<-d.opaqueSess.Done()


### PR DESCRIPTION
## Summary
- **Bound Peer Identity**: Implements full cryptographic verification for CLI targeted send (`sendbeam send <file> @target` or `--to target1,target2`) by loading local identity (`env.IdentityMgr`), validating target records and tombstones (`env.TrustStore`, `env.Tombstones`), resolving pairwise secrets (`env.Secrets.ResolvePairSecret`), parsing peer public keys, and deriving time-based opaque rendezvous handles (`wire.DeriveRendezvousHandleForTime`).
- **Bounded Dial and Transfer Concurrency**: Adds lazy `Dial` to `transfer.BroadcastTarget`. In `transfer.RunBroadcast`, workers acquire the concurrency slot semaphore before dialing, ensuring that both connection setup and file transfer honor the concurrency limit without unconstrained network socket creation.
- **Independent Outcomes & Error Isolation**: Transports each target independently. Succeeded targets report whole-file SHA-256 verified digests; unreachable or timed-out targets report `offline`; targets declining consent report `refused`. A failure or cancellation on one target does not interrupt or abort any other target.
- **Secret-Free Outputs**: Sanitizes diagnostics and excludes any cryptographic keys, seeds, invite codes, or internal parameters from structured JSON and interactive summaries.

## Verification
- Added engine transfer tests: `TestBroadcast_LazyDialer_BoundedConcurrency`, `TestBroadcast_LazyDialer_DialErrorIsolation`, `TestBroadcast_TargetTimeout`.
- Added CLI send tests: `TestExecuteSend_MissingPairSecret`, `TestExecuteSend_TargetDevice_SuccessfulSend`, `TestExecuteSend_Broadcast_MixedOutcomes`.
- Verified 100% green test suites across all packages with race detector enabled (`packages/wire`, `packages/engine`, `apps/server`, `apps/cli`, `apps/desktop`).
- Verified TypeScript/Web tests, typecheck, lint, and formatting (`pnpm run test`, `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check`, `pnpm run build`).