### PR TITLE
feat(web): browser targeted send, broadcast delivery, and incoming consent

### DIFF
--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -32,9 +32,21 @@
   } from './lib/transfer/durable-store.js';
   import QrCode from './lib/QrCode.svelte';
   import markUrl from './lib/assets/sendbeam-mark.svg';
+  import { onMount } from 'svelte';
   import DevicesModal from './lib/trust/DevicesModal.svelte';
   import IncomingTransferModal from './lib/trust/IncomingTransferModal.svelte';
-  import type { TrustedDeviceUI, IncomingTransferRequest } from './lib/trust/types.js';
+  import type {
+    TrustedDeviceUI,
+    IncomingTransferRequest,
+    BroadcastDeviceState,
+    BroadcastDeviceStatus,
+  } from './lib/trust/types.js';
+  import {
+    startTargetedSend,
+    runBroadcastSend,
+    type TargetedSendSession,
+  } from './lib/trust/targeted-send.js';
+  import { IncomingTransferCoordinator } from './lib/trust/incoming-listener.js';
   import { notifyTransferStart, notifyTransferEnd } from './lib/pwa/register.js';
 
   loadConfig();
@@ -60,7 +72,8 @@
     type ErrorLike,
   } from './lib/session/present.js';
 
-  type Screen = 'home' | 'sending' | 'receiving' | 'done' | 'failed';
+  type Screen =
+    'home' | 'sending' | 'receiving' | 'done' | 'failed' | 'targeted_send' | 'broadcast_send';
 
   /** One locally kept interrupted receive (V13-PR08). Safe metadata only — never secrets. */
   interface ReceiveJournalEntry {
@@ -141,27 +154,152 @@
   let outcome = $state<TransferOutcome | null>(null);
   let downloadUrl = $state<string | null>(null);
 
-  // Trusted Devices state (V15-PR06)
+  // Trusted Devices state (V15-PR06 & V19-PR09)
   let showDevicesModal = $state(false);
   let incomingTransfer = $state<IncomingTransferRequest | null>(null);
+  let incomingCoordinator = $state<IncomingTransferCoordinator | null>(null);
+
+  // Single targeted send state
+  let targetedRecipient = $state<TrustedDeviceUI | null>(null);
+  let targetedStatus = $state<BroadcastDeviceStatus>('pending');
+  let targetedSession = $state<TargetedSendSession | null>(null);
+
+  // Multi-send broadcast state
+  let broadcastRecipients = $state<TrustedDeviceUI[]>([]);
+  let broadcastStates = $state.raw<BroadcastDeviceState[]>([]);
+  let broadcastAllOk = $state(false);
+  let broadcastFinished = $state(false);
 
   function handleSendToTrustedDevice(dev: TrustedDeviceUI) {
-    void dev;
-    startSend();
+    reset();
+    targetedRecipient = dev;
+    if (pickedFiles.length > 0) {
+      void runTargetedTransfer(dev, pickedFiles);
+    } else {
+      screen = 'targeted_send';
+    }
   }
 
   function handleSendToTrustedDevices(devs: TrustedDeviceUI[]) {
-    void devs;
-    startSend();
+    reset();
+    broadcastRecipients = devs;
+    if (pickedFiles.length > 0) {
+      void runBroadcastTransfer(devs, pickedFiles);
+    } else {
+      screen = 'broadcast_send';
+    }
   }
 
-  function handleAcceptIncoming() {
-    incomingTransfer = null;
-    startReceive();
+  async function runTargetedTransfer(dev: TrustedDeviceUI, files: File[]) {
+    reset();
+    targetedRecipient = dev;
+    pickedFiles = files;
+    screen = 'targeted_send';
+    targetedStatus = 'connecting';
+    const ice = iceServers();
+
+    try {
+      const sess = await startTargetedSend({
+        target: dev,
+        files,
+        ...(ice ? { iceServers: ice } : {}),
+        onStateChange: (st) => {
+          targetedStatus = st;
+        },
+      });
+      targetedSession = sess;
+      beginTransfer(sess.transferCtrl);
+      sess.done
+        .then((res) => {
+          targetedStatus = 'ok';
+          outcome = res;
+          screen = 'done';
+        })
+        .catch((err: unknown) => {
+          errorText = describeError(asErrorLike(err));
+          screen = 'failed';
+        });
+    } catch (err: unknown) {
+      errorText = describeError(asErrorLike(err));
+      screen = 'failed';
+    }
   }
 
-  function handleDeclineIncoming() {
+  async function runBroadcastTransfer(devs: TrustedDeviceUI[], files: File[]) {
+    reset();
+    broadcastRecipients = devs;
+    pickedFiles = files;
+    screen = 'broadcast_send';
+    broadcastFinished = false;
+    broadcastAllOk = false;
+    const ice = iceServers();
+
+    const initialTotal = files.reduce((acc, f) => acc + f.size, 0);
+    broadcastStates = devs.map((d) => ({
+      deviceId: d.deviceId,
+      label: d.localLabel,
+      status: 'pending',
+      progressBytes: 0,
+      totalBytes: initialTotal,
+    }));
+
+    try {
+      const res = await runBroadcastSend(devs, files, {
+        ...(ice ? { iceServers: ice } : {}),
+        onTargetUpdate: (st) => {
+          const next = [...broadcastStates];
+          const idx = next.findIndex((x) => x.deviceId === st.deviceId);
+          if (idx >= 0) {
+            next[idx] = st;
+          } else {
+            next.push(st);
+          }
+          broadcastStates = next;
+        },
+      });
+      broadcastAllOk = res.allOk;
+      broadcastFinished = true;
+    } catch (err: unknown) {
+      errorText = describeError(asErrorLike(err));
+      screen = 'failed';
+    }
+  }
+
+  function onPickTargetedFiles(ev: Event) {
+    const input = ev.currentTarget as HTMLInputElement;
+    const files = canonicalizeFiles(Array.from(input.files ?? []));
+    if (files.length > 0 && targetedRecipient) {
+      void runTargetedTransfer(targetedRecipient, files);
+    }
+  }
+
+  function onPickBroadcastFiles(ev: Event) {
+    const input = ev.currentTarget as HTMLInputElement;
+    const files = canonicalizeFiles(Array.from(input.files ?? []));
+    if (files.length > 0 && broadcastRecipients.length > 0) {
+      void runBroadcastTransfer(broadcastRecipients, files);
+    }
+  }
+
+  function cancelTargetedSend() {
+    targetedSession?.cancel('cancelled by user');
+    backHome();
+  }
+
+  async function handleAcceptIncoming() {
+    const req = incomingTransfer;
     incomingTransfer = null;
+    if (req && incomingCoordinator) {
+      await incomingCoordinator.respondConsent(req.transferId, true);
+    }
+  }
+
+  async function handleDeclineIncoming() {
+    const req = incomingTransfer;
+    incomingTransfer = null;
+    if (req && incomingCoordinator) {
+      await incomingCoordinator.respondConsent(req.transferId, false, 'declined by user');
+    }
   }
 
   let controller: RendezvousController | undefined;
@@ -626,6 +764,14 @@
     activeReceiveResume = undefined;
     receiveResumeHint = '';
     resumeNote = '';
+    targetedSession?.cancel();
+    targetedSession = null;
+    targetedRecipient = null;
+    targetedStatus = 'pending';
+    broadcastRecipients = [];
+    broadcastStates = [];
+    broadcastAllOk = false;
+    broadcastFinished = false;
   }
 
   async function discardDurable() {
@@ -792,12 +938,40 @@
     void refreshReceiveJournals();
   }
 
-  // Populate the interrupted-receives AND interrupted-sends lists once the app mounts, so
-  // interrupted transfers are discoverable before a fresh rendezvous is created.
-  if (typeof window !== 'undefined') {
-    void refreshReceiveJournals();
-    void refreshSenderRecords();
-  }
+  onMount(() => {
+    if (typeof window !== 'undefined') {
+      void refreshReceiveJournals();
+      void refreshSenderRecords();
+
+      const ice = iceServers();
+      incomingCoordinator = new IncomingTransferCoordinator({
+        serverUrl: baseUrl(),
+        ...(ice ? { iceServers: ice } : {}),
+        onIncomingRequest: (req) => {
+          incomingTransfer = req;
+        },
+        onTransferStart: (_id, ctrl) => {
+          screen = 'receiving';
+          beginTransfer(ctrl);
+        },
+        onTransferComplete: (_id, out) => {
+          outcome = out;
+          screen = 'done';
+        },
+        onTransferError: (_id, err) => {
+          errorText = describeError(asErrorLike(err));
+          screen = 'failed';
+        },
+      });
+
+      void incomingCoordinator.start();
+
+      return () => {
+        incomingCoordinator?.stop();
+        incomingCoordinator = null;
+      };
+    }
+  });
 </script>
 
 <div class="backdrop" aria-hidden="true">
@@ -1069,6 +1243,199 @@
 
       <button class="ghost" onclick={backHome}>Cancel</button>
     </section>
+  {:else if screen === 'targeted_send'}
+    <section class="stage card targeted-stage">
+      {#if targetedRecipient}
+        <div class="stage-head">
+          <h2>Sending to @{targetedRecipient.localLabel}</h2>
+          <p class="muted">
+            Authenticated direct transfer to trusted device
+            <code class="fp-badge">{targetedRecipient.fingerprint}</code>
+          </p>
+        </div>
+
+        {#if pickedFiles.length === 0}
+          <div class="pick-box">
+            <p class="muted">
+              Choose the files you want to beam to <strong>@{targetedRecipient.localLabel}</strong>.
+            </p>
+            <div class="pick-actions">
+              <label class="primary btn file-input-label">
+                <span>Choose files</span>
+                <input type="file" multiple onchange={onPickTargetedFiles} style="display: none" />
+              </label>
+              <button class="ghost" onclick={backHome}>Cancel</button>
+            </div>
+          </div>
+        {:else}
+          <div class="targeted-transfer-info">
+            <div class="file-summary">
+              {#if pickedFiles.length === 1 && pickedFiles[0]}
+                <span
+                  >Sending <strong>{pickedFiles[0].name}</strong> ({humanBytes(
+                    pickedFiles[0].size,
+                  )})</span
+                >
+              {:else}
+                <span
+                  >Sending <strong>{pickedFiles.length} files</strong> ({humanBytes(
+                    totalBytes || pickedFiles.reduce((a, f) => a + f.size, 0),
+                  )})</span
+                >
+              {/if}
+            </div>
+
+            <div class="phase" aria-live="polite">
+              <span
+                class={targetedStatus === 'sending' || targetedStatus === 'ok'
+                  ? 'spinner ok'
+                  : 'spinner'}
+                aria-hidden="true"
+              ></span>
+              {#if targetedStatus === 'connecting'}
+                Connecting to @{targetedRecipient.localLabel}…
+              {:else if targetedStatus === 'sending'}
+                Sending to @{targetedRecipient.localLabel}…
+              {:else}
+                Preparing authenticated transfer…
+              {/if}
+            </div>
+
+            {#if targetedStatus === 'sending' || transfer}
+              <div class="transfer-block">
+                <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+                  <div
+                    class="bar-fill"
+                    style={`width:${progressPercent(sentBytes, totalBytes)}%`}
+                  ></div>
+                </div>
+                <p class="status" aria-live="polite">
+                  {progressLabel(sentBytes, totalBytes)}
+                </p>
+                <div class="stats">
+                  <div class="stat">
+                    <span class="stat-label">Rate</span>
+                    <span class="stat-value">{rateLabel(rateBps)}</span>
+                  </div>
+                  <div class="stat">
+                    <span class="stat-label">ETA</span>
+                    <span class="stat-value"
+                      >{etaSeconds !== undefined ? etaLabel(etaSeconds) : '—'}</span
+                    >
+                  </div>
+                </div>
+              </div>
+            {/if}
+
+            <button class="ghost" onclick={cancelTargetedSend}>Cancel</button>
+          </div>
+        {/if}
+      {/if}
+    </section>
+  {:else if screen === 'broadcast_send'}
+    <section class="stage card broadcast-stage">
+      <div class="stage-head">
+        <h2>Multi-device transfer</h2>
+        <p class="muted">
+          Broadcasting to {broadcastRecipients.length} trusted device(s) concurrently.
+        </p>
+      </div>
+
+      {#if pickedFiles.length === 0}
+        <div class="pick-box">
+          <p class="muted">Choose the files you want to broadcast to selected devices.</p>
+          <div class="pick-actions">
+            <label class="primary btn file-input-label">
+              <span>Choose files</span>
+              <input type="file" multiple onchange={onPickBroadcastFiles} style="display: none" />
+            </label>
+            <button class="ghost" onclick={backHome}>Cancel</button>
+          </div>
+        </div>
+      {:else}
+        <div class="file-summary-banner">
+          <span
+            >Payload: <strong
+              >{pickedFiles.length === 1
+                ? (pickedFiles[0]?.name ?? 'file')
+                : `${pickedFiles.length} files`}</strong
+            >
+            ({humanBytes(pickedFiles.reduce((a, f) => a + f.size, 0))})</span
+          >
+        </div>
+
+        <div class="broadcast-list">
+          {#each broadcastStates as devState}
+            <div class="broadcast-item">
+              <div class="broadcast-item-head">
+                <span class="device-label"><strong>@{devState.label}</strong></span>
+                <span class="status-badge {devState.status}">
+                  {#if devState.status === 'ok'}
+                    ✓ Verified
+                  {:else if devState.status === 'refused'}
+                    Declined
+                  {:else if devState.status === 'offline'}
+                    Offline
+                  {:else if devState.status === 'failed'}
+                    Failed
+                  {:else if devState.status === 'sending'}
+                    Sending ({progressPercent(devState.progressBytes, devState.totalBytes)}%)
+                  {:else if devState.status === 'connecting'}
+                    Connecting…
+                  {:else}
+                    Pending
+                  {/if}
+                </span>
+              </div>
+
+              {#if devState.status === 'sending'}
+                <div class="mini-bar-wrap">
+                  <div
+                    class="mini-bar-fill"
+                    style="width: {progressPercent(devState.progressBytes, devState.totalBytes)}%"
+                  ></div>
+                </div>
+              {/if}
+
+              <div class="broadcast-item-meta">
+                {#if devState.status === 'ok'}
+                  <span class="meta-digest"
+                    >SHA-256: <code
+                      >{devState.digest ? devState.digest.slice(0, 16) + '…' : '-'}</code
+                    ></span
+                  >
+                  {#if devState.durationMs}
+                    <span class="meta-duration">{(devState.durationMs / 1000).toFixed(1)}s</span>
+                  {/if}
+                {:else if devState.error}
+                  <span class="meta-error">{devState.error}</span>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        <div class="broadcast-footer">
+          {#if broadcastFinished}
+            <div class="broadcast-summary">
+              {#if broadcastAllOk}
+                <span class="summary-ok"
+                  >✓ All {broadcastStates.length} transfers completed successfully.</span
+                >
+              {:else}
+                {@const okCount = broadcastStates.filter((s) => s.status === 'ok').length}
+                <span class="summary-partial"
+                  >{okCount} of {broadcastStates.length} transfers succeeded.</span
+                >
+              {/if}
+            </div>
+            <button class="primary" onclick={backHome}>Done</button>
+          {:else}
+            <button class="ghost" onclick={backHome}>Cancel</button>
+          {/if}
+        </div>
+      {/if}
+    </section>
   {:else if screen === 'receiving'}
     <section class="stage card">
       <div class="stage-head">
@@ -1134,7 +1501,12 @@
         {:else}
           <div class="outcome">
             <p class="muted">
-              Sent <strong>{outcome.name}</strong> — verified by the receiver.
+              {#if targetedRecipient}
+                Sent <strong>{outcome.name}</strong> to
+                <strong>@{targetedRecipient.localLabel}</strong> — verified by the receiver.
+              {:else}
+                Sent <strong>{outcome.name}</strong> — verified by the receiver.
+              {/if}
             </p>
           </div>
         {/if}
@@ -2080,6 +2452,149 @@
     background: rgba(52, 211, 153, 0.07);
     border: 1px solid rgba(52, 211, 153, 0.28);
     text-align: left;
+  }
+
+  /* ————— targeted and broadcast send (V19-PR09) ————— */
+  .targeted-stage,
+  .broadcast-stage {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: stretch;
+  }
+  .pick-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-radius: 0.85rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px dashed rgba(255, 255, 255, 0.15);
+  }
+  .pick-actions {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+  }
+  .file-input-label {
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .targeted-transfer-info {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: center;
+  }
+  .file-summary-banner {
+    padding: 0.6rem 1rem;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    font-size: 0.875rem;
+    text-align: center;
+  }
+  .broadcast-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+  }
+  .broadcast-item {
+    padding: 0.85rem 1rem;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .broadcast-item-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .status-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    text-transform: capitalize;
+  }
+  .status-badge.ok {
+    background: rgba(52, 211, 153, 0.15);
+    color: #34d399;
+    border: 1px solid rgba(52, 211, 153, 0.3);
+  }
+  .status-badge.refused {
+    background: rgba(251, 191, 36, 0.15);
+    color: #fbbf24;
+    border: 1px solid rgba(251, 191, 36, 0.3);
+  }
+  .status-badge.offline {
+    background: rgba(148, 163, 184, 0.15);
+    color: #94a3b8;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+  }
+  .status-badge.failed {
+    background: rgba(248, 113, 113, 0.15);
+    color: #f87171;
+    border: 1px solid rgba(248, 113, 113, 0.3);
+  }
+  .status-badge.sending {
+    background: rgba(56, 189, 248, 0.15);
+    color: #38bdf8;
+    border: 1px solid rgba(56, 189, 248, 0.3);
+  }
+  .status-badge.connecting {
+    background: rgba(167, 139, 250, 0.15);
+    color: #a78bfa;
+    border: 1px solid rgba(167, 139, 250, 0.3);
+  }
+  .status-badge.pending {
+    background: rgba(255, 255, 255, 0.06);
+    color: #a1a1aa;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+  .mini-bar-wrap {
+    height: 4px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .mini-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #38bdf8, #818cf8);
+    transition: width 0.15s ease-out;
+  }
+  .broadcast-item-meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    color: #94a3b8;
+  }
+  .meta-error {
+    color: #f87171;
+  }
+  .broadcast-footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+  }
+  .broadcast-summary {
+    font-size: 0.9rem;
+    font-weight: 500;
+  }
+  .summary-ok {
+    color: #34d399;
+  }
+  .summary-partial {
+    color: #fbbf24;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1011,4 +1011,34 @@ describe('App transfer completion', () => {
     expect(target.textContent).toContain('armed to resume a different interrupted transfer');
     expect(target.textContent).toContain('nothing was sent');
   });
+
+  it('opens and closes trusted devices modal from the header', async () => {
+    mocks.offer.mockReturnValue({
+      code: undefined,
+      phase: 'idle',
+      done: new Promise(() => {}),
+      cancel: vi.fn(),
+      adoptSignaling: vi.fn(),
+    });
+
+    component = mount(App, { target });
+    await settle();
+
+    const devicesBtn = target.querySelector('.btn-devices-header') as HTMLButtonElement;
+    expect(devicesBtn).not.toBeNull();
+    devicesBtn.click();
+    await settle();
+
+    // Devices modal should be open
+    expect(target.querySelector('.modal-backdrop')).not.toBeNull();
+    expect(target.textContent).toContain('Trusted Devices');
+
+    // Close modal
+    const closeBtn = target.querySelector('.btn-close') as HTMLButtonElement;
+    expect(closeBtn).not.toBeNull();
+    closeBtn.click();
+    await settle();
+
+    expect(target.querySelector('.modal-backdrop')).toBeNull();
+  });
 });

--- a/apps/web/src/lib/session/opaque-rendezvous.ts
+++ b/apps/web/src/lib/session/opaque-rendezvous.ts
@@ -1,0 +1,199 @@
+/**
+ * Browser opaque rendezvous controller (V19-PR09).
+ * Bridges WebSocket signaling with pure OpaqueRendezvousSession state machine for sendbeam/3.
+ */
+
+import {
+  OpaqueRendezvousSession,
+  deriveTransferKeys,
+  type DeviceIdentity,
+  type Feature,
+  type OpaqueRendezvousPhase,
+  type RendezvousResult,
+  type Role,
+  type SignalMsg,
+} from '@sendbeam/protocol';
+import { SignalingClient, type BackoffOptions, type SignalChannel } from '../signaling/client.js';
+
+function defaultSignalingUrl(): string {
+  if (typeof window !== 'undefined' && window.location) {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${proto}//${window.location.host}/ws`;
+  }
+  return 'ws://localhost:8443/ws';
+}
+
+export interface OpaqueControllerOptions {
+  url?: string;
+  role: Role;
+  handle: string;
+  localIdentity: DeviceIdentity;
+  peerDeviceId: string;
+  peerPublicKey: string | Uint8Array;
+  kPair: Uint8Array;
+  pairCredentialRef: string;
+  localCapabilities?: string[];
+  onPhase?: (phase: OpaqueRendezvousPhase) => void;
+  backoff?: Partial<BackoffOptions>;
+  timeoutMs?: number;
+}
+
+export interface OpaqueRendezvousController {
+  readonly handle: string;
+  readonly phase: OpaqueRendezvousPhase;
+  readonly done: Promise<RendezvousResult>;
+  cancel(reason?: string): void;
+  adoptSignaling(): SignalChannel;
+}
+
+export function createOpaqueRendezvous(opts: OpaqueControllerOptions): OpaqueRendezvousController {
+  const url = opts.url ?? defaultSignalingUrl();
+  let route: (msg: SignalMsg) => void = (msg) => {
+    void session.handleMessage(msg);
+  };
+  let routeBinary: (frame: ArrayBuffer) => void = () => {
+    // Unexpected binary frame before transfer
+  };
+  let routeClose: (err: Error) => void = () => {
+    // Socket closed unexpectedly
+  };
+  let adopted = false;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const client = new SignalingClient({
+    url,
+    onMessage: (msg) => route(msg),
+    onBinary: (frame) => routeBinary(frame),
+    onClose: (clean, code, reason) => {
+      routeClose(
+        new Error(clean ? `signaling closed (${code})` : `signaling lost (${code} ${reason})`),
+      );
+    },
+    onError: () => {
+      // Ignored here; handled by session or close
+    },
+    ...(opts.backoff !== undefined ? { backoff: opts.backoff } : {}),
+  });
+
+  const session = new OpaqueRendezvousSession({
+    role: opts.role,
+    handle: opts.handle,
+    localIdentity: opts.localIdentity,
+    peerDeviceId: opts.peerDeviceId,
+    peerPublicKey: opts.peerPublicKey,
+    kPair: opts.kPair,
+    pairCredentialRef: opts.pairCredentialRef,
+    ...(opts.localCapabilities ? { localCapabilities: opts.localCapabilities } : {}),
+    send: (msg) => client.send(msg as SignalMsg),
+    ...(opts.onPhase ? { onPhase: opts.onPhase } : {}),
+    ...(opts.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}),
+  });
+
+  const donePromise = (async (): Promise<RendezvousResult> => {
+    let timeoutPromise: Promise<never> | undefined;
+    if (opts.timeoutMs && opts.timeoutMs > 0) {
+      timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutTimer = setTimeout(() => {
+          reject(new Error('timeout: peer unreachable or offline'));
+        }, opts.timeoutMs);
+      });
+    }
+
+    try {
+      await client.connect();
+      await session.start();
+
+      const ores = timeoutPromise
+        ? await Promise.race([session.result, timeoutPromise])
+        : await session.result;
+
+      clearTimeout(timeoutTimer);
+      const keys = await deriveTransferKeys(ores.master);
+
+      const features = (
+        ores.negotiatedCaps && ores.negotiatedCaps.length > 0
+          ? ores.negotiatedCaps
+          : ['transfer.v1', 'padding']
+      ) as Feature[];
+
+      const res: RendezvousResult = {
+        role: ores.role,
+        code: ores.handle,
+        master: ores.master,
+        keys,
+        authKeys: {
+          sign: ores.sendKey,
+          verify: ores.recvKey,
+        },
+        localCaps: {
+          version: 'sendbeam/3',
+          maxFrame: 65536,
+          blockSize: 1048576,
+          features,
+          sinkHints: [],
+        },
+        remoteCaps: {
+          version: 'sendbeam/3',
+          maxFrame: 65536,
+          blockSize: 1048576,
+          features,
+          sinkHints: [],
+        },
+        sendCounter: 0,
+        recvCounter: 0,
+      };
+
+      // Defer auto-close so adoptSignaling can be called
+      setTimeout(() => void (adopted || client.close()), 0);
+      return res;
+    } catch (err: unknown) {
+      clearTimeout(timeoutTimer);
+      client.close();
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+  })();
+
+  return {
+    get handle() {
+      return opts.handle;
+    },
+    get phase() {
+      return session.getPhase();
+    },
+    done: donePromise,
+    cancel: () => {
+      clearTimeout(timeoutTimer);
+      client.close();
+    },
+    adoptSignaling: () => {
+      adopted = true;
+      return {
+        send: (msg) => client.send(msg),
+        sendBinary: (frame) => client.sendBinary(frame),
+        onMessage: (h) => {
+          route = h;
+        },
+        onBinary: (h) => {
+          routeBinary = h;
+        },
+        onClose: (h) => {
+          routeClose = h;
+        },
+        setResume: (room, role) => client.setResume(room, role),
+        close: () => client.close(),
+      };
+    },
+  };
+}
+
+export function opaqueOffer(
+  opts: Omit<OpaqueControllerOptions, 'role'>,
+): OpaqueRendezvousController {
+  return createOpaqueRendezvous({ ...opts, role: 'offerer' });
+}
+
+export function opaqueJoin(
+  opts: Omit<OpaqueControllerOptions, 'role'>,
+): OpaqueRendezvousController {
+  return createOpaqueRendezvous({ ...opts, role: 'joiner' });
+}

--- a/apps/web/src/lib/session/transfer.ts
+++ b/apps/web/src/lib/session/transfer.ts
@@ -148,11 +148,19 @@ export function runReceive(
   rendezvous: RendezvousResult,
   signaling: SignalChannel,
   destination: ReceiveDestinationSpec = { kind: 'auto' },
-  opts: { iceServers?: RTCIceServer[]; resumeAttempt?: HostResumeAttempt } = {},
+  opts: {
+    iceServers?: RTCIceServer[];
+    resumeAttempt?: HostResumeAttempt;
+    onConsent?: (manifest: {
+      files: Array<{ name: string; size: number }>;
+      totalSize: number;
+    }) => Promise<boolean> | boolean;
+  } = {},
 ): TransferController {
   return run(rendezvous, signaling, {
     role: 'receive',
     ...(opts.iceServers ? { iceServers: opts.iceServers } : {}),
+    ...(opts.onConsent ? { onConsent: opts.onConsent } : {}),
     start: async () => ({
       kind: 'start-recv',
       destination,
@@ -174,6 +182,10 @@ interface RunSpec {
   total?: number;
   /** Operator-published ICE servers for direct-path candidate gathering. */
   iceServers?: RTCIceServer[];
+  onConsent?: (manifest: {
+    files: Array<{ name: string; size: number }>;
+    totalSize: number;
+  }) => Promise<boolean> | boolean;
   start: () => Promise<HostToWorker>;
 }
 
@@ -294,11 +306,13 @@ function run(
   const gen = generation.capture();
   void (async () => {
     try {
-      const auth = SignalAuthenticator.fromSession(
-        rendezvous.role,
-        rendezvous.room,
-        rendezvous.spake2,
-      );
+      const auth = rendezvous.authKeys
+        ? new SignalAuthenticator(0, rendezvous.authKeys)
+        : SignalAuthenticator.fromSession(
+            rendezvous.role,
+            rendezvous.room ?? 0,
+            rendezvous.spake2!,
+          );
       const p = createPeer({
         role: rendezvous.role,
         auth,
@@ -350,7 +364,9 @@ function run(
       // Arm post-establishment signaling reconnect with the persistent room/role, so a signaling
       // drop on a healthy direct path re-attaches to the room and a later ICE-restart
       // renegotiation can still exchange its SDP/ICE frames (V12-PR04 signaling recovery).
-      signaling.setResume(rendezvous.room, rendezvous.role);
+      if (rendezvous.room !== undefined) {
+        signaling.setResume(rendezvous.room, rendezvous.role);
+      }
 
       const w = new Worker(new URL('../transfer/transfer.worker.ts', import.meta.url), {
         type: 'module',
@@ -459,6 +475,24 @@ function run(
           case 'manifest':
             total = msg.totalSize;
             progress.setTotal(msg.totalSize);
+            if (spec.onConsent) {
+              void Promise.resolve(
+                spec.onConsent({
+                  files: msg.files,
+                  totalSize: msg.totalSize,
+                }),
+              )
+                .then((accepted) => {
+                  if (!accepted) {
+                    fail(new Error('transfer declined by user'));
+                    worker?.postMessage({ kind: 'control', op: 'cancel' } satisfies HostToWorker);
+                  }
+                })
+                .catch((err) => {
+                  fail(err instanceof Error ? err : new Error(String(err)));
+                  worker?.postMessage({ kind: 'control', op: 'cancel' } satisfies HostToWorker);
+                });
+            }
             return;
           case 'durable':
             durableInfo = { ...msg };

--- a/apps/web/src/lib/trust/IncomingTransferModal.test.ts
+++ b/apps/web/src/lib/trust/IncomingTransferModal.test.ts
@@ -1,0 +1,140 @@
+/** @vitest-environment jsdom */
+
+import { mount, tick, unmount } from 'svelte';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import IncomingTransferModal from './IncomingTransferModal.svelte';
+import type { IncomingTransferRequest } from './types.js';
+
+describe('IncomingTransferModal Component', () => {
+  let target: HTMLDivElement;
+  let component: ReturnType<typeof mount> | null = null;
+
+  beforeEach(() => {
+    target = document.createElement('div');
+    document.body.appendChild(target);
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    target.remove();
+  });
+
+  it('renders nothing when request is null', () => {
+    component = mount(IncomingTransferModal, {
+      target,
+      props: {
+        request: null,
+        onAccept: vi.fn(),
+        onDecline: vi.fn(),
+      },
+    });
+
+    expect(target.querySelector('.modal-backdrop')).toBeNull();
+  });
+
+  it('renders request details and triggers onAccept', async () => {
+    const onAccept = vi.fn();
+    const onDecline = vi.fn();
+
+    const request: IncomingTransferRequest = {
+      transferId: 'req-123',
+      senderDeviceId: 'sb-dev-phone123',
+      senderLabel: 'Pixel 8 Pro',
+      senderFingerprint: 'A1B2 C3D4',
+      fileCount: 2,
+      totalBytes: 2048,
+      files: [
+        { name: 'photo1.jpg', size: 1024 },
+        { name: 'photo2.jpg', size: 1024 },
+      ],
+    };
+
+    component = mount(IncomingTransferModal, {
+      target,
+      props: {
+        request,
+        onAccept,
+        onDecline,
+      },
+    });
+
+    expect(target.querySelector('.modal-backdrop')).not.toBeNull();
+    expect(target.textContent).toContain('Pixel 8 Pro');
+    expect(target.textContent).toContain('A1B2 C3D4');
+    expect(target.textContent).toContain('2 file(s)');
+    expect(target.textContent).toContain('photo1.jpg');
+    expect(target.textContent).toContain('photo2.jpg');
+
+    const acceptBtn = target.querySelector('.btn-accept') as HTMLButtonElement;
+    expect(acceptBtn).not.toBeNull();
+    acceptBtn.click();
+    await tick();
+
+    expect(onAccept).toHaveBeenCalledOnce();
+    expect(onDecline).not.toHaveBeenCalled();
+  });
+
+  it('triggers onDecline when decline button clicked', async () => {
+    const onAccept = vi.fn();
+    const onDecline = vi.fn();
+
+    const request: IncomingTransferRequest = {
+      transferId: 'req-456',
+      senderDeviceId: 'sb-dev-unknown',
+      senderLabel: 'Unknown Device',
+      senderFingerprint: '9988 7766',
+      fileCount: 1,
+      totalBytes: 500,
+      files: [{ name: 'secret.zip', size: 500 }],
+    };
+
+    component = mount(IncomingTransferModal, {
+      target,
+      props: {
+        request,
+        onAccept,
+        onDecline,
+      },
+    });
+
+    const declineBtn = target.querySelector('.btn-decline') as HTMLButtonElement;
+    expect(declineBtn).not.toBeNull();
+    declineBtn.click();
+    await tick();
+
+    expect(onDecline).toHaveBeenCalledOnce();
+    expect(onAccept).not.toHaveBeenCalled();
+  });
+
+  it('truncates file list when more than 5 files are sent', () => {
+    const files = Array.from({ length: 8 }, (_, i) => ({
+      name: `file_${i + 1}.txt`,
+      size: 100,
+    }));
+
+    const request: IncomingTransferRequest = {
+      transferId: 'req-multi',
+      senderDeviceId: 'sb-dev-sender',
+      senderLabel: 'Work Desktop',
+      senderFingerprint: '1122 3344',
+      fileCount: files.length,
+      totalBytes: 800,
+      files,
+    };
+
+    component = mount(IncomingTransferModal, {
+      target,
+      props: {
+        request,
+        onAccept: vi.fn(),
+        onDecline: vi.fn(),
+      },
+    });
+
+    expect(target.querySelectorAll('.file-item')).toHaveLength(5);
+    expect(target.textContent).toContain('+ 3 more file(s)');
+  });
+});

--- a/apps/web/src/lib/trust/devices.ts
+++ b/apps/web/src/lib/trust/devices.ts
@@ -44,6 +44,12 @@ declare global {
             dest: string,
           ): Promise<TrustedDeviceUI>;
         };
+        TransferService?: {
+          RespondConsent(
+            transferId: string,
+            decision: { accepted: boolean; destDir?: string; reason?: string },
+          ): Promise<void>;
+        };
       };
     };
     runtime?: {

--- a/apps/web/src/lib/trust/incoming-listener.test.ts
+++ b/apps/web/src/lib/trust/incoming-listener.test.ts
@@ -1,0 +1,501 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { IncomingTransferCoordinator } from './incoming-listener.js';
+import { resetBrowserStoresForTesting } from './devices.js';
+import {
+  generateDeviceIdentity,
+  bytesToHex,
+  MemoryTrustStore,
+  MemoryTombstoneStore,
+  MemorySecretResolver,
+  signRevocation,
+} from '@sendbeam/protocol';
+import type { IncomingTransferRequest } from './types.js';
+
+const mocks = vi.hoisted(() => ({
+  opaqueJoin: vi.fn(),
+  runReceive: vi.fn(),
+}));
+
+vi.mock('../session/opaque-rendezvous.js', () => ({
+  opaqueJoin: mocks.opaqueJoin,
+}));
+
+vi.mock('../session/transfer.js', () => ({
+  runReceive: mocks.runReceive,
+}));
+
+describe('IncomingTransferCoordinator', () => {
+  let trustStore: MemoryTrustStore;
+  let tombstoneStore: MemoryTombstoneStore;
+  let secretStore: MemorySecretResolver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    if (typeof window !== 'undefined') {
+      delete (window as unknown as Record<string, unknown>).go;
+      delete (window as unknown as Record<string, unknown>).runtime;
+    }
+    trustStore = new MemoryTrustStore();
+    tombstoneStore = new MemoryTombstoneStore();
+    secretStore = new MemorySecretResolver();
+    resetBrowserStoresForTesting(trustStore, secretStore, tombstoneStore);
+  });
+
+  afterEach(() => {
+    if (typeof window !== 'undefined') {
+      delete (window as unknown as Record<string, unknown>).go;
+      delete (window as unknown as Record<string, unknown>).runtime;
+    }
+  });
+
+  describe('Desktop mode (Wails bridge)', () => {
+    it('subscribes to sendbeam:consent and delegates decision to TransferService', async () => {
+      let eventCallback: ((data: unknown) => void) | null = null;
+      let cleanupCalled = false;
+      let respondCalledWith: [string, unknown] | null = null;
+
+      globalThis.window = {
+        go: {
+          engine: {
+            DeviceService: {},
+            TransferService: {
+              RespondConsent: async (id: string, decision: unknown) => {
+                respondCalledWith = [id, decision];
+              },
+            },
+          },
+        },
+        runtime: {
+          EventsOn: (evt: string, cb: (data: unknown) => void) => {
+            if (evt === 'sendbeam:consent') {
+              eventCallback = cb;
+            }
+            return () => {
+              cleanupCalled = true;
+            };
+          },
+        },
+      } as unknown as Window & typeof globalThis;
+
+      let incomingReq: IncomingTransferRequest | null = null;
+      const coordinator = new IncomingTransferCoordinator({
+        onIncomingRequest: (req) => {
+          incomingReq = req;
+        },
+      });
+
+      await coordinator.start();
+      expect(eventCallback).toBeDefined();
+
+      // Trigger incoming consent event from native desktop engine
+      eventCallback!({
+        transferId: 'tx-desktop-1',
+        peerDeviceId: 'sb-dev-desktop-peer',
+        peerLabel: 'MacBook Studio',
+        files: [{ name: 'presentation.key', size: 1024 * 1024 }],
+        totalSize: 1024 * 1024,
+      });
+
+      const req = incomingReq as IncomingTransferRequest | null;
+      expect(req).not.toBeNull();
+      expect(req?.transferId).toBe('tx-desktop-1');
+      expect(req?.senderLabel).toBe('MacBook Studio');
+      expect(req?.fileCount).toBe(1);
+      expect(req?.totalBytes).toBe(1024 * 1024);
+
+      // Respond accept
+      await coordinator.respondConsent('tx-desktop-1', true);
+      expect(respondCalledWith).toEqual(['tx-desktop-1', { accepted: true }]);
+
+      // Respond decline
+      await coordinator.respondConsent('tx-desktop-1', false, 'user declined');
+      expect(respondCalledWith).toEqual([
+        'tx-desktop-1',
+        { accepted: false, reason: 'user declined' },
+      ]);
+
+      // Stop coordinator
+      coordinator.stop();
+      expect(cleanupCalled).toBe(true);
+    });
+  });
+
+  describe('Browser mode (Opaque Rendezvous)', () => {
+    it('spawns listeners for active devices and ignores revoked or missing secrets', async () => {
+      const activePeer = await generateDeviceIdentity();
+      const revokedPeer = await generateDeviceIdentity();
+      const tombstonedPeer = await generateDeviceIdentity();
+      const noSecretPeer = await generateDeviceIdentity();
+
+      const kPair = new Uint8Array(32).fill(12);
+
+      // 1. Active device
+      await trustStore.addOrUpdateDevice({
+        deviceId: activePeer.deviceId,
+        localLabel: 'Active Phone',
+        publicKey: bytesToHex(activePeer.publicKey),
+        pairCredentialRef: 'cred-1',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(activePeer.deviceId, kPair);
+
+      // 2. Revoked device in trust store
+      await trustStore.addOrUpdateDevice({
+        deviceId: revokedPeer.deviceId,
+        localLabel: 'Revoked Phone',
+        publicKey: bytesToHex(revokedPeer.publicKey),
+        pairCredentialRef: 'cred-2',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: true,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(revokedPeer.deviceId, kPair);
+
+      // 3. Tombstoned device
+      await trustStore.addOrUpdateDevice({
+        deviceId: tombstonedPeer.deviceId,
+        localLabel: 'Tombstoned Tablet',
+        publicKey: bytesToHex(tombstonedPeer.publicKey),
+        pairCredentialRef: 'cred-3',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(tombstonedPeer.deviceId, kPair);
+      const rec = await signRevocation(activePeer, tombstonedPeer.deviceId, 1);
+      await tombstoneStore.storeTombstone(rec);
+
+      // 4. Device without pair secret
+      await trustStore.addOrUpdateDevice({
+        deviceId: noSecretPeer.deviceId,
+        localLabel: 'No Secret Peer',
+        publicKey: bytesToHex(noSecretPeer.publicKey),
+        pairCredentialRef: 'cred-4',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+
+      const cancelFn = vi.fn();
+      mocks.opaqueJoin.mockReturnValue({
+        handle: 'h1',
+        phase: 'listening',
+        done: new Promise(() => {}), // keeps listening
+        adoptSignaling: vi.fn(),
+        cancel: cancelFn,
+      });
+
+      const coordinator = new IncomingTransferCoordinator();
+      await coordinator.start();
+
+      // Only activePeer should have an opaqueJoin listener spawned
+      expect(mocks.opaqueJoin).toHaveBeenCalledTimes(1);
+      expect(mocks.opaqueJoin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          peerDeviceId: activePeer.deviceId,
+          kPair,
+        }),
+      );
+
+      coordinator.stop();
+      expect(cancelFn).toHaveBeenCalledWith('listener stopped');
+    });
+
+    it('handles auto-accept transfers without prompting user', async () => {
+      const peer = await generateDeviceIdentity();
+      const kPair = new Uint8Array(32).fill(15);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: peer.deviceId,
+        localLabel: 'Auto Accept Laptop',
+        publicKey: bytesToHex(peer.publicKey),
+        pairCredentialRef: 'cred-auto',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true }, // AUTO ACCEPT = TRUE
+      });
+      await secretStore.setPairSecret(peer.deviceId, kPair);
+
+      let resolveJoin!: (res: unknown) => void;
+      const joinDone = new Promise((res) => {
+        resolveJoin = res;
+      });
+
+      const fakeSignaling = { send: vi.fn(), close: vi.fn() };
+      mocks.opaqueJoin.mockReturnValue({
+        handle: 'h-auto',
+        phase: 'listening',
+        done: joinDone,
+        adoptSignaling: vi.fn(() => fakeSignaling),
+        cancel: vi.fn(),
+      });
+
+      const expectedOutcome = {
+        files: [{ name: 'auto.pdf', size: 50, sha256: 'xyz' }],
+        digest: 'sha256-xyz',
+        bytesTransferred: 50,
+        durationMs: 20,
+      };
+
+      let consentCallback:
+        | ((manifest: {
+            files: Array<{ name: string; size: number }>;
+            totalSize: number;
+          }) => Promise<boolean>)
+        | undefined;
+
+      mocks.runReceive.mockImplementation((_rendezvous, _signaling, _dest, opts) => {
+        consentCallback = opts?.onConsent;
+        return {
+          progress: () => 50,
+          done: Promise.resolve(expectedOutcome),
+          cancel: vi.fn(),
+        };
+      });
+
+      let promptCalled = false;
+      let transferStarted = false;
+      let completedOutcome: unknown = null;
+
+      const coordinator = new IncomingTransferCoordinator({
+        onIncomingRequest: () => {
+          promptCalled = true;
+        },
+        onTransferStart: () => {
+          transferStarted = true;
+        },
+        onTransferComplete: (_id, out) => {
+          completedOutcome = out;
+        },
+      });
+
+      await coordinator.start();
+
+      // Resolve rendezvous handshake
+      resolveJoin({
+        role: 'joiner',
+        sessionKey: new Uint8Array(32),
+        authKeys: { sign: new Uint8Array(32), verify: new Uint8Array(32) },
+      });
+
+      // Allow microtasks to settle
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mocks.runReceive).toHaveBeenCalled();
+      expect(consentCallback).toBeDefined();
+
+      // Trigger consent hook: should return true automatically without user prompt
+      const consentResult = await consentCallback!({
+        files: [{ name: 'auto.pdf', size: 50 }],
+        totalSize: 50,
+      });
+
+      expect(consentResult).toBe(true);
+      expect(promptCalled).toBe(false);
+
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(transferStarted).toBe(true);
+      expect(completedOutcome).toEqual(expectedOutcome);
+
+      coordinator.stop();
+    });
+
+    it('prompts user and handles consent acceptance', async () => {
+      const peer = await generateDeviceIdentity();
+      const kPair = new Uint8Array(32).fill(21);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: peer.deviceId,
+        localLabel: 'Manual Accept Laptop',
+        publicKey: bytesToHex(peer.publicKey),
+        pairCredentialRef: 'cred-manual',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: false }, // AUTO ACCEPT = FALSE
+      });
+      await secretStore.setPairSecret(peer.deviceId, kPair);
+
+      let resolveJoin!: (res: unknown) => void;
+      const joinDone = new Promise((res) => {
+        resolveJoin = res;
+      });
+
+      mocks.opaqueJoin.mockReturnValue({
+        handle: 'h-manual',
+        phase: 'listening',
+        done: joinDone,
+        adoptSignaling: vi.fn(() => ({ send: vi.fn(), close: vi.fn() })),
+        cancel: vi.fn(),
+      });
+
+      let consentCallback:
+        | ((manifest: {
+            files: Array<{ name: string; size: number }>;
+            totalSize: number;
+          }) => Promise<boolean>)
+        | undefined;
+
+      mocks.runReceive.mockImplementation((_rendezvous, _signaling, _dest, opts) => {
+        consentCallback = opts?.onConsent;
+        return {
+          progress: () => 100,
+          done: Promise.resolve({ digest: 'digest-manual' }),
+          cancel: vi.fn(),
+        };
+      });
+
+      let incomingRequest: IncomingTransferRequest | null = null;
+
+      const coordinator = new IncomingTransferCoordinator({
+        onIncomingRequest: (req) => {
+          incomingRequest = req;
+        },
+      });
+
+      await coordinator.start();
+
+      resolveJoin({
+        role: 'joiner',
+        sessionKey: new Uint8Array(32),
+        authKeys: { sign: new Uint8Array(32), verify: new Uint8Array(32) },
+      });
+
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(consentCallback).toBeDefined();
+
+      // Start consent inquiry
+      const consentPromise = consentCallback!({
+        files: [{ name: 'manual.pdf', size: 100 }],
+        totalSize: 100,
+      });
+
+      await Promise.resolve();
+      const manualReq = incomingRequest as IncomingTransferRequest | null;
+      expect(manualReq).not.toBeNull();
+      expect(manualReq?.senderLabel).toBe('Manual Accept Laptop');
+      expect(manualReq?.fileCount).toBe(1);
+
+      // Accept consent
+      await coordinator.respondConsent(manualReq!.transferId, true);
+
+      const decision = await consentPromise;
+      expect(decision).toBe(true);
+
+      coordinator.stop();
+    });
+
+    it('prompts user and handles consent decline', async () => {
+      const peer = await generateDeviceIdentity();
+      const kPair = new Uint8Array(32).fill(25);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: peer.deviceId,
+        localLabel: 'Decline Laptop',
+        publicKey: bytesToHex(peer.publicKey),
+        pairCredentialRef: 'cred-decline',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: false },
+      });
+      await secretStore.setPairSecret(peer.deviceId, kPair);
+
+      let resolveJoin!: (res: unknown) => void;
+      const joinDone = new Promise((res) => {
+        resolveJoin = res;
+      });
+
+      mocks.opaqueJoin.mockReturnValue({
+        handle: 'h-decline',
+        phase: 'listening',
+        done: joinDone,
+        adoptSignaling: vi.fn(() => ({ send: vi.fn(), close: vi.fn() })),
+        cancel: vi.fn(),
+      });
+
+      let consentCallback:
+        | ((manifest: {
+            files: Array<{ name: string; size: number }>;
+            totalSize: number;
+          }) => Promise<boolean>)
+        | undefined;
+
+      mocks.runReceive.mockImplementation((_rendezvous, _signaling, _dest, opts) => {
+        consentCallback = opts?.onConsent;
+        return {
+          progress: () => 0,
+          done: Promise.reject(new Error('transfer declined by user')),
+          cancel: vi.fn(),
+        };
+      });
+
+      let incomingRequest: IncomingTransferRequest | null = null;
+      let reportedError: Error | null = null;
+
+      const coordinator = new IncomingTransferCoordinator({
+        onIncomingRequest: (req) => {
+          incomingRequest = req;
+        },
+        onTransferError: (_id, err) => {
+          reportedError = err;
+        },
+      });
+
+      await coordinator.start();
+
+      resolveJoin({
+        role: 'joiner',
+        sessionKey: new Uint8Array(32),
+        authKeys: { sign: new Uint8Array(32), verify: new Uint8Array(32) },
+      });
+
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 10));
+
+      const consentPromise = consentCallback!({
+        files: [{ name: 'decline.pdf', size: 200 }],
+        totalSize: 200,
+      });
+
+      await Promise.resolve();
+      const declineReq = incomingRequest as IncomingTransferRequest | null;
+      expect(declineReq).not.toBeNull();
+
+      // Decline consent
+      await coordinator.respondConsent(declineReq!.transferId, false, 'not authorized');
+
+      const decision = await consentPromise;
+      expect(decision).toBe(false);
+
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 10));
+
+      const err = reportedError as Error | null;
+      expect(err).not.toBeNull();
+      expect(err?.message).toContain('declined');
+
+      coordinator.stop();
+    });
+  });
+});

--- a/apps/web/src/lib/trust/incoming-listener.ts
+++ b/apps/web/src/lib/trust/incoming-listener.ts
@@ -1,0 +1,282 @@
+/**
+ * Browser incoming transfer listener and consent coordinator (V19-PR09).
+ * Manages opaque rendezvous listener sockets in pure browser mode,
+ * handles user consent prompts via IncomingTransferModal,
+ * and bridges Wails v3 sendbeam:consent events in desktop mode.
+ */
+
+import {
+  deriveRendezvousHandleForTime,
+  formatFingerprint,
+  getOrCreateBrowserIdentity,
+  hexToBytes,
+  type TrustRecord,
+} from '@sendbeam/protocol';
+import { getBrowserStores, isDesktopApp } from './devices.js';
+import type { IncomingTransferRequest } from './types.js';
+import { opaqueJoin, type OpaqueRendezvousController } from '../session/opaque-rendezvous.js';
+import { runReceive, type TransferController, type TransferOutcome } from '../session/transfer.js';
+
+export interface IncomingListenerOptions {
+  serverUrl?: string;
+  iceServers?: RTCIceServer[];
+  onIncomingRequest?: (request: IncomingTransferRequest) => void;
+  onTransferStart?: (transferId: string, controller: TransferController) => void;
+  onTransferComplete?: (transferId: string, outcome: TransferOutcome) => void;
+  onTransferError?: (transferId: string, err: Error) => void;
+}
+
+export class IncomingTransferCoordinator {
+  private running = false;
+  private readonly options: IncomingListenerOptions;
+  private activeListeners = new Map<string, OpaqueRendezvousController>();
+  private startingListeners = new Set<string>();
+  private pendingConsents = new Map<string, (accepted: boolean) => void>();
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private desktopConsentCleanup: (() => void) | null = null;
+
+  constructor(options: IncomingListenerOptions = {}) {
+    this.options = options;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    // Desktop app delegates listening to native engine and receives events
+    if (isDesktopApp() && typeof window !== 'undefined' && window.runtime?.EventsOn) {
+      this.desktopConsentCleanup = window.runtime.EventsOn('sendbeam:consent', (data: unknown) => {
+        this.handleDesktopConsentEvent(data);
+      });
+      return;
+    }
+
+    // Pure browser mode: listen on opaque rendezvous handles
+    await this.refreshListeners();
+    this.refreshTimer = setInterval(
+      () => {
+        void this.refreshListeners();
+      },
+      3 * 60 * 1000,
+    ); // refresh every 3 minutes
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    if (this.desktopConsentCleanup) {
+      this.desktopConsentCleanup();
+      this.desktopConsentCleanup = null;
+    }
+    for (const ctrl of this.activeListeners.values()) {
+      ctrl.cancel('listener stopped');
+    }
+    this.activeListeners.clear();
+    this.startingListeners.clear();
+    for (const resolve of this.pendingConsents.values()) {
+      resolve(false);
+    }
+    this.pendingConsents.clear();
+  }
+
+  async respondConsent(transferId: string, accepted: boolean, reason?: string): Promise<void> {
+    if (isDesktopApp() && window.go?.engine?.TransferService?.RespondConsent) {
+      const decision = {
+        accepted,
+        ...(reason ? { reason } : {}),
+      };
+      await window.go.engine.TransferService.RespondConsent(transferId, decision);
+      return;
+    }
+
+    const resolver = this.pendingConsents.get(transferId);
+    if (resolver) {
+      this.pendingConsents.delete(transferId);
+      resolver(accepted);
+    }
+  }
+
+  private handleDesktopConsentEvent(data: unknown): void {
+    if (!data || typeof data !== 'object') return;
+    const req = data as Record<string, unknown>;
+    const transferId = String(req['transferId'] || '');
+    const peerDeviceId = String(req['peerDeviceId'] || '');
+    const peerLabel = String(req['peerLabel'] || peerDeviceId);
+    const totalSize = Number(req['totalSize'] || 0);
+
+    let files: Array<{ name: string; size: number }> = [];
+    if (Array.isArray(req['files'])) {
+      files = req['files'].map((f: Record<string, unknown>) => ({
+        name: String(f['name'] || ''),
+        size: Number(f['size'] || 0),
+      }));
+    }
+
+    const incomingReq: IncomingTransferRequest = {
+      transferId,
+      senderDeviceId: peerDeviceId,
+      senderLabel: peerLabel,
+      senderFingerprint: peerDeviceId.slice(0, 16),
+      fileCount: files.length > 0 ? files.length : 1,
+      totalBytes: totalSize,
+      files,
+    };
+
+    this.options.onIncomingRequest?.(incomingReq);
+  }
+
+  private async refreshListeners(): Promise<void> {
+    if (!this.running) return;
+
+    try {
+      const { trustStore, secretStore, tombstoneStore } = getBrowserStores();
+      const devices = await trustStore.listDevices();
+      const localId = await getOrCreateBrowserIdentity();
+
+      const activeDevIds = new Set<string>();
+
+      for (const dev of devices) {
+        if (dev.revoked) continue;
+        if (tombstoneStore && (await tombstoneStore.hasTombstone(dev.deviceId))) continue;
+
+        const kPair = await secretStore?.resolvePairSecret(dev.deviceId, dev.pairCredentialRef);
+        if (!kPair || kPair.length === 0) continue;
+
+        activeDevIds.add(dev.deviceId);
+
+        if (!this.activeListeners.has(dev.deviceId) && !this.startingListeners.has(dev.deviceId)) {
+          await this.startListeningForDevice(dev, kPair, localId);
+        }
+      }
+
+      // Prune listeners for devices no longer active
+      for (const [id, ctrl] of this.activeListeners.entries()) {
+        if (!activeDevIds.has(id)) {
+          ctrl.cancel('device unshared or revoked');
+          this.activeListeners.delete(id);
+        }
+      }
+    } catch {
+      // Ignored; retry on next tick
+    }
+  }
+
+  private async startListeningForDevice(
+    dev: TrustRecord,
+    kPair: Uint8Array,
+    localId: import('@sendbeam/protocol').DeviceIdentity,
+  ): Promise<void> {
+    this.startingListeners.add(dev.deviceId);
+    try {
+      const handle = await deriveRendezvousHandleForTime(kPair);
+      if (!this.running) return;
+      const peerPublicKey = hexToBytes(dev.publicKey);
+
+      let fp = '';
+      try {
+        fp = formatFingerprint(peerPublicKey);
+      } catch {
+        fp = dev.deviceId.slice(0, 16);
+      }
+
+      const ctrl = opaqueJoin({
+        ...(this.options.serverUrl ? { url: this.options.serverUrl } : {}),
+        handle,
+        localIdentity: localId,
+        peerDeviceId: dev.deviceId,
+        peerPublicKey,
+        kPair,
+        pairCredentialRef: dev.pairCredentialRef,
+        localCapabilities: ['sendbeam/3', 'transfer.v1', 'padding'],
+      });
+
+      this.activeListeners.set(dev.deviceId, ctrl);
+      void this.handleIncomingLoop(dev, kPair, localId, ctrl, fp);
+    } finally {
+      this.startingListeners.delete(dev.deviceId);
+    }
+  }
+
+  private async handleIncomingLoop(
+    dev: TrustRecord,
+    kPair: Uint8Array,
+    localId: import('@sendbeam/protocol').DeviceIdentity,
+    ctrl: OpaqueRendezvousController,
+    fp: string,
+  ): Promise<void> {
+    try {
+      const res = await ctrl.done;
+      this.activeListeners.delete(dev.deviceId);
+
+      // Successfully handshaked with sender! Adopt channel and prepare transfer
+      const signaling = ctrl.adoptSignaling();
+
+      const transferId = `transfer-${Date.now()}`;
+      const consentRequired = !dev.policy?.autoAccept;
+
+      const consentPromise = new Promise<boolean>((resolve) => {
+        if (!consentRequired) {
+          resolve(true);
+        } else {
+          this.pendingConsents.set(transferId, resolve);
+        }
+      });
+
+      const transferCtrl = runReceive(
+        res,
+        signaling,
+        { kind: 'auto' },
+        {
+          ...(this.options.iceServers ? { iceServers: this.options.iceServers } : {}),
+          onConsent: async (manifest) => {
+            if (!consentRequired) {
+              return true;
+            }
+
+            this.options.onIncomingRequest?.({
+              transferId,
+              senderDeviceId: dev.deviceId,
+              senderLabel: dev.localLabel,
+              senderFingerprint: fp,
+              fileCount: manifest.files.length,
+              totalBytes: manifest.totalSize,
+              files: manifest.files.map((f) => ({ name: f.name, size: f.size })),
+            });
+
+            return await consentPromise;
+          },
+        },
+      );
+
+      this.options.onTransferStart?.(transferId, transferCtrl);
+
+      try {
+        const outcome = await transferCtrl.done;
+        this.options.onTransferComplete?.(transferId, outcome);
+      } catch (err: unknown) {
+        this.options.onTransferError?.(
+          transferId,
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
+    } catch {
+      this.activeListeners.delete(dev.deviceId);
+    } finally {
+      // If still running, restart listener for this device
+      if (this.running) {
+        setTimeout(() => {
+          if (
+            this.running &&
+            !this.activeListeners.has(dev.deviceId) &&
+            !this.startingListeners.has(dev.deviceId)
+          ) {
+            void this.startListeningForDevice(dev, kPair, localId);
+          }
+        }, 1000);
+      }
+    }
+  }
+}

--- a/apps/web/src/lib/trust/targeted-send.test.ts
+++ b/apps/web/src/lib/trust/targeted-send.test.ts
@@ -1,0 +1,510 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  resolveTargetPeer,
+  classifyBroadcastError,
+  startTargetedSend,
+  runBroadcastSend,
+} from './targeted-send.js';
+import { resetBrowserStoresForTesting } from './devices.js';
+import {
+  generateDeviceIdentity,
+  bytesToHex,
+  MemoryTrustStore,
+  MemoryTombstoneStore,
+  MemorySecretResolver,
+  signRevocation,
+} from '@sendbeam/protocol';
+import type { TrustedDeviceUI } from './types.js';
+
+// Mocks for rendezvous and transfer
+const mocks = vi.hoisted(() => ({
+  opaqueOffer: vi.fn(),
+  runSend: vi.fn(),
+}));
+
+vi.mock('../session/opaque-rendezvous.js', () => ({
+  opaqueOffer: mocks.opaqueOffer,
+}));
+
+vi.mock('../session/transfer.js', () => ({
+  runSend: mocks.runSend,
+}));
+
+describe('Targeted Send & Multi-Send Engine', () => {
+  let trustStore: MemoryTrustStore;
+  let tombstoneStore: MemoryTombstoneStore;
+  let secretStore: MemorySecretResolver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    trustStore = new MemoryTrustStore();
+    tombstoneStore = new MemoryTombstoneStore();
+    secretStore = new MemorySecretResolver();
+    resetBrowserStoresForTesting(trustStore, secretStore, tombstoneStore);
+  });
+
+  describe('resolveTargetPeer', () => {
+    it('resolves active peer with derived handle and public key', async () => {
+      const peerId = await generateDeviceIdentity();
+      const kPair = new Uint8Array(32).fill(42);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: peerId.deviceId,
+        localLabel: 'Work Phone',
+        publicKey: bytesToHex(peerId.publicKey),
+        pairCredentialRef: 'cred-1',
+        capabilities: ['sendbeam/3', 'transfer.v1'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(peerId.deviceId, kPair);
+
+      const resolved = await resolveTargetPeer(peerId.deviceId);
+      expect(resolved.record.deviceId).toBe(peerId.deviceId);
+      expect(resolved.kPair).toEqual(kPair);
+      expect(resolved.peerPublicKey).toEqual(peerId.publicKey);
+      expect(typeof resolved.handle).toBe('string');
+      expect(resolved.handle).toHaveLength(64);
+    });
+
+    it('rejects unknown device', async () => {
+      await expect(resolveTargetPeer('unknown-device')).rejects.toThrow(
+        'Target device not found in trust store: unknown-device',
+      );
+    });
+
+    it('rejects device marked revoked in trust store', async () => {
+      const peerId = await generateDeviceIdentity();
+      await trustStore.addOrUpdateDevice({
+        deviceId: peerId.deviceId,
+        localLabel: 'Old Laptop',
+        publicKey: bytesToHex(peerId.publicKey),
+        pairCredentialRef: 'cred-2',
+        capabilities: ['transfer.v1'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: true,
+        policy: { autoAccept: false },
+      });
+
+      await expect(resolveTargetPeer(peerId.deviceId)).rejects.toThrow(
+        'Trust for device "Old Laptop" is revoked',
+      );
+    });
+
+    it('rejects device revoked by tombstone', async () => {
+      const peerId = await generateDeviceIdentity();
+      await trustStore.addOrUpdateDevice({
+        deviceId: peerId.deviceId,
+        localLabel: 'Compromised Tablet',
+        publicKey: bytesToHex(peerId.publicKey),
+        pairCredentialRef: 'cred-3',
+        capabilities: ['transfer.v1'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: false },
+      });
+      const localId = await generateDeviceIdentity();
+      const rec = await signRevocation(localId, peerId.deviceId, 1);
+      await tombstoneStore.storeTombstone(rec);
+
+      await expect(resolveTargetPeer(peerId.deviceId)).rejects.toThrow(
+        'Trust for device "Compromised Tablet" is revoked by tombstone',
+      );
+    });
+
+    it('rejects device when pairing secret is missing', async () => {
+      const peerId = await generateDeviceIdentity();
+      await trustStore.addOrUpdateDevice({
+        deviceId: peerId.deviceId,
+        localLabel: 'Forgotten Device',
+        publicKey: bytesToHex(peerId.publicKey),
+        pairCredentialRef: 'cred-4',
+        capabilities: ['transfer.v1'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: false },
+      });
+
+      await expect(resolveTargetPeer(peerId.deviceId)).rejects.toThrow(
+        'Pairing secret missing for device "Forgotten Device"',
+      );
+    });
+  });
+
+  describe('classifyBroadcastError', () => {
+    it('classifies refused/declined/canceled errors as refused', () => {
+      expect(classifyBroadcastError(new Error('transfer declined by user')).status).toBe('refused');
+      expect(classifyBroadcastError(new Error('transfer refused by user')).status).toBe('refused');
+      expect(classifyBroadcastError(new Error('request rejected')).status).toBe('refused');
+      expect(classifyBroadcastError(new Error('transfer cancelled')).status).toBe('refused');
+      expect(classifyBroadcastError(new Error('trust revoked')).status).toBe('refused');
+    });
+
+    it('classifies network and timeout errors as offline', () => {
+      expect(classifyBroadcastError(new Error('peer offline')).status).toBe('offline');
+      expect(classifyBroadcastError(new Error('connection timeout')).status).toBe('offline');
+      expect(classifyBroadcastError(new Error('signaling closed (1006)')).status).toBe('offline');
+      expect(classifyBroadcastError(new Error('peer unreachable')).status).toBe('offline');
+      expect(classifyBroadcastError(new Error('deadline exceeded')).status).toBe('offline');
+    });
+
+    it('classifies unknown and internal errors as failed', () => {
+      expect(classifyBroadcastError(new Error('disk write error')).status).toBe('failed');
+      expect(classifyBroadcastError(new Error('crypto auth failure')).status).toBe('failed');
+      expect(classifyBroadcastError('arbitrary string error').status).toBe('failed');
+    });
+  });
+
+  describe('startTargetedSend', () => {
+    it('successfully connects and runs transfer', async () => {
+      const peerId = await generateDeviceIdentity();
+      const kPair = new Uint8Array(32).fill(7);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: peerId.deviceId,
+        localLabel: 'Target Device',
+        publicKey: bytesToHex(peerId.publicKey),
+        pairCredentialRef: 'cred-send',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(peerId.deviceId, kPair);
+
+      const fakeSignaling = { send: vi.fn(), close: vi.fn() };
+      const fakeOutcome = {
+        files: [{ name: 'test.txt', size: 12, sha256: 'abc' }],
+        digest: 'sha256-abc',
+        bytesTransferred: 12,
+        durationMs: 50,
+      };
+
+      let transferDoneResolve!: (val: typeof fakeOutcome) => void;
+      const transferDonePromise = new Promise<typeof fakeOutcome>((res) => {
+        transferDoneResolve = res;
+      });
+
+      const fakeTransferCtrl = {
+        progress: vi.fn(() => 12),
+        done: transferDonePromise,
+        cancel: vi.fn(),
+      };
+
+      mocks.opaqueOffer.mockReturnValue({
+        handle: 'mock-handle',
+        phase: 'connected',
+        done: Promise.resolve({
+          role: 'offerer',
+          sessionKey: new Uint8Array(32),
+          authKeys: { sign: new Uint8Array(32), verify: new Uint8Array(32) },
+          remoteCaps: { version: 'sendbeam/3', maxFrame: 65536, blockSize: 65536, features: [] },
+        }),
+        adoptSignaling: vi.fn(() => fakeSignaling),
+        cancel: vi.fn(),
+      });
+
+      mocks.runSend.mockReturnValue(fakeTransferCtrl);
+
+      const states: string[] = [];
+      const file = new File(['hello world!'], 'test.txt', { type: 'text/plain' });
+      const targetUI: TrustedDeviceUI = {
+        deviceId: peerId.deviceId,
+        localLabel: 'Target Device',
+        fingerprint: '1234 5678',
+        publicKey: bytesToHex(peerId.publicKey),
+        status: 'online',
+        revoked: false,
+        lastSeenAt: new Date().toISOString(),
+        firstSeenAt: new Date().toISOString(),
+        capabilities: ['sendbeam/3'],
+        policy: { autoAccept: true },
+      };
+
+      const session = await startTargetedSend({
+        target: targetUI,
+        files: [file],
+        onStateChange: (st) => states.push(st),
+      });
+
+      expect(session.target).toBe(targetUI);
+      expect(states).toContain('connecting');
+
+      // Resolve transfer
+      transferDoneResolve(fakeOutcome);
+      const res = await session.done;
+
+      expect(res).toEqual(fakeOutcome);
+      expect(states).toContain('sending');
+      expect(mocks.runSend).toHaveBeenCalledWith(
+        expect.any(Object),
+        fakeSignaling,
+        expect.objectContaining({ files: [file] }),
+      );
+    });
+
+    it('cancels rendezvous and transfer when cancel is invoked', async () => {
+      const peerId = await generateDeviceIdentity();
+      await trustStore.addOrUpdateDevice({
+        deviceId: peerId.deviceId,
+        localLabel: 'Cancel Target',
+        publicKey: bytesToHex(peerId.publicKey),
+        pairCredentialRef: 'cred-cancel',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(peerId.deviceId, new Uint8Array(32));
+
+      const offerCancel = vi.fn();
+      let resolveOffer!: (v: unknown) => void;
+      const offerPromise = new Promise((res) => {
+        resolveOffer = res;
+      });
+
+      mocks.opaqueOffer.mockReturnValue({
+        handle: 'mock-handle',
+        phase: 'connecting',
+        done: offerPromise,
+        adoptSignaling: vi.fn(),
+        cancel: offerCancel,
+      });
+
+      const session = await startTargetedSend({
+        target: {
+          deviceId: peerId.deviceId,
+          localLabel: 'Cancel Target',
+          fingerprint: '1234',
+          publicKey: bytesToHex(peerId.publicKey),
+          status: 'online',
+          revoked: false,
+          lastSeenAt: new Date().toISOString(),
+          firstSeenAt: new Date().toISOString(),
+          capabilities: [],
+          policy: { autoAccept: true },
+        },
+        files: [new File(['data'], 'test.txt')],
+      });
+
+      session.cancel('user aborted');
+      expect(offerCancel).toHaveBeenCalledWith('user aborted');
+      resolveOffer({});
+      await expect(session.done).rejects.toThrow('transfer cancelled');
+    });
+  });
+
+  describe('runBroadcastSend', () => {
+    it('delivers to multiple targets with independent failure isolation', async () => {
+      // Setup 3 peer devices:
+      // Dev 1: succeeds
+      // Dev 2: declined/refused
+      // Dev 3: missing secret (fails resolution)
+      const p1 = await generateDeviceIdentity();
+      const p2 = await generateDeviceIdentity();
+      const p3 = await generateDeviceIdentity();
+
+      const kPair = new Uint8Array(32).fill(9);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: p1.deviceId,
+        localLabel: 'Peer Success',
+        publicKey: bytesToHex(p1.publicKey),
+        pairCredentialRef: 'cred-1',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(p1.deviceId, kPair);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: p2.deviceId,
+        localLabel: 'Peer Refuse',
+        publicKey: bytesToHex(p2.publicKey),
+        pairCredentialRef: 'cred-2',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(p2.deviceId, kPair);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: p3.deviceId,
+        localLabel: 'Peer Missing Secret',
+        publicKey: bytesToHex(p3.publicKey),
+        pairCredentialRef: 'cred-3',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      // No secret for p3
+
+      const targets: TrustedDeviceUI[] = [
+        {
+          deviceId: p1.deviceId,
+          localLabel: 'Peer Success',
+          fingerprint: '1111',
+          publicKey: bytesToHex(p1.publicKey),
+          status: 'online',
+          revoked: false,
+          lastSeenAt: '',
+          firstSeenAt: '',
+          capabilities: [],
+          policy: { autoAccept: true },
+        },
+        {
+          deviceId: p2.deviceId,
+          localLabel: 'Peer Refuse',
+          fingerprint: '2222',
+          publicKey: bytesToHex(p2.publicKey),
+          status: 'online',
+          revoked: false,
+          lastSeenAt: '',
+          firstSeenAt: '',
+          capabilities: [],
+          policy: { autoAccept: true },
+        },
+        {
+          deviceId: p3.deviceId,
+          localLabel: 'Peer Missing Secret',
+          fingerprint: '3333',
+          publicKey: bytesToHex(p3.publicKey),
+          status: 'online',
+          revoked: false,
+          lastSeenAt: '',
+          firstSeenAt: '',
+          capabilities: [],
+          policy: { autoAccept: true },
+        },
+      ];
+
+      mocks.opaqueOffer.mockImplementation((opts: { peerDeviceId: string }) => {
+        if (opts.peerDeviceId === p1.deviceId) {
+          return {
+            done: Promise.resolve({ role: 'offerer' }),
+            adoptSignaling: vi.fn(() => ({ send: vi.fn(), close: vi.fn() })),
+            cancel: vi.fn(),
+          };
+        }
+        if (opts.peerDeviceId === p2.deviceId) {
+          return {
+            done: Promise.reject(new Error('transfer declined by remote peer')),
+            adoptSignaling: vi.fn(),
+            cancel: vi.fn(),
+          };
+        }
+        return {
+          done: Promise.reject(new Error('unknown device')),
+          adoptSignaling: vi.fn(),
+          cancel: vi.fn(),
+        };
+      });
+
+      mocks.runSend.mockReturnValue({
+        progress: () => 100,
+        done: Promise.resolve({ digest: 'sha256-verified' }),
+        cancel: vi.fn(),
+      });
+
+      const files = [new File(['sample data'], 'file.txt')];
+      const updates: Array<{ id: string; status: string }> = [];
+
+      const result = await runBroadcastSend(targets, files, {
+        concurrency: 2,
+        onTargetUpdate: (s) => updates.push({ id: s.deviceId, status: s.status }),
+      });
+
+      expect(result.allOk).toBe(false);
+      expect(result.results).toHaveLength(3);
+
+      const res1 = result.results.find((r) => r.deviceId === p1.deviceId);
+      expect(res1?.status).toBe('ok');
+      expect(res1?.digest).toBe('sha256-verified');
+
+      const res2 = result.results.find((r) => r.deviceId === p2.deviceId);
+      expect(res2?.status).toBe('refused');
+      expect(res2?.error).toContain('transfer declined by remote peer');
+
+      const res3 = result.results.find((r) => r.deviceId === p3.deviceId);
+      expect(res3?.status).toBe('failed');
+      expect(res3?.error).toContain('Pairing secret missing');
+
+      // CRITICAL: Ensure NO secrets or raw keys leak into output results
+      for (const r of result.results) {
+        const str = JSON.stringify(r);
+        expect(str).not.toContain(bytesToHex(kPair));
+        expect(str).not.toContain('kPair');
+        expect(str).not.toContain('privateKey');
+      }
+    });
+
+    it('returns allOk true when all targets succeed', async () => {
+      const p1 = await generateDeviceIdentity();
+      const kPair = new Uint8Array(32).fill(11);
+
+      await trustStore.addOrUpdateDevice({
+        deviceId: p1.deviceId,
+        localLabel: 'Single Target',
+        publicKey: bytesToHex(p1.publicKey),
+        pairCredentialRef: 'cred-1',
+        capabilities: ['sendbeam/3'],
+        firstSeenAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        revoked: false,
+        policy: { autoAccept: true },
+      });
+      await secretStore.setPairSecret(p1.deviceId, kPair);
+
+      mocks.opaqueOffer.mockReturnValue({
+        done: Promise.resolve({ role: 'offerer' }),
+        adoptSignaling: vi.fn(() => ({ send: vi.fn(), close: vi.fn() })),
+        cancel: vi.fn(),
+      });
+
+      mocks.runSend.mockReturnValue({
+        progress: () => 50,
+        done: Promise.resolve({ digest: 'digest-1' }),
+        cancel: vi.fn(),
+      });
+
+      const targets: TrustedDeviceUI[] = [
+        {
+          deviceId: p1.deviceId,
+          localLabel: 'Single Target',
+          fingerprint: '1111',
+          publicKey: bytesToHex(p1.publicKey),
+          status: 'online',
+          revoked: false,
+          lastSeenAt: '',
+          firstSeenAt: '',
+          capabilities: [],
+          policy: { autoAccept: true },
+        },
+      ];
+
+      const result = await runBroadcastSend(targets, [new File(['x'], 'x.bin')]);
+      expect(result.allOk).toBe(true);
+      expect(result.results[0]?.status).toBe('ok');
+      expect(result.results[0]?.digest).toBe('digest-1');
+    });
+
+    it('handles empty target list gracefully', async () => {
+      const result = await runBroadcastSend([], []);
+      expect(result.allOk).toBe(true);
+      expect(result.results).toEqual([]);
+    });
+  });
+});

--- a/apps/web/src/lib/trust/targeted-send.ts
+++ b/apps/web/src/lib/trust/targeted-send.ts
@@ -1,0 +1,325 @@
+/**
+ * Browser targeted send and multi-send delivery (V19-PR09).
+ * Implements peer identity binding, bounded dial/transfer concurrency,
+ * and independent partial failure isolation matching Go packages/engine/transfer/broadcast.go.
+ */
+
+import {
+  type DeviceIdentity,
+  type TrustRecord,
+  deriveRendezvousHandleForTime,
+  getOrCreateBrowserIdentity,
+  hexToBytes,
+} from '@sendbeam/protocol';
+import { getBrowserStores } from './devices.js';
+import type { BroadcastDeviceState, BroadcastDeviceStatus, TrustedDeviceUI } from './types.js';
+import { opaqueOffer } from '../session/opaque-rendezvous.js';
+import { runSend, type TransferController, type TransferOutcome } from '../session/transfer.js';
+
+export interface ResolvedPeerTarget {
+  record: TrustRecord;
+  kPair: Uint8Array;
+  peerPublicKey: Uint8Array;
+  handle: string;
+}
+
+export async function resolveTargetPeer(deviceId: string): Promise<ResolvedPeerTarget> {
+  const { trustStore, secretStore, tombstoneStore } = getBrowserStores();
+
+  const dev = await trustStore.getDevice(deviceId);
+  if (!dev) {
+    throw new Error(`Target device not found in trust store: ${deviceId}`);
+  }
+
+  if (dev.revoked) {
+    throw new Error(`Trust for device "${dev.localLabel}" is revoked`);
+  }
+
+  if (tombstoneStore && (await tombstoneStore.hasTombstone(deviceId))) {
+    throw new Error(`Trust for device "${dev.localLabel}" is revoked by tombstone`);
+  }
+
+  const kPair = await secretStore?.resolvePairSecret(dev.deviceId, dev.pairCredentialRef);
+  if (!kPair || kPair.length === 0) {
+    throw new Error(`Pairing secret missing for device "${dev.localLabel}"`);
+  }
+
+  const peerPublicKey = hexToBytes(dev.publicKey);
+  const handle = await deriveRendezvousHandleForTime(kPair);
+
+  return {
+    record: dev,
+    kPair,
+    peerPublicKey,
+    handle,
+  };
+}
+
+export function classifyBroadcastError(err: unknown): {
+  status: BroadcastDeviceStatus;
+  message: string;
+} {
+  const raw = err instanceof Error ? err.message : String(err);
+  const lower = raw.toLowerCase();
+
+  if (
+    lower.includes('refused') ||
+    lower.includes('declined') ||
+    lower.includes('rejected') ||
+    lower.includes('canceled') ||
+    lower.includes('cancelled') ||
+    lower.includes('revoked')
+  ) {
+    return { status: 'refused', message: raw };
+  }
+
+  if (
+    lower.includes('offline') ||
+    lower.includes('unreachable') ||
+    lower.includes('timeout') ||
+    lower.includes('deadline exceeded') ||
+    lower.includes('peer not found') ||
+    lower.includes('closed')
+  ) {
+    return { status: 'offline', message: raw };
+  }
+
+  return { status: 'failed', message: raw };
+}
+
+export interface TargetedSendOptions {
+  target: TrustedDeviceUI;
+  files: File[];
+  serverUrl?: string;
+  iceServers?: RTCIceServer[];
+  timeoutMs?: number;
+  localIdentity?: DeviceIdentity;
+  onProgress?: (bytes: number) => void;
+  onStateChange?: (status: BroadcastDeviceStatus) => void;
+}
+
+export interface TargetedSendSession {
+  readonly target: TrustedDeviceUI;
+  readonly transferCtrl: TransferController;
+  readonly done: Promise<TransferOutcome>;
+  cancel(reason?: string): void;
+}
+
+export async function startTargetedSend(opts: TargetedSendOptions): Promise<TargetedSendSession> {
+  const localId = opts.localIdentity ?? (await getOrCreateBrowserIdentity());
+  const peer = await resolveTargetPeer(opts.target.deviceId);
+
+  opts.onStateChange?.('connecting');
+
+  const rendezvousCtrl = opaqueOffer({
+    ...(opts.serverUrl ? { url: opts.serverUrl } : {}),
+    handle: peer.handle,
+    localIdentity: localId,
+    peerDeviceId: peer.record.deviceId,
+    peerPublicKey: peer.peerPublicKey,
+    kPair: peer.kPair,
+    pairCredentialRef: peer.record.pairCredentialRef,
+    localCapabilities: ['sendbeam/3', 'transfer.v1', 'padding'],
+    timeoutMs: opts.timeoutMs ?? 45_000,
+  });
+
+  let canceled = false;
+  let activeTransfer: TransferController | null = null;
+
+  const donePromise = (async (): Promise<TransferOutcome> => {
+    try {
+      const res = await rendezvousCtrl.done;
+      if (canceled) {
+        throw new Error('transfer cancelled');
+      }
+
+      const signaling = rendezvousCtrl.adoptSignaling();
+      opts.onStateChange?.('sending');
+
+      const ctrl = runSend(res, signaling, {
+        files: opts.files,
+        ...(opts.iceServers ? { iceServers: opts.iceServers } : {}),
+      });
+      activeTransfer = ctrl;
+
+      return await ctrl.done;
+    } catch (err: unknown) {
+      rendezvousCtrl.cancel();
+      activeTransfer?.cancel();
+      throw err;
+    }
+  })();
+
+  return {
+    target: opts.target,
+    get transferCtrl() {
+      if (!activeTransfer) {
+        throw new Error('transfer not yet started');
+      }
+      return activeTransfer;
+    },
+    done: donePromise,
+    cancel: (reason = 'cancelled') => {
+      canceled = true;
+      rendezvousCtrl.cancel(reason);
+      activeTransfer?.cancel(reason);
+    },
+  };
+}
+
+export interface BroadcastSendOptions {
+  serverUrl?: string;
+  iceServers?: RTCIceServer[];
+  concurrency?: number;
+  timeoutMs?: number;
+  localIdentity?: DeviceIdentity;
+  onTargetUpdate?: (state: BroadcastDeviceState) => void;
+}
+
+export interface BroadcastSendResult {
+  allOk: boolean;
+  results: BroadcastDeviceState[];
+}
+
+export async function runBroadcastSend(
+  targets: TrustedDeviceUI[],
+  files: File[],
+  opts: BroadcastSendOptions = {},
+): Promise<BroadcastSendResult> {
+  const totalBytes = files.reduce((acc, f) => acc + f.size, 0);
+
+  const states = new Map<string, BroadcastDeviceState>();
+  for (const t of targets) {
+    const s: BroadcastDeviceState = {
+      deviceId: t.deviceId,
+      label: t.localLabel,
+      status: 'pending',
+      progressBytes: 0,
+      totalBytes,
+    };
+    states.set(t.deviceId, s);
+    opts.onTargetUpdate?.({ ...s });
+  }
+
+  const updateState = (deviceId: string, patch: Partial<BroadcastDeviceState>) => {
+    const curr = states.get(deviceId);
+    if (!curr) return;
+    const updated = { ...curr, ...patch };
+    states.set(deviceId, updated);
+    opts.onTargetUpdate?.({ ...updated });
+  };
+
+  const concurrency = Math.max(1, Math.min(opts.concurrency ?? 4, targets.length));
+  let running = 0;
+  let queueIndex = 0;
+
+  const localId = opts.localIdentity ?? (await getOrCreateBrowserIdentity());
+
+  const processTarget = async (target: TrustedDeviceUI): Promise<void> => {
+    const start = Date.now();
+    try {
+      updateState(target.deviceId, { status: 'connecting' });
+
+      let peer: ResolvedPeerTarget;
+      try {
+        peer = await resolveTargetPeer(target.deviceId);
+      } catch (err: unknown) {
+        const classified = classifyBroadcastError(err);
+        updateState(target.deviceId, {
+          status: classified.status,
+          durationMs: Date.now() - start,
+          error: classified.message,
+        });
+        return;
+      }
+
+      const rendezvousCtrl = opaqueOffer({
+        ...(opts.serverUrl ? { url: opts.serverUrl } : {}),
+        handle: peer.handle,
+        localIdentity: localId,
+        peerDeviceId: peer.record.deviceId,
+        peerPublicKey: peer.peerPublicKey,
+        kPair: peer.kPair,
+        pairCredentialRef: peer.record.pairCredentialRef,
+        localCapabilities: ['sendbeam/3', 'transfer.v1', 'padding'],
+        timeoutMs: opts.timeoutMs ?? 45_000,
+      });
+
+      const res = await rendezvousCtrl.done;
+      const signaling = rendezvousCtrl.adoptSignaling();
+
+      updateState(target.deviceId, { status: 'sending' });
+
+      const transferCtrl = runSend(res, signaling, {
+        files,
+        ...(opts.iceServers ? { iceServers: opts.iceServers } : {}),
+      });
+
+      // Poll progress while active
+      const progressTimer = setInterval(() => {
+        const p = transferCtrl.progress();
+        updateState(target.deviceId, { progressBytes: p });
+      }, 150);
+
+      try {
+        const outcome = await transferCtrl.done;
+        clearInterval(progressTimer);
+        updateState(target.deviceId, {
+          status: 'ok',
+          progressBytes: totalBytes,
+          durationMs: Date.now() - start,
+          digest: outcome.digest,
+        });
+      } catch (transferErr: unknown) {
+        clearInterval(progressTimer);
+        const classified = classifyBroadcastError(transferErr);
+        updateState(target.deviceId, {
+          status: classified.status,
+          durationMs: Date.now() - start,
+          error: classified.message,
+        });
+      }
+    } catch (err: unknown) {
+      const classified = classifyBroadcastError(err);
+      updateState(target.deviceId, {
+        status: classified.status,
+        durationMs: Date.now() - start,
+        error: classified.message,
+      });
+    }
+  };
+
+  await new Promise<void>((resolve) => {
+    if (targets.length === 0) {
+      resolve();
+      return;
+    }
+
+    const next = () => {
+      if (queueIndex >= targets.length && running === 0) {
+        resolve();
+        return;
+      }
+
+      while (running < concurrency && queueIndex < targets.length) {
+        const target = targets[queueIndex++];
+        if (!target) break;
+        running++;
+        void processTarget(target).finally(() => {
+          running--;
+          next();
+        });
+      }
+    };
+
+    next();
+  });
+
+  const finalResults = targets.map((t) => states.get(t.deviceId)!);
+  const allOk = finalResults.every((r) => r.status === 'ok');
+
+  return {
+    allOk,
+    results: finalResults,
+  };
+}

--- a/packages/protocol/src/rendezvous.ts
+++ b/packages/protocol/src/rendezvous.ts
@@ -65,7 +65,7 @@ export interface CapsPayload {
 /** Everything a completed handshake yields — enough to run the transfer under the same key. */
 export interface RendezvousResult {
   readonly role: Role;
-  readonly room: number;
+  readonly room?: number;
   /** The full normalized invite code (`<room>-<words>`); the SPAKE2 password. */
   readonly code: string;
   /** SendBeam master key, bound to the handshake transcript. */
@@ -73,7 +73,9 @@ export interface RendezvousResult {
   /** Both directional AEAD keys + nonce salts. */
   readonly keys: TransferKeys;
   /** Raw SPAKE2 output, retained for the SDP/ICE MAC keys (KcA/KcB). */
-  readonly spake2: Spake2Output;
+  readonly spake2?: Spake2Output;
+  /** Directional authentication keys for SDP/ICE signaling (used in sendbeam/3 opaque rendezvous). */
+  readonly authKeys?: { sign: Uint8Array; verify: Uint8Array };
   readonly localCaps: CapsPayload;
   readonly remoteCaps: CapsPayload;
   /**


### PR DESCRIPTION
### Summary
Implements browser selected-recipient send, multi-device broadcast delivery, and authenticated incoming transfer consent coordination [V19-PR09].

### Key Changes
- **Rendezvous Protocol (`@sendbeam/protocol`)**:
  - Made room and SPAKE2 parameters optional on `RendezvousResult` while introducing `authKeys: { sign, verify }` for sendbeam/3 opaque rendezvous signaling authentication.
- **Signaling & Transfer Integration (`apps/web/src/lib/session`)**:
  - Implemented `opaqueOffer` and `opaqueJoin` controllers in `apps/web/src/lib/session/opaque-rendezvous.ts` bridging WebSockets with `OpaqueRendezvousSession`.
  - Added `onConsent` callback to `runReceive` in `transfer.ts`, failing closed with `'transfer declined by user'` when declined.
  - Added support for `authKeys` in WebRTC signal authenticator.
- **Targeted Send & Multi-Send Engine (`apps/web/src/lib/trust/targeted-send.ts`)**:
  - `resolveTargetPeer`: Validates peer device identity, checks against signed tombstones, retrieves `kPair`, and derives time-windowed handles.
  - `classifyBroadcastError`: Maps failures into `ok | refused | offline | failed` without exposing secrets.
  - `startTargetedSend` & `runBroadcastSend`: Implements bounded concurrency, per-target state machines, and independent partial failure isolation.
- **Incoming Transfer Coordinator (`apps/web/src/lib/trust/incoming-listener.ts`)**:
  - In pure browser mode, coordinates opaque rendezvous listener sockets for paired devices, auto-accepts transfers when configured by policy, and triggers `IncomingTransferModal` when consent is required.
  - In desktop mode, subscribes to Wails `sendbeam:consent` events and routes user decisions to `window.go.engine.TransferService.RespondConsent`.
- **UI Integration & Tests**:
  - Added screen handlers for `targeted_send` and `broadcast_send` with progress monitoring, stats, and cancellation.
  - Unit tests in `targeted-send.test.ts`, `incoming-listener.test.ts`, `IncomingTransferModal.test.ts`, and updated `App.test.ts`.