### PR TITLE
feat(desktop): trusted-device flows, typed Wails adapters, and native smoke tests

### DIFF
--- a/apps/desktop/frontend/dist/index.html
+++ b/apps/desktop/frontend/dist/index.html
@@ -312,6 +312,78 @@
       }
       .table th { color: var(--text-muted); font-weight: 500; }
       .table tr:last-child td { border-bottom: none; }
+
+      .modal-backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.75);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+        padding: 1rem;
+      }
+      .modal-card {
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        width: 100%;
+        max-width: 520px;
+        padding: 1.5rem;
+        box-shadow: 0 16px 32px rgba(0, 0, 0, 0.5);
+      }
+      .modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 0.5rem;
+      }
+      .modal-header h3 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--text-heading);
+      }
+      .badge-lan {
+        background: rgba(35, 134, 54, 0.2);
+        color: #56d364;
+        border: 1px solid rgba(35, 134, 54, 0.4);
+        padding: 0.15rem 0.5rem;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+      .badge-online {
+        background: rgba(56, 139, 253, 0.2);
+        color: #58a6ff;
+        border: 1px solid rgba(56, 139, 253, 0.4);
+        padding: 0.15rem 0.5rem;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+      .badge-offline {
+        background: rgba(139, 148, 158, 0.2);
+        color: var(--text-muted);
+        border: 1px solid var(--border);
+        padding: 0.15rem 0.5rem;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+      .badge-revoked {
+        background: rgba(218, 54, 51, 0.2);
+        color: #f85149;
+        border: 1px solid rgba(218, 54, 51, 0.4);
+        padding: 0.15rem 0.5rem;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
     </style>
   </head>
   <body>
@@ -334,6 +406,7 @@
     <div class="tabs">
       <button class="tab active" id="tab-send">Send</button>
       <button class="tab" id="tab-receive">Receive</button>
+      <button class="tab" id="tab-devices">Devices</button>
       <button class="tab" id="tab-interrupted">Interrupted</button>
       <button class="tab" id="tab-settings">Settings</button>
     </div>
@@ -347,7 +420,15 @@
         </div>
         <ul class="file-list hidden" id="send-list"></ul>
         <div class="statusline" id="send-sel-status"></div>
-        <div class="controls">
+
+        <div style="margin-top:0.75rem;">
+          <label for="send-recipient" style="margin-bottom:0.25rem;">Recipient</label>
+          <select id="send-recipient" style="width:100%; background:var(--surface); border:1px solid var(--border); color:var(--text-heading); padding:0.45rem; border-radius:6px; font-size:0.85rem; outline:none;">
+            <option value="code">Anyone with invite code / link / QR (Default)</option>
+          </select>
+        </div>
+
+        <div class="controls" style="margin-top:0.75rem;">
           <button id="pick-send">Choose files &amp; folders…</button>
           <button class="primary" id="start-send" disabled>Start Transfer</button>
         </div>
@@ -420,6 +501,40 @@
           <button class="ghost hidden" id="recv-reveal">Reveal in Folder</button>
         </div>
         <div class="statusline" id="recv-status-line"></div>
+      </div>
+    </section>
+
+    <!-- DEVICES -->
+    <section class="panel" id="panel-devices">
+      <div class="card">
+        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:1rem;">
+          <div>
+            <h2 style="margin-bottom:0.25rem;">Trusted Devices</h2>
+            <span style="font-size:0.8rem; color:var(--text-muted);">Paired devices for authenticated, peer-to-peer transfers without one-time codes.</span>
+          </div>
+          <button class="primary small" id="open-pair-btn">+ Pair Device</button>
+        </div>
+
+        <div style="overflow-x:auto;">
+          <table class="table" id="devices-table">
+            <thead>
+              <tr>
+                <th>Device</th>
+                <th>Fingerprint</th>
+                <th>Status</th>
+                <th>Auto-Accept</th>
+                <th>Last Seen</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="devices-tbody"></tbody>
+          </table>
+        </div>
+
+        <div id="devices-empty" class="hidden" style="padding:2.5rem 1rem; text-align:center; color:var(--text-muted); font-size:0.85rem;">
+          No trusted devices paired yet. Click &ldquo;+ Pair Device&rdquo; to connect another computer or phone.
+        </div>
+        <div class="statusline" id="devices-status"></div>
       </div>
     </section>
 
@@ -502,11 +617,195 @@
       </div>
     </section>
 
+    <!-- PAIR MODAL -->
+    <div class="modal-backdrop hidden" id="modal-pair">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3>Pair Trusted Device</h3>
+          <button class="ghost small" id="pair-modal-close">&times;</button>
+        </div>
+        <div class="tabs" style="margin-bottom:1rem;">
+          <button class="tab active" id="pair-tab-offer">Show Code</button>
+          <button class="tab" id="pair-tab-join">Enter Code</button>
+        </div>
+
+        <!-- OFFER VIEW -->
+        <div id="pair-offer-view">
+          <p style="font-size:0.85rem; color:var(--text-muted); margin-bottom:1rem;">
+            Scan this QR code with the SendBeam mobile/web app or enter the 7-word code below on your other device to establish mutual cryptographic trust.
+          </p>
+          <div style="display:flex; justify-content:center; margin-bottom:1rem;">
+            <img id="pair-offer-qr" alt="Pairing QR Code" style="width:200px; height:200px; background:#fff; border-radius:6px; padding:8px;" class="hidden" />
+          </div>
+          <div style="text-align:center; margin-bottom:1rem;">
+            <span class="mono" id="pair-offer-code" style="font-size:1.15rem; font-weight:600; color:var(--primary-hover); word-break:break-all;">Generating invite code…</span>
+          </div>
+          <div class="statusline" id="pair-offer-status" style="text-align:center; margin-bottom:1rem;">Waiting for peer to connect…</div>
+          <div class="controls" style="justify-content:flex-end;">
+            <button id="pair-offer-cancel">Cancel</button>
+          </div>
+        </div>
+
+        <!-- JOIN VIEW -->
+        <div id="pair-join-view" class="hidden">
+          <p style="font-size:0.85rem; color:var(--text-muted); margin-bottom:0.75rem;">
+            Enter the 7-word invite code displayed on the other SendBeam device.
+          </p>
+          <label for="pair-join-code">Invite Code</label>
+          <input type="text" id="pair-join-code" placeholder="e.g. 7-words-here" />
+
+          <label for="pair-join-label">Custom Device Name (Optional)</label>
+          <input type="text" id="pair-join-label" placeholder="e.g. Work Laptop" />
+
+          <label style="display:flex; align-items:center; gap:0.5rem; margin-top:0.75rem;">
+            <input type="checkbox" id="pair-join-auto-accept" />
+            <span>Auto-accept incoming transfers from this device</span>
+          </label>
+
+          <div id="pair-join-dest-container" class="hidden" style="margin-top:0.5rem;">
+            <label for="pair-join-dest-dir">Destination Folder</label>
+            <div style="display:flex; gap:0.5rem;">
+              <input type="text" id="pair-join-dest-dir" placeholder="/path/to/downloads" style="flex:1" />
+              <button class="ghost" id="pair-join-browse-dest">Browse…</button>
+            </div>
+          </div>
+
+          <div class="statusline" id="pair-join-status"></div>
+          <div class="controls" style="justify-content:flex-end; margin-top:1rem;">
+            <button id="pair-join-cancel">Cancel</button>
+            <button class="primary" id="pair-join-submit">Pair Device</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- POLICY MODAL -->
+    <div class="modal-backdrop hidden" id="modal-policy">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3>Device Policy</h3>
+          <button class="ghost small" id="policy-modal-close">&times;</button>
+        </div>
+        <div id="policy-device-info" style="font-size:0.85rem; color:var(--text-muted); margin-bottom:1rem;"></div>
+
+        <label style="display:flex; align-items:center; gap:0.5rem; margin-top:0.5rem;">
+          <input type="checkbox" id="policy-auto-accept" />
+          <span>Auto-accept incoming transfers from this device</span>
+        </label>
+
+        <div id="policy-dest-container" class="hidden" style="margin-top:0.75rem;">
+          <label for="policy-dest-dir">Auto-Accept Destination Folder</label>
+          <div style="display:flex; gap:0.5rem;">
+            <input type="text" id="policy-dest-dir" placeholder="/path/to/downloads" style="flex:1" />
+            <button class="ghost" id="policy-browse-dest">Browse…</button>
+          </div>
+        </div>
+
+        <div class="statusline" id="policy-status"></div>
+        <div class="controls" style="justify-content:flex-end; margin-top:1rem;">
+          <button id="policy-cancel-btn">Cancel</button>
+          <button class="primary" id="policy-save-btn">Save Policy</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- RENAME MODAL -->
+    <div class="modal-backdrop hidden" id="modal-rename">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3>Rename Device</h3>
+          <button class="ghost small" id="rename-modal-close">&times;</button>
+        </div>
+        <label for="rename-label-input">Device Name</label>
+        <input type="text" id="rename-label-input" placeholder="e.g. Work Phone" />
+
+        <div class="statusline" id="rename-status"></div>
+        <div class="controls" style="justify-content:flex-end; margin-top:1rem;">
+          <button id="rename-cancel-btn">Cancel</button>
+          <button class="primary" id="rename-save-btn">Save Name</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- UNPAIR MODAL -->
+    <div class="modal-backdrop hidden" id="modal-unpair">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3 style="color:var(--danger-hover);">Unpair Device</h3>
+          <button class="ghost small" id="unpair-modal-close">&times;</button>
+        </div>
+        <p id="unpair-device-prompt" style="font-size:0.85rem; margin-bottom:1rem;"></p>
+
+        <div style="display:flex; flex-direction:column; gap:0.75rem; margin-bottom:1rem;">
+          <label style="display:flex; align-items:flex-start; gap:0.5rem; cursor:pointer;">
+            <input type="radio" name="unpair-mode" value="revoke" checked style="margin-top:0.25rem;" />
+            <div>
+              <strong style="color:var(--text-heading);">Revoke trust (Recommended)</strong>
+              <div style="font-size:0.75rem; color:var(--text-muted);">Creates a cryptographic tombstone that permanently prevents unauthorized re-pairing from this device ID until tombstone expiration.</div>
+            </div>
+          </label>
+          <label style="display:flex; align-items:flex-start; gap:0.5rem; cursor:pointer;">
+            <input type="radio" name="unpair-mode" value="purge" style="margin-top:0.25rem;" />
+            <div>
+              <strong style="color:var(--text-heading);">Purge completely</strong>
+              <div style="font-size:0.75rem; color:var(--text-muted);">Deletes all local trust records and cryptographic keys without issuing a tombstone.</div>
+            </div>
+          </label>
+        </div>
+
+        <div class="statusline" id="unpair-status"></div>
+        <div class="controls" style="justify-content:flex-end; margin-top:1rem;">
+          <button id="unpair-cancel-btn">Cancel</button>
+          <button class="danger" id="unpair-confirm-btn">Unpair</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- INCOMING CONSENT MODAL -->
+    <div class="modal-backdrop hidden" id="modal-consent">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3>Incoming Transfer Request</h3>
+        </div>
+        <p style="font-size:0.85rem; color:var(--text-muted); margin-bottom:0.75rem;">
+          A paired trusted device is sending files to you.
+        </p>
+
+        <div style="background:var(--surface); border:1px solid var(--border); border-radius:6px; padding:0.75rem; margin-bottom:1rem; font-size:0.85rem;">
+          <div style="margin-bottom:0.4rem;">
+            <span style="color:var(--text-muted);">From: </span>
+            <strong id="consent-device-name" style="color:var(--text-heading);"></strong>
+          </div>
+          <div style="margin-bottom:0.4rem;">
+            <span style="color:var(--text-muted);">Fingerprint: </span>
+            <span class="mono small" id="consent-fingerprint"></span>
+          </div>
+          <div>
+            <span style="color:var(--text-muted);">Files: </span>
+            <span id="consent-files-summary" style="color:var(--text-heading);"></span>
+          </div>
+        </div>
+
+        <label for="consent-dest-dir">Save into folder</label>
+        <div style="display:flex; gap:0.5rem;">
+          <input type="text" id="consent-dest-dir" placeholder="/path/to/downloads" style="flex:1" />
+          <button class="ghost" id="consent-browse-dest">Browse…</button>
+        </div>
+
+        <div class="statusline" id="consent-status"></div>
+        <div class="controls" style="justify-content:flex-end; margin-top:1.25rem;">
+          <button class="danger small" id="consent-decline-btn">Decline</button>
+          <button class="primary small" id="consent-accept-btn">Accept Transfer</button>
+        </div>
+      </div>
+    </div>
+
     <script>
       const SV = {
         Service:  "github.com/sendbeam/desktop/internal/engine.Service",
         Transfer: "github.com/sendbeam/desktop/internal/engine.TransferService",
         Update:   "github.com/sendbeam/desktop/internal/engine.UpdateService",
+        Device:   "github.com/sendbeam/desktop/internal/engine.DeviceService",
       };
       const call = (fqn, ...args) => wails.Call.ByName(fqn, ...args);
       const $ = (id) => document.getElementById(id);
@@ -532,21 +831,26 @@
       const state = {
         mode: "send",
         selected: [],
+        devices: [],
         send: { id: null },
         recv: { id: null, outPath: null },
+        activeDevice: null,
+        pendingConsentId: null,
       };
 
       function setMode(mode) {
         state.mode = mode;
-        ["send", "receive", "interrupted", "settings"].forEach((m) => {
+        ["send", "receive", "devices", "interrupted", "settings"].forEach((m) => {
           $("tab-" + m).classList.toggle("active", mode === m);
           $("panel-" + m).classList.toggle("active", mode === m);
         });
+        if (mode === "devices") loadDevicesList();
         if (mode === "interrupted") loadDurableList();
         if (mode === "settings") loadSettings();
       }
       $("tab-send").addEventListener("click", () => setMode("send"));
       $("tab-receive").addEventListener("click", () => setMode("receive"));
+      $("tab-devices").addEventListener("click", () => setMode("devices"));
       $("tab-interrupted").addEventListener("click", () => setMode("interrupted"));
       $("tab-settings").addEventListener("click", () => setMode("settings"));
 
@@ -604,7 +908,32 @@
       $("start-send").addEventListener("click", () => {
         if (!state.selected.length) return;
         const paths = state.selected.map((p) => p.path);
-        call(SV.Transfer + ".Send", paths, "").then((h) => {
+        const recipient = $("send-recipient") ? $("send-recipient").value : "code";
+
+        if (recipient === "broadcast:all") {
+          const devIds = state.devices.filter((d) => !d.revoked).map((d) => d.deviceId);
+          if (!devIds.length) {
+            $("send-status").textContent = "No trusted devices available for broadcast.";
+            return;
+          }
+          $("send-status").textContent = "Broadcasting to " + devIds.length + " devices…";
+          $("start-send").disabled = true;
+          call(SV.Transfer + ".BroadcastSend", paths, devIds, "").then((results) => {
+            const okCount = (results || []).filter((r) => r.status === "ok").length;
+            $("send-status").textContent = "Broadcast finished: " + okCount + "/" + devIds.length + " successful.";
+            $("start-send").disabled = false;
+          }).catch((err) => {
+            $("send-status").textContent = String(err);
+            $("start-send").disabled = false;
+          });
+          return;
+        }
+
+        const sendPromise = (recipient && recipient !== "code")
+          ? call(SV.Transfer + ".SendToDevice", paths, recipient, "")
+          : call(SV.Transfer + ".Send", paths, "");
+
+        sendPromise.then((h) => {
           if (h && h.error) { $("send-status").textContent = h.error; return; }
           state.send.id = h.id;
           $("send-status").textContent = "Preparing secure channel…";
@@ -757,6 +1086,467 @@
           catch (err) { $("invite-status").textContent = "Copy failed — select the code manually."; }
           document.body.removeChild(ta);
         }
+      });
+
+      // DEVICES
+      function formatStatusBadge(status, revoked) {
+        const span = document.createElement("span");
+        if (revoked || status === "revoked") {
+          span.className = "badge-revoked";
+          span.textContent = "Revoked";
+        } else if (status === "lan_direct") {
+          span.className = "badge-lan";
+          span.textContent = "LAN Direct";
+        } else if (status === "online") {
+          span.className = "badge-online";
+          span.textContent = "Online";
+        } else {
+          span.className = "badge-offline";
+          span.textContent = "Offline";
+        }
+        return span;
+      }
+
+      function updateRecipientSelect(devices) {
+        const sel = $("send-recipient");
+        if (!sel) return;
+        const currentVal = sel.value;
+        sel.replaceChildren();
+
+        const defOpt = document.createElement("option");
+        defOpt.value = "code";
+        defOpt.textContent = "Anyone with invite code / link / QR (Default)";
+        sel.appendChild(defOpt);
+
+        const activeDevs = (devices || []).filter((d) => !d.revoked);
+        for (const d of activeDevs) {
+          const opt = document.createElement("option");
+          opt.value = d.deviceId;
+          const statusText = d.status === "lan_direct" ? "LAN Direct" : d.status === "online" ? "Online" : "Offline";
+          opt.textContent = d.localLabel + " (" + statusText + ")";
+          sel.appendChild(opt);
+        }
+
+        if (activeDevs.length > 1) {
+          const bOpt = document.createElement("option");
+          bOpt.value = "broadcast:all";
+          bOpt.textContent = "Broadcast to all trusted devices (" + activeDevs.length + ")";
+          sel.appendChild(bOpt);
+        }
+
+        sel.value = currentVal || "code";
+        if (sel.selectedIndex === -1) sel.value = "code";
+      }
+
+      function renderDevicesList(devices) {
+        state.devices = devices || [];
+        updateRecipientSelect(state.devices);
+
+        const tbody = $("devices-tbody");
+        if (!tbody) return;
+        tbody.replaceChildren();
+
+        if (!devices || devices.length === 0) {
+          $("devices-empty").classList.remove("hidden");
+          $("devices-table").classList.add("hidden");
+          return;
+        }
+
+        $("devices-empty").classList.add("hidden");
+        $("devices-table").classList.remove("hidden");
+
+        for (const dev of devices) {
+          const tr = document.createElement("tr");
+
+          // Device Name + ID
+          const tdDev = document.createElement("td");
+          const strong = document.createElement("strong");
+          strong.textContent = dev.localLabel;
+          tdDev.appendChild(strong);
+          const devIdDiv = document.createElement("div");
+          devIdDiv.className = "mono small";
+          devIdDiv.style.color = "var(--text-muted)";
+          devIdDiv.textContent = dev.deviceId;
+          tdDev.appendChild(devIdDiv);
+          tr.appendChild(tdDev);
+
+          // Fingerprint
+          const tdFp = document.createElement("td");
+          const fpSpan = document.createElement("span");
+          fpSpan.className = "mono small";
+          fpSpan.textContent = dev.fingerprint;
+          tdFp.appendChild(fpSpan);
+          tr.appendChild(tdFp);
+
+          // Status Badge
+          const tdStatus = document.createElement("td");
+          tdStatus.appendChild(formatStatusBadge(dev.status, dev.revoked));
+          tr.appendChild(tdStatus);
+
+          // Auto-Accept
+          const tdAuto = document.createElement("td");
+          if (dev.policy && dev.policy.autoAccept) {
+            tdAuto.textContent = "Yes (" + (dev.policy.autoAcceptDestDir || "") + ")";
+          } else {
+            tdAuto.textContent = "No";
+          }
+          tr.appendChild(tdAuto);
+
+          // Last Seen
+          const tdSeen = document.createElement("td");
+          tdSeen.textContent = dev.lastSeenAt || "Never";
+          tr.appendChild(tdSeen);
+
+          // Actions
+          const tdActions = document.createElement("td");
+          tdActions.style.whiteSpace = "nowrap";
+
+          const btnPolicy = document.createElement("button");
+          btnPolicy.className = "ghost small";
+          btnPolicy.textContent = "Policy";
+          btnPolicy.setAttribute("data-id", dev.deviceId);
+          btnPolicy.setAttribute("data-action", "policy");
+          btnPolicy.addEventListener("click", () => openPolicyModal(dev));
+          tdActions.appendChild(btnPolicy);
+
+          const btnRename = document.createElement("button");
+          btnRename.className = "ghost small";
+          btnRename.textContent = "Rename";
+          btnRename.setAttribute("data-id", dev.deviceId);
+          btnRename.setAttribute("data-action", "rename");
+          btnRename.addEventListener("click", () => openRenameModal(dev));
+          tdActions.appendChild(btnRename);
+
+          if (!dev.revoked) {
+            const btnSend = document.createElement("button");
+            btnSend.className = "ghost small";
+            btnSend.textContent = "Send";
+            btnSend.setAttribute("data-id", dev.deviceId);
+            btnSend.setAttribute("data-action", "send");
+            btnSend.addEventListener("click", () => {
+              setMode("send");
+              if ($("send-recipient")) $("send-recipient").value = dev.deviceId;
+            });
+            tdActions.appendChild(btnSend);
+          }
+
+          const btnUnpair = document.createElement("button");
+          btnUnpair.className = "ghost small danger";
+          btnUnpair.textContent = "Unpair";
+          btnUnpair.setAttribute("data-id", dev.deviceId);
+          btnUnpair.setAttribute("data-action", "unpair");
+          btnUnpair.addEventListener("click", () => openUnpairModal(dev));
+          tdActions.appendChild(btnUnpair);
+
+          tr.appendChild(tdActions);
+          tbody.appendChild(tr);
+        }
+      }
+
+      async function loadDevicesList() {
+        try {
+          $("devices-status").textContent = "Loading devices…";
+          const list = await call(SV.Device + ".ListTrustedDevices");
+          $("devices-status").textContent = "";
+          renderDevicesList(list);
+        } catch (err) {
+          $("devices-status").textContent = "Failed to load devices: " + err;
+        }
+      }
+
+      wails.Events.On("sendbeam:devices", (devices) => {
+        renderDevicesList(devices);
+      });
+
+      // MODALS
+      function hideAllModals() {
+        ["modal-pair", "modal-policy", "modal-rename", "modal-unpair", "modal-consent"].forEach((id) => {
+          const m = $(id);
+          if (m) m.classList.add("hidden");
+        });
+      }
+
+      // 1. PAIR MODAL
+      let activeOfferCanceller = false;
+      function openPairModal() {
+        hideAllModals();
+        $("modal-pair").classList.remove("hidden");
+        setPairMode("offer");
+      }
+      function closePairModal() {
+        $("modal-pair").classList.add("hidden");
+        if (activeOfferCanceller) {
+          call(SV.Device + ".CancelPairingOffer").catch(() => {});
+          activeOfferCanceller = false;
+        }
+      }
+      $("open-pair-btn").addEventListener("click", openPairModal);
+      $("pair-modal-close").addEventListener("click", closePairModal);
+      $("pair-offer-cancel").addEventListener("click", closePairModal);
+      $("pair-join-cancel").addEventListener("click", closePairModal);
+
+      function setPairMode(mode) {
+        $("pair-tab-offer").classList.toggle("active", mode === "offer");
+        $("pair-tab-join").classList.toggle("active", mode === "join");
+        $("pair-offer-view").classList.toggle("hidden", mode !== "offer");
+        $("pair-join-view").classList.toggle("hidden", mode !== "join");
+
+        if (mode === "offer") {
+          startOfferCeremony();
+        } else {
+          if (activeOfferCanceller) {
+            call(SV.Device + ".CancelPairingOffer").catch(() => {});
+            activeOfferCanceller = false;
+          }
+        }
+      }
+      $("pair-tab-offer").addEventListener("click", () => setPairMode("offer"));
+      $("pair-tab-join").addEventListener("click", () => setPairMode("join"));
+
+      async function startOfferCeremony() {
+        activeOfferCanceller = true;
+        $("pair-offer-code").textContent = "Allocating pairing room…";
+        $("pair-offer-status").textContent = "Waiting for peer to connect…";
+        const qrImg = $("pair-offer-qr");
+        qrImg.classList.add("hidden");
+        qrImg.src = "";
+
+        try {
+          const res = await call(SV.Device + ".StartPairingOffer", "", "", false, "");
+          if (res && res.code) {
+            $("pair-offer-code").textContent = res.code;
+            if (res.qr && res.qr.startsWith("data:image/png;base64,")) {
+              qrImg.src = res.qr;
+              qrImg.classList.remove("hidden");
+            }
+          }
+        } catch (err) {
+          $("pair-offer-code").textContent = "Offer failed";
+          $("pair-offer-status").textContent = String(err);
+        }
+      }
+
+      $("pair-join-auto-accept").addEventListener("change", (e) => {
+        $("pair-join-dest-container").classList.toggle("hidden", !e.target.checked);
+      });
+      $("pair-join-browse-dest").addEventListener("click", async () => {
+        const res = await call(SV.Transfer + ".PickDestination");
+        if (res && res.paths && res.paths.length) {
+          $("pair-join-dest-dir").value = res.paths[0];
+        }
+      });
+      $("pair-join-submit").addEventListener("click", async () => {
+        const code = $("pair-join-code").value.trim();
+        const label = $("pair-join-label").value.trim();
+        const autoAccept = $("pair-join-auto-accept").checked;
+        const destDir = $("pair-join-dest-dir").value.trim();
+
+        if (!code) {
+          $("pair-join-status").textContent = "Invite code is required.";
+          return;
+        }
+        if (autoAccept && !destDir) {
+          $("pair-join-status").textContent = "Destination directory required when auto-accept is enabled.";
+          return;
+        }
+
+        $("pair-join-status").textContent = "Pairing with device…";
+        $("pair-join-submit").disabled = true;
+
+        try {
+          await call(SV.Device + ".PairDevice", "", code, label, autoAccept, destDir);
+          $("pair-join-status").textContent = "Paired successfully!";
+          closePairModal();
+          loadDevicesList();
+        } catch (err) {
+          $("pair-join-status").textContent = String(err);
+        } finally {
+          $("pair-join-submit").disabled = false;
+        }
+      });
+
+      wails.Events.On("sendbeam:pairing_complete", () => {
+        $("pair-offer-status").textContent = "Successfully paired!";
+        setTimeout(() => {
+          closePairModal();
+          loadDevicesList();
+        }, 1000);
+      });
+
+      wails.Events.On("sendbeam:pairing_failed", (ev) => {
+        $("pair-offer-status").textContent = "Pairing failed: " + (ev && ev.error ? ev.error : "unknown error");
+      });
+
+      // 2. POLICY MODAL
+      function openPolicyModal(dev) {
+        hideAllModals();
+        state.activeDevice = dev;
+        $("modal-policy").classList.remove("hidden");
+
+        const info = $("policy-device-info");
+        info.replaceChildren();
+        const st = document.createElement("strong");
+        st.textContent = dev.localLabel;
+        info.appendChild(st);
+        info.appendChild(document.createTextNode(" (" + dev.fingerprint + ")"));
+
+        const isAuto = !!(dev.policy && dev.policy.autoAccept);
+        $("policy-auto-accept").checked = isAuto;
+        $("policy-dest-container").classList.toggle("hidden", !isAuto);
+        $("policy-dest-dir").value = (dev.policy && dev.policy.autoAcceptDestDir) || "";
+        $("policy-status").textContent = "";
+      }
+      function closePolicyModal() {
+        $("modal-policy").classList.add("hidden");
+        state.activeDevice = null;
+      }
+      $("policy-modal-close").addEventListener("click", closePolicyModal);
+      $("policy-cancel-btn").addEventListener("click", closePolicyModal);
+      $("policy-auto-accept").addEventListener("change", (e) => {
+        $("policy-dest-container").classList.toggle("hidden", !e.target.checked);
+      });
+      $("policy-browse-dest").addEventListener("click", async () => {
+        const res = await call(SV.Transfer + ".PickDestination");
+        if (res && res.paths && res.paths.length) {
+          $("policy-dest-dir").value = res.paths[0];
+        }
+      });
+      $("policy-save-btn").addEventListener("click", async () => {
+        if (!state.activeDevice) return;
+        const autoAccept = $("policy-auto-accept").checked;
+        const destDir = $("policy-dest-dir").value.trim();
+        if (autoAccept && !destDir) {
+          $("policy-status").textContent = "Destination folder required when auto-accept is enabled.";
+          return;
+        }
+        $("policy-status").textContent = "Saving policy…";
+        try {
+          await call(SV.Device + ".UpdateDevicePolicy", state.activeDevice.deviceId, {
+            autoAccept: autoAccept,
+            autoAcceptDestDir: destDir,
+          });
+          closePolicyModal();
+          loadDevicesList();
+        } catch (err) {
+          $("policy-status").textContent = String(err);
+        }
+      });
+
+      // 3. RENAME MODAL
+      function openRenameModal(dev) {
+        hideAllModals();
+        state.activeDevice = dev;
+        $("modal-rename").classList.remove("hidden");
+        $("rename-label-input").value = dev.localLabel;
+        $("rename-status").textContent = "";
+      }
+      function closeRenameModal() {
+        $("modal-rename").classList.add("hidden");
+        state.activeDevice = null;
+      }
+      $("rename-modal-close").addEventListener("click", closeRenameModal);
+      $("rename-cancel-btn").addEventListener("click", closeRenameModal);
+      $("rename-save-btn").addEventListener("click", async () => {
+        if (!state.activeDevice) return;
+        const newLabel = $("rename-label-input").value.trim();
+        if (!newLabel) {
+          $("rename-status").textContent = "Name cannot be empty.";
+          return;
+        }
+        $("rename-status").textContent = "Saving…";
+        try {
+          await call(SV.Device + ".RenameDevice", state.activeDevice.deviceId, newLabel);
+          closeRenameModal();
+          loadDevicesList();
+        } catch (err) {
+          $("rename-status").textContent = String(err);
+        }
+      });
+
+      // 4. UNPAIR MODAL
+      function openUnpairModal(dev) {
+        hideAllModals();
+        state.activeDevice = dev;
+        $("modal-unpair").classList.remove("hidden");
+        const prompt = $("unpair-device-prompt");
+        prompt.replaceChildren();
+        prompt.appendChild(document.createTextNode("Are you sure you want to unpair "));
+        const st = document.createElement("strong");
+        st.textContent = dev.localLabel;
+        prompt.appendChild(st);
+        prompt.appendChild(document.createTextNode(" (" + dev.fingerprint + ")?"));
+        $("unpair-status").textContent = "";
+      }
+      function closeUnpairModal() {
+        $("modal-unpair").classList.add("hidden");
+        state.activeDevice = null;
+      }
+      $("unpair-modal-close").addEventListener("click", closeUnpairModal);
+      $("unpair-cancel-btn").addEventListener("click", closeUnpairModal);
+      $("unpair-confirm-btn").addEventListener("click", async () => {
+        if (!state.activeDevice) return;
+        const modeEl = document.querySelector('input[name="unpair-mode"]:checked');
+        const purge = modeEl ? modeEl.value === "purge" : false;
+        $("unpair-status").textContent = "Unpairing…";
+        try {
+          await call(SV.Device + ".UnpairDevice", state.activeDevice.deviceId, purge);
+          closeUnpairModal();
+          loadDevicesList();
+        } catch (err) {
+          $("unpair-status").textContent = String(err);
+        }
+      });
+
+      // 5. INCOMING CONSENT MODAL
+      function showConsentPrompt(req) {
+        if (!req || !req.transferId) return;
+        state.pendingConsentId = req.transferId;
+        $("modal-consent").classList.remove("hidden");
+        $("consent-device-name").textContent = req.peerName || req.peerDeviceId || "Trusted Device";
+        $("consent-fingerprint").textContent = req.fingerprint || "";
+        const label = req.fileName || "File";
+        $("consent-files-summary").textContent = label + " (" + humanBytes(req.totalSize || 0) + ")";
+        $("consent-dest-dir").value = req.destDir || $("cfg-downdir").value || "";
+        $("consent-status").textContent = "";
+      }
+      $("consent-browse-dest").addEventListener("click", async () => {
+        const res = await call(SV.Transfer + ".PickDestination");
+        if (res && res.paths && res.paths.length) {
+          $("consent-dest-dir").value = res.paths[0];
+        }
+      });
+      $("consent-accept-btn").addEventListener("click", async () => {
+        if (!state.pendingConsentId) return;
+        const destDir = $("consent-dest-dir").value.trim();
+        $("consent-status").textContent = "Accepting…";
+        try {
+          await call(SV.Transfer + ".RespondConsent", state.pendingConsentId, {
+            accepted: true,
+            destDir: destDir,
+          });
+          $("modal-consent").classList.add("hidden");
+          state.pendingConsentId = null;
+        } catch (err) {
+          $("consent-status").textContent = String(err);
+        }
+      });
+      $("consent-decline-btn").addEventListener("click", async () => {
+        if (!state.pendingConsentId) return;
+        $("consent-status").textContent = "Declining…";
+        try {
+          await call(SV.Transfer + ".RespondConsent", state.pendingConsentId, {
+            accepted: false,
+            reason: "Declined by user",
+          });
+          $("modal-consent").classList.add("hidden");
+          state.pendingConsentId = null;
+        } catch (err) {
+          $("consent-status").textContent = String(err);
+        }
+      });
+
+      wails.Events.On("sendbeam:consent", (req) => {
+        showConsentPrompt(req);
       });
 
       // DURABLE / INTERRUPTED
@@ -1017,6 +1807,15 @@
         try {
           const st = await call(SV.Update + ".GetStatus");
           if (st) renderUpdateStatus(st);
+        } catch (err) {}
+
+        try {
+          await loadDevicesList();
+        } catch (err) {}
+
+        try {
+          const consents = await call(SV.Transfer + ".PendingConsents");
+          if (consents && consents.length) showConsentPrompt(consents[0]);
         } catch (err) {}
       })();
     </script>

--- a/apps/desktop/internal/engine/device_service.go
+++ b/apps/desktop/internal/engine/device_service.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -18,10 +19,17 @@ import (
 	"github.com/sendbeam/engine/trust"
 	"github.com/sendbeam/engine/wsclient"
 	"github.com/sendbeam/wire"
+	qrcode "github.com/skip2/go-qrcode"
 )
 
 // DeviceEventName is emitted to frontend whenever trusted devices or presence states update.
 const DeviceEventName = "sendbeam:devices"
+
+// PairingOfferResult represents the generated invite code and QR code for an offerer pairing session.
+type PairingOfferResult struct {
+	Code string `json:"code"`
+	QR   string `json:"qr"`
+}
 
 // TrustedDeviceView is the JSON-serializable representation of a paired device for the UI.
 type TrustedDeviceView struct {
@@ -46,17 +54,19 @@ type discoveredPeerInfo struct {
 
 // DeviceService manages trusted device operations and background presence for the desktop UI.
 type DeviceService struct {
-	mu           sync.RWMutex
-	emit         func(name string, data any)
-	idMgr        *trust.IdentityManager
-	store        trust.Store
-	secrets      trust.CredentialStore
-	coordinator  *trust.PairingCoordinator
-	tombstones   trust.TombstoneStore
-	lanDiscovery *discovery.LanDiscoveryService
-	activePeers  map[string]discoveredPeerInfo // deviceID -> info
-	configDir    string
-	cancel       context.CancelFunc
+	mu            sync.RWMutex
+	emit          func(name string, data any)
+	idMgr         *trust.IdentityManager
+	store         trust.Store
+	secrets       trust.CredentialStore
+	coordinator   *trust.PairingCoordinator
+	tombstones    trust.TombstoneStore
+	lanDiscovery  *discovery.LanDiscoveryService
+	activePeers   map[string]discoveredPeerInfo // deviceID -> info
+	configDir     string
+	cancel        context.CancelFunc
+	pairingMu     sync.Mutex
+	pairingCancel context.CancelFunc
 }
 
 // NewDeviceService initializes the desktop device service with the default OS-protected credential store.
@@ -335,9 +345,6 @@ func (s *DeviceService) PairDevice(serverURL, inviteCode, customLabel string, au
 	if hostname == "" {
 		hostname = "Desktop Device"
 	}
-	if customLabel != "" {
-		hostname = customLabel
-	}
 
 	opts := rendezvous.Options{
 		Role: wire.RoleJoiner,
@@ -366,6 +373,10 @@ func (s *DeviceService) PairDevice(serverURL, inviteCode, customLabel string, au
 	if err != nil {
 		return nil, fmt.Errorf("pairing ceremony failed: %w", err)
 	}
+	if customLabel != "" {
+		pairResult.PeerRecord.LocalLabel = customLabel
+		_ = s.store.AddOrUpdateDevice(ctx, pairResult.PeerRecord)
+	}
 
 	s.notifyDevicesChanged()
 
@@ -386,6 +397,155 @@ func (s *DeviceService) PairDevice(serverURL, inviteCode, customLabel string, au
 	}, nil
 }
 
+// StartPairingOffer starts an offerer pairing session, returning the invite code and QR code.
+// The ceremony completes asynchronously when a peer connects with the invite code.
+func (s *DeviceService) StartPairingOffer(serverURL, customLabel string, autoAccept bool, destDir string) (*PairingOfferResult, error) {
+	if autoAccept {
+		if destDir == "" {
+			return nil, errors.New("destination directory is required when auto-accept is enabled")
+		}
+		if !filepath.IsAbs(destDir) {
+			return nil, errors.New("destination directory must be an absolute path")
+		}
+	}
+	server := serverURL
+	if server == "" {
+		server = DefaultServer
+	}
+
+	s.pairingMu.Lock()
+	if s.pairingCancel != nil {
+		s.pairingCancel()
+		s.pairingCancel = nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	s.pairingCancel = cancel
+	s.pairingMu.Unlock()
+
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "SendBeam Desktop"
+	}
+
+	codeChan := make(chan string, 1)
+	errChan := make(chan error, 1)
+
+	opts := rendezvous.Options{
+		Role: wire.RoleOfferer,
+		OnCode: func(code string) {
+			select {
+			case codeChan <- code:
+			default:
+			}
+		},
+	}
+	dopts := wsclient.DialOptions{
+		InsecureSkipVerify: true,
+	}
+
+	go func() {
+		pairSess, err := wsclient.RendezvousPair(ctx, server, dopts, opts)
+		if err != nil {
+			select {
+			case errChan <- err:
+			default:
+			}
+			return
+		}
+		defer pairSess.Close()
+
+		cfg := trust.PairingSessionConfig{
+			DeviceName:   hostname,
+			Capabilities: []string{"transfer.v1", "transfer.v2", "lan_direct"},
+			MasterKey:    pairSess.Result.Master,
+			AutoAccept:   autoAccept,
+			DestDir:      destDir,
+		}
+
+		pairResult, err := s.coordinator.InitiatePairing(ctx, pairSess, cfg)
+		if err != nil {
+			if s.emit != nil {
+				s.emit("sendbeam:pairing_failed", map[string]any{
+					"error": err.Error(),
+				})
+			}
+			return
+		}
+
+		if customLabel != "" {
+			pairResult.PeerRecord.LocalLabel = customLabel
+			_ = s.store.AddOrUpdateDevice(ctx, pairResult.PeerRecord)
+		}
+
+		s.notifyDevicesChanged()
+		if s.emit != nil {
+			s.emit("sendbeam:pairing_complete", map[string]any{
+				"deviceId":   pairResult.PeerRecord.DeviceID,
+				"localLabel": pairResult.PeerRecord.LocalLabel,
+			})
+		}
+	}()
+
+	select {
+	case code := <-codeChan:
+		var qr string
+		if png, err := qrcode.Encode(code, qrcode.Medium, 256); err == nil {
+			qr = "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
+		}
+		return &PairingOfferResult{
+			Code: code,
+			QR:   qr,
+		}, nil
+	case err := <-errChan:
+		_ = s.CancelPairingOffer()
+		return nil, fmt.Errorf("pairing offer failed: %w", err)
+	case <-time.After(15 * time.Second):
+		_ = s.CancelPairingOffer()
+		return nil, errors.New("timed out waiting for pairing room allocation")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// CancelPairingOffer cancels an in-progress pairing offer session.
+func (s *DeviceService) CancelPairingOffer() error {
+	s.pairingMu.Lock()
+	defer s.pairingMu.Unlock()
+	if s.pairingCancel != nil {
+		s.pairingCancel()
+		s.pairingCancel = nil
+	}
+	return nil
+}
+
+// GetIdentityManager returns the local IdentityManager.
+func (s *DeviceService) GetIdentityManager() *trust.IdentityManager {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.idMgr
+}
+
+// GetStore returns the local TrustStore.
+func (s *DeviceService) GetStore() trust.Store {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.store
+}
+
+// GetCredentialStore returns the local CredentialStore.
+func (s *DeviceService) GetCredentialStore() trust.CredentialStore {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.secrets
+}
+
+// GetTombstoneStore returns the local TombstoneStore.
+func (s *DeviceService) GetTombstoneStore() trust.TombstoneStore {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tombstones
+}
+
 func (s *DeviceService) notifyDevicesChanged() {
 	if s.emit == nil {
 		return
@@ -398,6 +558,7 @@ func (s *DeviceService) notifyDevicesChanged() {
 
 // Close gracefully stops the device service.
 func (s *DeviceService) Close() {
+	_ = s.CancelPairingOffer()
 	if s.cancel != nil {
 		s.cancel()
 	}

--- a/apps/desktop/internal/engine/device_service_test.go
+++ b/apps/desktop/internal/engine/device_service_test.go
@@ -263,10 +263,14 @@ func TestDeviceService_StartPairingOffer_ValidationAndCancel(t *testing.T) {
 	}
 
 	// 3. CancelPairingOffer is safe even before any offer starts
-	svc.CancelPairingOffer()
+	if err := svc.CancelPairingOffer(); err != nil {
+		t.Fatalf("CancelPairingOffer failed: %v", err)
+	}
 
 	// 4. Repeated Cancel is safe
-	svc.CancelPairingOffer()
+	if err := svc.CancelPairingOffer(); err != nil {
+		t.Fatalf("repeated CancelPairingOffer failed: %v", err)
+	}
 }
 
 type testBlindHub struct {

--- a/apps/desktop/internal/engine/device_service_test.go
+++ b/apps/desktop/internal/engine/device_service_test.go
@@ -5,11 +5,17 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
+	"github.com/sendbeam/engine/rendezvous"
 	"github.com/sendbeam/engine/trust"
 	"github.com/sendbeam/wire"
 )
@@ -235,4 +241,209 @@ func TestDeviceService_UnpairTombstoneAndCredentialDeletion(t *testing.T) {
 		t.Fatalf("expected 1 revoked device, got: %+v", views)
 	}
 }
+
+func TestDeviceService_StartPairingOffer_ValidationAndCancel(t *testing.T) {
+	tmpDir := t.TempDir()
+	svc, err := NewDeviceService(nil, tmpDir)
+	if err != nil {
+		t.Fatalf("NewDeviceService failed: %v", err)
+	}
+	defer svc.Close()
+
+	// 1. AutoAccept with relative path must fail
+	_, err = svc.StartPairingOffer("", "", true, "relative/dir")
+	if err == nil {
+		t.Fatal("expected error for relative destDir with autoAccept")
+	}
+
+	// 2. AutoAccept with empty path must fail
+	_, err = svc.StartPairingOffer("", "", true, "")
+	if err == nil {
+		t.Fatal("expected error for empty destDir with autoAccept")
+	}
+
+	// 3. CancelPairingOffer is safe even before any offer starts
+	svc.CancelPairingOffer()
+
+	// 4. Repeated Cancel is safe
+	svc.CancelPairingOffer()
+}
+
+type testBlindHub struct {
+	mu    sync.Mutex
+	rooms map[int]*testHubRoom
+	next  int
+}
+
+type testHubRoom struct {
+	offerer, joiner *testHubPeer
+}
+
+type testHubPeer struct {
+	conn *websocket.Conn
+	wmu  sync.Mutex
+}
+
+func (p *testHubPeer) send(ctx context.Context, m rendezvous.Message) {
+	data, err := rendezvous.MarshalMessage(m)
+	if err != nil {
+		return
+	}
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	_ = p.conn.Write(ctx, websocket.MessageText, data)
+}
+
+func (p *testHubPeer) forward(ctx context.Context, data []byte) {
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	_ = p.conn.Write(ctx, websocket.MessageText, data)
+}
+
+func (h *testBlindHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.CloseNow() }()
+	ctx := r.Context()
+	self := &testHubPeer{conn: conn}
+
+	var room *testHubRoom
+	var role rendezvous.Role
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		if typ != websocket.MessageText {
+			return
+		}
+		msg, err := rendezvous.UnmarshalMessage(data)
+		if err != nil {
+			return
+		}
+
+		switch msg.Type {
+		case "create":
+			h.mu.Lock()
+			id := h.next
+			h.next++
+			room = &testHubRoom{offerer: self}
+			h.rooms[id] = room
+			h.mu.Unlock()
+			role = rendezvous.RoleOfferer
+			self.send(ctx, rendezvous.Message{Type: "created", Room: &id})
+
+		case "join":
+			if msg.Room == nil {
+				return
+			}
+			h.mu.Lock()
+			room = h.rooms[*msg.Room]
+			h.mu.Unlock()
+			if room == nil {
+				return
+			}
+			room.joiner = self
+			role = rendezvous.RoleJoiner
+			self.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(rendezvous.RoleJoiner)})
+			room.offerer.send(ctx, rendezvous.Message{Type: "peer-joined", Role: string(rendezvous.RoleOfferer)})
+
+		default:
+			other := room.joiner
+			if role == rendezvous.RoleJoiner {
+				other = room.offerer
+			}
+			if other != nil {
+				other.forward(ctx, data)
+			}
+		}
+	}
+}
+
+func TestDeviceService_StartPairingOffer_AndPairDevice_Loopback(t *testing.T) {
+	hub := &testBlindHub{rooms: make(map[int]*testHubRoom)}
+	srv := httptest.NewServer(hub)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	pairedChanA := make(chan struct{}, 1)
+	memStoreA := trust.NewMemoryCredentialStore()
+	svcA, err := NewDeviceServiceWithCredentials(func(name string, _ any) {
+		if name == "sendbeam:pairing_complete" {
+			select {
+			case pairedChanA <- struct{}{}:
+			default:
+			}
+		}
+	}, dirA, memStoreA)
+	if err != nil {
+		t.Fatalf("svcA NewDeviceServiceWithCredentials: %v", err)
+	}
+	defer svcA.Close()
+
+	memStoreB := trust.NewMemoryCredentialStore()
+	svcB, err := NewDeviceServiceWithCredentials(nil, dirB, memStoreB)
+	if err != nil {
+		t.Fatalf("svcB NewDeviceServiceWithCredentials: %v", err)
+	}
+	defer svcB.Close()
+
+	// svcA starts offer with custom label for peer as "Joiner Laptop"
+	offer, err := svcA.StartPairingOffer(wsURL, "Joiner Laptop", false, "")
+	if err != nil {
+		t.Fatalf("StartPairingOffer failed: %v", err)
+	}
+	if offer.Code == "" {
+		t.Fatal("expected non-empty invite code")
+	}
+	if !strings.HasPrefix(offer.QR, "data:image/png;base64,") {
+		t.Fatalf("expected data:image/png;base64 QR, got: %s", offer.QR)
+	}
+
+	// svcB joins using offer.Code and custom label for peer as "Offerer Workstation"
+	viewB, err := svcB.PairDevice(wsURL, offer.Code, "Offerer Workstation", true, dirB)
+	if err != nil {
+		t.Fatalf("svcB PairDevice failed: %v", err)
+	}
+	if viewB.DeviceID == "" {
+		t.Fatal("expected viewB to have DeviceID")
+	}
+
+	// Wait for svcA to complete pairing
+	select {
+	case <-pairedChanA:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for svcA pairing_complete event")
+	}
+
+	// Check trusted devices on both sides
+	devsA, err := svcA.ListTrustedDevices()
+	if err != nil {
+		t.Fatalf("svcA ListTrustedDevices: %v", err)
+	}
+	if len(devsA) != 1 {
+		t.Fatalf("expected 1 trusted device on svcA, got %d", len(devsA))
+	}
+	if devsA[0].LocalLabel != "Joiner Laptop" {
+		t.Fatalf("expected svcA trusted device label 'Joiner Laptop', got %q", devsA[0].LocalLabel)
+	}
+
+	devsB, err := svcB.ListTrustedDevices()
+	if err != nil {
+		t.Fatalf("svcB ListTrustedDevices: %v", err)
+	}
+	if len(devsB) != 1 {
+		t.Fatalf("expected 1 trusted device on svcB, got %d", len(devsB))
+	}
+	if devsB[0].LocalLabel != "Offerer Workstation" {
+		t.Fatalf("expected svcB trusted device label 'Offerer Workstation', got %q", devsB[0].LocalLabel)
+	}
+}
+
 

--- a/apps/desktop/internal/engine/smoke_test.go
+++ b/apps/desktop/internal/engine/smoke_test.go
@@ -1,0 +1,180 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sendbeam/engine/receiver"
+	"github.com/sendbeam/engine/trust"
+)
+
+func TestNativeArtifactSmoke_BuiltFrontendHTML(t *testing.T) {
+	// Locate apps/desktop/frontend/dist/index.html relative to engine test directory
+	// In internal/engine: ../../frontend/dist/index.html
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	htmlPath := filepath.Clean(filepath.Join(cwd, "..", "..", "frontend", "dist", "index.html"))
+	contentBytes, err := os.ReadFile(htmlPath)
+	if err != nil {
+		t.Fatalf("failed to read built frontend HTML asset at %s: %v", htmlPath, err)
+	}
+	content := string(contentBytes)
+	if len(content) == 0 {
+		t.Fatalf("built frontend HTML asset is empty at %s", htmlPath)
+	}
+
+	// 1. Critical DOM elements for trusted-device handoffs
+	requiredIDs := []string{
+		`id="tab-devices"`,
+		`id="panel-devices"`,
+		`id="devices-table"`,
+		`id="devices-tbody"`,
+		`id="devices-empty"`,
+		`id="open-pair-btn"`,
+		`id="send-recipient"`,
+		`id="modal-pair"`,
+		`id="pair-offer-code"`,
+		`id="pair-offer-qr"`,
+		`id="pair-join-code"`,
+		`id="pair-join-submit"`,
+		`id="modal-policy"`,
+		`id="policy-auto-accept"`,
+		`id="policy-dest-dir"`,
+		`id="policy-save-btn"`,
+		`id="modal-rename"`,
+		`id="rename-label-input"`,
+		`id="rename-save-btn"`,
+		`id="modal-unpair"`,
+		`id="unpair-confirm-btn"`,
+		`id="modal-consent"`,
+		`id="consent-accept-btn"`,
+		`id="consent-decline-btn"`,
+	}
+
+	for _, req := range requiredIDs {
+		if !strings.Contains(content, req) {
+			t.Errorf("built HTML missing required element %s", req)
+		}
+	}
+
+	// 2. Critical CSS badge classes
+	requiredClasses := []string{
+		"badge-lan",
+		"badge-online",
+		"badge-offline",
+		"badge-revoked",
+		"modal-backdrop",
+		"modal-card",
+	}
+
+	for _, cls := range requiredClasses {
+		if !strings.Contains(content, cls) {
+			t.Errorf("built HTML missing required CSS class %s", cls)
+		}
+	}
+
+	// 3. Security invariant checks: Zero innerHTML / outerHTML / document.write / insertAdjacentHTML
+	forbiddenSinks := []string{
+		"innerHTML",
+		"outerHTML",
+		"document.write",
+		"insertAdjacentHTML",
+		"javascript:",
+		"vbscript:",
+	}
+
+	for _, sink := range forbiddenSinks {
+		if strings.Contains(content, sink) {
+			t.Errorf("built HTML violates strict safety invariant, contains forbidden pattern: %q", sink)
+		}
+	}
+}
+
+func TestNativeArtifactSmoke_EngineServicesWiring(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	sink := &eventSink{}
+	transferSvc := NewTransferService(sink.emit, nil)
+
+	memCreds := trust.NewMemoryCredentialStore()
+	deviceSvc, err := NewDeviceServiceWithCredentials(sink.emit, tmpDir, memCreds)
+	if err != nil {
+		t.Fatalf("NewDeviceServiceWithCredentials failed: %v", err)
+	}
+	defer deviceSvc.Close()
+
+	// 1. Verify accessors
+	if deviceSvc.GetIdentityManager() == nil {
+		t.Fatal("expected non-nil IdentityManager")
+	}
+	if deviceSvc.GetStore() == nil {
+		t.Fatal("expected non-nil Store")
+	}
+	if deviceSvc.GetCredentialStore() == nil {
+		t.Fatal("expected non-nil CredentialStore")
+	}
+	if deviceSvc.GetTombstoneStore() == nil {
+		t.Fatal("expected non-nil TombstoneStore")
+	}
+
+	// 2. Wire DeviceService into TransferService
+	transferSvc.SetDeviceService(deviceSvc)
+	if transferSvc.DeviceService() != deviceSvc {
+		t.Fatal("expected DeviceService to be wired into TransferService")
+	}
+
+	// 3. Retrieve local identity
+	localID, err := deviceSvc.GetIdentityManager().GetOrCreateIdentity()
+	if err != nil {
+		t.Fatalf("GetOrCreateIdentity failed: %v", err)
+	}
+
+	// 4. Start Native Receiver using DeviceService identity and stores
+	cfg := receiver.Config{
+		Server:     DefaultServer,
+		DestDir:    tmpDir,
+		AutoAccept: false,
+		Identity:   localID,
+		TrustStore: deviceSvc.GetStore(),
+		Secrets:    deviceSvc.GetCredentialStore(),
+		Tombstones: deviceSvc.GetTombstoneStore(),
+		Port:       0, // disable LAN listener in smoke test
+	}
+
+	if err := transferSvc.StartNativeReceiver(cfg); err != nil {
+		t.Fatalf("StartNativeReceiver failed: %v", err)
+	}
+
+	if transferSvc.NativeReceiver() == nil {
+		t.Fatal("expected active NativeReceiver")
+	}
+
+	// 5. Query pending consents (should be empty initially)
+	consents := transferSvc.PendingConsents()
+	if len(consents) != 0 {
+		t.Fatalf("expected 0 pending consents, got %d", len(consents))
+	}
+
+	// 6. Stop Native Receiver cleanly
+	if err := transferSvc.StopNativeReceiver(); err != nil {
+		t.Fatalf("StopNativeReceiver failed: %v", err)
+	}
+
+	if transferSvc.NativeReceiver() != nil {
+		t.Fatal("expected nil NativeReceiver after stop")
+	}
+
+	// 7. Verify device listing queries work on clean state
+	devs, err := deviceSvc.ListTrustedDevices()
+	if err != nil {
+		t.Fatalf("ListTrustedDevices failed: %v", err)
+	}
+	if len(devs) != 0 {
+		t.Fatalf("expected 0 trusted devices initially, got %d", len(devs))
+	}
+}

--- a/apps/desktop/internal/engine/transfer_service.go
+++ b/apps/desktop/internal/engine/transfer_service.go
@@ -177,6 +177,22 @@ type TransferService struct {
 
 	nativeReceiver       *receiver.Listener
 	nativeReceiverCancel context.CancelFunc
+
+	deviceService *DeviceService
+}
+
+// SetDeviceService sets the device service reference for targeted sends and peer trust resolution.
+func (s *TransferService) SetDeviceService(ds *DeviceService) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deviceService = ds
+}
+
+// DeviceService returns the configured device service or nil.
+func (s *TransferService) DeviceService() *DeviceService {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.deviceService
 }
 
 // SetPicker sets the native dialog picker provider (e.g. Wails dialogs).
@@ -447,6 +463,201 @@ func (s *TransferService) Send(paths []string, server string) (Handle, error) {
 
 	go r.runSend(r.ctx, server, sources, paths, iceServers)
 	return Handle{ID: id, Role: "send"}, nil
+}
+
+// SendToDevice starts a targeted send to a paired trusted device using sendbeam/3 opaque rendezvous.
+func (s *TransferService) SendToDevice(paths []string, deviceID string, server string) (Handle, error) {
+	if len(paths) == 0 {
+		return Handle{}, errors.New("no files or folders selected")
+	}
+	if deviceID == "" {
+		return Handle{}, errors.New("device ID is required")
+	}
+	if server == "" {
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.ServerURL != "" {
+				server = cfg.ServerURL
+			}
+		}
+		if server == "" {
+			server = DefaultServer
+		}
+	}
+	if err := validatePaths(paths); err != nil {
+		return Handle{}, err
+	}
+	iceServers, err := s.resolveICEServers()
+	if err != nil {
+		return Handle{}, err
+	}
+
+	ds := s.DeviceService()
+	if ds == nil {
+		return Handle{}, errors.New("device service not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dev, err := ds.GetStore().GetDevice(ctx, deviceID)
+	if err != nil {
+		return Handle{}, fmt.Errorf("device %s not found: %w", deviceID, err)
+	}
+	tombstones := ds.GetTombstoneStore()
+	if dev.Revoked || (tombstones != nil && tombstones.HasTombstone(ctx, dev.DeviceID)) {
+		return Handle{}, fmt.Errorf("trust for device %q is revoked", dev.LocalLabel)
+	}
+	kPair, err := ds.GetCredentialStore().ResolvePairSecret(ctx, dev.DeviceID, dev.PairCredentialRef)
+	if err != nil || len(kPair) == 0 {
+		return Handle{}, fmt.Errorf("failed to resolve pair secret for device %q: %w", dev.LocalLabel, err)
+	}
+	peerPubKey, err := wire.ParsePublicKeyHex(dev.PublicKey)
+	if err != nil {
+		return Handle{}, fmt.Errorf("invalid public key for device %q: %w", dev.LocalLabel, err)
+	}
+	localID, err := ds.GetIdentityManager().GetOrCreateIdentity()
+	if err != nil {
+		return Handle{}, fmt.Errorf("failed to get local identity: %w", err)
+	}
+
+	handle := wire.DeriveRendezvousHandleForTime(kPair, time.Now().UTC(), wire.DefaultRendezvousEpochWindow)
+	replayCache := wire.NewNonceReplayCache(5 * time.Minute)
+	opaqueOpts := &rendezvous.OpaqueOptions{
+		Role:              rendezvous.RoleOfferer,
+		Handle:            handle,
+		LocalIdentity:     localID,
+		PeerDeviceID:      dev.DeviceID,
+		PeerPublicKey:     peerPubKey,
+		KPair:             kPair,
+		PairCredentialRef: dev.PairCredentialRef,
+		LocalCaps:         []string{"sendbeam/3", "rendezvous", "resume"},
+		ReplayCache:       replayCache,
+		Tombstones:        tombstones,
+		TrustStore:        ds.GetStore(),
+	}
+
+	sources, total, err := transfer.NewOSFileSources(paths)
+	if err != nil {
+		return Handle{}, err
+	}
+
+	id := s.newID()
+	r := s.newRun(id, wire.RoleOfferer)
+	for _, src := range sources {
+		meta := src.Meta()
+		r.mu.Lock()
+		r.files = append(r.files, FileInfo{Name: meta.Name, Size: meta.Size})
+		r.totalBytes += meta.Size
+		r.mu.Unlock()
+	}
+	_ = total
+
+	go r.runSendTargeted(r.ctx, server, sources, paths, iceServers, opaqueOpts, dev.LocalLabel, dev.DeviceID)
+	return Handle{ID: id, Role: "send"}, nil
+}
+
+// BroadcastSend sends files concurrently to multiple trusted devices.
+func (s *TransferService) BroadcastSend(paths []string, deviceIDs []string, server string) ([]transfer.TargetResult, error) {
+	if len(paths) == 0 {
+		return nil, errors.New("no files or folders selected")
+	}
+	if len(deviceIDs) == 0 {
+		return nil, errors.New("no target devices selected")
+	}
+	if server == "" {
+		if s.configStore != nil {
+			if cfg, err := s.configStore.Load(); err == nil && cfg.ServerURL != "" {
+				server = cfg.ServerURL
+			}
+		}
+		if server == "" {
+			server = DefaultServer
+		}
+	}
+	if err := validatePaths(paths); err != nil {
+		return nil, err
+	}
+	iceServers, err := s.resolveICEServers()
+	if err != nil {
+		return nil, err
+	}
+
+	ds := s.DeviceService()
+	if ds == nil {
+		return nil, errors.New("device service not available")
+	}
+
+	ctx := context.Background()
+	localID, err := ds.GetIdentityManager().GetOrCreateIdentity()
+	if err != nil {
+		return nil, fmt.Errorf("local identity error: %w", err)
+	}
+
+	sources, _, err := transfer.NewOSFileSources(paths)
+	if err != nil {
+		return nil, err
+	}
+
+	replayCache := wire.NewNonceReplayCache(5 * time.Minute)
+	targets := make([]transfer.BroadcastTarget, 0, len(deviceIDs))
+
+	for _, devID := range deviceIDs {
+		dev, err := ds.GetStore().GetDevice(ctx, devID)
+		if err != nil {
+			return nil, fmt.Errorf("device %s not found: %w", devID, err)
+		}
+		tombstones := ds.GetTombstoneStore()
+		if dev.Revoked || (tombstones != nil && tombstones.HasTombstone(ctx, dev.DeviceID)) {
+			return nil, fmt.Errorf("trust for device %q is revoked", dev.LocalLabel)
+		}
+		kPair, err := ds.GetCredentialStore().ResolvePairSecret(ctx, dev.DeviceID, dev.PairCredentialRef)
+		if err != nil || len(kPair) == 0 {
+			return nil, fmt.Errorf("failed to resolve pair secret for device %q: %w", dev.LocalLabel, err)
+		}
+		peerPubKey, err := wire.ParsePublicKeyHex(dev.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid public key for device %q: %w", dev.LocalLabel, err)
+		}
+
+		handle := wire.DeriveRendezvousHandleForTime(kPair, time.Now().UTC(), wire.DefaultRendezvousEpochWindow)
+		opaqueOpts := &rendezvous.OpaqueOptions{
+			Role:              rendezvous.RoleOfferer,
+			Handle:            handle,
+			LocalIdentity:     localID,
+			PeerDeviceID:      dev.DeviceID,
+			PeerPublicKey:     peerPubKey,
+			KPair:             kPair,
+			PairCredentialRef: dev.PairCredentialRef,
+			LocalCaps:         []string{"sendbeam/3", "rendezvous", "resume"},
+			ReplayCache:       replayCache,
+			Tombstones:        tombstones,
+			TrustStore:        ds.GetStore(),
+		}
+
+		spec := transfer.Spec{
+			Opaque:       opaqueOpts,
+			PeerDeviceID: dev.DeviceID,
+			PeerLabel:    dev.LocalLabel,
+			Sources:      sources,
+			ICEServers:   iceServers,
+			ForceRelay:   s.forceRelay,
+		}
+
+		targets = append(targets, transfer.BroadcastTarget{
+			ID:    dev.DeviceID,
+			Label: dev.LocalLabel,
+			Dial: func(dialCtx context.Context) (transfer.Signal, error) {
+				return s.dial(dialCtx, server, wire.RoleOfferer)
+			},
+			Spec: spec,
+		})
+	}
+
+	bResult := transfer.RunBroadcast(ctx, targets, transfer.BroadcastOptions{
+		Concurrency: 4,
+	})
+
+	return bResult.Results, nil
 }
 
 // Receive starts a joiner (receive) transfer for a code (or a full invite
@@ -1282,6 +1493,91 @@ func (r *transferRun) runSend(ctx context.Context, server string, sources []wire
 
 	if r.svc.notifier != nil {
 		summary := fmt.Sprintf("Sent %d file(s) (%s)", len(out.Files), humanBytes(r.totalBytes))
+		r.svc.notifier.NotifySuccess("Transfer Complete", summary, "")
+	}
+}
+
+// runSendTargeted drives an offerer transfer targeted to a specific paired device via opaque rendezvous.
+func (r *transferRun) runSendTargeted(ctx context.Context, server string, sources []wire.FileSource, paths []string, iceServers []webrtc.ICEServer, opaqueOpts *rendezvous.OpaqueOptions, peerLabel, peerDeviceID string) {
+	defer r.svc.remove(r)
+
+	sig, err := r.svc.dial(ctx, server, wire.RoleOfferer)
+	if err != nil {
+		r.fail("dial: " + err.Error())
+		if r.svc.notifier != nil {
+			r.svc.notifier.NotifyFailure("Transfer Failed", "dial: "+err.Error())
+		}
+		return
+	}
+	defer sig.Close()
+
+	lastProgress := time.Time{}
+	emitProgress := func() {
+		now := time.Now()
+		if now.Sub(lastProgress) < 200*time.Millisecond {
+			return
+		}
+		lastProgress = now
+		r.publish("progress")
+	}
+
+	spec := transfer.Spec{
+		Opaque:         opaqueOpts,
+		PeerDeviceID:   peerDeviceID,
+		PeerLabel:      peerLabel,
+		Sources:        sources,
+		ForceRelay:     r.svc.forceRelay,
+		ICEServers:     iceServers,
+		OnTransport:    r.onTransport,
+		OnConnect:      func() { r.publish("connect") },
+		OnFileProgress: r.onFileProgress,
+		OnProgress: func(n int64) {
+			r.mu.Lock()
+			r.doneBytes = n
+			r.recordSample(n)
+			r.mu.Unlock()
+			emitProgress()
+		},
+		OnControls: func(c transfer.Controls) {
+			r.mu.Lock()
+			r.controls = c
+			r.mu.Unlock()
+			r.publish("connect")
+		},
+		OnStateChange: r.onState,
+	}
+
+	out, err := transfer.Run(ctx, sig, spec)
+	if err != nil {
+		r.fail(err.Error())
+		if r.svc.notifier != nil {
+			r.svc.notifier.NotifyFailure("Transfer Failed", err.Error())
+		}
+		return
+	}
+
+	r.mu.Lock()
+	var done int64
+	for i, f := range out.Files {
+		done += f.Size
+		if i < len(r.files) {
+			r.files[i].Size = f.Size
+		}
+	}
+	r.doneBytes = done
+	r.filesDone = len(out.Files)
+	if out.Handshake != nil {
+		r.fingerprint = fingerprint(out.Handshake.Master)
+	}
+	r.mu.Unlock()
+
+	r.publish("done", func(ev *TransferEvent) {
+		ev.Digest = out.Digest
+		ev.Percent = 100
+	})
+
+	if r.svc.notifier != nil {
+		summary := fmt.Sprintf("Sent %d file(s) (%s) to %s", len(out.Files), humanBytes(r.totalBytes), peerLabel)
 		r.svc.notifier.NotifySuccess("Transfer Complete", summary, "")
 	}
 }

--- a/apps/desktop/internal/engine/transfer_service.go
+++ b/apps/desktop/internal/engine/transfer_service.go
@@ -1498,7 +1498,7 @@ func (r *transferRun) runSend(ctx context.Context, server string, sources []wire
 }
 
 // runSendTargeted drives an offerer transfer targeted to a specific paired device via opaque rendezvous.
-func (r *transferRun) runSendTargeted(ctx context.Context, server string, sources []wire.FileSource, paths []string, iceServers []webrtc.ICEServer, opaqueOpts *rendezvous.OpaqueOptions, peerLabel, peerDeviceID string) {
+func (r *transferRun) runSendTargeted(ctx context.Context, server string, sources []wire.FileSource, _ []string, iceServers []webrtc.ICEServer, opaqueOpts *rendezvous.OpaqueOptions, peerLabel, peerDeviceID string) {
 	defer r.svc.remove(r)
 
 	sig, err := r.svc.dial(ctx, server, wire.RoleOfferer)

--- a/apps/desktop/internal/engine/transfer_service_test.go
+++ b/apps/desktop/internal/engine/transfer_service_test.go
@@ -2,7 +2,10 @@ package engine
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -679,5 +682,84 @@ func TestTransferService_PendingConsentAndRespond(t *testing.T) {
 	err = svc.RespondConsent("nonexistent", receiver.ConsentDecision{Accepted: false})
 	if err == nil {
 		t.Fatal("expected error responding to nonexistent consent request")
+	}
+}
+
+func TestTransferService_SendToDeviceAndBroadcast(t *testing.T) {
+	sink := &eventSink{}
+	svc := NewTransferService(sink.emit, nil)
+
+	dir := t.TempDir()
+	src := writePayload(t, dir, "broadcast-test.txt", 1024)
+
+	// 1. SendToDevice without DeviceService fails
+	_, err := svc.SendToDevice([]string{src}, "dev-some-id", "")
+	if err == nil {
+		t.Fatal("expected error when device service is not configured")
+	}
+
+	// 2. Wire DeviceService
+	memCreds := trust.NewMemoryCredentialStore()
+	devSvc, err := NewDeviceServiceWithCredentials(nil, dir, memCreds)
+	if err != nil {
+		t.Fatalf("NewDeviceServiceWithCredentials: %v", err)
+	}
+	defer devSvc.Close()
+
+	svc.SetDeviceService(devSvc)
+	if svc.DeviceService() != devSvc {
+		t.Fatal("expected DeviceService to be set")
+	}
+
+	// 3. Validation errors
+	if _, err := svc.SendToDevice([]string{}, "dev-1", ""); err == nil {
+		t.Fatal("expected error for empty files")
+	}
+	if _, err := svc.SendToDevice([]string{src}, "", ""); err == nil {
+		t.Fatal("expected error for empty recipient ID")
+	}
+
+	// 4. Unknown device returns error
+	if _, err := svc.SendToDevice([]string{src}, "dev-unknown-123", ""); err == nil {
+		t.Fatal("expected error for unknown device")
+	}
+
+	// 5. Revoked device returns error
+	ctx := context.Background()
+	pubA, _, _ := ed25519.GenerateKey(rand.Reader)
+	devID := wire.DeriveDeviceID(pubA)
+	pubHex := hex.EncodeToString(pubA)
+	rec := &wire.TrustRecord{
+		DeviceID:          devID,
+		PublicKey:         pubHex,
+		LocalLabel:        "Old Stale Peer",
+		PairCredentialRef: "cred-revoked",
+		Revoked:           true,
+		FirstSeenAt:       time.Now().UTC(),
+		Policy:            wire.DefaultTrustPolicy(),
+	}
+	if err := devSvc.GetStore().AddOrUpdateDevice(ctx, rec); err != nil {
+		t.Fatalf("AddOrUpdateDevice: %v", err)
+	}
+
+	if _, err := svc.SendToDevice([]string{src}, devID, ""); err == nil {
+		t.Fatal("expected error for revoked device in SendToDevice")
+	}
+
+	// 6. BroadcastSend validation
+	if _, err := svc.BroadcastSend([]string{}, []string{"dev-1"}, ""); err == nil {
+		t.Fatal("expected error for empty files in BroadcastSend")
+	}
+	if _, err := svc.BroadcastSend([]string{src}, []string{}, ""); err == nil {
+		t.Fatal("expected error for empty targets in BroadcastSend")
+	}
+	if _, err := svc.BroadcastSend([]string{src}, []string{"dev-unknown-123"}, ""); err == nil {
+		t.Fatal("expected error for unknown target device in BroadcastSend")
+	}
+
+	// 7. Nil DeviceService in BroadcastSend
+	svc.SetDeviceService(nil)
+	if _, err := svc.BroadcastSend([]string{src}, []string{"dev-1"}, ""); err == nil {
+		t.Fatal("expected error when device service is nil in BroadcastSend")
 	}
 }

--- a/apps/desktop/main.go
+++ b/apps/desktop/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sendbeam/desktop/internal/config"
 	"github.com/sendbeam/desktop/internal/engine"
 	"github.com/sendbeam/desktop/internal/lifecycle"
+	"github.com/sendbeam/engine/receiver"
 )
 
 //go:embed all:frontend/dist
@@ -97,6 +98,29 @@ func main() {
 	}
 	if deviceSvc != nil {
 		defer deviceSvc.Close()
+		transferSvc.SetDeviceService(deviceSvc)
+		if id, err := deviceSvc.GetIdentityManager().GetOrCreateIdentity(); err == nil {
+			downloadDir := cfg.DownloadDir
+			if downloadDir == "" {
+				downloadDir = "."
+			}
+			serverURL := cfg.ServerURL
+			if serverURL == "" {
+				serverURL = engine.DefaultServer
+			}
+			if err := transferSvc.StartNativeReceiver(receiver.Config{
+				Server:     serverURL,
+				DestDir:    downloadDir,
+				AutoAccept: false,
+				Identity:   id,
+				TrustStore: deviceSvc.GetStore(),
+				Secrets:    deviceSvc.GetCredentialStore(),
+				Tombstones: deviceSvc.GetTombstoneStore(),
+				Port:       0, // LAN discovery handled by deviceSvc
+			}); err != nil {
+				log.Printf("SendBeam Desktop: native receiver failed to start: %v", err)
+			}
+		}
 	}
 
 	updateSvc := engine.NewUpdateService(

--- a/apps/web/src/desktop-render.test.ts
+++ b/apps/web/src/desktop-render.test.ts
@@ -246,4 +246,400 @@ describe('Desktop frontend literal-text rendering', () => {
     });
     expect(qrImg.src).toBe(validDataUrl);
   });
+
+  it('renders trusted devices list with literal text and status badges without injecting HTML', async () => {
+    const maliciousLabel = '<script id="xss-dev-label">alert(1)</script>Workstation';
+    const maliciousFp = '<b id="xss-dev-fp">deadbeefcafe1234</b>';
+
+    const { document } = setupDesktopDOM({
+      onCall: (name) => {
+        if (name.includes('ListTrustedDevices')) {
+          return Promise.resolve([
+            {
+              deviceId: 'dev-lan-1',
+              localLabel: maliciousLabel,
+              fingerprint: maliciousFp,
+              status: 'lan_direct',
+              revoked: false,
+              policy: { autoAccept: true, autoAcceptDestDir: '/tmp/incoming' },
+              lastSeen: 1710000000,
+            },
+            {
+              deviceId: 'dev-online-2',
+              localLabel: 'Phone',
+              fingerprint: '1122334455667788',
+              status: 'online',
+              revoked: false,
+              policy: { autoAccept: false },
+              lastSeen: 0,
+            },
+            {
+              deviceId: 'dev-revoked-3',
+              localLabel: 'Old Laptop',
+              fingerprint: '9988776655443322',
+              status: 'offline',
+              revoked: true,
+              policy: { autoAccept: false },
+              lastSeen: 1709000000,
+            },
+          ]);
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    const tab = document.getElementById('tab-devices') as HTMLButtonElement;
+    tab.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(document.querySelector('#xss-dev-label')).toBeNull();
+    expect(document.querySelector('#xss-dev-fp')).toBeNull();
+
+    const tbody = document.getElementById('devices-tbody');
+    expect(tbody).not.toBeNull();
+    const rows = tbody?.querySelectorAll('tr');
+    expect(rows?.length).toBe(3);
+
+    // Verify row 1 (lan_direct)
+    const row1 = rows?.[0];
+    expect(row1?.textContent).toContain(maliciousLabel);
+    expect(row1?.textContent).toContain(maliciousFp);
+    expect(row1?.querySelector('.badge-lan')?.textContent).toBe('LAN Direct');
+    expect(row1?.textContent).toContain('Yes (/tmp/incoming)');
+
+    // Verify row 2 (online)
+    const row2 = rows?.[1];
+    expect(row2?.querySelector('.badge-online')?.textContent).toBe('Online');
+    expect(row2?.textContent).toContain('No');
+
+    // Verify row 3 (revoked takes precedence)
+    const row3 = rows?.[2];
+    expect(row3?.querySelector('.badge-revoked')?.textContent).toBe('Revoked');
+
+    // Action buttons must exist
+    expect(row1?.querySelector('button[data-action="policy"]')).not.toBeNull();
+    expect(row1?.querySelector('button[data-action="rename"]')).not.toBeNull();
+    expect(row1?.querySelector('button[data-action="unpair"]')).not.toBeNull();
+  });
+
+  it('updates send recipient dropdown with trusted devices and broadcast option', async () => {
+    const { document } = setupDesktopDOM({
+      onCall: (name) => {
+        if (name.includes('ListTrustedDevices')) {
+          return Promise.resolve([
+            {
+              deviceId: 'dev-100',
+              localLabel: '<script id="xss-opt">alert(1)</script>Tablet',
+              fingerprint: 'aabbccddeeff0011',
+              status: 'online',
+              revoked: false,
+            },
+            {
+              deviceId: 'dev-200',
+              localLabel: 'Desktop PC',
+              fingerprint: '3344556677889900',
+              status: 'lan_direct',
+              revoked: false,
+            },
+            {
+              deviceId: 'dev-revoked',
+              localLabel: 'Old Phone',
+              fingerprint: '1100ffeeddccbbaa',
+              status: 'offline',
+              revoked: true,
+            },
+          ]);
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    const tab = document.getElementById('tab-devices') as HTMLButtonElement;
+    tab.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const recipientSelect = document.getElementById('send-recipient') as HTMLSelectElement;
+    expect(recipientSelect).not.toBeNull();
+    expect(document.querySelector('#xss-opt')).toBeNull();
+
+    const options = Array.from(recipientSelect.options);
+    expect(options.some((opt) => opt.value === 'code')).toBe(true);
+    expect(options.some((opt) => opt.value === 'broadcast:all')).toBe(true);
+    const tabletOpt = options.find((opt) => opt.value === 'dev-100');
+    expect(tabletOpt).toBeDefined();
+    expect(tabletOpt?.textContent).toContain('<script id="xss-opt">alert(1)</script>Tablet');
+    // Revoked device should not appear in active recipients
+    expect(options.some((opt) => opt.value === 'dev-revoked')).toBe(false);
+  });
+
+  it('handles pairing modal offer and join flows securely', async () => {
+    let pairingOfferCalled = false;
+    let cancelPairingOfferCalled = false;
+    let pairDevicePayload: unknown[] | null = null;
+
+    const { document } = setupDesktopDOM({
+      onCall: (name, ...args) => {
+        if (name.includes('StartPairingOffer')) {
+          pairingOfferCalled = true;
+          return Promise.resolve({
+            code: 'test-pair-code',
+            qr: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+          });
+        }
+        if (name.includes('CancelPairingOffer')) {
+          cancelPairingOfferCalled = true;
+          return Promise.resolve({});
+        }
+        if (name.includes('PairDevice')) {
+          pairDevicePayload = args;
+          return Promise.resolve({});
+        }
+        if (name.includes('ListTrustedDevices')) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    const pairBtn = document.getElementById('open-pair-btn') as HTMLButtonElement;
+    pairBtn.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const modalPair = document.getElementById('modal-pair');
+    expect(modalPair?.classList.contains('hidden')).toBe(false);
+    expect(pairingOfferCalled).toBe(true);
+    expect(document.getElementById('pair-offer-code')?.textContent).toBe('test-pair-code');
+    const qrImg = document.getElementById('pair-offer-qr') as HTMLImageElement;
+    expect(qrImg.src).toContain('data:image/png;base64');
+
+    // Switch to Join tab
+    const joinTab = document.getElementById('pair-tab-join') as HTMLButtonElement;
+    joinTab.click();
+    expect(document.getElementById('pair-join-view')?.classList.contains('hidden')).toBe(false);
+
+    // Fill form and submit
+    const codeInput = document.getElementById('pair-join-code') as HTMLInputElement;
+    const labelInput = document.getElementById('pair-join-label') as HTMLInputElement;
+    const autoAccept = document.getElementById('pair-join-auto-accept') as HTMLInputElement;
+    const destDir = document.getElementById('pair-join-dest-dir') as HTMLInputElement;
+
+    codeInput.value = 'partner-code-99';
+    labelInput.value = 'My Partner';
+    autoAccept.checked = true;
+    autoAccept.dispatchEvent(
+      new (document.defaultView as unknown as { Event: typeof Event }).Event('change'),
+    );
+    destDir.value = '/tmp/partner-downloads';
+
+    const joinSubmit = document.getElementById('pair-join-submit') as HTMLButtonElement;
+    joinSubmit.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(pairDevicePayload).toEqual([
+      '',
+      'partner-code-99',
+      'My Partner',
+      true,
+      '/tmp/partner-downloads',
+    ]);
+
+    // Closing modal invokes cancel
+    const closeBtn = document.getElementById('pair-modal-close') as HTMLButtonElement;
+    closeBtn.click();
+    expect(cancelPairingOfferCalled).toBe(true);
+  });
+
+  it('handles policy modal editing and saving', async () => {
+    let updatedPolicy: unknown = null;
+
+    const { document } = setupDesktopDOM({
+      onCall: (name, ...args) => {
+        if (name.includes('ListTrustedDevices')) {
+          return Promise.resolve([
+            {
+              deviceId: 'dev-policy-test',
+              localLabel: 'Policy Node',
+              fingerprint: 'deadbeef1122',
+              status: 'online',
+              revoked: false,
+              policy: { autoAccept: false, autoAcceptDestDir: '' },
+            },
+          ]);
+        }
+        if (name.includes('UpdateDevicePolicy')) {
+          updatedPolicy = args;
+          return Promise.resolve({});
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    const tab = document.getElementById('tab-devices') as HTMLButtonElement;
+    tab.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const policyBtn = document.querySelector('button[data-action="policy"]') as HTMLButtonElement;
+    policyBtn.click();
+
+    const modalPolicy = document.getElementById('modal-policy');
+    expect(modalPolicy?.classList.contains('hidden')).toBe(false);
+
+    const autoAccept = document.getElementById('policy-auto-accept') as HTMLInputElement;
+    const destDir = document.getElementById('policy-dest-dir') as HTMLInputElement;
+    autoAccept.checked = true;
+    destDir.value = '/home/user/vault';
+
+    const saveBtn = document.getElementById('policy-save-btn') as HTMLButtonElement;
+    saveBtn.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(updatedPolicy).toEqual([
+      'dev-policy-test',
+      { autoAccept: true, autoAcceptDestDir: '/home/user/vault' },
+    ]);
+  });
+
+  it('handles rename modal editing and saving', async () => {
+    let renameArgs: unknown = null;
+
+    const { document } = setupDesktopDOM({
+      onCall: (name, ...args) => {
+        if (name.includes('ListTrustedDevices')) {
+          return Promise.resolve([
+            {
+              deviceId: 'dev-rename-test',
+              localLabel: 'Old Name',
+              fingerprint: 'deadbeef1122',
+              status: 'online',
+              revoked: false,
+            },
+          ]);
+        }
+        if (name.includes('RenameDevice')) {
+          renameArgs = args;
+          return Promise.resolve({});
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    const tab = document.getElementById('tab-devices') as HTMLButtonElement;
+    tab.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const renameBtn = document.querySelector('button[data-action="rename"]') as HTMLButtonElement;
+    renameBtn.click();
+
+    const modalRename = document.getElementById('modal-rename');
+    expect(modalRename?.classList.contains('hidden')).toBe(false);
+
+    const input = document.getElementById('rename-label-input') as HTMLInputElement;
+    expect(input.value).toBe('Old Name');
+    input.value = 'New Friendly Name';
+
+    const saveBtn = document.getElementById('rename-save-btn') as HTMLButtonElement;
+    saveBtn.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(renameArgs).toEqual(['dev-rename-test', 'New Friendly Name']);
+  });
+
+  it('handles unpair modal with purge option', async () => {
+    let unpairArgs: unknown = null;
+
+    const { document } = setupDesktopDOM({
+      onCall: (name, ...args) => {
+        if (name.includes('ListTrustedDevices')) {
+          return Promise.resolve([
+            {
+              deviceId: 'dev-unpair-test',
+              localLabel: '<b id="xss-unpair">Node</b>',
+              fingerprint: 'deadbeef1122',
+              status: 'online',
+              revoked: false,
+            },
+          ]);
+        }
+        if (name.includes('UnpairDevice')) {
+          unpairArgs = args;
+          return Promise.resolve({});
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    const tab = document.getElementById('tab-devices') as HTMLButtonElement;
+    tab.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const unpairBtn = document.querySelector('button[data-action="unpair"]') as HTMLButtonElement;
+    unpairBtn.click();
+
+    expect(document.querySelector('#xss-unpair')).toBeNull();
+    const modalUnpair = document.getElementById('modal-unpair');
+    expect(modalUnpair?.classList.contains('hidden')).toBe(false);
+
+    // Select purge radio
+    const purgeRadio = document.querySelector(
+      'input[name="unpair-mode"][value="purge"]',
+    ) as HTMLInputElement;
+    purgeRadio.checked = true;
+
+    const confirmBtn = document.getElementById('unpair-confirm-btn') as HTMLButtonElement;
+    confirmBtn.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(unpairArgs).toEqual(['dev-unpair-test', true]);
+  });
+
+  it('handles incoming consent modal prompt and responses safely', async () => {
+    let consentResponse: unknown = null;
+
+    const { document, emit } = setupDesktopDOM({
+      onCall: (name, ...args) => {
+        if (name.includes('RespondConsent')) {
+          consentResponse = args;
+          return Promise.resolve({});
+        }
+        return Promise.resolve({});
+      },
+    });
+
+    const maliciousPeer = '<script id="xss-peer-name">alert(1)</script>Bob';
+    const maliciousFp = '<i id="xss-peer-fp">1234abcd</i>';
+    const maliciousFile = '<span id="xss-peer-file">report.pdf</span>';
+
+    emit('sendbeam:consent', {
+      transferId: 'tx-consent-101',
+      peerDeviceId: 'peer-device-id',
+      peerName: maliciousPeer,
+      fingerprint: maliciousFp,
+      fileName: maliciousFile,
+      totalSize: 4194304,
+      destDir: '/tmp/safe-inbox',
+    });
+
+    const modalConsent = document.getElementById('modal-consent');
+    expect(modalConsent?.classList.contains('hidden')).toBe(false);
+
+    expect(document.querySelector('#xss-peer-name')).toBeNull();
+    expect(document.querySelector('#xss-peer-fp')).toBeNull();
+    expect(document.querySelector('#xss-peer-file')).toBeNull();
+
+    expect(document.getElementById('consent-device-name')?.textContent).toBe(maliciousPeer);
+    expect(document.getElementById('consent-fingerprint')?.textContent).toBe(maliciousFp);
+    expect(document.getElementById('consent-files-summary')?.textContent).toContain(maliciousFile);
+
+    const acceptBtn = document.getElementById('consent-accept-btn') as HTMLButtonElement;
+    acceptBtn.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(consentResponse).toEqual([
+      'tx-consent-101',
+      {
+        accepted: true,
+        destDir: '/tmp/safe-inbox',
+      },
+    ]);
+  });
 });

--- a/apps/web/src/lib/trust/devices.ts
+++ b/apps/web/src/lib/trust/devices.ts
@@ -25,6 +25,7 @@ import {
   type SignalMsg,
 } from '@sendbeam/protocol';
 import { join, offer } from '../session/rendezvous.js';
+import { getWailsBridge, isWailsV3Available } from '../wails/wails-adapter.js';
 import type { TrustedDeviceUI } from './types.js';
 
 declare global {
@@ -61,7 +62,9 @@ declare global {
 export { isPersistentTrustSupported };
 
 export function isDesktopApp(): boolean {
-  return typeof window !== 'undefined' && !!window.go?.engine?.DeviceService;
+  return (
+    typeof window !== 'undefined' && (!!window.go?.engine?.DeviceService || isWailsV3Available())
+  );
 }
 
 type BrowserSecretStore = IndexedDBSecretStore | MemorySecretResolver;
@@ -104,6 +107,10 @@ export function getBrowserStores(): {
 }
 
 export async function listTrustedDevices(): Promise<TrustedDeviceUI[]> {
+  const bridge = getWailsBridge();
+  if (bridge) {
+    return bridge.device.listTrustedDevices();
+  }
   if (isDesktopApp() && window.go?.engine?.DeviceService) {
     return window.go.engine.DeviceService.ListTrustedDevices();
   }
@@ -149,6 +156,10 @@ export async function listTrustedDevices(): Promise<TrustedDeviceUI[]> {
 }
 
 export async function renameTrustedDevice(deviceId: string, newLabel: string): Promise<void> {
+  const bridge = getWailsBridge();
+  if (bridge) {
+    return bridge.device.renameDevice(deviceId, newLabel);
+  }
   if (isDesktopApp() && window.go?.engine?.DeviceService) {
     return window.go.engine.DeviceService.RenameDevice(deviceId, newLabel);
   }
@@ -164,6 +175,10 @@ export async function updateTrustedDevicePolicy(
   deviceId: string,
   policy: TrustPolicy,
 ): Promise<void> {
+  const bridge = getWailsBridge();
+  if (bridge) {
+    return bridge.device.updateDevicePolicy(deviceId, policy);
+  }
   if (isDesktopApp() && window.go?.engine?.DeviceService) {
     return window.go.engine.DeviceService.UpdateDevicePolicy(deviceId, policy);
   }
@@ -173,6 +188,10 @@ export async function updateTrustedDevicePolicy(
 }
 
 export async function unpairTrustedDevice(deviceId: string, purge: boolean): Promise<void> {
+  const bridge = getWailsBridge();
+  if (bridge) {
+    return bridge.device.unpairDevice(deviceId, purge);
+  }
   if (isDesktopApp() && window.go?.engine?.DeviceService) {
     return window.go.engine.DeviceService.UnpairDevice(deviceId, purge);
   }
@@ -276,6 +295,10 @@ export async function pairTrustedDevice(
   autoAccept: boolean,
   dest: string,
 ): Promise<TrustedDeviceUI> {
+  const bridge = getWailsBridge();
+  if (bridge) {
+    return bridge.device.pairDevice(server, code, name, autoAccept, dest);
+  }
   if (isDesktopApp() && window.go?.engine?.DeviceService) {
     return window.go.engine.DeviceService.PairDevice(server, code, name, autoAccept, dest);
   }

--- a/apps/web/src/lib/trust/incoming-listener.ts
+++ b/apps/web/src/lib/trust/incoming-listener.ts
@@ -13,6 +13,7 @@ import {
   type TrustRecord,
 } from '@sendbeam/protocol';
 import { getBrowserStores, isDesktopApp } from './devices.js';
+import { getWailsBridge } from '../wails/wails-adapter.js';
 import type { IncomingTransferRequest } from './types.js';
 import { opaqueJoin, type OpaqueRendezvousController } from '../session/opaque-rendezvous.js';
 import { runReceive, type TransferController, type TransferOutcome } from '../session/transfer.js';
@@ -44,6 +45,13 @@ export class IncomingTransferCoordinator {
     this.running = true;
 
     // Desktop app delegates listening to native engine and receives events
+    const bridge = getWailsBridge();
+    if (bridge) {
+      this.desktopConsentCleanup = bridge.events.on('sendbeam:consent', (data: unknown) => {
+        this.handleDesktopConsentEvent(data);
+      });
+      return;
+    }
     if (isDesktopApp() && typeof window !== 'undefined' && window.runtime?.EventsOn) {
       this.desktopConsentCleanup = window.runtime.EventsOn('sendbeam:consent', (data: unknown) => {
         this.handleDesktopConsentEvent(data);
@@ -83,6 +91,15 @@ export class IncomingTransferCoordinator {
   }
 
   async respondConsent(transferId: string, accepted: boolean, reason?: string): Promise<void> {
+    const bridge = getWailsBridge();
+    if (bridge) {
+      const decision = {
+        accepted,
+        ...(reason ? { reason } : {}),
+      };
+      await bridge.transfer.respondConsent(transferId, decision);
+      return;
+    }
     if (isDesktopApp() && window.go?.engine?.TransferService?.RespondConsent) {
       const decision = {
         accepted,

--- a/apps/web/src/lib/wails/wails-adapter.test.ts
+++ b/apps/web/src/lib/wails/wails-adapter.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createDeviceServiceAdapter,
+  createTransferServiceAdapter,
+  createUpdateServiceAdapter,
+  createEngineServiceAdapter,
+  getWailsBridge,
+  isWailsV3Available,
+  WAILS_SERVICES,
+  WAILS_EVENTS,
+} from './wails-adapter.js';
+
+describe('Wails v3 typed adapter layer', () => {
+  it('exposes correct service FQNs and event names', () => {
+    expect(WAILS_SERVICES.Device).toBe('github.com/sendbeam/desktop/internal/engine.DeviceService');
+    expect(WAILS_SERVICES.Transfer).toBe(
+      'github.com/sendbeam/desktop/internal/engine.TransferService',
+    );
+    expect(WAILS_SERVICES.Update).toBe('github.com/sendbeam/desktop/internal/engine.UpdateService');
+    expect(WAILS_SERVICES.Service).toBe('github.com/sendbeam/desktop/internal/engine.Service');
+
+    expect(WAILS_EVENTS.Transfer).toBe('sendbeam:transfer');
+    expect(WAILS_EVENTS.Consent).toBe('sendbeam:consent');
+    expect(WAILS_EVENTS.Devices).toBe('sendbeam:devices');
+    expect(WAILS_EVENTS.Update).toBe('sendbeam:update');
+  });
+
+  it('detects Wails v3 availability correctly', () => {
+    const originalWindow = globalThis.window;
+    try {
+      (globalThis as unknown as { window: unknown }).window = {};
+      expect(isWailsV3Available()).toBe(false);
+
+      (globalThis as unknown as { window: unknown }).window = {
+        wails: {
+          Call: { ByName: vi.fn() },
+        },
+      };
+      expect(isWailsV3Available()).toBe(true);
+      expect(getWailsBridge()).not.toBeNull();
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it('device service adapter formats calls correctly', async () => {
+    const mockCall = vi.fn().mockResolvedValue([]);
+    const adapter = createDeviceServiceAdapter(mockCall);
+
+    await adapter.listTrustedDevices();
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Device}.ListTrustedDevices`);
+
+    mockCall.mockResolvedValue({ code: '7-words', qr: 'data:image/png;base64,123' });
+    const offer = await adapter.startPairingOffer('wss://hub', 'Desktop', true, '/tmp/down');
+    expect(mockCall).toHaveBeenCalledWith(
+      `${WAILS_SERVICES.Device}.StartPairingOffer`,
+      'wss://hub',
+      'Desktop',
+      true,
+      '/tmp/down',
+    );
+    expect(offer.code).toBe('7-words');
+
+    await adapter.cancelPairingOffer();
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Device}.CancelPairingOffer`);
+
+    await adapter.pairDevice('wss://hub', 'code1', 'label1', false, '');
+    expect(mockCall).toHaveBeenCalledWith(
+      `${WAILS_SERVICES.Device}.PairDevice`,
+      'wss://hub',
+      'code1',
+      'label1',
+      false,
+      '',
+    );
+
+    await adapter.renameDevice('dev-1', 'New Name');
+    expect(mockCall).toHaveBeenCalledWith(
+      `${WAILS_SERVICES.Device}.RenameDevice`,
+      'dev-1',
+      'New Name',
+    );
+
+    await adapter.updateDevicePolicy('dev-1', { autoAccept: true, autoAcceptDestDir: '/dl' });
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Device}.UpdateDevicePolicy`, 'dev-1', {
+      autoAccept: true,
+      autoAcceptDestDir: '/dl',
+    });
+
+    await adapter.unpairDevice('dev-1', true);
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Device}.UnpairDevice`, 'dev-1', true);
+  });
+
+  it('transfer service adapter formats targeted and broadcast calls correctly', async () => {
+    const mockCall = vi.fn().mockResolvedValue({ id: 'tx-1', role: 'send' });
+    const adapter = createTransferServiceAdapter(mockCall);
+
+    await adapter.send(['/tmp/file.txt']);
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Transfer}.Send`, ['/tmp/file.txt'], '');
+
+    await adapter.sendToDevice(['/tmp/file.txt'], 'dev-42');
+    expect(mockCall).toHaveBeenCalledWith(
+      `${WAILS_SERVICES.Transfer}.SendToDevice`,
+      ['/tmp/file.txt'],
+      'dev-42',
+      '',
+    );
+
+    mockCall.mockResolvedValue([{ target_id: 'dev-1', status: 'ok', duration_ms: 100 }]);
+    const bResult = await adapter.broadcastSend(['/tmp/file.txt'], ['dev-1', 'dev-2']);
+    expect(mockCall).toHaveBeenCalledWith(
+      `${WAILS_SERVICES.Transfer}.BroadcastSend`,
+      ['/tmp/file.txt'],
+      ['dev-1', 'dev-2'],
+      '',
+    );
+    expect(bResult[0]?.status).toBe('ok');
+
+    await adapter.respondConsent('tx-99', { accepted: true, destDir: '/downloads' });
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Transfer}.RespondConsent`, 'tx-99', {
+      accepted: true,
+      destDir: '/downloads',
+    });
+  });
+
+  it('update and engine service adapters format calls correctly', async () => {
+    const mockCall = vi.fn().mockResolvedValue({});
+    const updateAdapter = createUpdateServiceAdapter(mockCall);
+
+    await updateAdapter.getStatus();
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Update}.GetStatus`);
+
+    await updateAdapter.checkUpdate('beta');
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Update}.CheckUpdate`, 'beta');
+
+    await updateAdapter.setChannel('stable');
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Update}.SetChannel`, 'stable');
+
+    await updateAdapter.applyUpdate();
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Update}.ApplyUpdate`);
+
+    const engineAdapter = createEngineServiceAdapter(mockCall);
+    await engineAdapter.info();
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Service}.Info`);
+
+    await engineAdapter.caps();
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Service}.Caps`);
+
+    await engineAdapter.selfCheck();
+    expect(mockCall).toHaveBeenCalledWith(`${WAILS_SERVICES.Service}.SelfCheck`);
+  });
+});

--- a/apps/web/src/lib/wails/wails-adapter.ts
+++ b/apps/web/src/lib/wails/wails-adapter.ts
@@ -1,0 +1,354 @@
+import type { TrustPolicy } from '@sendbeam/protocol';
+
+export const WAILS_SERVICES = {
+  Service: 'github.com/sendbeam/desktop/internal/engine.Service',
+  Transfer: 'github.com/sendbeam/desktop/internal/engine.TransferService',
+  Update: 'github.com/sendbeam/desktop/internal/engine.UpdateService',
+  Device: 'github.com/sendbeam/desktop/internal/engine.DeviceService',
+} as const;
+
+export const WAILS_EVENTS = {
+  Transfer: 'sendbeam:transfer',
+  Consent: 'sendbeam:consent',
+  Devices: 'sendbeam:devices',
+  Update: 'sendbeam:update',
+  PairingComplete: 'sendbeam:pairing_complete',
+  PairingFailed: 'sendbeam:pairing_failed',
+} as const;
+
+export interface TrustedDeviceView {
+  deviceId: string;
+  localLabel: string;
+  fingerprint: string;
+  publicKey: string;
+  status: 'lan_direct' | 'online' | 'offline' | 'revoked';
+  revoked: boolean;
+  lastSeenAt: string;
+  firstSeenAt: string;
+  capabilities: string[];
+  policy: TrustPolicy;
+  directEndpoint?: string;
+}
+
+export interface PairingOfferResult {
+  code: string;
+  qr: string;
+}
+
+export interface TransferHandle {
+  id: string;
+  role: 'send' | 'receive';
+}
+
+export interface TargetResult {
+  target_id: string;
+  label: string;
+  status: 'ok' | 'offline' | 'refused' | 'failed';
+  digest?: string;
+  size?: number;
+  duration_ms: number;
+  error?: string;
+  outcome?: {
+    name: string;
+    size: number;
+    digest: string;
+    path?: string;
+  };
+}
+
+export interface ConsentRequest {
+  transferId: string;
+  peerDeviceId: string;
+  peerName?: string;
+  fingerprint: string;
+  fileName: string;
+  fileCount: number;
+  totalSize: number;
+  destDir?: string;
+}
+
+export interface ConsentDecision {
+  accepted: boolean;
+  destDir?: string;
+  reason?: string;
+}
+
+export interface DurableTransferItem {
+  transferId: string;
+  role: 'send' | 'receive';
+  totalBytes: number;
+  committedBytes: number;
+  files: number;
+  createdAt: number;
+  updatedAt: number;
+  status: string;
+  resumable: boolean;
+  paths?: string[];
+}
+
+export interface DurableInspectResult {
+  transferId: string;
+  totalBytes: number;
+  committedBytes: number;
+  createdAt: number;
+  updatedAt: number;
+  protocolVersion: string;
+  manifestFingerprint: string;
+  journalPath: string;
+  partialDir: string;
+  resumable: boolean;
+  problems?: string[];
+  files?: { name: string; size: number }[];
+}
+
+export interface DesktopConfig {
+  downloadDir?: string;
+  serverUrl?: string;
+  closeToTray?: boolean;
+  startMinimized?: boolean;
+  updateChannel?: string;
+  iceServers?: string[];
+}
+
+export interface EngineInfo {
+  version: string;
+  platform: string;
+  buildTime: string;
+}
+
+export interface EngineCaps {
+  features: string[];
+  protocolVersion: string;
+}
+
+export interface SelfCheckResult {
+  ok: boolean;
+  problems?: string[];
+}
+
+export interface UpdateStatus {
+  state: string;
+  currentVersion: string;
+  latestVersion?: string;
+  releaseNotes?: string;
+  channel: string;
+  error?: string;
+}
+
+export type WailsCaller = (name: string, ...args: unknown[]) => Promise<unknown>;
+export type WailsEventSubscriber = (name: string, callback: (data: unknown) => void) => () => void;
+
+export interface DeviceServiceAdapter {
+  listTrustedDevices(): Promise<TrustedDeviceView[]>;
+  pairDevice(
+    server: string,
+    code: string,
+    label: string,
+    autoAccept: boolean,
+    destDir: string,
+  ): Promise<TrustedDeviceView>;
+  startPairingOffer(
+    server: string,
+    label: string,
+    autoAccept: boolean,
+    destDir: string,
+  ): Promise<PairingOfferResult>;
+  cancelPairingOffer(): Promise<void>;
+  renameDevice(deviceId: string, newLabel: string): Promise<void>;
+  updateDevicePolicy(deviceId: string, policy: TrustPolicy): Promise<void>;
+  unpairDevice(deviceId: string, purge: boolean): Promise<void>;
+}
+
+export interface TransferServiceAdapter {
+  send(paths: string[], server?: string): Promise<TransferHandle>;
+  sendToDevice(paths: string[], deviceId: string, server?: string): Promise<TransferHandle>;
+  broadcastSend(paths: string[], deviceIds: string[], server?: string): Promise<TargetResult[]>;
+  receive(code: string, destDir?: string, server?: string): Promise<TransferHandle>;
+  pause(id: string): Promise<void>;
+  resume(id: string): Promise<void>;
+  cancel(id: string): Promise<void>;
+  respondConsent(transferId: string, decision: ConsentDecision): Promise<void>;
+  pendingConsents(): Promise<ConsentRequest[]>;
+  pickFiles(): Promise<{ paths: string[]; error?: string }>;
+  pickDestination(): Promise<{ path: string; error?: string }>;
+  listInterrupted(outDir?: string): Promise<DurableTransferItem[]>;
+  inspectInterrupted(transferId: string, outDir?: string): Promise<DurableInspectResult>;
+  resumeInterrupted(
+    transferId: string,
+    code: string,
+    destDir?: string,
+    server?: string,
+  ): Promise<TransferHandle>;
+  discardInterrupted(transferId: string, outDir?: string): Promise<void>;
+  discardAllInterrupted(outDir?: string): Promise<void>;
+  revealCompleted(id: string): Promise<void>;
+  getConfig(): Promise<DesktopConfig>;
+  saveConfig(cfg: DesktopConfig): Promise<void>;
+}
+
+export interface UpdateServiceAdapter {
+  checkUpdate(channel: string): Promise<UpdateStatus>;
+  setChannel(channel: string): Promise<void>;
+  applyUpdate(): Promise<UpdateStatus>;
+  getStatus(): Promise<UpdateStatus>;
+}
+
+export interface EngineServiceAdapter {
+  info(): Promise<EngineInfo>;
+  caps(): Promise<EngineCaps>;
+  selfCheck(): Promise<SelfCheckResult>;
+}
+
+export interface WailsBridge {
+  device: DeviceServiceAdapter;
+  transfer: TransferServiceAdapter;
+  update: UpdateServiceAdapter;
+  engine: EngineServiceAdapter;
+  events: {
+    on(name: string, cb: (data: unknown) => void): () => void;
+  };
+}
+
+export function createDeviceServiceAdapter(call: WailsCaller): DeviceServiceAdapter {
+  return {
+    listTrustedDevices: () =>
+      call(`${WAILS_SERVICES.Device}.ListTrustedDevices`) as Promise<TrustedDeviceView[]>,
+    pairDevice: (server, code, label, autoAccept, destDir) =>
+      call(
+        `${WAILS_SERVICES.Device}.PairDevice`,
+        server,
+        code,
+        label,
+        autoAccept,
+        destDir,
+      ) as Promise<TrustedDeviceView>,
+    startPairingOffer: (server, label, autoAccept, destDir) =>
+      call(
+        `${WAILS_SERVICES.Device}.StartPairingOffer`,
+        server,
+        label,
+        autoAccept,
+        destDir,
+      ) as Promise<PairingOfferResult>,
+    cancelPairingOffer: () => call(`${WAILS_SERVICES.Device}.CancelPairingOffer`) as Promise<void>,
+    renameDevice: (deviceId, newLabel) =>
+      call(`${WAILS_SERVICES.Device}.RenameDevice`, deviceId, newLabel) as Promise<void>,
+    updateDevicePolicy: (deviceId, policy) =>
+      call(`${WAILS_SERVICES.Device}.UpdateDevicePolicy`, deviceId, policy) as Promise<void>,
+    unpairDevice: (deviceId, purge) =>
+      call(`${WAILS_SERVICES.Device}.UnpairDevice`, deviceId, purge) as Promise<void>,
+  };
+}
+
+export function createTransferServiceAdapter(call: WailsCaller): TransferServiceAdapter {
+  return {
+    send: (paths, server = '') =>
+      call(`${WAILS_SERVICES.Transfer}.Send`, paths, server) as Promise<TransferHandle>,
+    sendToDevice: (paths, deviceId, server = '') =>
+      call(
+        `${WAILS_SERVICES.Transfer}.SendToDevice`,
+        paths,
+        deviceId,
+        server,
+      ) as Promise<TransferHandle>,
+    broadcastSend: (paths, deviceIds, server = '') =>
+      call(`${WAILS_SERVICES.Transfer}.BroadcastSend`, paths, deviceIds, server) as Promise<
+        TargetResult[]
+      >,
+    receive: (code, destDir = '', server = '') =>
+      call(`${WAILS_SERVICES.Transfer}.Receive`, code, destDir, server) as Promise<TransferHandle>,
+    pause: (id) => call(`${WAILS_SERVICES.Transfer}.Pause`, id) as Promise<void>,
+    resume: (id) => call(`${WAILS_SERVICES.Transfer}.Resume`, id) as Promise<void>,
+    cancel: (id) => call(`${WAILS_SERVICES.Transfer}.Cancel`, id) as Promise<void>,
+    respondConsent: (transferId, decision) =>
+      call(`${WAILS_SERVICES.Transfer}.RespondConsent`, transferId, decision) as Promise<void>,
+    pendingConsents: () =>
+      call(`${WAILS_SERVICES.Transfer}.PendingConsents`) as Promise<ConsentRequest[]>,
+    pickFiles: () =>
+      call(`${WAILS_SERVICES.Transfer}.PickFiles`) as Promise<{
+        paths: string[];
+        error?: string;
+      }>,
+    pickDestination: () =>
+      call(`${WAILS_SERVICES.Transfer}.PickDestination`) as Promise<{
+        path: string;
+        error?: string;
+      }>,
+    listInterrupted: (outDir = '') =>
+      call(`${WAILS_SERVICES.Transfer}.ListInterrupted`, outDir) as Promise<DurableTransferItem[]>,
+    inspectInterrupted: (transferId, outDir = '') =>
+      call(
+        `${WAILS_SERVICES.Transfer}.InspectInterrupted`,
+        transferId,
+        outDir,
+      ) as Promise<DurableInspectResult>,
+    resumeInterrupted: (transferId, code, destDir = '', server = '') =>
+      call(
+        `${WAILS_SERVICES.Transfer}.ResumeInterrupted`,
+        transferId,
+        code,
+        destDir,
+        server,
+      ) as Promise<TransferHandle>,
+    discardInterrupted: (transferId, outDir = '') =>
+      call(`${WAILS_SERVICES.Transfer}.DiscardInterrupted`, transferId, outDir) as Promise<void>,
+    discardAllInterrupted: (outDir = '') =>
+      call(`${WAILS_SERVICES.Transfer}.DiscardAllInterrupted`, outDir) as Promise<void>,
+    revealCompleted: (id) =>
+      call(`${WAILS_SERVICES.Transfer}.RevealCompleted`, id) as Promise<void>,
+    getConfig: () => call(`${WAILS_SERVICES.Transfer}.GetConfig`) as Promise<DesktopConfig>,
+    saveConfig: (cfg) => call(`${WAILS_SERVICES.Transfer}.SaveConfig`, cfg) as Promise<void>,
+  };
+}
+
+export function createUpdateServiceAdapter(call: WailsCaller): UpdateServiceAdapter {
+  return {
+    checkUpdate: (channel) =>
+      call(`${WAILS_SERVICES.Update}.CheckUpdate`, channel) as Promise<UpdateStatus>,
+    setChannel: (channel) => call(`${WAILS_SERVICES.Update}.SetChannel`, channel) as Promise<void>,
+    applyUpdate: () => call(`${WAILS_SERVICES.Update}.ApplyUpdate`) as Promise<UpdateStatus>,
+    getStatus: () => call(`${WAILS_SERVICES.Update}.GetStatus`) as Promise<UpdateStatus>,
+  };
+}
+
+export function createEngineServiceAdapter(call: WailsCaller): EngineServiceAdapter {
+  return {
+    info: () => call(`${WAILS_SERVICES.Service}.Info`) as Promise<EngineInfo>,
+    caps: () => call(`${WAILS_SERVICES.Service}.Caps`) as Promise<EngineCaps>,
+    selfCheck: () => call(`${WAILS_SERVICES.Service}.SelfCheck`) as Promise<SelfCheckResult>,
+  };
+}
+
+export function isWailsV3Available(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    !!(window as unknown as { wails?: { Call?: { ByName?: unknown } } }).wails?.Call?.ByName
+  );
+}
+
+export function getWailsBridge(): WailsBridge | null {
+  if (!isWailsV3Available()) {
+    return null;
+  }
+  const w = window as unknown as {
+    wails: {
+      Call: { ByName(name: string, ...args: unknown[]): Promise<unknown> };
+      Events?: { On(name: string, callback: (data: unknown) => void): () => void };
+    };
+  };
+  const caller: WailsCaller = (name, ...args) => w.wails.Call.ByName(name, ...args);
+  const subscriber: WailsEventSubscriber = (name, cb) => {
+    if (w.wails.Events?.On) {
+      return w.wails.Events.On(name, cb);
+    }
+    return () => {};
+  };
+
+  return {
+    device: createDeviceServiceAdapter(caller),
+    transfer: createTransferServiceAdapter(caller),
+    update: createUpdateServiceAdapter(caller),
+    engine: createEngineServiceAdapter(caller),
+    events: { on: subscriber },
+  };
+}


### PR DESCRIPTION
### Summary of Changes

Delivers **V19-PR10**: Trusted-device flows in the actual built desktop frontend, with typed Wails v3 adapters and native artifact smoke tests.

1. **Desktop Engine & Services**:
   - **DeviceService**: Added `StartPairingOffer`, `CancelPairingOffer`, and `PairingOfferResult` (`code` + `qr` base64 data URI). Exposed stores via `GetIdentityManager()`, `GetStore()`, `GetCredentialStore()`, `GetTombstoneStore()`. Updated `PairDevice` to respect custom peer labels.
   - **TransferService**: Added `SetDeviceService(ds)`, `DeviceService()`, `SendToDevice`, `BroadcastSend`, and `runSendTargeted` delivering files over authenticated opaque channels.
   - **main.go**: Wired `transferSvc.SetDeviceService(deviceSvc)` and initialized native receiver on startup with device identity and stores.

2. **Typed Wails v3 Adapters**:
   - Implemented `apps/web/src/lib/wails/wails-adapter.ts` exposing complete type definitions, FQNs (`github.com/sendbeam/desktop/internal/engine.*Service`), events (`sendbeam:transfer`, `sendbeam:consent`, `sendbeam:devices`, `sendbeam:update`), and typed adapters for `DeviceService`, `TransferService`, `UpdateService`, and `EngineService`.
   - Wired `getWailsBridge()` and `isWailsV3Available()` into `devices.ts` and `incoming-listener.ts`.

3. **Desktop Built Frontend (`apps/desktop/frontend/dist/index.html`)**:
   - Added Devices tab (`#tab-devices`) and panel (`#panel-devices`) with devices table and honest status badges (`lan_direct` -> `.badge-lan`, `online` -> `.badge-online`, `offline` -> `.badge-offline`, `revoked` -> `.badge-revoked`).
   - Added modals: Pairing (`#modal-pair`), Policy (`#modal-policy`), Rename (`#modal-rename`), Unpair (`#modal-unpair`), and Incoming Consent (`#modal-consent`).
   - Added send recipient selector (`#send-recipient`) with support for one-time codes, trusted devices, or broadcast to all devices.
   - Strict XSS safety: zero `innerHTML` / `outerHTML` / `document.write` / `insertAdjacentHTML`, protocol check on QR codes, and no inline `on*` event handlers.

4. **Testing & Verification**:
   - Added pairing offer, loopback pairing ceremony, and cancellation tests in `device_service_test.go`.
   - Added targeted send and broadcast validation tests in `transfer_service_test.go`.
   - Added native artifact smoke tests in `smoke_test.go` verifying HTML asset presence, DOM IDs, CSS classes, safety invariants, and service wiring.
   - Expanded `desktop-render.test.ts` with 15 tests covering tabs, modals, badges, recipient selection, and consent flows.
   - Vitest, Go tests (-race), svelte-check, Prettier, and ESLint all 100% green.